### PR TITLE
Match Taal and Taam

### DIFF
--- a/examples/2d/elixir_euler_blob_shockcapturing_amr.jl
+++ b/examples/2d/elixir_euler_blob_shockcapturing_amr.jl
@@ -46,12 +46,13 @@ summary_callback = SummaryCallback()
 amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_max=1.0,
                                           alpha_min=0.0001,
-                                          alpha_smooth=true,
-                                          variable=pressure)
-amr_controller = ControllerThreeLevel(semi, amr_indicator,
-                                      base_level=4,
-                                      med_level =7, med_threshold=0.003,
-                                      max_level =7, max_threshold=0.3)
+                                          alpha_smooth=false,
+                                          variable=density)
+amr_controller = ControllerThreeLevelCombined(semi, amr_indicator, indicator_sc,
+                                              base_level=4,
+                                              med_level =0, med_threshold=0.0003, # med_level = current level
+                                              max_level =7, max_threshold=0.003,
+                                              max_threshold_secondary=indicator_sc.alpha_max)
 amr_callback = AMRCallback(semi, amr_controller,
                            interval=1,
                            adapt_initial_condition=true,

--- a/examples/2d/elixir_euler_khi_shockcapturing.jl
+++ b/examples/2d/elixir_euler_khi_shockcapturing.jl
@@ -1,4 +1,5 @@
 
+using Random: seed!
 using OrdinaryDiffEq
 using Trixi
 
@@ -7,6 +8,7 @@ using Trixi
 gamma = 1.4
 equations = CompressibleEulerEquations2D(gamma)
 
+seed!(0)
 initial_condition = initial_condition_khi
 
 surface_flux = flux_lax_friedrichs

--- a/examples/2d/elixir_euler_khi_shockcapturing_amr.jl
+++ b/examples/2d/elixir_euler_khi_shockcapturing_amr.jl
@@ -46,11 +46,12 @@ summary_callback = SummaryCallback()
 amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_max=1.0,
                                           alpha_min=0.0001,
-                                          alpha_smooth=true,
+                                          alpha_smooth=false,
                                           variable=density)
 amr_controller = ControllerThreeLevel(semi, amr_indicator,
-                                      base_level=4, med_threshold=0.0003,
-                                      max_level =6, max_threshold=0.003)
+                                      base_level=4,
+                                      med_level=0, med_threshold=0.0003, # med_level = current level
+                                      max_level=6, max_threshold=0.003)
 amr_callback = AMRCallback(semi, amr_controller,
                            interval=1,
                            adapt_initial_condition=true,

--- a/examples/2d/parameters_euler_blob_shockcapturing_amr.toml
+++ b/examples/2d/parameters_euler_blob_shockcapturing_amr.toml
@@ -2,15 +2,7 @@
 # Simulation
 ndims = 2
 equations = "CompressibleEulerEquations"
-gamma = 1.66667
-# equations = "LinearScalarAdvectionEquation"
-# advectionvelocity = [1.0, 1.0] # Need only for linarscalaradvection
-# initial_condition = "initial_condition_convergence_test"
-# initial_condition = "initial_condition_isentropic_vortex"
-# initial_condition = "initial_condition_linear_x_y"
-# initial_condition = "initial_condition_linear_x"
-# initial_condition = "initial_condition_constant"
-#initial_condition = "initial_condition_weak_blast_wave"
+gamma = 1.6666666666666667
 initial_condition = "initial_condition_blob"
 # source_terms =
 t_start = 0.0
@@ -22,24 +14,15 @@ t_end   = 8.0
 # Solver
 solver = "dg"
 polydeg = 4
-cfl = 0.2
+cfl = 0.3
 n_steps_max = 15000
 analysis_interval = 100
 shock_indicator_variable = "pressure"
 shock_alpha_max = 0.4
 shock_alpha_min = 0.0001
 volume_integral_type = "shock_capturing"
-#volume_integral_type = "new_trick"
-#volume_integral_type = "split_form"
-#volume_integral_type = "weak_form"
-#volume_integral_type = "entropy_fix"
-#volume_integral_type = "entropy_fix2"
 surface_flux = "flux_lax_friedrichs"
-#surface_flux = "flux_chandrashekar"
-#surface_flux = "flux_shima_etal"
-#volume_flux = "flux_shima_etal"
 volume_flux = "flux_chandrashekar"
-# volume_flux = "flux_central"
 
 ####################################################################################################
 # Mesh

--- a/examples/2d/parameters_euler_khi_shockcapturing.toml
+++ b/examples/2d/parameters_euler_khi_shockcapturing.toml
@@ -21,7 +21,7 @@ t_end   = 5.0
 # Solver
 solver = "dg"
 polydeg = 3
-cfl = 0.7
+cfl = 1.4
 n_steps_max = 10000
 analysis_interval = 100
 shock_alpha_max = 0.002

--- a/examples/2d/parameters_euler_khi_shockcapturing_amr.toml
+++ b/examples/2d/parameters_euler_khi_shockcapturing_amr.toml
@@ -21,23 +21,14 @@ t_end   = 5.0
 # Solver
 solver = "dg"
 polydeg = 3
-cfl = 0.7
+cfl = 1.4
 n_steps_max = 10000
 analysis_interval = 100
 shock_alpha_max = 0.002
 shock_alpha_min = 0.0001
 volume_integral_type = "shock_capturing"
-#volume_integral_type = "new_trick"
-#volume_integral_type = "split_form"
-#volume_integral_type = "weak_form"
-#volume_integral_type = "entropy_fix"
-#volume_integral_type = "entropy_fix2"
 surface_flux = "flux_lax_friedrichs"
-#surface_flux = "flux_chandrashekar"
-#surface_flux = "flux_shima_etal"
-#volume_flux = "flux_shima_etal"
 volume_flux = "flux_chandrashekar"
-# volume_flux = "flux_central"
 
 ####################################################################################################
 # Mesh

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -102,7 +102,8 @@ export SemidiscretizationEulerGravity, ParametersEulerGravity, timestep_gravity_
 export SummaryCallback, SteadyStateCallback, AMRCallback, StepsizeCallback,
        AnalysisCallback, SaveSolutionCallback, AliveCallback
 
-export ControllerThreeLevel, IndicatorLöhner, IndicatorLoehner, IndicatorMax
+export ControllerThreeLevel, ControllerThreeLevelCombined,
+       IndicatorLöhner, IndicatorLoehner, IndicatorMax
 export density, pressure, density_pressure
 
 export entropy, energy_total, energy_kinetic, energy_internal, energy_magnetic, cross_helicity

--- a/src/callbacks/amr.jl
+++ b/src/callbacks/amr.jl
@@ -137,73 +137,6 @@ end
 end
 
 
-"""
-    ControllerThreeLevel(semi, indicator; base_level=1,
-                                          med_level=base_level, med_threshold=0.0,
-                                          max_level=base_level, max_threshold=1.0)
-
-An AMR controller based on three levels (in decending order of precedence):
-- set the target level to `max_level` if `indicator > max_threshold`
-- set the target level to `med_level` if `indicator > med_threshold`;
-  if `med_level < 0`, set the target level to the current level
-- set the target level to `base_level` otherwise
-"""
-struct ControllerThreeLevel{RealT<:Real, Indicator, Cache}
-  base_level::Int
-  med_level ::Int
-  max_level ::Int
-  med_threshold::RealT
-  max_threshold::RealT
-  indicator::Indicator
-  cache::Cache
-end
-
-function ControllerThreeLevel(semi, indicator; base_level=1,
-                                               med_level=base_level, med_threshold=0.0,
-                                               max_level=base_level, max_threshold=1.0)
-  med_threshold, max_threshold = promote(med_threshold, max_threshold)
-  cache = create_cache(ControllerThreeLevel, semi)
-  ControllerThreeLevel{typeof(max_threshold), typeof(indicator), typeof(cache)}(
-    base_level, med_level, max_level, med_threshold, max_threshold, indicator, cache)
-end
-
-create_cache(indicator_type::Type{ControllerThreeLevel}, semi) = create_cache(indicator_type, mesh_equations_solver_cache(semi)...)
-
-
-function Base.show(io::IO, controller::ControllerThreeLevel)
-  print(io, "ControllerThreeLevel(")
-  print(io, controller.indicator)
-  print(io, ", base_level=", controller.base_level)
-  print(io, ", med_level=",  controller.med_level)
-  print(io, ", max_level=",  controller.max_level)
-  print(io, ", med_threshold=", controller.med_threshold)
-  print(io, ", max_threshold=", controller.max_threshold)
-  print(io, ")")
-end
-
-function Base.show(io::IO, ::MIME"text/plain", controller::ControllerThreeLevel)
-  println(io, "ControllerThreeLevel with")
-  println(io, "- ", controller.indicator)
-  println(io, "- base_level: ", controller.base_level)
-  println(io, "- med_level:  ", controller.med_level)
-  println(io, "- max_level:  ", controller.max_level)
-  println(io, "- med_threshold: ", controller.med_threshold)
-  print(io,   "- max_threshold: ", controller.max_threshold)
-end
-
-
-function get_element_variables!(element_variables, u, mesh, equations, solver, cache, controller::ControllerThreeLevel, amr_callback::AMRCallback)
-  # call the indicator to get up-to-date values for IO
-  controller.indicator(u, equations, solver, cache)
-  get_element_variables!(element_variables, controller.indicator, amr_callback)
-end
-
-function get_element_variables!(element_variables, indicator::AbstractIndicator, ::AMRCallback)
-  element_variables[:indicator_amr] = indicator.cache.alpha
-  return nothing
-end
-
-
 
 # `passive_args` is currently used for Euler with self-gravity to adapt the gravity solver
 # passively without querying its indicator, based on the assumption that both solvers use
@@ -323,12 +256,79 @@ end
 # function original2refined(original_cell_ids, refined_original_cells, mesh) in src/amr/amr.jl
 
 
-# TODO: Taal dimension agnostic
+
+"""
+    ControllerThreeLevel(semi, indicator; base_level=1,
+                                          med_level=base_level, med_threshold=0.0,
+                                          max_level=base_level, max_threshold=1.0)
+
+An AMR controller based on three levels (in decending order of precedence):
+- set the target level to `max_level` if `indicator > max_threshold`
+- set the target level to `med_level` if `indicator > med_threshold`;
+  if `med_level < 0`, set the target level to the current level
+- set the target level to `base_level` otherwise
+"""
+struct ControllerThreeLevel{RealT<:Real, Indicator, Cache}
+  base_level::Int
+  med_level ::Int
+  max_level ::Int
+  med_threshold::RealT
+  max_threshold::RealT
+  indicator::Indicator
+  cache::Cache
+end
+
+function ControllerThreeLevel(semi, indicator; base_level=1,
+                                               med_level=base_level, med_threshold=0.0,
+                                               max_level=base_level, max_threshold=1.0)
+  med_threshold, max_threshold = promote(med_threshold, max_threshold)
+  cache = create_cache(ControllerThreeLevel, semi)
+  ControllerThreeLevel{typeof(max_threshold), typeof(indicator), typeof(cache)}(
+    base_level, med_level, max_level, med_threshold, max_threshold, indicator, cache)
+end
+
+create_cache(indicator_type::Type{ControllerThreeLevel}, semi) = create_cache(indicator_type, mesh_equations_solver_cache(semi)...)
+
+
+function Base.show(io::IO, controller::ControllerThreeLevel)
+  print(io, "ControllerThreeLevel(")
+  print(io, controller.indicator)
+  print(io, ", base_level=", controller.base_level)
+  print(io, ", med_level=",  controller.med_level)
+  print(io, ", max_level=",  controller.max_level)
+  print(io, ", med_threshold=", controller.med_threshold)
+  print(io, ", max_threshold=", controller.max_threshold)
+  print(io, ")")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", controller::ControllerThreeLevel)
+  println(io, "ControllerThreeLevel with")
+  println(io, "- ", controller.indicator)
+  println(io, "- base_level: ", controller.base_level)
+  println(io, "- med_level:  ", controller.med_level)
+  println(io, "- max_level:  ", controller.max_level)
+  println(io, "- med_threshold: ", controller.med_threshold)
+  print(io,   "- max_threshold: ", controller.max_threshold)
+end
+
+
+function get_element_variables!(element_variables, u, mesh, equations, solver, cache, controller::ControllerThreeLevel, amr_callback::AMRCallback)
+  # call the indicator to get up-to-date values for IO
+  controller.indicator(u, equations, solver, cache)
+  get_element_variables!(element_variables, controller.indicator, amr_callback)
+end
+
+function get_element_variables!(element_variables, indicator::AbstractIndicator, ::AMRCallback)
+  element_variables[:indicator_amr] = indicator.cache.alpha
+  return nothing
+end
+
+
 # TODO: Taal refactor, merge the two loops of ControllerThreeLevel and IndicatorLöhner etc.?
 #       But that would remove the simplest possibility to write that stuff to a file...
 #       We could of course implement some additional logic and workarounds, but is it worth the effort?
 function (controller::ControllerThreeLevel)(u::AbstractArray{<:Any},
-                                           mesh::TreeMesh, equations, dg::DG, cache)
+                                            mesh::TreeMesh, equations, dg::DG, cache)
 
   @unpack controller_value = controller.cache
   resize!(controller_value, nelements(dg, cache))
