### PR TITLE
Simple self-cooked time integration faking the interface of OrdinaryDiffEq

### DIFF
--- a/examples/2d/elixir_advection_timeintegration.jl
+++ b/examples/2d/elixir_advection_timeintegration.jl
@@ -53,6 +53,6 @@ callbacks = CallbackSet(summary_callback, stepsize_callback,
 
 # sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
 sol = Trixi.solve(ode, Trixi.SimpleAlgorithm2N45(),
-                  dt=0.025, # solve needs some value here but it will be overwritten by the stepsize_callback
+                  dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
                   save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_advection_timeintegration.jl
+++ b/examples/2d/elixir_advection_timeintegration.jl
@@ -1,0 +1,58 @@
+
+using Trixi
+
+###############################################################################
+# semidiscretization of the linear advection equation
+
+advectionvelocity = (1.0, 1.0)
+# advectionvelocity = (0.2, -0.3)
+equations = LinearScalarAdvectionEquation2D(advectionvelocity)
+
+initial_condition = initial_condition_convergence_test
+
+surface_flux = flux_lax_friedrichs
+solver = DGSEM(3, surface_flux)
+
+coordinates_min = (-1, -1)
+coordinates_max = ( 1,  1)
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level=4,
+                n_cells_max=30_000)
+
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan);
+
+summary_callback = SummaryCallback()
+
+stepsize_callback = StepsizeCallback(cfl=1.6)
+
+save_solution = SaveSolutionCallback(interval=100,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=:conservative)
+
+analysis_interval = 100
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval,
+                                     extra_analysis_integrals=(entropy, energy_total))
+
+callbacks = CallbackSet(summary_callback, stepsize_callback,
+                        save_solution,
+                        analysis_callback, alive_callback)
+
+
+###############################################################################
+# run the simulation
+
+# sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+sol = Trixi.solve(ode, Trixi.SimpleAlgorithm2N45(),
+                  dt=0.025, # solve needs some value here but it will be overwritten by the stepsize_callback
+                  save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -20,7 +20,7 @@ using Printf: @printf, @sprintf, println
 using Profile: clear_malloc_data
 using Random: seed!
 
-using DiffEqBase: ODEProblem, ODESolution, get_du, u_modified!, set_proposed_dt!, terminate!
+import DiffEqBase: ODEProblem, ODESolution, get_du, u_modified!, set_proposed_dt!, terminate!
 using DiffEqCallbacks: CallbackSet, DiscreteCallback
 using EllipsisNotation # ..
 using HDF5: h5open, attrs

--- a/src/callbacks/analysis.jl
+++ b/src/callbacks/analysis.jl
@@ -334,7 +334,7 @@ end
 
 
 # used for error checks and EOC analysis
-function (cb::DiscreteCallback{Condition,Affect!})(sol::ODESolution) where {Condition, Affect!<:AnalysisCallback}
+function (cb::DiscreteCallback{Condition,Affect!})(sol) where {Condition, Affect!<:AnalysisCallback}
   analysis_callback = cb.affect!
   semi = sol.prob.p
   @unpack analyzer = analysis_callback

--- a/src/timedisc/timedisc.jl
+++ b/src/timedisc/timedisc.jl
@@ -1,4 +1,99 @@
 
