### PR TITLE
introduce isfinished(integrator)

### DIFF
--- a/examples/2d/elixir_advection_basic.jl
+++ b/examples/2d/elixir_advection_basic.jl
@@ -55,6 +55,7 @@ callbacks = CallbackSet(summary_callback, stepsize_callback,
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1);
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/elixir_advection_basic.jl
+++ b/examples/2d/elixir_advection_basic.jl
@@ -56,5 +56,5 @@ callbacks = CallbackSet(summary_callback, stepsize_callback,
 # run the simulation
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks);
+            save_everystep=false, callback=callbacks, maxiters=1);
 summary_callback() # print the timer summary

--- a/src/callbacks/alive.jl
+++ b/src/callbacks/alive.jl
@@ -48,9 +48,7 @@ end
 function (alive_callback::AliveCallback)(integrator)
   @unpack t, dt, iter = integrator
 
-  # Checking for floating point equality is OK here as `DifferentialEquations.jl`
-  # sets the time exactly to the final time in the last iteration
-  if t == integrator.sol.prob.tspan[2] || isempty(integrator.opts.tstops)
+  if isfinished(integrator)
     println("-"^80)
     println("Trixi simulation run finished.    Final time: ", integrator.t, "    Time steps: ", integrator.iter)
     println("-"^80)

--- a/src/callbacks/alive.jl
+++ b/src/callbacks/alive.jl
@@ -15,9 +15,10 @@ end
 
 function AliveCallback(; analysis_interval=0,
                          alive_interval=analysis_interval÷10)
+  # when is the callback activated
   condition = (u, t, integrator) -> alive_interval > 0 && (
     (integrator.iter % alive_interval == 0 && (analysis_interval == 0 || integrator.iter % analysis_interval != 0)) ||
-    t == integrator.sol.prob.tspan[2] || isempty(integrator.opts.tstops))
+    isfinished(integrator))
 
   alive_callback = AliveCallback(0.0, alive_interval, analysis_interval)
 

--- a/src/callbacks/analysis.jl
+++ b/src/callbacks/analysis.jl
@@ -61,8 +61,7 @@ function AnalysisCallback(semi::SemidiscretizationHyperbolic;
                           kwargs...)
   # when is the callback activated
   condition = (u, t, integrator) -> interval > 0 && (integrator.iter % interval == 0 ||
-                                                     t in integrator.sol.prob.tspan ||
-                                                     isempty(integrator.opts.tstops))
+                                                     isfinished(integrator))
 
   _, equations, solver, _ = mesh_equations_solver_cache(semi)
   analysis_callback = AnalysisCallback(0.0, interval, save_analysis, output_directory, analysis_filename,

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -14,7 +14,7 @@ get_element_variables!(element_variables, u, mesh, equations, solver, cache,
 end
 
 
-function isfinished(integrator)
+@inline function isfinished(integrator)
   # Checking for floating point equality is OK here as `DifferentialEquations.jl`
   # sets the time exactly to the final time in the last iteration
   return integrator.t == last(integrator.sol.prob.tspan) ||

--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -14,6 +14,15 @@ get_element_variables!(element_variables, u, mesh, equations, solver, cache,
 end
 
 
+function isfinished(integrator)
+  # Checking for floating point equality is OK here as `DifferentialEquations.jl`
+  # sets the time exactly to the final time in the last iteration
+  return integrator.t == last(integrator.sol.prob.tspan) ||
+         isempty(integrator.opts.tstops) ||
+         integrator.iter == integrator.opts.maxiters
+end
+
+
 # `include` callback definitions in the order that we currently prefer
 # when combining them into a `CallbackSet` which is called after a complete step
 include("summary.jl")

--- a/src/callbacks/save_restart.jl
+++ b/src/callbacks/save_restart.jl
@@ -25,11 +25,9 @@ end
 function SaveRestartCallback(; interval=0,
                                save_final_restart=true,
                                output_directory="out")
-  # Checking for floating point equality is OK here as `DifferentialEquations.jl`
-  # sets the time exactly to the final time in the last iteration
+  # when is the callback activated
   condition = (u, t, integrator) -> interval > 0 && ((integrator.iter % interval == 0) ||
-                                                     (save_final_restart && (t == integrator.sol.prob.tspan[2] ||
-                                                                              isempty(integrator.opts.tstops))))
+                                                     (save_final_restart && isfinished(integrator)))
 
   restart_callback = SaveRestartCallback(interval, save_final_restart,
                                          output_directory)

--- a/src/callbacks/save_solution.jl
+++ b/src/callbacks/save_solution.jl
@@ -33,11 +33,9 @@ function SaveSolutionCallback(; interval=0,
                                 save_final_solution=true,
                                 output_directory="out",
                                 solution_variables=:primitive)
-  # Checking for floating point equality is OK here as `DifferentialEquations.jl`
-  # sets the time exactly to the final time in the last iteration
+  # when is the callback activated
   condition = (u, t, integrator) -> interval > 0 && ((integrator.iter % interval == 0) ||
-                                                     (save_final_solution && (t == integrator.sol.prob.tspan[2] ||
-                                                                              isempty(integrator.opts.tstops))))
+                                                     (save_final_solution && isfinished(integrator)))
 
   solution_callback = SaveSolutionCallback(interval, save_initial_solution, save_final_solution,
                                            output_directory, solution_variables)

--- a/src/timedisc/timedisc.jl
+++ b/src/timedisc/timedisc.jl
@@ -26,12 +26,13 @@ mutable struct SimpleIntegrator2NOptions{Callback}
   callback::Callback # callbacks; used in Trixi
   adaptive::Bool # whether the algorithm is adaptive; ignored
   dtmax::Float64 # ignored
+  maxiters::Int # maximal numer of time steps
   tstops::Vector{Float64} # tstops from https://diffeq.sciml.ai/v6.8/basics/common_solver_opts/#Output-Control-1; ignored
 end
 
-function SimpleIntegrator2NOptions(callback, tspan; kwargs...)
+function SimpleIntegrator2NOptions(callback, tspan; maxiters=typemax(Int), kwargs...)
   SimpleIntegrator2NOptions{typeof(callback)}(
-    callback, false, Inf, [last(tspan)])
+    callback, false, Inf, maxiters, [last(tspan)])
 end
 
 # This struct is needed to fake https://github.com/SciML/OrdinaryDiffEq.jl/blob/0c2048a502101647ac35faabd80da8a5645beac7/src/integrators/type.jl#L77
