### PR TITLE
Resolve CFL magic

### DIFF
--- a/examples/1d/elixir_euler_sedov_blast_wave_shockcapturing_amr.jl
+++ b/examples/1d/elixir_euler_sedov_blast_wave_shockcapturing_amr.jl
@@ -55,7 +55,7 @@ amr_callback = AMRCallback(semi, amr_controller,
 summary_callback = SummaryCallback()
 
 # FIXME Taal restore after Taam sync: increase value with new timestep size calculation?
-stepsize_callback = StepsizeCallback(cfl=0.5)
+stepsize_callback = StepsizeCallback(cfl=0.3)
 
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,

--- a/examples/1d/parameters_euler_sedov_blast_wave_shockcapturing_amr.toml
+++ b/examples/1d/parameters_euler_sedov_blast_wave_shockcapturing_amr.toml
@@ -14,7 +14,7 @@ t_end   = 12.5
 # Solver
 solver = "dg"
 polydeg = 3
-cfl = 0.5
+cfl = 0.3
 n_steps_max = 10000
 analysis_interval = 1000
 volume_integral_type = "shock_capturing"

--- a/examples/2d/elixir_euler_blob_shockcapturing_amr.jl
+++ b/examples/2d/elixir_euler_blob_shockcapturing_amr.jl
@@ -58,7 +58,8 @@ amr_callback = AMRCallback(semi, amr_controller,
                            adapt_initial_condition=true,
                            adapt_initial_condition_only_refine=true)
 
-stepsize_callback = StepsizeCallback(cfl=0.3)
+# FIXME Taal restore after Taam sync
+stepsize_callback = StepsizeCallback(cfl=0.2)
 
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,

--- a/examples/2d/elixir_mhd_blast_wave_shockcapturing_amr.jl
+++ b/examples/2d/elixir_mhd_blast_wave_shockcapturing_amr.jl
@@ -53,6 +53,7 @@ amr_callback = AMRCallback(semi, amr_controller,
                            adapt_initial_condition=true,
                            adapt_initial_condition_only_refine=true)
 
+# FIXME Taal restore after Taam sync
 stepsize_callback = StepsizeCallback(cfl=0.2)
 
 save_solution = SaveSolutionCallback(interval=100,

--- a/examples/2d/elixir_mhd_orszag_tang_shockcapturing_amr.jl
+++ b/examples/2d/elixir_mhd_orszag_tang_shockcapturing_amr.jl
@@ -53,6 +53,7 @@ amr_callback = AMRCallback(semi, amr_controller,
                            adapt_initial_condition=true,
                            adapt_initial_condition_only_refine=true)
 
+# FIXME Taal restore after Taam sync
 stepsize_callback = StepsizeCallback(cfl=0.25)
 
 save_solution = SaveSolutionCallback(interval=100,

--- a/examples/2d/elixir_mhd_rotor_shockcapturing_amr.jl
+++ b/examples/2d/elixir_mhd_rotor_shockcapturing_amr.jl
@@ -54,6 +54,7 @@ amr_callback = AMRCallback(semi, amr_controller,
                            adapt_initial_condition=true,
                            adapt_initial_condition_only_refine=true)
 
+# FIXME Taal restore after Taam sync
 stepsize_callback = StepsizeCallback(cfl=0.2)
 
 save_solution = SaveSolutionCallback(interval=100,

--- a/examples/2d/parameters_euler_blob_shockcapturing_amr.toml
+++ b/examples/2d/parameters_euler_blob_shockcapturing_amr.toml
@@ -14,7 +14,7 @@ t_end   = 8.0
 # Solver
 solver = "dg"
 polydeg = 4
-cfl = 0.3
+cfl = 0.2
 n_steps_max = 15000
 analysis_interval = 100
 shock_indicator_variable = "pressure"

--- a/examples/paper-self-gravitating-gas-dynamics/elixir_eulergravity_sedov_blast_wave.jl
+++ b/examples/paper-self-gravitating-gas-dynamics/elixir_eulergravity_sedov_blast_wave.jl
@@ -83,7 +83,6 @@ amr_callback = AMRCallback(semi, amr_controller,
                            adapt_initial_condition_only_refine=true)
 
 # FIXME Taal restore after Taam sync
-# stepsize_callback = StepsizeCallback(cfl=1.0)
 stepsize_callback = StepsizeCallback(cfl=0.5)
 
 save_solution = SaveSolutionCallback(interval=100,

--- a/test/test_examples_1d.jl
+++ b/test/test_examples_1d.jl
@@ -102,25 +102,21 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
 
   @testset "taal-confirmed elixir_euler_sedov_blast_wave_shockcapturing_amr.jl" begin
     test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_sedov_blast_wave_shockcapturing_amr.jl"),
-      l2   = [1.2500050612446159, 0.06878411345533555, 0.9447942342833009],
-      linf = [2.9791692123401017, 0.1683336841958163, 2.665578807135144])
+      l2   = [1.252250990134887, 0.068566581088377, 0.9448804645921002],
+      linf = [2.989362275712484, 0.16948139637812973, 2.665646470846281])
   end
 
-  @testset "taal-check-me cfl-magic elixir_euler_sedov_blast_wave_shockcapturing_amr.jl with pressure" begin
-    # Michael says: Results match only with CFL = 0.3 (ref values not yet updated)
-    # Note: this test currently passes due to our tolerances being too large
+  @testset "taal-confirmed elixir_euler_sedov_blast_wave_shockcapturing_amr.jl with pressure" begin
     test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_sedov_blast_wave_shockcapturing_amr.jl"),
-      l2   = [1.2974912081242604, 0.07965704393481755, 0.9453618260835944],
-      linf = [3.1823155476320926, 0.21380426507857242, 2.6650734792251995],
+      l2   = [1.297435677146544, 0.07960523576439762, 0.9453356096003658],
+      linf = [3.1803117766542313, 0.21385627917778924, 2.665017066963603],
       shock_indicator_variable = pressure)
   end
 
-  @testset "taal-check-me cfl-magic elixir_euler_sedov_blast_wave_shockcapturing_amr.jl with density" begin
-    # Michael says: Results match only with CFL = 0.3 (ref values not yet updated)
-    # Note: this test currently passes due to our tolerances being too large
+  @testset "taal-confirmed elixir_euler_sedov_blast_wave_shockcapturing_amr.jl with density" begin
     test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_sedov_blast_wave_shockcapturing_amr.jl"),
-      l2   = [1.2797014548135697, 0.07077838776630381, 0.9457917493772532],
-      linf = [3.117424382044245, 0.17775688760995997, 2.666854886766347],
+      l2   = [1.2778131494486642, 0.0709461986289949, 0.9456057083034296],
+      linf = [3.1163652756237115, 0.17652352860779985, 2.66646958937844],
       shock_indicator_variable = density)
   end
 

--- a/test/test_examples_1d_old.jl
+++ b/test/test_examples_1d_old.jl
@@ -80,19 +80,19 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
   end
   @testset "taal-confirmed parameters_euler_sedov_blast_wave_shockcapturing_amr.toml" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_sedov_blast_wave_shockcapturing_amr.toml"),
-            l2   = [1.2500050612446159, 0.06878411345533555, 0.9447942342833009],
-            linf = [2.9791692123401017, 0.1683336841958163, 2.665578807135144])
+            l2   = [1.252250990134887, 0.068566581088377, 0.9448804645921002],
+            linf = [2.989362275712484, 0.16948139637812973, 2.665646470846281])
   end
