### PR TITLE
test_trixi_include as macro

### DIFF
--- a/examples/2d/elixir_euler_gravity_jeans_instability.jl
+++ b/examples/2d/elixir_euler_gravity_jeans_instability.jl
@@ -3,60 +3,63 @@ using OrdinaryDiffEq
 using Trixi
 
 
-# If you're developing an elixir for Trixi for some project, you can define
-# initial conditions etc. directly inside the elixir, e.g. using the code below
-# (which is commented out).
-# For example, running
-# trixi_include("examples/2d/elixir_euler_gravity_jeans_instability.jl")
-# from the REPL works fine with that setting.
-# However, we're running CI with automated tests of Trixi. In that case,
-# we get annoying world age issues. Hence, we keep initial_condition_jeans_instability
-# in Trixi/src for now.
-#
-# function initial_condition_jeans_instability(x, t,
-#                                             equations::CompressibleEulerEquations2D)
-#   # Jeans gravitational instability test case
-#   # see Derigs et al. https://arxiv.org/abs/1605.03572; Sec. 4.6
-#   # OBS! this uses cgs (centimeter, gram, second) units
-#   # periodic boundaries
-#   # domain size [0,L]^2 depends on the wave number chosen for the perturbation
-#   # OBS! Be very careful here L must be chosen such that problem is periodic
-#   # typical final time is T = 5
-#   # gamma = 5/3
-#   dens0  = 1.5e7 # g/cm^3
-#   pres0  = 1.5e7 # dyn/cm^2
-#   delta0 = 1e-3
-#   # set wave vector values for pertubation (units 1/cm)
-#   # see FLASH manual: https://flash.uchicago.edu/site/flashcode/user_support/flash_ug_devel.pdf
-#   kx = 2.0*pi/0.5 # 2π/λ_x, λ_x = 0.5
-#   ky = 0.0   # 2π/λ_y, λ_y = 1e10
-#   k_dot_x = kx*x[1] + ky*x[2]
-#   # perturb density and pressure away from reference states ρ_0 and p_0
-#   dens = dens0*(1.0 + delta0*cos(k_dot_x))                 # g/cm^3
-#   pres = pres0*(1.0 + equations.gamma*delta0*cos(k_dot_x)) # dyn/cm^2
-#   # flow starts as stationary
-#   velx = 0.0 # cm/s
-#   vely = 0.0 # cm/s
-#   return Trixi.prim2cons((dens, velx, vely, pres), equations)
-# end
+"""
+    initial_condition_jeans_instability(x, t,
+                                        equations::Union{CompressibleEulerEquations2D,
+                                                         HyperbolicDiffusionEquations2D})
 
-# function initial_condition_jeans_instability(x, t,
-#                                              equations::HyperbolicDiffusionEquations2D)
-#   # gravity equation: -Δϕ = -4πGρ
-#   # Constants taken from the FLASH manual
-#   # https://flash.uchicago.edu/site/flashcode/user_support/flash_ug_devel.pdf
-#   rho0   = 1.5e7
-#   delta0 = 1e-3
+The classical Jeans instability taken from
+- Michael Schlottke-Lakemper, Andrew R. Winters, Hendrik Ranocha, Gregor J. Gassner (2020)
+  A purely hyperbolic discontinuous Galerkin approach for self-gravitating gas dynamics
+  [arXiv: 2008.10593](https://arxiv.org/abs/2008.10593)
+- Dominik Derigs, Andrew R. Winters, Gregor J. Gassner, Stefanie Walch (2016)
+  A Novel High-Order, Entropy Stable, 3D AMR MHD Solver with Guaranteed Positive Pressure
+  [arXiv: 1605.03572](https://arxiv.org/abs/1605.03572)
+- Flash manual https://flash.uchicago.edu/site/flashcode/user_support/flash_ug_devel.pdf
+in CGS (centimeter, gram, second) units.
+"""
+function initial_condition_jeans_instability(x, t,
+                                            equations::CompressibleEulerEquations2D)
+  # Jeans gravitational instability test case
+  # see Derigs et al. https://arxiv.org/abs/1605.03572; Sec. 4.6
+  # OBS! this uses cgs (centimeter, gram, second) units
+  # periodic boundaries
+  # domain size [0,L]^2 depends on the wave number chosen for the perturbation
+  # OBS! Be very careful here L must be chosen such that problem is periodic
+  # typical final time is T = 5
+  # gamma = 5/3
+  dens0  = 1.5e7 # g/cm^3
+  pres0  = 1.5e7 # dyn/cm^2
+  delta0 = 1e-3
+  # set wave vector values for pertubation (units 1/cm)
+  # see FLASH manual: https://flash.uchicago.edu/site/flashcode/user_support/flash_ug_devel.pdf
+  kx = 2.0*pi/0.5 # 2π/λ_x, λ_x = 0.5
+  ky = 0.0   # 2π/λ_y, λ_y = 1e10
+  k_dot_x = kx*x[1] + ky*x[2]
+  # perturb density and pressure away from reference states ρ_0 and p_0
+  dens = dens0*(1.0 + delta0*cos(k_dot_x))                 # g/cm^3
+  pres = pres0*(1.0 + equations.gamma*delta0*cos(k_dot_x)) # dyn/cm^2
+  # flow starts as stationary
+  velx = 0.0 # cm/s
+  vely = 0.0 # cm/s
+  return Trixi.prim2cons((dens, velx, vely, pres), equations)
+end
 
