### PR TITLE
set sol.t correctly in home brewed integrators

### DIFF
--- a/src/time_integration/methods_2N.jl
+++ b/src/time_integration/methods_2N.jl
@@ -158,7 +158,7 @@ function solve!(integrator::SimpleIntegrator2N)
     end
   end
 
-  return (t=prob.tspan,
+  return (t=(first(prob.tspan), integrator.t),
           u=(copy(prob.u0), copy(integrator.u)),
           prob=integrator.sol.prob)
 end

--- a/src/time_integration/methods_3Sstar.jl
+++ b/src/time_integration/methods_3Sstar.jl
@@ -196,7 +196,7 @@ function solve!(integrator::SimpleIntegrator3Sstar)
     end
   end
 
-  return (t=prob.tspan,
+  return (t=(first(prob.tspan), integrator.t),
           u=(copy(prob.u0), copy(integrator.u)),
           prob=integrator.sol.prob)
 end


### PR DESCRIPTION
That's consistent if the integration is terminated earlier, e.g. by a steady state callback.