-  @testset "taal-check-me cfl-magic parameters_euler_sedov_blast_wave_shockcapturing_amr.toml with pressure" begin
+  @testset "taal-confirmed parameters_euler_sedov_blast_wave_shockcapturing_amr.toml with pressure" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_sedov_blast_wave_shockcapturing_amr.toml"),
-            l2   = [1.2974912081242604, 0.07965704393481755, 0.9453618260835944],
-            linf = [3.1823155476320926, 0.21380426507857242, 2.6650734792251995],
+            l2   = [1.297435677146544, 0.07960523576439762, 0.9453356096003658],
+            linf = [3.1803117766542313, 0.21385627917778924, 2.665017066963603],
             shock_indicator_variable = "pressure")
   end
-  @testset "taal-check-me cfl-magic parameters_euler_sedov_blast_wave_shockcapturing_amr.toml with density" begin
+  @testset "taal-confirmed parameters_euler_sedov_blast_wave_shockcapturing_amr.toml with density" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_sedov_blast_wave_shockcapturing_amr.toml"),
-            l2   = [1.2797014548135697, 0.07077838776630381, 0.9457917493772532],
-            linf = [3.117424382044245, 0.17775688760995997, 2.666854886766347],
+            l2   = [1.2778131494486642, 0.0709461986289949, 0.9456057083034296],
+            linf = [3.1163652756237115, 0.17652352860779985, 2.66646958937844],
             shock_indicator_variable = "density")
   end
   @testset "taal-confirmed parameters_euler_weak_blast_wave_shockcapturing.toml" begin

--- a/test/test_examples_2d.jl
+++ b/test/test_examples_2d.jl
@@ -165,11 +165,10 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
       tspan = (0.0, 0.5))
   end
 