-#   phi = rho0*delta0 # constant background pertubation magnitude
-#   q1  = 0.0
-#   q2  = 0.0
-#   return (phi, q1, q2)
-# end
-#
-# initial_condition = initial_condition_jeans_instability
+function initial_condition_jeans_instability(x, t,
+                                             equations::HyperbolicDiffusionEquations2D)
+  # gravity equation: -Δϕ = -4πGρ
+  # Constants taken from the FLASH manual
+  # https://flash.uchicago.edu/site/flashcode/user_support/flash_ug_devel.pdf
+  rho0   = 1.5e7
+  delta0 = 1e-3
 
-initial_condition = Trixi.initial_condition_jeans_instability
+  phi = rho0*delta0 # constant background pertubation magnitude
+  q1  = 0.0
+  q2  = 0.0
+  return (phi, q1, q2)
+end
+
+initial_condition = initial_condition_jeans_instability
 
 
 ###############################################################################

--- a/src/equations/2d/compressible_euler.jl
+++ b/src/equations/2d/compressible_euler.jl
@@ -481,19 +481,7 @@ function initial_condition_blob(x, t, equations::CompressibleEulerEquations2D)
 end
 
 
-"""
-    initial_condition_jeans_instability(x, t, equations::CompressibleEulerEquations2D)
-
-The classical Jeans instability taken from
-- Michael Schlottke-Lakemper, Andrew R. Winters, Hendrik Ranocha, Gregor J. Gassner (2020)
-  A purely hyperbolic discontinuous Galerkin approach for self-gravitating gas dynamics
-  [arXiv: 2008.10593](https://arxiv.org/abs/2008.10593)
-- Dominik Derigs, Andrew R. Winters, Gregor J. Gassner, Stefanie Walch (2016)
-  A Novel High-Order, Entropy Stable, 3D AMR MHD Solver with Guaranteed Positive Pressure
-  [arXiv: 1605.03572](https://arxiv.org/abs/1605.03572)
-- Flash manual https://flash.uchicago.edu/site/flashcode/user_support/flash_ug_devel.pdf
-in CGS (centimeter, gram, second) units.
-"""
+# TODO: Taal, remove the method below (moved to the elixir)
 function initial_condition_jeans_instability(x, t, equations::CompressibleEulerEquations2D)
   # Jeans gravitational instability test case
   # see Derigs et al. https://arxiv.org/abs/1605.03572; Sec. 4.6

--- a/src/equations/2d/hyperbolic_diffusion.jl
+++ b/src/equations/2d/hyperbolic_diffusion.jl
@@ -224,19 +224,7 @@ function boundary_condition_harmonic_nonperiodic(u_inner, orientation, direction
 end
 
 
-"""
-    initial_condition_jeans_instability(x, t, equations::HyperbolicDiffusionEquations2D)
-
-The classical Jeans instability taken from
-- Michael Schlottke-Lakemper, Andrew R. Winters, Hendrik Ranocha, Gregor J. Gassner (2020)
-  A purely hyperbolic discontinuous Galerkin approach for self-gravitating gas dynamics
-  [arXiv: 2008.10593](https://arxiv.org/abs/2008.10593)
-- Dominik Derigs, Andrew R. Winters, Gregor J. Gassner, Stefanie Walch (2016)
-  A Novel High-Order, Entropy Stable, 3D AMR MHD Solver with Guaranteed Positive Pressure
-  [arXiv: 1605.03572](https://arxiv.org/abs/1605.03572)
-- Flash manual https://flash.uchicago.edu/site/flashcode/user_support/flash_ug_devel.pdf
-in CGS (centimeter, gram, second) units.
-"""
+# TODO: Taal, remove the method below (moved to the elixir)
 function initial_condition_jeans_instability(x, t, equations::HyperbolicDiffusionEquations2D)
   # gravity equation: -Δϕ = -4πGρ
   # Constants taken from the FLASH manual

--- a/test/test_examples_1d.jl
+++ b/test/test_examples_1d.jl
@@ -17,44 +17,44 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
 # Run basic tests
 @testset "Examples 1D" begin
   @testset "elixir_advection_basic.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_basic.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_basic.jl"),
       l2   = [6.0388296447998465e-6],
       linf = [3.217887726258972e-5])
   end
 
   @testset "elixir_advection_amr.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr.jl"),
     l2   = [0.3540209654959832],
     linf = [0.9999905446337742])
   end
 
   @testset "elixir_advection_amr_nonperiodic.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr_nonperiodic.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr_nonperiodic.jl"),
     l2   = [4.323675034078241e-6],
     linf = [3.239622040579655e-5])
   end
 
 
   @testset "elixir_euler_source_terms.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms.jl"),
     l2   = [2.3017487546631118e-8, 1.9137514928527178e-8, 7.732828544277078e-8],
     linf = [1.6282751857943367e-7, 1.426988238684146e-7, 5.298297782729833e-7])
   end
 
   @testset "elixir_euler_nonperiodic.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_nonperiodic.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_nonperiodic.jl"),
     l2   = [3.80950031272884e-6, 1.671745083458876e-6, 7.730956863549413e-6],
     linf = [1.2966215741316844e-5, 9.2635164730126e-6, 3.090770562241829e-5])
   end
 
   @testset "elixir_euler_ec.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_ec.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_ec.jl"),
     l2   = [0.1188410508446165, 0.15463666913848456, 0.4444355816866067],
     linf = [0.23934128951004474, 0.27246473813214184, 0.8697154266487717])
   end
 
   @testset "elixir_euler_blast_wave_shockcapturing.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blast_wave_shockcapturing.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blast_wave_shockcapturing.jl"),
       l2   = [0.21218593029900773, 0.2769530413665288, 0.5518482111667276],
       linf = [1.505221631144809, 1.4864840122024228, 2.0501644413816162],
       tspan = (0.0, 0.13))