@@ -180,12 +181,13 @@ mutable struct SimpleIntegrator3SstarOptions{Callback}
   callback::Callback # callbacks; used in Trixi
   adaptive::Bool # whether the algorithm is adaptive; ignored
   dtmax::Float64 # ignored
+  maxiters::Int # maximal numer of time steps
   tstops::Vector{Float64} # tstops from https://diffeq.sciml.ai/v6.8/basics/common_solver_opts/#Output-Control-1; ignored
 end
 
-function SimpleIntegrator3SstarOptions(callback, tspan; kwargs...)
+function SimpleIntegrator3SstarOptions(callback, tspan; maxiters=typemax(Int), kwargs...)
   SimpleIntegrator3SstarOptions{typeof(callback)}(
-    callback, false, Inf, [last(tspan)])
+    callback, false, Inf, maxiters, [last(tspan)])
 end
 
 mutable struct SimpleIntegrator3Sstar{RealT<:Real, uType, Params, Sol, Alg, SimpleIntegrator3SstarOptions}


### PR DESCRIPTION
Using this PR, I get
```julia
julia> using Trixi

shell> git diff
diff --git a/examples/2d/elixir_advection_basic.jl b/examples/2d/elixir_advection_basic.jl
index 11b5898..029ca08 100644
--- a/examples/2d/elixir_advection_basic.jl
+++ b/examples/2d/elixir_advection_basic.jl
@@ -57,5 +57,5 @@ callbacks = CallbackSet(summary_callback, stepsize_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks);
+            save_everystep=false, callback=callbacks, maxiters=25);
 summary_callback() # print the timer summary

julia> trixi_include("examples/2d/elixir_advection_basic.jl", maxiters=25)
...
#t/s:     10 | dt: 2.5000e-02 | Sim. time: 2.5000e-01 | Run time: 3.1320e-03 s
#t/s:     20 | dt: 2.5000e-02 | Sim. time: 5.0000e-01 | Run time: 8.9260e-03 s

--------------------------------------------------------------------------------
 Simulation running 'LinearScalarAdvectionEquation2D' with POLYDEG = 3
--------------------------------------------------------------------------------
 #timesteps:                 25                run time:       1.39449994e+00 s
 dt:             2.50000000e-02                Time/DOF/rhs!:  2.53920801e-06 s
 sim. time:      6.25000000e-01

 Variable:       scalar        
 L2 error:       8.40925972e-06
 Linf error:     6.44375777e-05
 ∑∂S/∂U ⋅ Uₜ :  -4.35336126e-09
 ∑S          :   5.62499906e-01
 ∑e_total    :   5.62499906e-01
--------------------------------------------------------------------------------

--------------------------------------------------------------------------------
Trixi simulation run finished.    Final time: 0.6250000000000002    Time steps: 25
--------------------------------------------------------------------------------

┌ Warning: Interrupted. Larger maxiters is needed.
└ @ DiffEqBase ~/.julia/packages/DiffEqBase/3iigH/src/integrator_interface.jl:329
 -------------------------------------------------------------------------------
            Trixi.jl                    Time                   Allocations      
                                ----------------------   -----------------------
        Tot / % measured:            2.43s / 78.6%            231MiB / 85.4%    

 Section                ncalls     time   %tot     avg     alloc   %tot      avg
 -------------------------------------------------------------------------------
 analyze solution            2    1.37s  71.6%   684ms    182MiB  92.3%  91.1MiB
 I/O                         5    535ms  28.0%   107ms   10.7MiB  5.40%  2.13MiB
 rhs!                      126   7.22ms  0.38%  57.3μs   4.60MiB  2.33%  37.4KiB
   volume integral         126   1.61ms  0.08%  12.7μs    580KiB  0.29%  4.61KiB
   interface flux          126    942μs  0.05%  7.47μs    567KiB  0.28%  4.50KiB
   prolong2interfaces      126    841μs  0.04%  6.67μs    565KiB  0.28%  4.48KiB
   surface integral        126    814μs  0.04%  6.46μs    572KiB  0.28%  4.54KiB
   Jacobian                126    696μs  0.04%  5.52μs    568KiB  0.28%  4.51KiB
   prolong2mortars         126    682μs  0.04%  5.41μs    633KiB  0.31%  5.02KiB
   prolong2boundaries      126    648μs  0.03%  5.14μs    566KiB  0.28%  4.50KiB
   mortar flux             126    633μs  0.03%  5.03μs    639KiB  0.32%  5.07KiB
   reset ∂u/∂t             126    111μs  0.01%   885ns     0.00B  0.00%    0.00B
   boundary flux           126   7.17μs  0.00%  56.9ns     0.00B  0.00%    0.00B
   source terms            126   5.12μs  0.00%  40.6ns     0.00B  0.00%    0.00B
 calculate dt               26   19.1μs  0.00%   736ns     0.00B  0.00%    0.00B
 -------------------------------------------------------------------------------
```

Fixes #295 