@@ -351,6 +351,126 @@ function (controller::ControllerThreeLevel)(u::AbstractArray{<:Any},
       end
     else
       target_level = controller.base_level
+    end
+
+    # compare target level with actual level to set controller
+    if current_level < target_level
+      controller_value[element] = 1 # refine!
+    elseif current_level > target_level
+      controller_value[element] = -1 # coarsen!
+    else
+      controller_value[element] = 0 # we're good
+    end
+  end
+
+  return controller_value
+end
+
+
+
+"""
+    ControllerThreeLevelCombined(semi, indicator_primary, indicator_secondary;
+                                 base_level=1,
+                                 med_level=base_level, med_threshold=0.0,
+                                 max_level=base_level, max_threshold=1.0,
+                                 max_threshold_secondary=1.0)
+
+An AMR controller based on three levels (in decending order of precedence):
+- set the target level to `max_level` if `indicator_primary > max_threshold`
+- set the target level to `med_level` if `indicator_primary > med_threshold`;
+  if `med_level < 0`, set the target level to the current level
+- set the target level to `base_level` otherwise
+If `indicator_secondary >= max_threshold_secondary`,
+set the target level to `max_level`.
+"""
+struct ControllerThreeLevelCombined{RealT<:Real, IndicatorPrimary, IndicatorSecondary, Cache}
+  base_level::Int
+  med_level ::Int
+  max_level ::Int
+  med_threshold::RealT
+  max_threshold::RealT
+  max_threshold_secondary::RealT
+  indicator_primary::IndicatorPrimary
+  indicator_secondary::IndicatorSecondary
+  cache::Cache
+end
+
+function ControllerThreeLevelCombined(semi, indicator_primary, indicator_secondary;
+                                      base_level=1,
+                                      med_level=base_level, med_threshold=0.0,
+                                      max_level=base_level, max_threshold=1.0,
+                                      max_threshold_secondary=1.0)
+  med_threshold, max_threshold, max_threshold_secondary = promote(med_threshold, max_threshold, max_threshold_secondary)
+  cache = create_cache(ControllerThreeLevelCombined, semi)
+  ControllerThreeLevelCombined{typeof(max_threshold), typeof(indicator_primary), typeof(indicator_secondary), typeof(cache)}(
+    base_level, med_level, max_level, med_threshold, max_threshold,
+    max_threshold_secondary, indicator_primary, indicator_secondary, cache)
+end
+
+create_cache(indicator_type::Type{ControllerThreeLevelCombined}, semi) = create_cache(indicator_type, mesh_equations_solver_cache(semi)...)
+
+
+function Base.show(io::IO, controller::ControllerThreeLevelCombined)
+  print(io, "ControllerThreeLevelCombined(")
+  print(io, controller.indicator_primary)
+  print(io, ", ", controller.indicator_secondary)
+  print(io, ", base_level=", controller.base_level)
+  print(io, ", med_level=",  controller.med_level)
+  print(io, ", max_level=",  controller.max_level)
+  print(io, ", med_threshold=", controller.med_threshold)
+  print(io, ", max_threshold_secondary=", controller.max_threshold_secondary)
+  print(io, ")")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", controller::ControllerThreeLevelCombined)
+  println(io, "ControllerThreeLevelCombined with")
+  println(io, "- ", controller.indicator_primary)
+  println(io, "- ", controller.indicator_secondary)
+  println(io, "- base_level: ", controller.base_level)
+  println(io, "- med_level:  ", controller.med_level)
+  println(io, "- max_level:  ", controller.max_level)
+  println(io, "- med_threshold: ", controller.med_threshold)
+  println(io, "- max_threshold: ", controller.max_threshold)
+  print(io,   "- max_threshold_secondary: ", controller.max_threshold_secondary)
+end
+
+
+function get_element_variables!(element_variables, u, mesh, equations, solver, cache, controller::ControllerThreeLevelCombined, amr_callback::AMRCallback)
+  # call the indicator to get up-to-date values for IO
+  controller.indicator_primary(u, equations, solver, cache)
+  get_element_variables!(element_variables, controller.indicator_primary, amr_callback)
+end
+
+
+function (controller::ControllerThreeLevelCombined)(u::AbstractArray{<:Any},
+                                                    mesh::TreeMesh, equations, dg::DG, cache)
+
+  @unpack controller_value = controller.cache
+  resize!(controller_value, nelements(dg, cache))
+
+  alpha = controller.indicator_primary(u, equations, dg, cache)
+  alpha_secondary = controller.indicator_secondary(u, equations, dg, cache)
+
+  Threads.@threads for element in eachelement(dg, cache)
+    cell_id = cache.elements.cell_ids[element]
+    current_level = mesh.tree.levels[cell_id]
+
+    # set target level
+    target_level = current_level
+    if alpha[element] > controller.max_threshold
+      target_level = controller.max_level
+    elseif alpha[element] > controller.med_threshold
+      if controller.med_level > 0
+        target_level = controller.med_level
+        # otherwise, target_level = current_level
+        # set med_level = -1 to implicitly use med_level = current_level
+      end
+    else
+      target_level = controller.base_level
+    end
+
+    if alpha_secondary[element] >= controller.max_threshold_secondary
+      target_level = controller.max_level
     end
 
     # compare target level with actual level to set controller

--- a/src/callbacks/amr_dg1d.jl
+++ b/src/callbacks/amr_dg1d.jl
@@ -250,3 +250,9 @@ function create_cache(::Type{ControllerThreeLevel}, mesh::TreeMesh{1}, equations
   return (; controller_value)
 end
 
+function create_cache(::Type{ControllerThreeLevelCombined}, mesh::TreeMesh{1}, equations, dg::DG, cache)
+
+  controller_value = Vector{Int}(undef, nelements(dg, cache))
+  return (; controller_value)
+end
+

--- a/src/callbacks/amr_dg2d.jl
+++ b/src/callbacks/amr_dg2d.jl
@@ -295,3 +295,9 @@ function create_cache(::Type{ControllerThreeLevel}, mesh::TreeMesh{2}, equations
   return (; controller_value)
 end
 
+function create_cache(::Type{ControllerThreeLevelCombined}, mesh::TreeMesh{2}, equations, dg::DG, cache)
+
+  controller_value = Vector{Int}(undef, nelements(dg, cache))
+  return (; controller_value)
+end
+

--- a/src/equations/2d/compressible_euler.jl
+++ b/src/equations/2d/compressible_euler.jl
@@ -226,12 +226,17 @@ function initial_condition_khi(x, t, equation::CompressibleEulerEquations2D)
   slope = 50 # used for tanh instead of discontinuous initial condition
   # pressure equilibrium
   p     = 2.5
-  #  y velocity v2 is only white noise
-  v2  = 0.01*(rand(Float64,1)[1]-0.5)
   # density
   rho = dens0 + (dens1-dens0) * 0.5*(1+(tanh(slope*(x[2]+0.25)) - (tanh(slope*(x[2]-0.25)) + 1)))
-  #  x velocity is also augmented with noise
-  v1 = velx0 + (velx1-velx0) * 0.5*(1+(tanh(slope*(x[2]+0.25)) - (tanh(slope*(x[2]-0.25)) + 1)))+0.01*(rand(Float64,1)[1]-0.5)
+  if iszero(t) # initial condition
+    #  y velocity v2 is only white noise
+    v2  = 0.01*(rand(Float64,1)[1]-0.5)
+    #  x velocity is also augmented with noise
+    v1 = velx0 + (velx1-velx0) * 0.5*(1+(tanh(slope*(x[2]+0.25)) - (tanh(slope*(x[2]-0.25)) + 1)))+0.01*(rand(Float64,1)[1]-0.5)
+  else # background values to compute reference values for CI
+    v2 = 0.0
+    v1 = velx0 + (velx1-velx0) * 0.5*(1+(tanh(slope*(x[2]+0.25)) - (tanh(slope*(x[2]-0.25)) + 1)))
+  end
   return prim2cons(SVector(rho, v1, v2, p), equation)
 end
 

--- a/src/solvers/dg/2d/amr.jl
+++ b/src/solvers/dg/2d/amr.jl
@@ -422,9 +422,9 @@ function calc_amr_indicator(dg::Dg2D, mesh::TreeMesh, time)
       actual_level = mesh.tree.levels[cell_id]
       target_level = actual_level
       # adapt for the amr indicator
-      if alpha[element_id] >= blending_factor_threshold0
+      if alpha[element_id] > blending_factor_threshold0
         target_level = super_max_level
-      elseif alpha[element_id] >= blending_factor_threshold1
+      elseif alpha[element_id] > blending_factor_threshold1
         target_level = max_level
       elseif alpha[element_id] <= blending_factor_threshold2
         target_level = base_level

--- a/src/solvers/dg/2d/amr.jl
+++ b/src/solvers/dg/2d/amr.jl
@@ -361,9 +361,9 @@ function calc_amr_indicator(dg::Dg2D, mesh::TreeMesh, time)
       cell_id = dg.elements.cell_ids[element_id]
       actual_level = mesh.tree.levels[cell_id]
       target_level = actual_level
-      if alpha[element_id] >= blending_factor_threshold0
+      if alpha[element_id] > blending_factor_threshold0
         target_level = super_max_level
-      elseif alpha[element_id] >= blending_factor_threshold1
+      elseif alpha[element_id] > blending_factor_threshold1
         target_level = max_level
       elseif alpha[element_id] <= blending_factor_threshold2
         target_level = base_level

--- a/test/test_examples_2d.jl
+++ b/test/test_examples_2d.jl
@@ -100,8 +100,8 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
 
   @testset "elixir_euler_blast_wave_shockcapturing_amr.jl" begin
     test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blast_wave_shockcapturing_amr.jl"),
-      l2   = [0.6779856619001925, 0.2814963219016726, 0.2814961545188141, 0.7227078877591626],
-      linf = [2.8903767693905342, 1.8018637904659396, 1.801813163681165, 3.0522925471933595],
+      l2   = [0.677942303998742, 0.2814895891803175, 0.28148956453746193, 0.7216004707929102],
+      linf = [2.8903767693905342, 1.8018637904659396, 1.801813163681165, 3.052175526995035],
       tspan = (0.0, 1.0))
   end
 
@@ -304,7 +304,6 @@ end
 if haskey(ENV, "TRIXI_TEST_EXTENDED") && lowercase(ENV["TRIXI_TEST_EXTENDED"]) in ("1", "on", "yes")
   @testset "Examples (long execution time)" begin
     @test_nowarn test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blob_mortar_shockcapturing.jl"))
-    @test_nowarn test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blob_shockcapturing_amr.jl"))
     @test_nowarn test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_khi_shockcapturing.jl"))
   end
 end

--- a/test/test_examples_2d.jl
+++ b/test/test_examples_2d.jl
@@ -119,7 +119,25 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
       tspan = (0.0, 0.12))
   end
 
-  @testset "elixir_euler_khi_shockcapturing_amr.jl with tend = 0.2" begin
+  @testset "elixir_euler_khi_shockcapturing.jl" begin
+    if Threads.nthreads() == 1
+      # This example uses random numbers to generate the initial condition.
+      # Hence, we can only check "errors" if everything is made reproducible.
+      # However, that's not enough to ensure reproducibility since the stream
+      # of random numbers is not guaranteed to be the same across different
+      # minor versions of Julia.
+      # See https://github.com/trixi-framework/Trixi.jl/issues/232#issuecomment-709738400
+      test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_khi_shockcapturing.jl"),
+        l2   = [0.0020460050625351277, 0.0028624298590723372, 0.001971035381754319, 0.004814883331768111],
+        linf = [0.02437585564403255, 0.018033033465721604, 0.00993916546672498, 0.02097263472404709],
+        tspan = (0.0, 0.2))
+    else
+      test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_khi_shockcapturing.jl"),
+        tspan = (0.0, 0.2))
+    end
+  end
+
+  @testset "elixir_euler_khi_shockcapturing_amr.jl" begin
     if Threads.nthreads() == 1
       # This example uses random numbers to generate the initial condition.
       # Hence, we can only check "errors" if everything is made reproducible.
