### PR TITLE
Travis: Build also for another dev branch and not on Julia nightly anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: julia
 
 julia:
   - 1 # latest 1.x.y
-  - nightly
+  # - nightly
 
 os:
   - linux
@@ -47,6 +47,7 @@ codecov: true
 branches:
   only:
     - master
+    - dev
 
 # we could use groups to trigger multiple builds in parallel to speed-up running expensive tests
 # env:


### PR DESCRIPTION
I know that I've argued to build on Julia nightly in the past, but I think we should skip this now. It just costs time, in particular when multiple PRs are modified at the same time, while the benefits are comparably low. I've added the `dev` branch since I want to target that one while developing Taal in #187 etc.