### PR TITLE
document some common options to solve [ci skip]

### DIFF
--- a/docs/src/time_integration.md
+++ b/docs/src/time_integration.md
@@ -19,8 +19,8 @@ Some common options for `solve` from [OrdinaryDiffEq.jl](https://github.com/SciM
 are the following. Further documentation can be found in the
 [SciML docs](https://diffeq.sciml.ai/v6.8/basics/common_solver_opts/).
 - If you use a fixed time step method like `CarpenterKennedy2N54`, you need to pass
-  a time step as `dt=...`. If you use a `CFLCallback`, the value passed as `dt=...`
-  is irrelevant since it will be overwritten by the `CFLCallback`.
+  a time step as `dt=...`. If you use a `StepsizeCallback`, the value passed as `dt=...`
+  is irrelevant since it will be overwritten by the `StepsizeCallback`.
 - You should usually set `save_everystep=false`. Otherwise, OrdinaryDiffEq.jl will
   (try to) save the numerical solution after every time step in RAM (until you run
   out of memory or start to swap).

--- a/docs/src/time_integration.md
+++ b/docs/src/time_integration.md
@@ -14,3 +14,13 @@ Interesting classes of time integration schemes are
   of stages, e.g. to allow for interpolation (dense output), root-finding for continuous callbacks,
   and error-based time step control. In general, you often should not need to worry about this if you
   use Trixi.
+
+Some common options for `solve` are the following. Further documentation can be found
+in the [SciML docs](https://diffeq.sciml.ai/v6.8/basics/common_solver_opts/).
+- If you use a fixed time step method like `CarpenterKennedy2N54`, you need to pass
+  a time step as `dt=...`. If you use a `CFLCallback`, the value passed as `dt=...`
+  is irrelevant since it will be overwritten by the `CFLCallback`.
+- You should usually set `save_everystep=false`. Otherwise, OrdinaryDiffEq.jl will
+  (try to) save the numerical solution after every time step in RAM (until you run
+  out of memory or start to swap).
+- You can set the maximal number of time steps via `maxiters=...`.

--- a/docs/src/time_integration.md
+++ b/docs/src/time_integration.md
@@ -15,8 +15,9 @@ Interesting classes of time integration schemes are
   and error-based time step control. In general, you often should not need to worry about this if you
   use Trixi.
 
-Some common options for `solve` are the following. Further documentation can be found
-in the [SciML docs](https://diffeq.sciml.ai/v6.8/basics/common_solver_opts/).
+Some common options for `solve` from [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl)
+are the following. Further documentation can be found in the
+[SciML docs](https://diffeq.sciml.ai/v6.8/basics/common_solver_opts/).
 - If you use a fixed time step method like `CarpenterKennedy2N54`, you need to pass
   a time step as `dt=...`. If you use a `CFLCallback`, the value passed as `dt=...`
   is irrelevant since it will be overwritten by the `CFLCallback`.

--- a/examples/1d/elixir_advection_amr.jl
+++ b/examples/1d/elixir_advection_amr.jl
@@ -61,6 +61,6 @@ callbacks = CallbackSet(summary_callback, amr_callback, stepsize_callback, save_
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/1d/elixir_advection_basic.jl
+++ b/examples/1d/elixir_advection_basic.jl
@@ -51,6 +51,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/1d/elixir_euler_blast_wave_shockcapturing.jl
+++ b/examples/1d/elixir_euler_blast_wave_shockcapturing.jl
@@ -57,6 +57,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/1d/elixir_euler_ec.jl
+++ b/examples/1d/elixir_euler_ec.jl
@@ -51,6 +51,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/1d/elixir_euler_nonperiodic.jl
+++ b/examples/1d/elixir_euler_nonperiodic.jl
@@ -61,6 +61,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/1d/elixir_euler_source_terms.jl
+++ b/examples/1d/elixir_euler_source_terms.jl
@@ -50,6 +50,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_advection_amr.jl
+++ b/examples/2d/elixir_advection_amr.jl
@@ -62,6 +62,6 @@ callbacks = CallbackSet(summary_callback, amr_callback, stepsize_callback, save_
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_advection_basic.jl
+++ b/examples/2d/elixir_advection_basic.jl
@@ -52,6 +52,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_advection_mortar.jl
+++ b/examples/2d/elixir_advection_mortar.jl
@@ -56,6 +56,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_blast_wave_shockcapturing.jl
+++ b/examples/2d/elixir_euler_blast_wave_shockcapturing.jl
@@ -57,6 +57,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_blast_wave_shockcapturing_amr.jl
+++ b/examples/2d/elixir_euler_blast_wave_shockcapturing_amr.jl
@@ -70,6 +70,6 @@ callbacks = CallbackSet(summary_callback, amr_callback, stepsize_callback, save_
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_blob_mortar_shockcapturing.jl
+++ b/examples/2d/elixir_euler_blob_mortar_shockcapturing.jl
@@ -63,6 +63,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_blob_shockcapturing_amr.jl
+++ b/examples/2d/elixir_euler_blob_shockcapturing_amr.jl
@@ -74,6 +74,6 @@ callbacks = CallbackSet(summary_callback, amr_callback, stepsize_callback, save_
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_density_wave.jl
+++ b/examples/2d/elixir_euler_density_wave.jl
@@ -50,6 +50,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_ec.jl
+++ b/examples/2d/elixir_euler_ec.jl
@@ -49,6 +49,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_gravity_jeans_instability.jl
+++ b/examples/2d/elixir_euler_gravity_jeans_instability.jl
@@ -93,7 +93,7 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 
 ###############################################################################
 # run the simulation
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary
 println("Number of gravity subcycles: ", semi.gravity_counter.ncalls_since_readout)

--- a/examples/2d/elixir_euler_gravity_sedov_blast_wave_shockcapturing_amr.jl
+++ b/examples/2d/elixir_euler_gravity_sedov_blast_wave_shockcapturing_amr.jl
@@ -102,7 +102,7 @@ callbacks = CallbackSet(summary_callback, amr_callback, stepsize_callback, save_
 
 ###############################################################################
 # run the simulation
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary
 println("Number of gravity subcycles: ", semi.gravity_counter.ncalls_since_readout)

--- a/examples/2d/elixir_euler_khi_shockcapturing.jl
+++ b/examples/2d/elixir_euler_khi_shockcapturing.jl
@@ -55,6 +55,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_khi_shockcapturing_amr.jl
+++ b/examples/2d/elixir_euler_khi_shockcapturing_amr.jl
@@ -73,6 +73,6 @@ callbacks = CallbackSet(summary_callback, amr_callback, stepsize_callback, save_
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_nonperiodic.jl
+++ b/examples/2d/elixir_euler_nonperiodic.jl
@@ -62,6 +62,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_sedov_blast_wave_shockcapturing_amr.jl
+++ b/examples/2d/elixir_euler_sedov_blast_wave_shockcapturing_amr.jl
@@ -70,6 +70,6 @@ callbacks = CallbackSet(summary_callback, amr_callback, stepsize_callback, save_
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_source_terms.jl
+++ b/examples/2d/elixir_euler_source_terms.jl
@@ -50,6 +50,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_vortex.jl
+++ b/examples/2d/elixir_euler_vortex.jl
@@ -52,6 +52,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_vortex_mortar.jl
+++ b/examples/2d/elixir_euler_vortex_mortar.jl
@@ -55,6 +55,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_vortex_mortar_shockcapturing.jl
+++ b/examples/2d/elixir_euler_vortex_mortar_shockcapturing.jl
@@ -66,6 +66,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_vortex_mortar_split.jl
+++ b/examples/2d/elixir_euler_vortex_mortar_split.jl
@@ -56,6 +56,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_vortex_shockcapturing.jl
+++ b/examples/2d/elixir_euler_vortex_shockcapturing.jl
@@ -62,6 +62,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_weak_blast_wave_shockcapturing.jl
+++ b/examples/2d/elixir_euler_weak_blast_wave_shockcapturing.jl
@@ -57,6 +57,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_hyp_diff_harmonic_nonperiodic.jl
+++ b/examples/2d/elixir_hyp_diff_harmonic_nonperiodic.jl
@@ -54,6 +54,6 @@ callbacks = CallbackSet(summary_callback, steady_state_callback, stepsize_callba
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_hyp_diff_llf.jl
+++ b/examples/2d/elixir_hyp_diff_llf.jl
@@ -52,6 +52,6 @@ callbacks = CallbackSet(summary_callback, steady_state_callback, stepsize_callba
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_hyp_diff_nonperiodic.jl
+++ b/examples/2d/elixir_hyp_diff_nonperiodic.jl
@@ -58,6 +58,6 @@ callbacks = CallbackSet(summary_callback, steady_state_callback, stepsize_callba
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_hyp_diff_upwind.jl
+++ b/examples/2d/elixir_hyp_diff_upwind.jl
@@ -52,6 +52,6 @@ callbacks = CallbackSet(summary_callback, steady_state_callback, stepsize_callba
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_mhd_alfven_wave.jl
+++ b/examples/2d/elixir_mhd_alfven_wave.jl
@@ -52,6 +52,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_mhd_alfven_wave_mortar.jl
+++ b/examples/2d/elixir_mhd_alfven_wave_mortar.jl
@@ -55,6 +55,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_mhd_blast_wave_shockcapturing_amr.jl
+++ b/examples/2d/elixir_mhd_blast_wave_shockcapturing_amr.jl
@@ -75,6 +75,6 @@ callbacks = CallbackSet(summary_callback, amr_callback, stepsize_callback, save_
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_mhd_ec.jl
+++ b/examples/2d/elixir_mhd_ec.jl
@@ -48,6 +48,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_mhd_orszag_tang_shockcapturing_amr.jl
+++ b/examples/2d/elixir_mhd_orszag_tang_shockcapturing_amr.jl
@@ -75,6 +75,6 @@ callbacks = CallbackSet(summary_callback, amr_callback, stepsize_callback, save_
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_mhd_rotor_shockcapturing_amr.jl
+++ b/examples/2d/elixir_mhd_rotor_shockcapturing_amr.jl
@@ -74,6 +74,6 @@ callbacks = CallbackSet(summary_callback, amr_callback, stepsize_callback, save_
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/3d/elixir_advection_amr.jl
+++ b/examples/3d/elixir_advection_amr.jl
@@ -61,6 +61,6 @@ callbacks = CallbackSet(summary_callback, amr_callback, stepsize_callback, save_
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/3d/elixir_advection_basic.jl
+++ b/examples/3d/elixir_advection_basic.jl
@@ -52,6 +52,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/3d/elixir_euler_source_terms.jl
+++ b/examples/3d/elixir_euler_source_terms.jl
@@ -50,6 +50,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/3d/elixir_hyp_diff_llf.jl
+++ b/examples/3d/elixir_hyp_diff_llf.jl
@@ -52,6 +52,6 @@ callbacks = CallbackSet(summary_callback, steady_state_callback, stepsize_callba
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/3d/elixir_mhd_ec.jl
+++ b/examples/3d/elixir_mhd_ec.jl
@@ -48,6 +48,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback, save_solution, anal
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=stepsize_callback(ode),
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary


### PR DESCRIPTION
Closes #224. We don't set the maximal number of time steps often and can easily mimic something like it via setting `tspan` appropriately in tests. It's only useful for debugging, I think. Thus, it should be enough to document `maxiters` and we don't need to be able to modify it in `trixi_include`.