@@ -304,7 +322,6 @@ end
 if haskey(ENV, "TRIXI_TEST_EXTENDED") && lowercase(ENV["TRIXI_TEST_EXTENDED"]) in ("1", "on", "yes")
   @testset "Examples (long execution time)" begin
     @test_nowarn test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blob_mortar_shockcapturing.jl"))
-    @test_nowarn test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_khi_shockcapturing.jl"))
   end
 end
 

--- a/test/test_examples_2d.jl
+++ b/test/test_examples_2d.jl
@@ -114,8 +114,8 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
 
   @testset "elixir_euler_blob_shockcapturing_amr.jl" begin
     test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blob_shockcapturing_amr.jl"),
-      l2   = [0.2079529146644449, 1.2165976525172113, 0.10497525531751525, 5.343396906455776],
-      linf = [14.746412579562035, 73.35401826630807, 7.945659812348401, 299.28120847051116],
+      l2   = [0.2012143467980036, 1.1813241716700988, 0.10144725208346557, 5.230607564921326],
+      linf = [14.111578610092542, 71.21944410118338, 7.304666476530256, 291.9385076318331],
       tspan = (0.0, 0.12))
   end
 

--- a/test/test_examples_2d_old.jl
+++ b/test/test_examples_2d_old.jl
@@ -181,8 +181,8 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
             linf = [0.02437585564403255, 0.018033033465721604, 0.00993916546672498, 0.02097263472404709],
             t_end = 0.2)
   end