--- a/test/test_examples_2d.jl
+++ b/test/test_examples_2d.jl
@@ -17,109 +17,109 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
 # Run basic tests
 @testset "Examples 2D" begin
   @testset "elixir_advection_basic.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_basic.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_basic.jl"),
       l2   = [9.144681765639205e-6],
       linf = [6.437440532547356e-5])
   end
 
   @testset "elixir_advection_mortar.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_mortar.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_mortar.jl"),
       l2   = [0.022356422238096973],
       linf = [0.5043638249003257])
   end
 
   @testset "elixir_advection_amr.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr.jl"),
       l2   = [0.009801425100170215],
       linf = [0.04335954152178878])
   end
 
   @testset "elixir_advection_restart.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_restart.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_restart.jl"),
       l2   = [1.2148032444677485e-5],
       linf = [6.495644794757283e-5])
   end
 
 
   @testset "elixir_hyp_diff_llf.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hyp_diff_llf.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hyp_diff_llf.jl"),
       l2   = [0.00015687751816056159, 0.001025986772217084, 0.0010259867722169909],
       linf = [0.0011986956416591976, 0.006423873516411049, 0.006423873516411049])
   end
 
   @testset "elixir_hyp_diff_harmonic_nonperiodic.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hyp_diff_harmonic_nonperiodic.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hyp_diff_harmonic_nonperiodic.jl"),
       l2   = [8.61813235543625e-8, 5.619399844542781e-7, 5.6193998447443e-7],
       linf = [1.124861862180196e-6, 8.622436471039663e-6, 8.622436470151484e-6])
   end
 
   @testset "elixir_hyp_diff_nonperiodic.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hyp_diff_nonperiodic.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hyp_diff_nonperiodic.jl"),
       l2   = [8.523077653955306e-6, 2.8779323653065056e-5, 5.4549427691297846e-5],
       linf = [5.5227409524905013e-5, 0.0001454489597927185, 0.00032396328684569653])
   end
 
   @testset "elixir_hyp_diff_upwind.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hyp_diff_upwind.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hyp_diff_upwind.jl"),
       l2   = [5.868147556385677e-6, 3.805179273239753e-5, 3.805179273248075e-5],
       linf = [3.7019654930525725e-5, 0.00021224229433514097, 0.00021224229433514097])
   end
 
 
   @testset "elixir_euler_source_terms.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms.jl"),
     l2   = [8.517783186497567e-7, 1.2350199409361865e-6, 1.2350199409828616e-6, 4.277884398786315e-6],
     linf = [8.357934254688004e-6, 1.0326389653148027e-5, 1.0326389654924384e-5, 4.4961900057316484e-5])
   end
 
   @testset "elixir_euler_density_wave.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_density_wave.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_density_wave.jl"),
     l2   = [0.0010600778457965205, 0.00010600778457646603, 0.0002120155691588112, 2.6501946142012653e-5],
     linf = [0.006614198043407127, 0.0006614198043931596, 0.001322839608845383, 0.00016535495117153687],
     tspan = (0.0, 0.5))
   end
 
   @testset "elixir_euler_nonperiodic.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_nonperiodic.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_nonperiodic.jl"),
     l2   = [2.3652137675654753e-6, 2.1386731303685556e-6, 2.138673130413185e-6, 6.009920290578574e-6],
     linf = [1.4080448659026246e-5, 1.7581818010814487e-5, 1.758181801525538e-5, 5.9568540361709665e-5])
   end
 
   @testset "elixir_euler_ec.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_ec.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_ec.jl"),
     l2   = [0.061733846713578594, 0.05020086119442834, 0.05020836856347214, 0.2259064869636338],
     linf = [0.29894122391731826, 0.30853631977725215, 0.3084722538869674, 1.0652455597305965])
   end
 
   @testset "elixir_euler_blast_wave_shockcapturing.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blast_wave_shockcapturing.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blast_wave_shockcapturing.jl"),
     l2   = [0.13575932799459445, 0.11346025131402862, 0.11346028941202581, 0.33371846538168354],
     linf = [1.4662633480487193, 1.3203905049492335, 1.320390504949303, 1.8131376065886553],
     tspan = (0.0, 0.13))
   end
 
   @testset "elixir_euler_weak_blast_wave_shockcapturing.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_weak_blast_wave_shockcapturing.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_weak_blast_wave_shockcapturing.jl"),
     l2   = [0.053797693352771236, 0.0469609422046655, 0.04696357535470453, 0.19685219525959569],
     linf = [0.18540098690235163, 0.2402949901937739, 0.23266805976720523, 0.6874635927547934])
   end
 
   @testset "elixir_euler_blast_wave_shockcapturing_amr.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blast_wave_shockcapturing_amr.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blast_wave_shockcapturing_amr.jl"),
     l2   = [0.6778339184192986, 0.28136085729167076, 0.2813607687129121, 0.7202946425475186],
     linf = [2.8891939545999277, 1.8038083274644838, 1.8036523839220984, 3.0363712085327177],
     tspan = (0.0, 1.0))
   end
 
   @testset "elixir_euler_sedov_blast_wave_shockcapturing_amr.jl with tend = 1.0" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_sedov_blast_wave_shockcapturing_amr.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_sedov_blast_wave_shockcapturing_amr.jl"),
     l2   = [0.48179128651635356, 0.16552908046011455, 0.16553045844776362, 0.6182628255460497],
     linf = [2.4847876521233907, 1.2814307117459813, 1.2814769220593392, 6.474196250771773],
     tspan = (0.0, 1.0))
   end
 
   @testset "elixir_euler_blob_shockcapturing_amr.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blob_shockcapturing_amr.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blob_shockcapturing_amr.jl"),
       l2   = [0.2012143467980036, 1.1813241716700988, 0.10144725208346557, 5.230607564921326],
       linf = [14.111578610092542, 71.21944410118338, 7.304666476530256, 291.9385076318331],
       tspan = (0.0, 0.12))
