### PR TITLE
analytic vortex AMR: t, iter as kwargs in AMR indicator

### DIFF
--- a/examples/2d/elixir_euler_vortex_amr.jl
+++ b/examples/2d/elixir_euler_vortex_amr.jl
@@ -1,0 +1,124 @@
+
+using OrdinaryDiffEq
+using Trixi
+
+# define new structs inside a module to allow re-evaluating the file
+module TrixiExtension
+
+using Trixi
+
+struct IndicatorVortex{Cache<:NamedTuple} <: Trixi.AbstractIndicator
+  cache::Cache
+end
+
+function IndicatorVortex(semi)
+  basis = semi.solver.basis
+  alpha = Vector{real(basis)}()
+  A = Array{real(basis), 2}
+  indicator_threaded = [A(undef, Trixi.nnodes(basis), Trixi.nnodes(basis))
+                        for _ in 1:Threads.nthreads()]
+  cache = (; semi.mesh, alpha, indicator_threaded)
+
+  return IndicatorVortex{typeof(cache)}(cache)
+end
+
+function (indicator_vortex::IndicatorVortex)(u::AbstractArray{<:Any,4},
+                                             equations, dg, cache;
+                                             t, kwargs...)
+  mesh = indicator_vortex.cache.mesh
+  alpha = indicator_vortex.cache.alpha
+  indicator_threaded = indicator_vortex.cache.indicator_threaded
+  resize!(alpha, Trixi.nelements(dg, cache))
+
+
+  # get analytical vortex center (based on assumption that center=[0.0,0.0]
+  # at t=0.0 and that we stop after one period)
+  domain_length = mesh.tree.length_level_0
+  if t < 0.5 * domain_length
+    center = (t, t)
+  else
+    center = (t-domain_length, t-domain_length)
+  end
+
+  Threads.@threads for element in Trixi.eachelement(dg, cache)
+    cell_id = cache.elements.cell_ids[element]
+    coordinates = (mesh.tree.coordinates[1, cell_id], mesh.tree.coordinates[2, cell_id])
+    # use the negative radius as indicator since the AMR controller increases
+    # the level with increasing value of the indicator and we want to use
+    # high levels near the vortex center
+    alpha[element] = -periodic_distance_2d(coordinates, center, domain_length)
+  end
+
+  return alpha
+end
+
+function periodic_distance_2d(coordinates, center, domain_length)
+  dx = @. abs(coordinates - center)
+  dx_periodic = @. min(dx, domain_length - dx)
+  return sqrt(sum(abs2, dx_periodic))
+end
+
+end # module TrixiExtension
+
+import .TrixiExtension
+
+###############################################################################
+# semidiscretization of the compressible Euler equations
+
+equations = CompressibleEulerEquations2D(1.4)
+
+initial_condition = initial_condition_isentropic_vortex
+
+surface_flux = flux_lax_friedrichs
+solver = DGSEM(3, surface_flux)
+
+coordinates_min = (-10, -10)
+coordinates_max = ( 10,  10)
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level=3,
+                n_cells_max=10_000)
+
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 20.0)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+amr_controller = ControllerThreeLevel(semi, TrixiExtension.IndicatorVortex(semi),
+                                      base_level=3,
+                                      med_level=4, med_threshold=-3.0,
+                                      max_level=5, max_threshold=-2.0)
+amr_callback = AMRCallback(semi, amr_controller,
+                           interval=5,
+                           adapt_initial_condition=true,
+                           adapt_initial_condition_only_refine=true)
+
+stepsize_callback = StepsizeCallback(cfl=1.1)
+
+save_solution = SaveSolutionCallback(interval=50,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=:primitive)
+
+analysis_interval = 200
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval, save_analysis=true,
+                                     extra_analysis_errors=(:conservation_error,),
+                                     extra_analysis_integrals=(entropy, energy_total,
+                                                               energy_kinetic, energy_internal))
+
+callbacks = CallbackSet(summary_callback, amr_callback, stepsize_callback, save_solution, analysis_callback, alive_callback)
+
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -1,13 +1,16 @@
 
 # overload this function for specific callbacks which use element element variables
 # that should be saved
-get_element_variables!(element_variables, u, mesh, equations, solver, cache, callback) = nothing
+get_element_variables!(element_variables, u, mesh, equations, solver, cache,
+                       callback; kwargs...) = nothing
 
 @inline function get_element_variables!(element_variables, u_ode::AbstractVector,
-                                        semi::AbstractSemidiscretization, cb::DiscreteCallback)
+                                        semi::AbstractSemidiscretization, cb::DiscreteCallback;
+                                        kwargs...)
   mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
   u = wrap_array(u_ode, mesh, equations, solver, cache)
