### PR TITLE
hack to allow passing functions defined in the REPL to Trixi.run etc.

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -52,7 +52,7 @@ export CompressibleEulerEquations2D, CompressibleEulerEquations3D,
        IdealGlmMhdEquations2D, IdealGlmMhdEquations3D,
        HyperbolicDiffusionEquations2D, HyperbolicDiffusionEquations3D,
        LinearScalarAdvectionEquation2D, LinearScalarAdvectionEquation3D
-export flux_central, flux_lax_friedrichs,
+export flux_central, flux_lax_friedrichs, flux_hll,
        flux_chandrashekar, flux_ranocha, flux_derigs_etal, flux_kennedy_gruber, flux_shima_etal
 export examples_dir, get_examples, default_example
 

--- a/src/solvers/solvers.jl
+++ b/src/solvers/solvers.jl
@@ -3,6 +3,15 @@
 abstract type AbstractSolver{NDIMS} end
 
 
+# "eval is evil"
+# This is a temporary hack until we have switched to a library based approach
+# with pure Julia code instead of parameter files.
+# This hack enables users to define functions outside of Trixi.jl and pass
+# them as keyword arguments to Trixi.run etc.
+eval_if_not_function(func) = eval(Symbol(func))
+eval_if_not_function(func::Function) = func
+
+
 # Create an instance of a solver based on a given name
 function make_solver(name::String, equations::AbstractEquation, mesh::TreeMesh;
                      surface_flux_function=nothing, volume_flux_function=nothing)
@@ -11,19 +20,19 @@ function make_solver(name::String, equations::AbstractEquation, mesh::TreeMesh;
     # This is a temporary hack until we have switched to a library based approach
     # with pure Julia code instead of parameter files.
     if isnothing(surface_flux_function)
-      surface_flux_type = Symbol(parameter("surface_flux", "flux_lax_friedrichs"))
-      surface_flux_function = eval(surface_flux_type)
+      surface_flux_type = parameter("surface_flux", "flux_lax_friedrichs")
+      surface_flux_function = eval_if_not_function(surface_flux_type)
     end
     if isnothing(volume_flux_function)
-      volume_flux_type = Symbol(parameter("volume_flux", "flux_central"))
-      volume_flux_function = eval(volume_flux_type)
+      volume_flux_type = parameter("volume_flux", "flux_central")
+      volume_flux_function = eval_if_not_function(volume_flux_type)
     end
 
-    initial_conditions_type = Symbol(parameter("initial_conditions"))
-    initial_conditions = eval(initial_conditions_type)
+    initial_conditions_type = parameter("initial_conditions")
+    initial_conditions = eval_if_not_function(initial_conditions_type)
 
-    source_terms_type = Symbol(parameter("source_terms", "nothing"))
-    source_terms = eval(source_terms_type)
+    source_terms_type = parameter("source_terms", "nothing")
+    source_terms = eval_if_not_function(source_terms_type)
 
     if ndims(equations) == 2
       return Dg2D(equations, surface_flux_function, volume_flux_function, initial_conditions, source_terms, mesh, parameter("polydeg"))


### PR DESCRIPTION
Since Taal (#177) will take some time and I want to use this feature right now, I've hacked a possibility allowing users to define initial conditions and source terms in the REPL before passing them as keyword arguments to Trixi.run etc.

I would like to get this merged and make a new minor release afterwards.