-  @testset "taal-check-me cfl-magic elixir_euler_blob_shockcapturing_amr.jl" begin
-  # Gregor and Hendrik say: Results match only with CFL = 0.2 (ref values not yet updated)
+  @testset "taal-confirmed elixir_euler_blob_shockcapturing_amr.jl" begin
     test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_blob_shockcapturing_amr.jl"),
-      l2   = [0.2012143467980036, 1.1813241716700988, 0.10144725208346557, 5.230607564921326],
-      linf = [14.111578610092542, 71.21944410118338, 7.304666476530256, 291.9385076318331],
+      l2   = [0.2016728420174888, 1.1836138789789359, 0.10165086496270354, 5.237367755805095],
+      linf = [14.085819993255987, 71.07473800830421, 7.366144023918916, 297.24197965204814],
       tspan = (0.0, 0.12))
   end
 
@@ -406,19 +405,17 @@ end
       initial_condition = initial_condition_constant)
   end
 
-  @testset "taal-check-me cfl-magic elixir_mhd_rotor_shockcapturing_amr.jl" begin
-  # Andrew and Michael say: Results match only with CFL = 0.2 (ref values not yet updated)
+  @testset "taal-confirmed elixir_mhd_rotor_shockcapturing_amr.jl" begin
   test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_rotor_shockcapturing_amr.jl"),
-    l2   = [1.2635449181120562, 1.8356372101225815, 1.7037178920138905, 0.0, 2.3126474248436755, 0.21626214510814928, 0.23683073618598693, 0.0, 0.002132844459180628],
-    linf = [10.353812749882609, 14.287005221052532, 15.749922601372482, 0.0, 17.089103075830185, 1.342006287193983, 1.4341241435029897, 0.0, 0.053488038358224646],
+    l2   = [1.2428140306560267, 1.7997194450337968, 1.6900291785233619, 0.0, 2.2634513724749357, 0.212710214030601, 0.233276208669814, 0.0, 0.0026495769095112244],
+    linf = [10.47092272020676, 14.061476930703114, 15.55246880748034, 0.0, 16.619962600809156, 1.3033533536346604, 1.4125607690546562, 0.0, 0.07338769474671016],
     tspan = (0.0, 0.05))
   end
 
-  @testset "taal-check-me cfl-magic elixir_mhd_blast_wave_shockcapturing_amr.jl" begin
-  # Andrew and Michael say: Results match only with CFL = 0.2 (ref values not yet updated)
+  @testset "taal-confirmed elixir_mhd_blast_wave_shockcapturing_amr.jl" begin
   test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_blast_wave_shockcapturing_amr.jl"),
-    l2   = [0.2101138028554417, 4.4379574949560014, 2.6239651859752238, 0.0, 359.15092246795564, 2.458555512327778, 1.4961525378625697, 0.0, 0.01346996306689436],
-    linf = [2.4484577379812915, 63.229017006957584, 15.321798382742966, 0.0, 2257.8231751993367, 13.692356305778407, 10.026947993726841, 0.0, 0.2839557716528234],
+    l2   = [0.1757875762080873, 3.8532519959458216, 2.4727214755520532, 0.0, 355.0835842161213, 2.3454068130466776, 1.3916366548136, 0.0, 0.028930416439621368],
+    linf = [1.5948842870594393, 44.31605592215359, 12.854945034752436, 0.0, 2207.513124699695, 12.706623740109995, 8.987432397883575, 0.0, 0.4980365769225257],
     tspan = (0.0, 0.003))
   end
 end

--- a/test/test_examples_2d_old.jl
+++ b/test/test_examples_2d_old.jl
@@ -193,11 +193,10 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
             linf = [10.524044134146688, 27.5126438384907, 9.454012378298625, 97.53392910067888],
             t_end = 0.5)
   end
-  @testset "taal-check-me cfl-magic parameters_euler_blob_shockcapturing_amr.toml" begin
-  # Gregor and Hendrik say: Results match only with CFL = 0.2 (ref values not yet updated)
+  @testset "taal-confirmed parameters_euler_blob_shockcapturing_amr.toml" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_euler_blob_shockcapturing_amr.toml"),
-            l2   = [0.20079146298714926, 1.178526565356443, 0.1011961418887176, 5.2218453410238554],
-            linf = [14.056399346555613, 70.84481014603705, 7.154598484845931, 296.78986167690556],
+            l2   = [0.2016728420174888, 1.1836138789789359, 0.10165086496270354, 5.237367755805095],
+            linf = [14.085819993255987, 71.07473800830421, 7.366144023918916, 297.24197965204814],
             t_end = 0.12)
   end
   @testset "taal-confirmed parameters_mhd_orszag_tang.toml" begin