@@ -133,12 +133,12 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
       # of random numbers is not guaranteed to be the same across different
       # minor versions of Julia.
       # See https://github.com/trixi-framework/Trixi.jl/issues/232#issuecomment-709738400
-      test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_khi_shockcapturing.jl"),
+      @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_khi_shockcapturing.jl"),
         l2   = [0.0020460050625351277, 0.0028624298590723372, 0.001971035381754319, 0.004814883331768111],
         linf = [0.02437585564403255, 0.018033033465721604, 0.00993916546672498, 0.02097263472404709],
         tspan = (0.0, 0.2))
     else
-      test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_khi_shockcapturing.jl"),
+      @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_khi_shockcapturing.jl"),
         tspan = (0.0, 0.2))
     end
   end
@@ -151,130 +151,130 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
       # of random numbers is not guaranteed to be the same across different
       # minor versions of Julia.
       # See https://github.com/trixi-framework/Trixi.jl/issues/232#issuecomment-709738400
-      test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_khi_shockcapturing_amr.jl"),
+      @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_khi_shockcapturing_amr.jl"),
         l2   = [0.001617236176233394, 0.0023394729603446697, 0.001296199247911843, 0.0033150160736185323],
         linf = [0.019002843896656074, 0.017242107049387223, 0.008179888370650977, 0.016885672229959958],
         tspan = (0.0, 0.2))
     else