+struct SimpleAlgorithm2N45
+  a::SVector{5, Float64}
+  b::SVector{5, Float64}
+  c::SVector{5, Float64}
+
+  function SimpleAlgorithm2N45()
+    a = @SVector [0.0, 567301805773.0 / 1357537059087.0,2404267990393.0 / 2016746695238.0,
+       3550918686646.0 / 2091501179385.0, 1275806237668.0 / 842570457699.0]
+    b = @SVector [1432997174477.0 / 9575080441755.0, 5161836677717.0 / 13612068292357.0,
+        1720146321549.0 / 2090206949498.0, 3134564353537.0 / 4481467310338.0,
+        2277821191437.0 / 14882151754819.0]
+    c = @SVector [0.0, 1432997174477.0 / 9575080441755.0, 2526269341429.0 / 6820363962896.0,
+        2006345519317.0 / 3224310063776.0, 2802321613138.0 / 2924317926251.0]
+
+    new(a, b, c)
+  end
+end
+
+mutable struct SimpleIntegrator2N{RealT<:Real, uType, ODE, Alg, Callbacks}
+  u::uType
+  du::uType
+  u_tmp::uType
+  t::RealT
+  dt::RealT
+  iter::Int
+  prob::ODE
+  alg::Alg
+  callbacks::Callbacks
+end
+
+function solve(ode::ODEProblem, alg::SimpleAlgorithm2N45;
+               dt, callback=nothing, kwargs...)
+  u = copy(ode.u0)
+  du = similar(u)
+  u_tmp = similar(u)
+  t = first(ode.tspan)
+  iter = 0
+  integrator = SimpleIntegrator2N(u, du, u_tmp, t, dt, iter, ode, alg, callback)
+  init!(integrator)
+  solve!(integrator)
+end
+
+function init!(integrator::SimpleIntegrator2N)
+  # TODO: Taal time integration
+
+  return nothing
+end
+
+function solve!(integrator::SimpleIntegrator2N)
+  @unpack prob, alg = integrator
+  t_end = last(prob.tspan)
+
+  integrator.t = first(prob.tspan)
+  integrator.iter = 0
+  finalstep = false
+  @timeit_debug timer() "main loop" while !finalstep
+    if isnan(integrator.dt)
+      error("time step size `dt` is NaN")
+    end
+
+    # if the next iteration would push the simulation beyond the end time, set dt accordingly
+    if integrator.t + integrator.dt > t_end || isapprox(integrator.t + integrator.dt, t_end)
+      integrator.dt = t_end - integrator.t
+      finalstep = true
+    end
+
+    # one time step
+    integrator.u_tmp .= 0
+    for stage in eachindex(alg.c)
+      t_stage = integrator.t + integrator.dt * alg.c[stage]
+      prob.f(integrator.du, integrator.u, prob.p, t_stage)
+
+      a_stage    = alg.a[stage]
+      b_stage_dt = alg.b[stage] * integrator.dt
+      @timeit_debug timer() "Runge-Kutta step" begin
+        Threads.@threads for i in eachindex(integrator.u)
+          integrator.u_tmp[i] = integrator.du[i] - integrator.u_tmp[i] * a_stage
+          integrator.u[i] += integrator.u_tmp[i] * b_stage_dt
+        end
+      end
+    end
+    integrator.iter += 1
+    integrator.t += integrator.dt
+
+    # handle callbacks
+    # TODO: Taal time integration
+  end
+
+  return (t=integrator.prob.tspan,
+          u=(copy(integrator.prob.u0), copy(integrator.u)))
+end
+
+
+# TODO: Taal, the code below can probably be removed completely
+
 # Integrate solution by repeatedly calling the rhs! method on the solver solution.
 # function timestep_XYZ!(solver::AbstractSolver, t, dt)
 

--- a/test/test_examples_2d.jl
+++ b/test/test_examples_2d.jl
@@ -146,8 +146,8 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
       # minor versions of Julia.
       # See https://github.com/trixi-framework/Trixi.jl/issues/232#issuecomment-709738400
       test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_khi_shockcapturing_amr.jl"),
-        l2   = [0.0019809356303815313, 0.006538462481807526, 0.004737804472678921, 0.0050181776990539505],
-        linf = [0.016342197215556853, 0.03993613023503173, 0.015293069044755532, 0.024177402362647094],
+        l2   = [0.001617236176233394, 0.0023394729603446697, 0.001296199247911843, 0.0033150160736185323],
+        linf = [0.019002843896656074, 0.017242107049387223, 0.008179888370650977, 0.016885672229959958],
         tspan = (0.0, 0.2))
     else
       test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_khi_shockcapturing_amr.jl"),


### PR DESCRIPTION
~The self-cooked RK method doesn't support `resize!` yet, so you can't use AMR with it. However, I don't think that's necessary to demonstrate how to create our own time integrator, which is the main purpose of this PR.~