-  @testset "parameters_euler_khi_amr.toml" begin
-    test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_khi_amr.toml"),
+  @testset "parameters_euler_khi_shockcapturing_amr.toml" begin
+    test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_khi_shockcapturing_amr.toml"),
             l2   = [0.0016901662212296502, 0.005064145650514081, 0.004794017657493158, 0.0039877996168673525],
             linf = [0.027437774935491266, 0.02344577999610231, 0.016129408502293267, 0.018237901415986357],
             t_end = 0.2)
@@ -342,10 +342,7 @@ end
 if haskey(ENV, "TRIXI_TEST_EXTENDED") && lowercase(ENV["TRIXI_TEST_EXTENDED"]) in ("1", "on", "yes")
   @testset "Examples (long execution time)" begin
     @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_euler_blob_mortar_shockcapturing.toml"))
-    @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_euler_blob_shockcapturing_amr.toml"))
-    @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_euler_khi_shockcapturing.toml"))
     @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_euler_ec_mortar.toml"))
-    @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_euler_khi_amr.toml"))
     @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_mhd_blast_wave.toml"))
     @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_mhd_orszag_tang.toml"))
     @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_mhd_rotor.toml"))

--- a/test/test_examples_2d_old.jl
+++ b/test/test_examples_2d_old.jl
@@ -217,8 +217,8 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
   @test_nowarn Trixi.convtest(joinpath(EXAMPLES_DIR, "parameters_advection_basic.toml"), 3)
   @testset "parameters_euler_blast_wave_shockcapturing_amr.toml" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_blast_wave_shockcapturing_amr.toml"), t_end=1.0,
