### PR TITLE
confirm elixir_euler_blob_shockcapturing_mortar.jl

### DIFF
--- a/examples/2d/elixir_euler_blob_shockcapturing_mortar.jl
+++ b/examples/2d/elixir_euler_blob_shockcapturing_mortar.jl
@@ -14,7 +14,7 @@ volume_flux  = flux_chandrashekar
 basis = LobattoLegendreBasis(3)
 
 indicator_sc = IndicatorHennemannGassner(equations, basis,
-                                         alpha_max=0.5,
+                                         alpha_max=0.05,
                                          alpha_min=0.0001,
                                          alpha_smooth=true,
                                          variable=pressure)
@@ -28,6 +28,7 @@ solver = DGSEM(basis, surface_flux, volume_integral)
 coordinates_min = (-32, -32)
 coordinates_max = ( 32,  32)
 refinement_patches = (
+  (type="box", coordinates_min=(-40, -5), coordinates_max=(40, 5)),
   (type="box", coordinates_min=(-40, -5), coordinates_max=(40, 5)),
 )
 mesh = TreeMesh(coordinates_min, coordinates_max,
@@ -46,7 +47,9 @@ ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 
-stepsize_callback = StepsizeCallback(cfl=0.7)
+# FIXME Taal restore after Taam sync
+# stepsize_callback = StepsizeCallback(cfl=0.7)
+stepsize_callback = StepsizeCallback(cfl=0.5)
 
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
@@ -65,6 +68,7 @@ callbacks = CallbackSet(summary_callback, stepsize_callback,
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/2d/parameters_euler_blob_shockcapturing_mortar.toml
+++ b/examples/2d/parameters_euler_blob_shockcapturing_mortar.toml
@@ -2,7 +2,7 @@
 # Simulation
 ndims = 2
 equations = "CompressibleEulerEquations"
-gamma = 1.66667
+gamma = 1.6666666666666667
 # equations = "LinearScalarAdvectionEquation"
 # advectionvelocity = [1.0, 1.0] # Need only for linarscalaradvection
 # initial_condition = "initial_condition_convergence_test"

--- a/test/test_examples_2d.jl
+++ b/test/test_examples_2d.jl
@@ -158,6 +158,13 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
     tspan = (0.0, 1.0))
   end
 
+  @testset "taal-confirmed elixir_euler_blob_shockcapturing_mortar.jl" begin
+    test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blob_shockcapturing_mortar.jl"),
+      l2   = [0.22114610074017435, 0.6275613030540599, 0.24325218693791564, 2.925865235621878],
+      linf = [10.524011747446043, 27.512527136693347, 9.454054943042742, 97.53367336970214],
+      tspan = (0.0, 0.5))
+  end
+
   @testset "taal-check-me cfl-magic elixir_euler_blob_shockcapturing_amr.jl" begin
   # Gregor and Hendrik say: Results match only with CFL = 0.2 (ref values not yet updated)
     test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blob_shockcapturing_amr.jl"),
@@ -496,13 +503,6 @@ end
   @test_nowarn display(alive_callback)
 
   @test_nowarn println(callbacks)
-end
-
-# Only run extended tests if environment variable is set
-if haskey(ENV, "TRIXI_TEST_EXTENDED") && lowercase(ENV["TRIXI_TEST_EXTENDED"]) in ("1", "on", "yes")
-  @testset "Examples (long execution time)" begin
-    @test_nowarn test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blob_shockcapturing_mortar.jl"))
-  end
 end
 
 # Clean up afterwards: delete Trixi output directory

--- a/test/test_examples_2d_old.jl
+++ b/test/test_examples_2d_old.jl
@@ -187,6 +187,12 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
             linf = [0.022479473484114054, 0.015056172762090259, 0.0070761455651367836, 0.01461791479513419],
             t_end = 0.2)
   end
+  @testset "taal-confirmed parameters_euler_blob_shockcapturing_mortar.toml" begin
+    test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_blob_shockcapturing_mortar.toml"),
+            l2   = [0.22114615931709608, 0.6275614586395163, 0.24325207085080508, 2.9258710844826785],
+            linf = [10.524044134146688, 27.5126438384907, 9.454012378298625, 97.53392910067888],
+            t_end = 0.5)
+  end
   @testset "taal-check-me cfl-magic parameters_euler_blob_shockcapturing_amr.toml" begin
   # Gregor and Hendrik say: Results match only with CFL = 0.2 (ref values not yet updated)
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_blob_shockcapturing_amr.toml"),
@@ -343,15 +349,6 @@ end
             l2   = [0.17537979197656783, 3.85063790427908, 2.475262063280408, 0.0, 355.77751756307794, 2.35355645151502, 1.3962841115302977, 0.0, 0.02800989397835333],
             linf = [1.5861429668357858, 44.06819961699249, 12.86121814597942, 0.0, 2240.622032533027, 13.20064555739219, 8.990518759210023, 0.0, 0.5100373526240609],
             t_end = 0.003)
-  end
-end
-
-
-# Only run extended tests if environment variable is set
-if haskey(ENV, "TRIXI_TEST_EXTENDED") && lowercase(ENV["TRIXI_TEST_EXTENDED"]) in ("1", "on", "yes")
-  @testset "Examples (long execution time)" begin
-    @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_euler_blob_shockcapturing_mortar.toml"))
-    @test_nowarn Trixi.run(joinpath(EXAMPLES_DIR, "parameters_euler_ec_mortar.toml"))
   end
 end
 

--- a/test/test_examples_3d_old.jl
+++ b/test/test_examples_3d_old.jl
@@ -210,7 +210,8 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
             l2   = [0.0043911605751115424, 0.04144735653371165, 0.04150129965650717, 0.04150353600000829, 0.036931197750736805, 0.021125598820694595, 0.032956068087418154, 0.03296235602392588, 6.318083915607208e-6],
             linf = [0.01789383976134809, 0.08496187610572214, 0.08909116075943745, 0.08505952838326755, 0.10443373959204932, 0.05387852204182135, 0.08812990990777562, 0.07804874749131957, 8.138512446081734e-5],
             t_end = 0.06)
-  end  # too expensive for CI
+  end
+  # too expensive for CI
   # @testset "taal-check-me parameters_euler_sedov_blast_wave_shockcapturing_amr.toml with n_steps_max = 2" begin
   #   test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_sedov_blast_wave_shockcapturing_amr.toml"),
   #           l2   = [0.00015213881280510253, 0.001481110249423103, 0.0014811102494231387, 0.001481110249423187, 0.002940437008367858],


### PR DESCRIPTION
I've confirmed `examples/2d/elixir_euler_blob_shockcapturing_mortar.jl` and assimilated the extended tests into the normal tests. After more than 1000 time steps, I get
```julia
julia> verify_taal("examples/2d/parameters_euler_blob_shockcapturing_mortar.toml",
                   "examples/2d/elixir_euler_blob_shockcapturing_mortar.jl",
                   t_end=10.0)
[...]
================================================================================
L2 (Taam - Taal):
4-element StaticArrays.SArray{Tuple{4},Float64,1,4} with indices SOneTo(4):
 3.608224830031759e-16
 9.2148511043888e-15
 3.608224830031759e-16
 2.3092638912203256e-14
================================================================================
Linf (Taam - Taal):
4-element StaticArrays.SArray{Tuple{4},Float64,1,4} with indices SOneTo(4):
 8.881784197001252e-15
 2.4300561562995426e-12
 3.455014052633487e-13
 1.3528733688872308e-11
================================================================================
```
That's okay, I think.

Closes #243.