-      test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_khi_shockcapturing_amr.jl"),
+      @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_khi_shockcapturing_amr.jl"),
         tspan = (0.0, 0.2))
     end
   end
 
   @testset "elixir_euler_vortex.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex.jl"),
     l2   = [3.6342636871275523e-6, 0.0032111366825032443, 0.0032111479254594345, 0.004545714785045611],
     linf = [7.903587114788113e-5, 0.030561314311228993, 0.030502600162385596, 0.042876297246817074])
   end
 
   @testset "elixir_euler_vortex_mortar.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_mortar.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_mortar.jl"),
     l2   = [2.120307461394424e-6, 2.7929229084570266e-5, 3.759342242369596e-5, 8.813646673773311e-5],
     linf = [5.9320459189771135e-5, 0.0007491265403041236, 0.0008165690047976515, 0.0022122638048145404])
   end
 
   @testset "elixir_euler_vortex_mortar_split.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_mortar_split.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_mortar_split.jl"),
     l2   = [2.1203693476896995e-6, 2.8053512416422296e-5, 3.76179445622429e-5, 8.840787521479401e-5],
     linf = [5.9005667252809424e-5, 0.0007554116730550398, 0.00081660478740464, 0.002209016304192346])
   end
 
   @testset "elixir_euler_vortex_mortar_split.jl with flux_central" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_mortar_split.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_mortar_split.jl"),
     l2   = [2.120307461409829e-6, 2.7929229084583212e-5, 3.759342242369501e-5, 8.813646673812448e-5],
     linf = [5.932045918888296e-5, 0.0007491265403021252, 0.0008165690047987617, 0.002212263804818093],
     volume_flux = flux_central)
   end
 
   @testset "elixir_euler_vortex_mortar_split.jl with flux_shima_etal" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_mortar_split.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_mortar_split.jl"),
     l2   = [2.120103291509122e-6, 2.805652562691104e-5, 3.759500428816484e-5, 8.841374592860891e-5],
     linf = [5.934103184424e-5, 0.0007552316820342853, 0.0008152449048961508, 0.002206987374638203],
     volume_flux = flux_shima_etal)
   end
 
   @testset "elixir_euler_vortex_mortar_split.jl with flux_ranocha" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_mortar_split.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_mortar_split.jl"),
     l2   = [2.1201032806889955e-6, 2.8056528074361895e-5, 3.759500957406334e-5, 8.841379428954133e-5],
     linf = [5.934027760512439e-5, 0.0007552314317718078, 0.0008152450117491217, 0.0022069976113101575],
     volume_flux = flux_ranocha)
   end
 
   @testset "elixir_euler_vortex_shockcapturing.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_shockcapturing.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_shockcapturing.jl"),
     l2   = [3.80342739421474e-6, 5.561118953968859e-5, 5.564042529709319e-5, 0.0001570628548096201],
     linf = [8.491382365727329e-5, 0.0009602965158113097, 0.0009669978616948516, 0.0030750353269972663])
   end
 
   @testset "elixir_euler_vortex_mortar_shockcapturing.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_mortar_shockcapturing.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_mortar_shockcapturing.jl"),
     l2   = [2.1203693476896995e-6, 2.8053512416422296e-5, 3.76179445622429e-5, 8.840787521479401e-5],
     linf = [5.9005667252809424e-5, 0.0007554116730550398, 0.00081660478740464, 0.002209016304192346])
   end
 
   @testset "elixir_euler_vortex_amr.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_amr.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_vortex_amr.jl"),
     l2   = [2.077084130934081e-6, 0.0032815991956917493, 0.0032807020145523757, 0.004646298951577697],
     linf = [4.435791998502747e-5, 0.03176757178286449, 0.031797053799604846, 0.045615287239808566])
   end
 
 
   @testset "elixir_mhd_alfven_wave.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_alfven_wave.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_alfven_wave.jl"),
     l2   = [0.00011134312019581907, 5.880417517656501e-6, 5.880417517683334e-6, 8.433533326833135e-6, 1.2944026635567339e-6, 1.2259080543012733e-6, 1.2259080543038862e-6, 1.8334999489680995e-6, 8.098795948637635e-7],
     linf = [0.0002678907090871707, 1.6257637592484442e-5, 1.6257637592095864e-5, 2.7343412701746894e-5, 5.327954748168828e-6, 8.10079419122367e-6, 8.100794191445715e-6, 1.2083599637696674e-5, 4.179907421413125e-6])
   end
 
   @testset "elixir_mhd_alfven_wave_mortar.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_alfven_wave_mortar.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_alfven_wave_mortar.jl"),
     l2   = [4.6108151315202035e-6, 1.6897860606321754e-6, 1.6208236429504275e-6, 1.6994662614575904e-6, 1.486435064660995e-6, 1.3875465211720615e-6, 1.3411325436690753e-6, 1.7155153011375413e-6, 9.813872476368202e-7],
     linf = [3.5225667207927636e-5, 1.5349379665866025e-5, 1.4264328575347429e-5, 1.4421439547898651e-5, 7.744170905765735e-6, 1.0187833250130396e-5, 9.861911995590056e-6, 1.6018139446766222e-5, 5.563892853177171e-6],
     tspan = (0.0, 1.0))
   end
 
   @testset "elixir_mhd_ec.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_ec.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_ec.jl"),
     l2   = [0.03628315925311581, 0.04301306535453907, 0.042998910996002976, 0.025746791646914315, 0.1620587870592711, 0.01745580631201365, 0.01745656644392971, 0.02688212902288343, 0.00014263322984147517],
     linf = [0.23504901239438747, 0.31563591777956146, 0.3094412744514615, 0.21177505529310434, 0.9738775041875032, 0.09120517132559702, 0.0919645047337756, 0.15691668358334432, 0.0035581030835232378])
   end
 
   @testset "elixir_mhd_orszag_tang_shockcapturing_amr.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_orszag_tang_shockcapturing_amr.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_orszag_tang_shockcapturing_amr.jl"),
     l2   = [0.21894721281911703, 0.26463302881957645, 0.31507117273918805, 0.0, 0.5152448296476039, 0.23023274798808147, 0.3441658797437742, 0.0, 0.0026733194007546126],
     linf = [1.2352286192592534, 0.6678377088690369, 0.8739431671403393, 0.0, 2.740788100988533, 0.6552251870441527, 0.9546253266155187, 0.0, 0.03816123862195953],
     tspan = (0.0, 0.09))
   end
 
   @testset "elixir_mhd_orszag_tang_shockcapturing_amr.jl with flux_hll" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_orszag_tang_shockcapturing_amr.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_orszag_tang_shockcapturing_amr.jl"),
     l2   = [0.10811766489910432, 0.20202956511451342, 0.22988158838731435, 0.0, 0.29953446216629687, 0.1570994904887061, 0.24308871328334844, 0.0, 0.011100323402918071],
     linf = [0.5520018702830969, 0.5101514485370506, 0.6565173233469559, 0.0, 0.9528527119850311, 0.3990329190790233, 0.6737022346309564, 0.0, 0.18244193667531056],
     tspan = (0.0, 0.06), surface_flux = flux_hll)
   end
 
   @testset "elixir_mhd_rotor_shockcapturing_amr.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_rotor_shockcapturing_amr.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_rotor_shockcapturing_amr.jl"),
     l2   = [1.2635449181120562, 1.8356372101225815, 1.7037178920138905, 0.0, 2.3126474248436755, 0.21626214510814928, 0.23683073618598693, 0.0, 0.002132844459180628],
     linf = [10.353812749882609, 14.287005221052532, 15.749922601372482, 0.0, 17.089103075830185, 1.342006287193983, 1.4341241435029897, 0.0, 0.053488038358224646],
     tspan = (0.0, 0.05))
   end
 
   @testset "elixir_mhd_blast_wave_shockcapturing_amr.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_blast_wave_shockcapturing_amr.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_blast_wave_shockcapturing_amr.jl"),
     l2   = [0.2101138028554417, 4.4379574949560014, 2.6239651859752238, 0.0, 359.15092246795564, 2.458555512327778, 1.4961525378625697, 0.0, 0.01346996306689436],
     linf = [2.4484577379812915, 63.229017006957584, 15.321798382742966, 0.0, 2257.8231751993367, 13.692356305778407, 10.026947993726841, 0.0, 0.2839557716528234],
     tspan = (0.0, 0.003))
   end
 
   @testset "elixir_euler_gravity_jeans_instability.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_gravity_jeans_instability.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_gravity_jeans_instability.jl"),
     l2   = [10733.633835505429, 13356.78041873671, 1.6035728244276416e-6, 26834.076946460955],
     linf = [15194.296496834606, 18881.481413976213, 7.967111441550177e-6, 37972.997184962034],
     tspan = (0.0, 0.1))
   end
 
   @testset "elixir_euler_gravity_sedov_blast_wave_shockcapturing_amr.jl" begin