-            l2   = [0.6776486969229697, 0.2813026529898539, 0.28130256451012314, 0.7174702524881598],
-            linf = [2.8939055423031532, 1.7997630098946864, 1.799711865996927, 3.034122348258568])
+            l2   = [0.677942303998742, 0.2814895891803175, 0.28148956453746193, 0.7216004707929102],
+            linf = [2.8903767693905342, 1.8018637904659396, 1.801813163681165, 3.052175526995035],)
   end
   @testset "parameters_euler_sedov_blast_wave_shockcapturing_amr.toml" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_sedov_blast_wave_shockcapturing_amr.toml"), t_end=1.0,

--- a/test/test_examples_2d_old.jl
+++ b/test/test_examples_2d_old.jl
@@ -181,10 +181,10 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
             linf = [0.027437774935491266, 0.02344577999610231, 0.016129408502293267, 0.018237901415986357],
             t_end = 0.2)
   end
-  @testset "parameters_euler_blob_split_shockcapturing_amr.toml with t_end=0.12" begin
-    test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_blob_split_shockcapturing_amr.toml"),
-            l2   = [0.20167272820008805, 1.1836133229138053, 0.10165112533393011, 5.237361125542303],
-            linf = [14.085801194734044, 71.07468448364403, 7.366158173410174, 297.2413787328775],
+  @testset "parameters_euler_blob_shockcapturing_amr.toml" begin
+    test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_blob_shockcapturing_amr.toml"),
+            l2   = [0.2012143467980036, 1.1813241716700988, 0.10144725208346557, 5.230607564921326],
+            linf = [14.111578610092542, 71.21944410118338, 7.304666476530256, 291.9385076318331],
             t_end = 0.12)
   end
   @testset "parameters_mhd_orszag_tang.toml with t_end=0.09" begin