@@ -336,18 +335,16 @@ end
             n_steps_max = 1,
             initial_condition = "initial_condition_constant")
   end
-  @testset "taal-check-me cfl-magic parameters_mhd_rotor.toml" begin
-    # Andrew and Michael say: Results match only with CFL = 0.2 (ref values not yet updated)
+  @testset "taal-confirmed parameters_mhd_rotor.toml" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_mhd_rotor.toml"),
-            l2   = [1.251062755110083, 1.8146501210703296, 1.6947702119211985, 0.0, 2.286126233832582, 0.2142656906510094, 0.23453619782492716, 0.0, 0.003028222728287231],
-            linf = [10.472575582440642, 14.089807317509075, 15.561008992418031, 0.0, 16.731740428408308, 1.3219222046920664, 1.4167075971532137, 0.0, 0.08046487935486654],
+            l2   = [1.2428140306560267, 1.7997194450337968, 1.6900291785233619, 0.0, 2.2634513724749357, 0.212710214030601, 0.233276208669814, 0.0, 0.0026495769095112244],
+            linf = [10.47092272020676, 14.061476930703114, 15.55246880748034, 0.0, 16.619962600809156, 1.3033533536346604, 1.4125607690546562, 0.0, 0.07338769474671016],
             t_end = 0.05)
   end
-  @testset "taal-check-me cfl-magic parameters_mhd_blast_wave.toml" begin
-    # Andrew and Michael say: Results match only with CFL = 0.2 (ref values not yet updated)
+  @testset "taal-confirmed parameters_mhd_blast_wave.toml" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_mhd_blast_wave.toml"),
-            l2   = [0.17537979197656783, 3.85063790427908, 2.475262063280408, 0.0, 355.77751756307794, 2.35355645151502, 1.3962841115302977, 0.0, 0.02800989397835333],
-            linf = [1.5861429668357858, 44.06819961699249, 12.86121814597942, 0.0, 2240.622032533027, 13.20064555739219, 8.990518759210023, 0.0, 0.5100373526240609],
+            l2   = [0.1757875762080873, 3.8532519959458216, 2.4727214755520532, 0.0, 355.0835842161213, 2.3454068130466776, 1.3916366548136, 0.0, 0.028930416439621368],
+            linf = [1.5948842870594393, 44.31605592215359, 12.854945034752436, 0.0, 2207.513124699695, 12.706623740109995, 8.987432397883575, 0.0, 0.4980365769225257],
             t_end = 0.003)
   end
 end

--- a/test/test_paper-self-gravitating-gas-dynamics-old.jl
+++ b/test/test_paper-self-gravitating-gas-dynamics-old.jl
@@ -75,7 +75,7 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
             t_end=0.1, time_integration_scheme_gravity="timestep_gravity_erk53_3Sstar!")
   end
 
-  @testset "taal-confirmed cfl-magic parameters_eulergravity_jeans_instability.toml" begin
+  @testset "taal-confirmed parameters_eulergravity_jeans_instability.toml" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_eulergravity_jeans_instability.toml"),
             l2   = [10734.053145404043, 13357.12732236844, 1.7837692768650575e-6, 26835.12522125218],
             linf = [15194.889944849536, 18881.971585248222, 8.201044698652684e-6, 37974.48081559688],
@@ -89,7 +89,7 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
             t_end=0.1, update_gravity_once_per_stage=false)
   end
 
-  @testset "taal-confirmed cfl-magic parameters_eulergravity_jeans_instability.toml with RK3S*" begin
+  @testset "taal-confirmed parameters_eulergravity_jeans_instability.toml with RK3S*" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_eulergravity_jeans_instability.toml"),
             l2   = [10734.45053135681, 13358.158052105966, 2.77477865977926e-6, 26836.118686572947],
             linf = [15195.451977761462, 18883.428246416606, 1.2227873818940334e-5, 37975.88590713963],
@@ -99,15 +99,15 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
 
   @testset "taal-confirmed parameters_eulergravity_sedov_blast_wave.toml" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_eulergravity_sedov_blast_wave.toml"),
