### PR TITLE
Ensure final time step size `dt` is not nearly zero

### DIFF
--- a/src/run.jl
+++ b/src/run.jl
@@ -299,7 +299,7 @@ function run_simulation(mesh, solver, time_parameters, time_integration_function
     end
 
     # If the next iteration would push the simulation beyond the end time, set dt accordingly
-    if time + dt > t_end
+    if time + dt > t_end || isapprox(time + dt, t_end)
       dt = t_end - time
       finalstep = true
     end

--- a/src/run_euler_gravity.jl
+++ b/src/run_euler_gravity.jl
@@ -241,7 +241,7 @@ function run_simulation_euler_gravity(mesh, solvers, time_parameters, time_integ
     end
 
     # If the next iteration would push the simulation beyond the end time, set dt accordingly
-    if time + dt > t_end
+    if time + dt > t_end || isapprox(time + dt, t_end)
       dt = t_end - time
       finalstep = true
     end


### PR DESCRIPTION
This seemingly trivial modification can change the final result of a simulation if, due to floating point truncation, a last time step with `dt ~ 0` is performed. The reason is that AMR is not performed after the final time step, thus even though the solution is not changed significantly with `dt ~ 0`, the mesh may get adapted one final time.

Since `DiffEq.jl` does this check automatically, it prevents us from having the same results in Taam and Taal, and thus this minor PR.