### PR TITLE
WIP: Investigating eulergravity and Jeans instability

### DIFF
--- a/examples/2d/elixir_eulergravity_jeans_instability.jl
+++ b/examples/2d/elixir_eulergravity_jeans_instability.jl
@@ -103,7 +103,9 @@ semi = SemidiscretizationEulerGravity(semi_euler, semi_gravity, parameters)
 ###############################################################################
 # ODE solvers, callbacks etc.
 tspan = (0.0, 5.0)
-ode = semidiscretize(semi, tspan);
+# TODO: eulergravity
+ode = semidiscretize(semi_euler, tspan);
+# ode = semidiscretize(semi, tspan);
 
 summary_callback = SummaryCallback()
 
@@ -142,8 +144,9 @@ function Trixi.analyze(::Val{:energy_potential}, du, u_euler, t, semi::Semidiscr
 end
 
 analysis_callback = AnalysisCallback(semi_euler, interval=analysis_interval,
-                                     save_analysis=true,
-                                     extra_analysis_integrals=(entropy, energy_total, energy_kinetic, energy_internal, Val(:energy_potential)))
+                                     save_analysis=true)
+                                     # TODO: eulergravity
+                                    #  extra_analysis_integrals=(entropy, energy_total, energy_kinetic, energy_internal, Val(:energy_potential)))
 
 callbacks = CallbackSet(summary_callback, stepsize_callback,
                         save_restart, save_solution,
@@ -152,7 +155,9 @@ callbacks = CallbackSet(summary_callback, stepsize_callback,
 
 ###############################################################################
 # run the simulation
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+# TODO: eulergravity
+# sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+sol = Trixi.solve(ode, Trixi.CarpenterKennedy2N54(),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/paper-self-gravitating-gas-dynamics/parameters_eulergravity_jeans_instability.toml
+++ b/examples/paper-self-gravitating-gas-dynamics/parameters_eulergravity_jeans_instability.toml
@@ -1,7 +1,9 @@
 ####################################################################################################
 # Simulation
 ndims = 2
-equations = "euler_gravity"
+# TODO: eulergravity
+equations = "CompressibleEulerEquations"
+# equations = "euler_gravity"
 gamma = 1.6666666666666667
 initial_condition = "initial_condition_jeans_instability"
 surface_flux = "flux_hll"
@@ -22,7 +24,8 @@ cfl = 0.5
 n_steps_max = 10000
 n_iterations_max = 1000
 analysis_interval = 100
-extra_analysis_quantities = ["energy_total","energy_kinetic","energy_internal", "energy_potential"]
+# TODO: eulergravity
+# extra_analysis_quantities = ["energy_total","energy_kinetic","energy_internal", "energy_potential"]
 save_analysis = true
 
 # Gravity

--- a/src/run_euler_gravity.jl
+++ b/src/run_euler_gravity.jl
@@ -52,6 +52,9 @@ function init_simulation_euler_gravity()
   amr_interval = parameter("amr_interval", 0)
   adapt_initial_condition = parameter("adapt_initial_condition", true)
   adapt_initial_condition_only_refine = parameter("adapt_initial_condition_only_refine", true)
+
+  # make sure that the random number generator is reseted and the ICs are reproducible in the julia REPL/interactive mode
+  seed!(0)
   begin
     print("Applying initial conditions... ")
     t_start = parameter("t_start")

--- a/src/timedisc/timedisc_euler_gravity.jl
+++ b/src/timedisc/timedisc_euler_gravity.jl
@@ -35,10 +35,11 @@ function timestep_euler_gravity!(solver_euler, solver_gravity, t::Float64, dt::F
 
   for stage in eachindex(c)
     # Update gravity in every RK stage
-    if update_gravity_once_per_stage
-      @timeit timer() "gravity solver" update_gravity!(solver_gravity, solver_euler.elements.u,
-                                                       gravity_parameters)
-    end
+    # TODO: eulergravity
+    # if update_gravity_once_per_stage
+    #   @timeit timer() "gravity solver" update_gravity!(solver_gravity, solver_euler.elements.u,
+    #                                                    gravity_parameters)
+    # end
 
     # Update stage time
     t_stage = t + dt * c[stage]
@@ -50,19 +51,20 @@ function timestep_euler_gravity!(solver_euler, solver_gravity, t::Float64, dt::F
     u_euler = solver_euler.elements.u
     u_t_euler = solver_euler.elements.u_t
     u_gravity = solver_gravity.elements.u
-    if ndims(solver_euler) == 2
-      @views @. u_t_euler[2,:,:,:] -= u_euler[1,:,:,:]*u_gravity[2,:,:,:]
-      @views @. u_t_euler[3,:,:,:] -= u_euler[1,:,:,:]*u_gravity[3,:,:,:]
-      @views @. u_t_euler[4,:,:,:] -= (u_euler[2,:,:,:]*u_gravity[2,:,:,:]
-                                      +u_euler[3,:,:,:]*u_gravity[3,:,:,:])
-    else
-      @views @. u_t_euler[2,:,:,:,:] -= u_euler[1,:,:,:,:]*u_gravity[2,:,:,:,:]
-      @views @. u_t_euler[3,:,:,:,:] -= u_euler[1,:,:,:,:]*u_gravity[3,:,:,:,:]
-      @views @. u_t_euler[4,:,:,:,:] -= u_euler[1,:,:,:,:]*u_gravity[4,:,:,:,:]
-      @views @. u_t_euler[5,:,:,:,:] -= (u_euler[2,:,:,:,:]*u_gravity[2,:,:,:,:]
-                                        +u_euler[3,:,:,:,:]*u_gravity[3,:,:,:,:]
-                                        +u_euler[4,:,:,:,:]*u_gravity[4,:,:,:,:])
-    end
+    # TODO: eulergravity
+    # if ndims(solver_euler) == 2
+    #   @views @. u_t_euler[2,:,:,:] -= u_euler[1,:,:,:]*u_gravity[2,:,:,:]
+    #   @views @. u_t_euler[3,:,:,:] -= u_euler[1,:,:,:]*u_gravity[3,:,:,:]
+    #   @views @. u_t_euler[4,:,:,:] -= (u_euler[2,:,:,:]*u_gravity[2,:,:,:]
+    #                                   +u_euler[3,:,:,:]*u_gravity[3,:,:,:])
+    # else
+    #   @views @. u_t_euler[2,:,:,:,:] -= u_euler[1,:,:,:,:]*u_gravity[2,:,:,:,:]
+    #   @views @. u_t_euler[3,:,:,:,:] -= u_euler[1,:,:,:,:]*u_gravity[3,:,:,:,:]
+    #   @views @. u_t_euler[4,:,:,:,:] -= u_euler[1,:,:,:,:]*u_gravity[4,:,:,:,:]
+    #   @views @. u_t_euler[5,:,:,:,:] -= (u_euler[2,:,:,:,:]*u_gravity[2,:,:,:,:]
+    #                                     +u_euler[3,:,:,:,:]*u_gravity[3,:,:,:,:]
+    #                                     +u_euler[4,:,:,:,:]*u_gravity[4,:,:,:,:])
+    # end
     # take RK step for compressible Euler
     @timeit timer() "Runge-Kutta step" begin
       @. solver_euler.elements.u_tmp2 = (solver_euler.elements.u_t


### PR DESCRIPTION
While trying to understand the differences of Taam and Taal for Euler with self-gravity, I basically removed everything related to self-gravity and looked only at the Euler part.

I used the following code.
```julia
julia> using Revise; using Trixi

julia> function verify_taal(toml_file, elixir; t_end=nothing, kwargs...)
         # Run tests and convert `t_end` appropriately
         if isnothing(t_end)
           taam = Trixi.run(toml_file; kwargs...)
           trixi_include(elixir; kwargs...); taal = analysis_callback(sol)
         else
           taam = Trixi.run(toml_file; t_end=t_end, kwargs...)
           trixi_include(elixir; tspan=(0.0, t_end), kwargs...); taal = analysis_callback(sol)
         end


         # Show results
         println("="^80)
         println("L2 (Taam - Taal):")
         display(taam.l2 - taal.l2)
         println("="^80)
         println("Linf (Taam - Taal):")
         display(taam.linf - taal.linf)
         println("="^80)
       end

julia> verify_taal("examples/paper-self-gravitating-gas-dynamics/parameters_eulergravity_jeans_instability.toml",
                   "examples/2d/elixir_eulergravity_jeans_instability.jl",
                   t_end=1.0e1, 
                   save_initial_solution=false, save_final_solution=false)
[...]
```

- If I set `equations = "CompressibleEulerEquations"` in the TOML file and either `ode = semidiscretize(semi_euler, tspan);` or `ode = semidiscretize(semi, tspan);` in the elixir, the final results match exactly.
- If I set `equations = "euler_gravity"` in the TOML file and either `ode = semidiscretize(semi_euler, tspan);` or `ode = semidiscretize(semi, tspan);` in the elixir, I get
  ```
  ================================================================================
  L2 (Taam - Taal):
  4-element StaticArrays.SArray{Tuple{4},Float64,1,4} with indices SOneTo(4):
  -2.586602931842208e-9
    2.35741026699543e-9
  -9.693394269193118e-10
    3.339118848089129e-8
  ================================================================================
  Linf (Taam - Taal):
  4-element StaticArrays.SArray{Tuple{4},Float64,1,4} with indices SOneTo(4):
    1.30385160446167e-8
    1.8892023945227265e-8
  -1.0928168592602975e-8
    5.21540641784668e-8
  ================================================================================
  ```
  Thus, there seem to be some differences already inside Taam.
- If I use `sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),` instead of `sol = Trixi.solve(ode, Trixi.CarpenterKennedy2N54(),` in the elixir and `equations = "CompressibleEulerEquations"` in the TOML file, I get similar differences:
  ```
  ================================================================================
  L2 (Taam - Taal):
  4-element StaticArrays.SArray{Tuple{4},Float64,1,4} with indices SOneTo(4):
    1.0923940862994641e-8
    3.92901711165905e-10
    4.468592891849448e-10
  -2.1744199329987168e-8
  ================================================================================
  Linf (Taam - Taal):
  4-element StaticArrays.SArray{Tuple{4},Float64,1,4} with indices SOneTo(4):
  -9.685754776000977e-8
  -4.511093720793724e-9
    9.278197068942485e-9
  -1.1175870895385742e-8
  ================================================================================
  ```
  Hence, already the pure Euler part of this example seems to be very sensitive to rounding errors.