--- a/test/test_examples_2d_old.jl
+++ b/test/test_examples_2d_old.jl
@@ -175,7 +175,13 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
             l2   = [0.05365734539276933, 0.04683903386565478, 0.04684207891980008, 0.19632055541821553],
             linf = [0.18542234326379825, 0.24074440953554058, 0.23261143887822433, 0.687464986948263])
   end
-  @testset "parameters_euler_khi_amr.toml with t_end=0.2" begin
+  @testset "parameters_euler_khi_shockcapturing.toml" begin
+    test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_khi_shockcapturing.toml"),
+            l2   = [0.0020460050625351277, 0.0028624298590723372, 0.001971035381754319, 0.004814883331768111],
+            linf = [0.02437585564403255, 0.018033033465721604, 0.00993916546672498, 0.02097263472404709],
+            t_end = 0.2)
+  end
+  @testset "parameters_euler_khi_amr.toml" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_khi_amr.toml"),
             l2   = [0.0016901662212296502, 0.005064145650514081, 0.004794017657493158, 0.0039877996168673525],
             linf = [0.027437774935491266, 0.02344577999610231, 0.016129408502293267, 0.018237901415986357],
@@ -337,7 +343,7 @@ if haskey(ENV, "TRIXI_TEST_EXTENDED") && lowercase(ENV["TRIXI_TEST_EXTENDED"]) i
   @testset "Examples (long execution time)" begin
     @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_euler_blob_mortar_shockcapturing.toml"))
     @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_euler_blob_shockcapturing_amr.toml"))
-    @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_euler_khi.toml"))
+    @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_euler_khi_shockcapturing.toml"))
     @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_euler_ec_mortar.toml"))
     @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_euler_khi_amr.toml"))
     @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_mhd_blast_wave.toml"))


### PR DESCRIPTION
```julia
julia> begin
           t_end = 1.0
           taam = Trixi.run("examples/2d/parameters_euler_blob_shockcapturing_amr.toml", t_end=t_end)
           trixi_include("examples/2d/elixir_euler_blob_shockcapturing_amr.jl", tspan=(0.0, t_end))
           taal = analysis_callback(sol)
           display(taal.l2 - taam.l2)
           display(taal.linf - taam.linf)
       end
...
4-element StaticArrays.SArray{Tuple{4},Float64,1,4} with indices SOneTo(4):
 -1.887379141862766e-15
 -1.3100631690576847e-14
 -5.551115123125783e-16
 -2.842170943040401e-14
4-element StaticArrays.SArray{Tuple{4},Float64,1,4} with indices SOneTo(4):
 -2.7000623958883807e-13
 -2.1316282072803006e-13
 -3.82804898890754e-13
 -2.5579538487363607e-13
```
This is acceptable after `1097` time steps, I think. 