-  test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_gravity_sedov_blast_wave_shockcapturing_amr.jl"),
+  @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_gravity_sedov_blast_wave_shockcapturing_amr.jl"),
     l2   = [0.04630745182870653, 0.06507397069667138, 0.06507397069667123, 0.48971269294890085],
     linf = [2.383463161765847, 4.0791883314039605, 4.07918833140396, 16.246070713311475],
     tspan = (0.0, 0.05))
@@ -344,7 +344,7 @@ end
 # Only run extended tests if environment variable is set
 if haskey(ENV, "TRIXI_TEST_EXTENDED") && lowercase(ENV["TRIXI_TEST_EXTENDED"]) in ("1", "on", "yes")
   @testset "Examples (long execution time)" begin
-    @test_nowarn test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blob_shockcapturing_mortar.jl"))
+    @test_nowarn @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blob_shockcapturing_mortar.jl"))
   end
 end
 

--- a/test/test_examples_3d.jl
+++ b/test/test_examples_3d.jl
@@ -17,46 +17,46 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
 # Run basic tests
 @testset "Examples 3D" begin
   @testset "elixir_advection_basic.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_basic.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_basic.jl"),
       l2   = [0.00015975754755823664],
       linf = [0.001503873297666436])
   end
 
   @testset "elixir_advection_amr.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr.jl"),
             l2   = [9.773858425669403e-6],
             linf = [0.0005853874124926092])
   end
 
 
   @testset "elixir_hyp_diff_llf.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hyp_diff_llf.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hyp_diff_llf.jl"),
       l2   = [0.0015303316090388799, 0.011314177033289297, 0.011314177033289444, 0.011314177033289696],
       linf = [0.02263459034012283, 0.10139777904690916, 0.10139777904690916, 0.10139777904690828],
       initial_refinement_level=2)
   end
 
   @testset "elixir_hyp_diff_nonperiodic.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hyp_diff_nonperiodic.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hyp_diff_nonperiodic.jl"),
       l2   = [0.00022868340901898148, 0.0007974312252173769, 0.0015035143230655171, 0.0015035143230655694],
       linf = [0.0016405261410663563, 0.0029871222930526976, 0.009410031618266146, 0.009410031618266146])
   end
 
 
   @testset "elixir_euler_source_terms.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms.jl"),
       l2   = [0.010323099666828388, 0.00972876713766357, 0.00972876713766343, 0.009728767137663324, 0.015080409341036285],
       linf = [0.034894880154510144, 0.03383545920056008, 0.033835459200560525, 0.03383545920054587, 0.06785780622711979])
   end
 
   @testset "elixir_euler_mortar.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_mortar.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_mortar.jl"),
       l2   = [0.0019011097544691046, 0.0018289464161846331, 0.0018289464161847266, 0.0018289464161847851, 0.0033547668596639966],
       linf = [0.011918626829790169, 0.011808582902362641, 0.01180858290237552, 0.011808582902357312, 0.024648094686513744])
   end
 
   @testset "elixir_euler_blob_amr.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blob_amr.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blob_amr.jl"),
       l2   = [0.04867856452253151, 0.2640486962336911, 0.0354927658652858, 0.03549276586528571, 1.0777274757408568],
       linf = [9.558543313792217, 49.4518309553356, 10.319859082570309, 10.319859082570487, 195.1066220797401],
       tspan = (0.0, 0.2))
