### PR TITLE
fix flux_shima_etal

### DIFF
--- a/src/equations/2d/compressible_euler.jl
+++ b/src/equations/2d/compressible_euler.jl
@@ -456,45 +456,44 @@ end
 """
     function flux_shima_etal(u_ll, u_rr, orientation, equation::CompressibleEulerEquations2D)
 
-Preventing spurious pressure oscillations in split convective form discretizations for
-compressible flows
-by Nao Shima, Yuichi Kuya, Yoshiharu Tamaki, Soshi Kawai (JCP 2020)
-
-This flux is is a modification of the original kinetic energy preserving two-point flux by Kuya,
-Totani and Kawai (2018)
+This flux is is a modification of the original kinetic energy preserving two-point flux by
+Kuya, Totani and Kawai (2018)
   Kinetic energy and entropy preserving schemes for compressible flows
   by split convective forms
   [DOI: 10.1016/j.jcp.2018.08.058](https://doi.org/10.1016/j.jcp.2018.08.058)
-The modification is in the energy flux to guarantee pressure equilibrium.
+The modification is in the energy flux to guarantee pressure equilibrium and was developed by
+Nao Shima, Yuichi Kuya, Yoshiharu Tamaki, Soshi Kawai (JCP 2020)
+  Preventing spurious pressure oscillations in split convective form discretizations for
+  compressible flows
 """
 @inline function flux_shima_etal(u_ll, u_rr, orientation, equation::CompressibleEulerEquations2D)
   # Unpack left and right state
   rho_ll, rho_v1_ll, rho_v2_ll, rho_e_ll = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, rho_e_rr = u_rr
 
-  v1_ll = rho_v1_ll/rho_ll
-  v2_ll = rho_v2_ll/rho_ll
-  v1_rr = rho_v1_rr/rho_rr
-  v2_rr = rho_v2_rr/rho_rr
-  p_ll =  (equation.gamma - 1) * (rho_e_ll - 1/2 * rho_ll * (v1_ll^2 + v2_ll^2))
-  p_rr =  (equation.gamma - 1) * (rho_e_rr - 1/2 * rho_rr * (v1_rr^2 + v2_rr^2))
+  v1_ll = rho_v1_ll / rho_ll
+  v2_ll = rho_v2_ll / rho_ll
+  v1_rr = rho_v1_rr / rho_rr
+  v2_rr = rho_v2_rr / rho_rr
+  p_ll  = (equation.gamma - 1) * (rho_e_ll - 1/2 * rho_ll * (v1_ll^2 + v2_ll^2))
+  p_rr  = (equation.gamma - 1) * (rho_e_rr - 1/2 * rho_rr * (v1_rr^2 + v2_rr^2))
 
   # Average each factor of products in flux
   rho_avg = 1/2 * (rho_ll + rho_rr)
-  v1_avg = 1/2 * (v1_ll + v1_rr)
-  v2_avg = 1/2 * (v2_ll + v2_rr)
-  p_avg = 1/2 * (p_ll + p_rr)
+  v1_avg  = 1/2 * ( v1_ll +  v1_rr)
+  v2_avg  = 1/2 * ( v2_ll +  v2_rr)
+  p_avg   = 1/2 * (  p_ll +   p_rr)
   kin_avg = 1/2 * (v1_ll*v1_rr + v2_ll*v2_rr)
 
   # Calculate fluxes depending on orientation
   if orientation == 1
-    pv1_avg = 1/2 * ( p_ll*v1_ll + p_rr*v1_rr)
+    pv1_avg = 1/2 * (p_ll*v1_rr + p_rr*v1_ll)
     f1 = rho_avg * v1_avg
     f2 = rho_avg * v1_avg * v1_avg + p_avg
     f3 = rho_avg * v1_avg * v2_avg
     f4 = p_avg*v1_avg/(equation.gamma-1) + rho_avg*v1_avg*kin_avg + pv1_avg
   else