-            l2   = [0.04630745182870653, 0.06507397069667138, 0.06507397069667123, 0.48971269294890085],
-            linf = [2.3861430058270847, 4.083635578775231, 4.083635578775232, 16.246070713311475],
+            l2   = [0.04630745182870653, 0.06507397069667135, 0.06507397069667123, 0.4897126929489009],
+            linf = [2.3861430058270825, 4.083635578775232, 4.083635578775231, 16.246070713311482],
             t_end=0.05)
   end
 
   @testset "taal-confirmed parameters_eulergravity_sedov_blast_wave.toml with amr_interval=0 and ref-level=8" begin
     test_trixi_run(joinpath(EXAMPLES_DIR, "parameters_eulergravity_sedov_blast_wave.toml"),
-            l2   = [0.0028922121586238323, 0.013724796675028317, 0.013724796675028307, 0.05822941648860658],
-            linf = [0.26747911779347966, 1.385822018653034, 1.385822018653034, 4.071204772447614],
+            l2   = [0.002892212158623831, 0.013724796675028317, 0.013724796675028307, 0.05822941648860658],
+            linf = [0.26747911779347944, 1.3858220186530343, 1.3858220186530334, 4.071204772447612],
             t_end=0.005, amr_interval=0, initial_refinement_level=8)
   end
 end

--- a/test/test_paper-self-gravitating-gas-dynamics.jl
+++ b/test/test_paper-self-gravitating-gas-dynamics.jl
@@ -1,4 +1,4 @@
-module TestExamples2D
+module TestPaperSelfgravitatingGasDynamics
 
 using Test
 using Trixi
@@ -73,14 +73,14 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
   end
 
 
-  @testset "taal-confirmed cfl-magic elixir_eulergravity_jeans_instability.jl" begin
+  @testset "taal-confirmed elixir_eulergravity_jeans_instability.jl" begin
     test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_eulergravity_jeans_instability.jl"),
       l2   = [10733.634574440104, 13356.777246273672, 1.9930894028451876e-6, 26834.07879379781],
       linf = [15194.297536645085, 18881.47693900588, 8.325325156694497e-6, 37972.99978450313],
       tspan = (0.0, 0.1))
   end
 
-  @testset "taal-confirmed cfl-magic elixir_eulergravity_jeans_instability.jl with RK3S*" begin
+  @testset "taal-confirmed elixir_eulergravity_jeans_instability.jl with RK3S*" begin
     test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_eulergravity_jeans_instability.jl"),
       l2   = [10734.59878993429, 13358.214052395579, 2.7246732181080924e-6, 26836.489332980615],
       linf = [15195.661845114082, 18883.507539561684, 1.1096401891274226e-5, 37976.4105797708],
@@ -94,22 +94,17 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
   end
 
 
-  @testset "taal-confirmed cfl-magic elixir_eulergravity_sedov_blast_wave.jl" begin
-    # Reducing the CFL number reduces the differences between Taam and Taal.
-    # Using Trixi.solve(ode, Trixi.CarpenterKennedy2N54() instead of
-    # solve(ode, CarpenterKennedy2N54(williamson_condition=false)
-    # reduces the differences even further (often a factor of ca. 2).
+  @testset "taal-confirmed elixir_eulergravity_sedov_blast_wave.jl" begin
     test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_eulergravity_sedov_blast_wave.jl"),
-      l2   = [0.04630745182870653, 0.06507397069667138, 0.06507397069667123, 0.48971269294890085],
-      linf = [2.3861430058270847, 4.083635578775231, 4.083635578775232, 16.246070713311475],
+      l2   = [0.04630745182888786, 0.06507397069616608, 0.0650739706961657, 0.48971269294846076],
+      linf = [2.386143005917894, 4.083635578827995, 4.0836355788279946, 16.24607071330087],
       tspan = (0.0, 0.05))
   end
 
-  @testset "taal-confirmed cfl-magic elixir_eulergravity_sedov_blast_wave.jl with amr_interval=0 and ref-level=8" begin
-    # Same comments as for `elixir_eulergravity_sedov_blast_wave.jl` with default settings
+  @testset "taal-confirmed elixir_eulergravity_sedov_blast_wave.jl with amr_interval=0 and ref-level=8" begin
     test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_eulergravity_sedov_blast_wave.jl"),
-      l2   = [0.0028922121586238323, 0.013724796675028317, 0.013724796675028307, 0.05822941648860658],
-      linf = [0.26747911779347966, 1.385822018653034, 1.385822018653034, 4.071204772447614],
+      l2   = [0.0028922121586240916, 0.013724796675028319, 0.013724796675028305, 0.05822941648860658],
+      linf = [0.26747911779347966, 1.3858220186530341, 1.3858220186530337, 4.0712047724476115],
       tspan = (0.0, 0.005), initial_refinement_level=8, amr_callback=TrivialCallback())
   end
 end


### PR DESCRIPTION
I've marked the `cfl-magic` examples as resolved. For most of them, I just switched to the more robust CFL number. The Euler+gravity examples are also sensitive to the choice of `resid_tol`, but I didn't change that.