@@ -64,14 +64,14 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
 
 
   @testset "elixir_mhd_ec.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_ec.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_ec.jl"),
       l2   = [0.017285648572570363, 0.01777055834391421, 0.01777055834391415, 0.017772303802227787, 0.07402246754850351, 0.010363311581708652, 0.010363311581708655, 0.010365244788128367, 0.00020795117986261875],
       linf = [0.26483877701302616, 0.3347840483592971, 0.3347840483592973, 0.3698107272043008, 1.2339463134928033, 0.09858876654056647, 0.09858876654056714, 0.10426402075606456, 0.008001763586594345])
   end
 
 
   @testset "elixir_eulergravity_eoc_test.jl" begin
-    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_eulergravity_eoc_test.jl"),
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_eulergravity_eoc_test.jl"),
       l2   = [0.00042767201750631214, 0.0004720121013484361, 0.00047201210134851195, 0.00047201210134847107, 0.0010986046486879376],
       linf = [0.003497353351708421, 0.0037653614087260756, 0.003765361408728074, 0.0037653614087242993, 0.008372792646797134],
       resid_tol = 1.0e-4, tspan = (0.0, 0.2))

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -45,9 +45,9 @@ end
 # Use a macro to avoid world age issues when defining new initial conditions etc.
 # inside an elixir.
 """
-    test_trixi_include(elixir; l2=nothing, linf=nothing,
-                               atol=10*eps(), rtol=0.001,
-                               parameters...)
+    @test_trixi_include(elixir; l2=nothing, linf=nothing,
+                                atol=10*eps(), rtol=0.001,
+                                parameters...)
 
 Test Trixi by calling `trixi_include(elixir; parameters...)`.
 By default, only the absence of error output is checked.
@@ -96,4 +96,3 @@ macro test_trixi_include(elixir, args...)
     println("\n\n")
   end
 end
-

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -29,53 +29,25 @@ function test_trixi_run(parameters_file; l2=nothing, linf=nothing, atol=200*eps(
 end
 
 
-"""
-    test_trixi_include(elixir; l2=nothing, linf=nothing, atol=10*eps(), rtol=0.001, parameters...)
-
-Test Trixi by calling `trixi_include(elixir; parameters...)`.
-By default, only the absence of error output is checked.
-If `l2` or `linf` are specified, in addition the resulting L2/Linf errors
-are compared approximately against these reference values, using `atol, rtol`
-as absolute/relative tolerance.
-"""
-function test_trixi_include(elixir; l2=nothing, linf=nothing,
-                                    atol=200*eps(), rtol=0.001,
-                                    kwargs...)
-
-  println("#"^80)
-  println(elixir)
-
-  # evaluate examples in the scope of the module they're called from
-  @test_nowarn trixi_include(@__MODULE__, elixir; kwargs...)
-
-  # If present, compare L2 and Linf errors against reference values
-  if !isnothing(l2) || !isnothing(linf)
-    l2_measured, linf_measured = analysis_callback(sol)
-
-    if !isnothing(l2)
-      for (l2_expected, l2_actual) in zip(l2, l2_measured)
-        @test isapprox(l2_expected, l2_actual, atol=atol, rtol=rtol)
-      end
-    end
-
-    if !isnothing(linf)
-      for (linf_expected, linf_actual) in zip(linf, linf_measured)
-        @test isapprox(linf_expected, linf_actual, atol=atol, rtol=rtol)
-      end
+# Get the first value assigned to `keyword` in `args` and return `default_value`
+# if there are no assignments to `keyword` in `args`.
+function get_kwarg(args, keyword, default_value)
+  val = default_value
+  for arg in args
+    if arg.head == :(=) && arg.args[1] == keyword
+      val = arg.args[2]
+      break
     end
   end
-
-  println("#"^80)
-  println("\n\n")
-
-  return nothing
+  return val
 end
 
-
-
-
+# Use a macro to avoid world age issues when defining new initial conditions etc.
+# inside an elixir.
 """