-    pv2_avg = 1/2 * ( p_ll*v2_ll + p_rr*v2_rr)
+    pv2_avg = 1/2 * (p_ll*v2_rr + p_rr*v2_ll)
     f1 = rho_avg * v2_avg
     f2 = rho_avg * v2_avg * v1_avg
     f3 = rho_avg * v2_avg * v2_avg + p_avg

--- a/src/equations/3d/compressible_euler.jl
+++ b/src/equations/3d/compressible_euler.jl
@@ -298,56 +298,55 @@ end
 """
     function flux_shima_etal(u_ll, u_rr, orientation, equation::CompressibleEulerEquations3D)
 
-Preventing spurious pressure oscillations in split convective form discretizations for
-compressible flows
-by Nao Shima, Yuichi Kuya, Yoshiharu Tamaki, Soshi Kawai (JCP 2020)
-
-This flux is is a modification of the original kinetic energy preserving two-point flux by Kuya,
-Totani and Kawai (2018)
+This flux is is a modification of the original kinetic energy preserving two-point flux by
+Kuya, Totani and Kawai (2018)
   Kinetic energy and entropy preserving schemes for compressible flows
   by split convective forms
   [DOI: 10.1016/j.jcp.2018.08.058](https://doi.org/10.1016/j.jcp.2018.08.058)
-The modification is in the energy flux to guarantee pressure equilibrium.
+The modification is in the energy flux to guarantee pressure equilibrium and was developed by
+Nao Shima, Yuichi Kuya, Yoshiharu Tamaki, Soshi Kawai (JCP 2020)
+  Preventing spurious pressure oscillations in split convective form discretizations for
+  compressible flows
 """
 @inline function flux_shima_etal(u_ll, u_rr, orientation, equation::CompressibleEulerEquations3D)
   # Unpack left and right state
   rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr = u_rr
 
-  v1_ll = rho_v1_ll/rho_ll
-  v2_ll = rho_v2_ll/rho_ll
-  v3_ll = rho_v3_ll/rho_ll
-  v1_rr = rho_v1_rr/rho_rr
-  v2_rr = rho_v2_rr/rho_rr
-  v3_rr = rho_v3_rr/rho_rr
+  v1_ll = rho_v1_ll / rho_ll
+  v2_ll = rho_v2_ll / rho_ll
+  v3_ll = rho_v3_ll / rho_ll
+  v1_rr = rho_v1_rr / rho_rr
+  v2_rr = rho_v2_rr / rho_rr
+  v3_rr = rho_v3_rr / rho_rr
   p_ll =  (equation.gamma - 1) * (rho_e_ll - 1/2 * rho_ll * (v1_ll^2 + v2_ll^2 + v3_ll^2))
   p_rr =  (equation.gamma - 1) * (rho_e_rr - 1/2 * rho_rr * (v1_rr^2 + v2_rr^2 + v3_rr^2))
 
   # Average each factor of products in flux
   rho_avg = 1/2 * (rho_ll + rho_rr)
-  v1_avg = 1/2 * (v1_ll + v1_rr)
-  v2_avg = 1/2 * (v2_ll + v2_rr)
-  v3_avg = 1/2 * (v3_ll + v3_rr)
-  p_avg = 1/2 * (p_ll + p_rr)
+  v1_avg  = 1/2 * ( v1_ll +  v1_rr)
+  v2_avg  = 1/2 * ( v2_ll +  v2_rr)
+  v3_avg  = 1/2 * ( v3_ll +  v3_rr)
+  p_avg   = 1/2 * (  p_ll +   p_rr)
   kin_avg = 1/2 * (v1_ll*v1_rr + v2_ll*v2_rr + v3_ll*v3_rr)
 
   # Calculate fluxes depending on orientation
   if orientation == 1
