### PR TITLE
Some CI updates

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,11 +1,13 @@
 # https://docs.codecov.io/docs/codecovyml-reference
 
-# We have 8 * [number of OS] parallel jobs in ci.yml
+# We have
+#   8 * [number of basic OS] + 2 * [number of additional OS]
+# parallel jobs in ci.yml
 codecov:
   notify:
-    after_n_builds: 8
+    after_n_builds: 12
 comment:
-  after_n_builds: 8
+  after_n_builds: 12
 
 coverage:
   range: 70..95

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,11 +1,11 @@
 # https://docs.codecov.io/docs/codecovyml-reference
 
-# We have 8 * 3 parallel jobs in ci.yml
+# We have 8 * [number of OS] parallel jobs in ci.yml
 codecov:
   notify:
-    after_n_builds: 24
+    after_n_builds: 8
 comment:
-  after_n_builds: 24
+  after_n_builds: 8
 
 coverage:
   range: 70..95

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,25 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'AUTHORS.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE.md'
+      - 'README.md'
+      - '.zenodo.json'
+      - '.github/workflows/CompatHelper.yml'
+      - '.github/workflows/TagBot.yml'
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - 'AUTHORS.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE.md'
+      - 'README.md'
+      - '.zenodo.json'
+      - '.github/workflows/CompatHelper.yml'
+      - '.github/workflows/TagBot.yml'
+      - 'docs/**'
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   test:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.trixi_test }} - ${{ github.event_name }}
+    name: ${{ matrix.trixi_test }} - ${{ matrix.os }} - Julia ${{ matrix.version }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -37,8 +37,8 @@ jobs:
           # - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
+          # - macOS-latest
+          # - windows-latest
         arch:
           - x64
         trixi_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
           # - 'nightly'
         os:
           - ubuntu-latest
-          # - macOS-latest
-          # - windows-latest
         arch:
           - x64
         trixi_test:
@@ -50,6 +48,23 @@ jobs:
           - parallel_2d
           - 1D
           - misc
+        include:
+          - version: 1.5
+            os: macOS-latest
+            arch: x64
+            trixi_test: 2D
+          - version: 1.5
+            os: macOS-latest
+            arch: x64
+            trixi_test: parallel_2d
+          - version: 1.5
+            os: windows-latest
+            arch: x64
+            trixi_test: 2D
+          - version: 1.5
+            os: windows-latest
+            arch: x64
+            trixi_test: parallel_2d
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
Using this, CI shouldn't run anymore when changing files where it's definitely not necessary. I included `skip ci` in the commit message to check again whether it works - it doesn't. As far as I know, `skip ci` works only in `push` events and not in PRs.