-  get_element_variables!(element_variables, u, mesh, equations, solver, cache, cb.affect!)
+  get_element_variables!(element_variables, u, mesh, equations, solver, cache,
+                         cb.affect!; kwargs...)
 end
 
 

--- a/src/callbacks/save_solution.jl
+++ b/src/callbacks/save_solution.jl
@@ -85,10 +85,10 @@ function (solution_callback::SaveSolutionCallback)(integrator)
     callbacks = integrator.opts.callback
     if callbacks isa CallbackSet
       for cb in callbacks.continuous_callbacks
-        get_element_variables!(element_variables, u_ode, semi, cb)
+        get_element_variables!(element_variables, u_ode, semi, cb; t=integrator.t, iter=integrator.iter)
       end
       for cb in callbacks.discrete_callbacks
-        get_element_variables!(element_variables, u_ode, semi, cb)
+        get_element_variables!(element_variables, u_ode, semi, cb; t=integrator.t, iter=integrator.iter)
       end
     end
 

--- a/src/semidiscretization_euler_gravity.jl
+++ b/src/semidiscretization_euler_gravity.jl
@@ -317,8 +317,9 @@ end
 
 
 @inline function (amr_callback::AMRCallback)(u_ode::AbstractVector,
-                                             semi::SemidiscretizationEulerGravity; kwargs...)
+                                             semi::SemidiscretizationEulerGravity,
+                                             t, iter; kwargs...)
   passive_args = ((semi.cache.u_ode, mesh_equations_solver_cache(semi.semi_gravity)...),)
-  amr_callback(u_ode, mesh_equations_solver_cache(semi.semi_euler)...;
+  amr_callback(u_ode, mesh_equations_solver_cache(semi.semi_euler)..., t, iter;
                kwargs..., passive_args=passive_args)
 end

--- a/src/solvers/dg/indicators_1d.jl
+++ b/src/solvers/dg/indicators_1d.jl
@@ -18,7 +18,9 @@ function create_cache(typ::Type{IndicatorHennemannGassner}, mesh, equations::Abs
 end
 
 
-function (indicator_hg::IndicatorHennemannGassner)(u::AbstractArray{<:Any,3}, equations, dg::DGSEM, cache)
+function (indicator_hg::IndicatorHennemannGassner)(u::AbstractArray{<:Any,3},
+                                                   equations, dg::DGSEM, cache;
+                                                   kwargs...)
   @unpack alpha_max, alpha_min, alpha_smooth, variable = indicator_hg
   @unpack alpha, alpha_tmp, indicator_threaded, modal_threaded = indicator_hg.cache
   # TODO: Taal refactor, when to `resize!` stuff changed possibly by AMR?
@@ -119,7 +121,9 @@ function create_cache(typ::Type{IndicatorLöhner}, mesh, equations::AbstractEqua
 end
 
 
-function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any,3}, equations, dg::DGSEM, cache)
+function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any,3},
+                                   equations, dg::DGSEM, cache;
+                                   kwargs...)
   @assert nnodes(dg) >= 3 "IndicatorLöhner only works for nnodes >= 3 (polydeg > 1)"
   @unpack alpha, indicator_threaded = löhner.cache
   resize!(alpha, nelements(dg, cache))
@@ -168,7 +172,9 @@ function create_cache(typ::Type{IndicatorMax}, mesh, equations::AbstractEquation
 end
 
 
-function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any,3}, equations, dg::DGSEM, cache)
+function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any,3},
+                                       equations, dg::DGSEM, cache;
+                                       kwargs...)
   @unpack alpha, indicator_threaded = indicator_max.cache
   resize!(alpha, nelements(dg, cache))
 