-    pv1_avg = 1/2 * (p_ll*v1_ll + p_rr*v1_rr)
+    pv1_avg = 1/2 * (p_ll*v1_rr + p_rr*v1_ll)
     f1 = rho_avg * v1_avg
     f2 = rho_avg * v1_avg * v1_avg + p_avg
     f3 = rho_avg * v1_avg * v2_avg
     f4 = rho_avg * v1_avg * v3_avg
     f5 = p_avg*v1_avg/(equation.gamma-1) + rho_avg*v1_avg*kin_avg + pv1_avg
   elseif orientation == 2
-    pv2_avg = 1/2 * (p_ll*v2_ll + p_rr*v2_rr)
+    pv2_avg = 1/2 * (p_ll*v2_rr + p_rr*v2_ll)
     f1 = rho_avg * v2_avg
     f2 = rho_avg * v2_avg * v1_avg
     f3 = rho_avg * v2_avg * v2_avg + p_avg
     f4 = rho_avg * v2_avg * v3_avg
     f5 = p_avg*v2_avg/(equation.gamma-1) + rho_avg*v2_avg*kin_avg + pv2_avg
   else
-    pv3_avg = 1/2 * (p_ll*v3_ll + p_rr*v3_rr)
+    pv3_avg = 1/2 * (p_ll*v3_rr + p_rr*v3_ll)
     f1 = rho_avg * v3_avg
     f2 = rho_avg * v3_avg * v1_avg
     f3 = rho_avg * v3_avg * v2_avg

--- a/test/test_examples_2d.jl
+++ b/test/test_examples_2d.jl
@@ -123,8 +123,8 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
   end
   @testset "parameters_mortar_vortex_split.toml with flux_shima_etal" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_mortar_vortex_split.toml"),
-            l2   = [2.1179157511237394e-6, 2.805652962710273e-5, 3.7597878575795916e-5, 8.8405400202012e-5],
-            linf = [5.913671873580828e-5, 0.0007547162965326759, 0.000816284733694328, 0.0022072012966312116],
+            l2   = [2.1200379425410095e-6, 2.805632600815787e-5, 3.759464715100376e-5, 8.84115216688531e-5],
+            linf = [5.934112354222254e-5, 0.00075475390405777, 0.0008162778009123128, 0.002206991473730824],
             volume_flux = "flux_shima_etal")
   end
   @testset "parameters_mortar_vortex_split.toml with flux_ranocha" begin

--- a/test/test_examples_3d.jl
+++ b/test/test_examples_3d.jl
@@ -112,8 +112,8 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
   end
   @testset "parameters_ec.toml with flux_shima_etal" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_ec.toml"),
-            l2   = [0.025158572247744777, 0.016638273163668674, 0.016638273163668692, 0.016631581587765128, 0.09097798883433982],
-            linf = [0.4298582725942134, 0.28561096934734514, 0.28561096934734487, 0.287502111001965, 1.5313368512936554],
+            l2   = [0.025099944530993942, 0.016561611274319134, 0.016561611274319127, 0.01655478190136039, 0.09076538812894279],
+            linf = [0.43472962954165273, 0.2824065323711477, 0.2824065323711474, 0.28409419760015847, 1.4995295774522692],
             surface_flux=flux_shima_etal, volume_flux=flux_shima_etal)
   end
   @testset "parameters_density_pulse.toml with source_terms_harmonic" begin
@@ -121,7 +121,6 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
             l2   = [0.05719652660597408, 0.0571965266059741, 0.05719652660597407, 0.05719652660597409, 0.08579478990896279],
             linf = [0.27375961853433606, 0.27375961853433517, 0.27375961853433384, 0.2737596185343343, 0.4106394278015033],
             source_terms=Trixi.source_terms_harmonic)
-            
   end
   @testset "parameters_taylor_green_vortex.toml" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_taylor_green_vortex.toml"),


### PR DESCRIPTION
@gregorgassner Could you please check whether the fixed version is correct? The important change were replacements of arithmetic means
```julia
pv1_avg = 1/2 * (p_ll*v1_ll + p_rr*v1_rr)
```
by product means
```julia
pv1_avg = 1/2 * (p_ll*v1_rr + p_rr*v1_ll)
```
etc.