-    test_trixi_include(elixir; l2=nothing, linf=nothing, atol=10*eps(), rtol=0.001, parameters...)
+    test_trixi_include(elixir; l2=nothing, linf=nothing,
+                               atol=10*eps(), rtol=0.001,
+                               parameters...)
 
 Test Trixi by calling `trixi_include(elixir; parameters...)`.
 By default, only the absence of error output is checked.
@@ -123,18 +95,5 @@ macro test_trixi_include(elixir, args...)
     println("#"^80)
     println("\n\n")
   end
-end
-
-# Get the first value assigned to `keyword` in `args` and return `default_value`
-# if there are no assignments to `keyword` in `args`.
-function get_kwarg(args, keyword, default_value)
-  val = default_value
-  for arg in args
-    if arg.head == :(=) && arg.args[1] == keyword
-      val = arg.args[2]
-      break
-    end
-  end
-  return val
 end
 

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -30,23 +30,23 @@ end
 
 
 """
-    test_trixi_include(parameters_file; l2=nothing, linf=nothing, atol=10*eps(), rtol=0.001, parameters...)
+    test_trixi_include(elixir; l2=nothing, linf=nothing, atol=10*eps(), rtol=0.001, parameters...)
 
-Test Trixi by calling `trixi_include(parameters_file; parameters...)`.
+Test Trixi by calling `trixi_include(elixir; parameters...)`.
 By default, only the absence of error output is checked.
 If `l2` or `linf` are specified, in addition the resulting L2/Linf errors
 are compared approximately against these reference values, using `atol, rtol`
 as absolute/relative tolerance.
 """
-function test_trixi_include(parameters_file; l2=nothing, linf=nothing,
-                                             atol=200*eps(), rtol=0.001,
-                                             kwargs...)
+function test_trixi_include(elixir; l2=nothing, linf=nothing,
+                                    atol=200*eps(), rtol=0.001,
+                                    kwargs...)
 
   println("#"^80)
-  println(parameters_file)
+  println(elixir)
 
   # evaluate examples in the scope of the module they're called from
-  @test_nowarn trixi_include(@__MODULE__, parameters_file; kwargs...)
+  @test_nowarn trixi_include(@__MODULE__, elixir; kwargs...)
 
   # If present, compare L2 and Linf errors against reference values
   if !isnothing(l2) || !isnothing(linf)
@@ -70,3 +70,71 @@ function test_trixi_include(parameters_file; l2=nothing, linf=nothing,
 
   return nothing
 end
+
+
+
+
+"""
+    test_trixi_include(elixir; l2=nothing, linf=nothing, atol=10*eps(), rtol=0.001, parameters...)
+
+Test Trixi by calling `trixi_include(elixir; parameters...)`.
+By default, only the absence of error output is checked.
+If `l2` or `linf` are specified, in addition the resulting L2/Linf errors
+are compared approximately against these reference values, using `atol, rtol`
+as absolute/relative tolerance.
+"""
+macro test_trixi_include(elixir, args...)
+
+  local l2   = get_kwarg(args, :l2, nothing)
+  local linf = get_kwarg(args, :linf, nothing)
+  local atol = get_kwarg(args, :atol, 200*eps())
+  local rtol = get_kwarg(args, :rtol, 0.001)
+  local kwargs = Pair{Symbol, Any}[]
+  for arg in args
+    if arg.head == :(=) && !(arg.args[1] in (:l2, :linf, :atol, :rtol))
+      push!(kwargs, Pair(arg.args...))
+    end
+  end
+
+  quote
+    println("#"^80)
+    println($elixir)
+
+    # evaluate examples in the scope of the module they're called from
+    @test_nowarn trixi_include(@__MODULE__, $elixir; $kwargs...)
+
+    # if present, compare l2 and linf errors against reference values
+    if !isnothing($l2) || !isnothing($linf)
+      l2_measured, linf_measured = analysis_callback(sol)
+
+      if !isnothing($l2)
+        for (l2_expected, l2_actual) in zip($l2, l2_measured)
+          @test isapprox(l2_expected, l2_actual, atol=$atol, rtol=$rtol)
+        end
+      end
+
+      if !isnothing($linf)
+        for (linf_expected, linf_actual) in zip($linf, linf_measured)
+          @test isapprox(linf_expected, linf_actual, atol=$atol, rtol=$rtol)
+        end
+      end
+    end
+
+    println("#"^80)
+    println("\n\n")
+  end
+end
+
+# Get the first value assigned to `keyword` in `args` and return `default_value`
+# if there are no assignments to `keyword` in `args`.
+function get_kwarg(args, keyword, default_value)
+  val = default_value
+  for arg in args
+    if arg.head == :(=) && arg.args[1] == keyword
+      val = arg.args[2]
+      break
+    end
+  end
+  return val
+end
+


### PR DESCRIPTION
I've rewritten `test_trixi_include` as a macro to allow defining the IC for Jeans instability in the elixir without world age issues when running tests.