--- a/src/solvers/dg/indicators_2d.jl
+++ b/src/solvers/dg/indicators_2d.jl
@@ -19,7 +19,9 @@ function create_cache(typ::Type{IndicatorHennemannGassner}, mesh, equations::Abs
 end
 
 
-function (indicator_hg::IndicatorHennemannGassner)(u::AbstractArray{<:Any,4}, equations, dg::DGSEM, cache)
+function (indicator_hg::IndicatorHennemannGassner)(u::AbstractArray{<:Any,4},
+                                                   equations, dg::DGSEM, cache;
+                                                   kwargs...)
   @unpack alpha_max, alpha_min, alpha_smooth, variable = indicator_hg
   @unpack alpha, alpha_tmp, indicator_threaded, modal_threaded, modal_tmp1_threaded = indicator_hg.cache
   # TODO: Taal refactor, when to `resize!` stuff changed possibly by AMR?
@@ -135,7 +137,9 @@ function create_cache(typ::Type{IndicatorLöhner}, mesh, equations::AbstractEqua
 end
 
 
-function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any,4}, equations, dg::DGSEM, cache)
+function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any,4},
+                                   equations, dg::DGSEM, cache;
+                                   kwargs...)
   @assert nnodes(dg) >= 3 "IndicatorLöhner only works for nnodes >= 3 (polydeg > 1)"
   @unpack alpha, indicator_threaded = löhner.cache
   resize!(alpha, nelements(dg, cache))
@@ -192,7 +196,9 @@ function create_cache(typ::Type{IndicatorMax}, mesh, equations::AbstractEquation
 end
 
 
-function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any,4}, equations, dg::DGSEM, cache)
+function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any,4},
+                                       equations, dg::DGSEM, cache;
+                                       kwargs...)
   @unpack alpha, indicator_threaded = indicator_max.cache
   resize!(alpha, nelements(dg, cache))
 

--- a/src/solvers/dg/indicators_3d.jl
+++ b/src/solvers/dg/indicators_3d.jl
@@ -20,7 +20,9 @@ function create_cache(typ::Type{IndicatorHennemannGassner}, mesh, equations::Abs
 end
 
 
-function (indicator_hg::IndicatorHennemannGassner)(u::AbstractArray{<:Any,5}, equations, dg::DGSEM, cache)
+function (indicator_hg::IndicatorHennemannGassner)(u::AbstractArray{<:Any,5},
+                                                   equations, dg::DGSEM, cache;
+                                                   kwargs...)
   @unpack alpha_max, alpha_min, alpha_smooth, variable = indicator_hg
   @unpack alpha, alpha_tmp, indicator_threaded, modal_threaded,
           modal_tmp1_threaded, modal_tmp2_threaded = indicator_hg.cache
@@ -149,7 +151,9 @@ function create_cache(typ::Type{IndicatorLöhner}, mesh, equations::AbstractEqua
 end
 
 
-function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any,5}, equations, dg::DGSEM, cache)
+function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any,5},
+                                   equations, dg::DGSEM, cache;
+                                   kwargs...)
   @assert nnodes(dg) >= 3 "IndicatorLöhner only works for nnodes >= 3 (polydeg > 1)"
   @unpack alpha, indicator_threaded = löhner.cache
   resize!(alpha, nelements(dg, cache))
@@ -214,7 +218,9 @@ function create_cache(typ::Type{IndicatorMax}, mesh, equations::AbstractEquation
 end
 
 
-function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any,5}, equations, dg::DGSEM, cache)
+function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any,5},
+                                       equations, dg::DGSEM, cache;
+                                       kwargs...)
   @unpack alpha, indicator_threaded = indicator_max.cache
   resize!(alpha, nelements(dg, cache))
 

--- a/test/test_examples_2d.jl
+++ b/test/test_examples_2d.jl
@@ -188,6 +188,13 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
     linf = [5.9005667252809424e-5, 0.0007554116730550398, 0.00081660478740464, 0.002209016304192346])
   end
 
+  @testset "elixir_euler_vortex_amr.jl" begin
+  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_amr.jl"),
+    l2   = [2.077084130934081e-6, 0.0032815991956917493, 0.0032807020145523757, 0.004646298951577697],
+    linf = [4.435791998502747e-5, 0.03176757178286449, 0.031797053799604846, 0.045615287239808566])
+  end
+
+
   @testset "elixir_mhd_alfven_wave.jl" begin
   test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_alfven_wave.jl"),
     l2   = [0.00011134312019581907, 5.880417517656501e-6, 5.880417517683334e-6, 8.433533326833135e-6, 1.2944026635567339e-6, 1.2259080543012733e-6, 1.2259080543038862e-6, 1.8334999489680995e-6, 8.098795948637635e-7],

--- a/test/test_examples_3d.jl
+++ b/test/test_examples_3d.jl
@@ -1,4 +1,4 @@
-module TestExamples2D
+module TestExamples3D
 
 using Test
 using Trixi


### PR DESCRIPTION
Closes #233. Additionally, this provides an example how to extend Trixi, cf. #235.