### PR TITLE
Support conversion of conservative variables to arbitrary variables in SaveSolutionCallback

### DIFF
--- a/examples/1d/elixir_advection_amr.jl
+++ b/examples/1d/elixir_advection_amr.jl
@@ -43,7 +43,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_controller = ControllerThreeLevel(semi, IndicatorMax(semi, variable=first),
                                       base_level=4,

--- a/examples/1d/elixir_advection_amr_nonperiodic.jl
+++ b/examples/1d/elixir_advection_amr_nonperiodic.jl
@@ -49,7 +49,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_controller = ControllerThreeLevel(semi, IndicatorMax(semi, variable=first),
                                       base_level=4,

--- a/examples/1d/elixir_advection_basic.jl
+++ b/examples/1d/elixir_advection_basic.jl
@@ -38,7 +38,7 @@ analysis_callback = AnalysisCallback(semi, interval=100)
 
 # The SaveSolutionCallback allows to save the solution to a file in regular intervals
 save_solution = SaveSolutionCallback(interval=100,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 # The StepsizeCallback handles the re-calculcation of the maximum Δt after each time step
 stepsize_callback = StepsizeCallback(cfl=1.6)

--- a/examples/1d/elixir_advection_extended.jl
+++ b/examples/1d/elixir_advection_extended.jl
@@ -63,7 +63,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 # The StepsizeCallback handles the re-calculcation of the maximum Δt after each time step
 stepsize_callback = StepsizeCallback(cfl=1.6)

--- a/examples/1d/elixir_euler_blast_wave.jl
+++ b/examples/1d/elixir_euler_blast_wave.jl
@@ -49,7 +49,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.5)
 

--- a/examples/1d/elixir_euler_density_wave.jl
+++ b/examples/1d/elixir_euler_density_wave.jl
@@ -41,7 +41,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.8)
 

--- a/examples/1d/elixir_euler_ec.jl
+++ b/examples/1d/elixir_euler_ec.jl
@@ -41,7 +41,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.8)
 

--- a/examples/1d/elixir_euler_nonperiodic.jl
+++ b/examples/1d/elixir_euler_nonperiodic.jl
@@ -53,7 +53,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.8)
 

--- a/examples/1d/elixir_euler_positivity.jl
+++ b/examples/1d/elixir_euler_positivity.jl
@@ -49,7 +49,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorLöhner(semi,
                                 variable=density_pressure)

--- a/examples/1d/elixir_euler_sedov_blast_wave.jl
+++ b/examples/1d/elixir_euler_sedov_blast_wave.jl
@@ -50,7 +50,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_max=0.5,

--- a/examples/1d/elixir_euler_shockcapturing.jl
+++ b/examples/1d/elixir_euler_shockcapturing.jl
@@ -48,7 +48,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.8)
 

--- a/examples/1d/elixir_euler_source_terms.jl
+++ b/examples/1d/elixir_euler_source_terms.jl
@@ -44,7 +44,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.8)
 

--- a/examples/1d/elixir_eulergravity_eoc_test.jl
+++ b/examples/1d/elixir_eulergravity_eoc_test.jl
@@ -62,7 +62,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=10,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.1)
 

--- a/examples/1d/elixir_hypdiff_harmonic_nonperiodic.jl
+++ b/examples/1d/elixir_hypdiff_harmonic_nonperiodic.jl
@@ -45,7 +45,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.75)
 

--- a/examples/1d/elixir_hypdiff_nonperiodic.jl
+++ b/examples/1d/elixir_hypdiff_nonperiodic.jl
@@ -46,7 +46,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.0)
 

--- a/examples/1d/elixir_mhd_alfven_wave.jl
+++ b/examples/1d/elixir_mhd_alfven_wave.jl
@@ -47,7 +47,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.8)
 

--- a/examples/1d/elixir_mhd_briowu_shock_tube.jl
+++ b/examples/1d/elixir_mhd_briowu_shock_tube.jl
@@ -58,7 +58,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_max=0.5,

--- a/examples/1d/elixir_mhd_ec.jl
+++ b/examples/1d/elixir_mhd_ec.jl
@@ -44,7 +44,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.5)
 

--- a/examples/1d/elixir_mhd_ryujones_shock_tube.jl
+++ b/examples/1d/elixir_mhd_ryujones_shock_tube.jl
@@ -56,7 +56,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 # amr_indicator = IndicatorHennemannGassner(semi,
 #                                           alpha_max=0.5,

--- a/examples/1d/elixir_mhd_shu_osher_shock_tube.jl
+++ b/examples/1d/elixir_mhd_shu_osher_shock_tube.jl
@@ -58,7 +58,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_max=0.5,

--- a/examples/1d/elixir_mhd_torrilhon_shock_tube.jl
+++ b/examples/1d/elixir_mhd_torrilhon_shock_tube.jl
@@ -58,7 +58,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.5)
 

--- a/examples/2d/elixir_advection_amr.jl
+++ b/examples/2d/elixir_advection_amr.jl
@@ -44,7 +44,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_controller = ControllerThreeLevel(semi, IndicatorMax(semi, variable=first),
                                       base_level=4,

--- a/examples/2d/elixir_advection_amr_nonperiodic.jl
+++ b/examples/2d/elixir_advection_amr_nonperiodic.jl
@@ -50,7 +50,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_controller = ControllerThreeLevel(semi, IndicatorMax(semi, variable=first),
                                       base_level=4,

--- a/examples/2d/elixir_advection_basic.jl
+++ b/examples/2d/elixir_advection_basic.jl
@@ -38,7 +38,7 @@ analysis_callback = AnalysisCallback(semi, interval=100)
 
 # The SaveSolutionCallback allows to save the solution to a file in regular intervals
 save_solution = SaveSolutionCallback(interval=100,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 # The StepsizeCallback handles the re-calculcation of the maximum Δt after each time step
 stepsize_callback = StepsizeCallback(cfl=1.6)

--- a/examples/2d/elixir_advection_callbacks.jl
+++ b/examples/2d/elixir_advection_callbacks.jl
@@ -136,7 +136,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:conservative)
+                                     solution_variables=cons2cons)
 
 example_callback = TrixiExtensionExample.ExampleStepCallback(message="안녕하세요?")
 

--- a/examples/2d/elixir_advection_extended.jl
+++ b/examples/2d/elixir_advection_extended.jl
@@ -64,7 +64,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 # The StepsizeCallback handles the re-calculcation of the maximum Δt after each time step
 stepsize_callback = StepsizeCallback(cfl=1.6)

--- a/examples/2d/elixir_advection_mortar.jl
+++ b/examples/2d/elixir_advection_mortar.jl
@@ -48,7 +48,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.6)
 

--- a/examples/2d/elixir_advection_timeintegration.jl
+++ b/examples/2d/elixir_advection_timeintegration.jl
@@ -41,7 +41,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:conservative)
+                                     solution_variables=cons2cons)
 
 amr_controller = ControllerThreeLevel(semi, IndicatorMax(semi, variable=first),
                                       base_level=4,

--- a/examples/2d/elixir_euler_blast_wave.jl
+++ b/examples/2d/elixir_euler_blast_wave.jl
@@ -48,7 +48,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.9)
 

--- a/examples/2d/elixir_euler_blast_wave_amr.jl
+++ b/examples/2d/elixir_euler_blast_wave_amr.jl
@@ -48,7 +48,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_max=0.5,

--- a/examples/2d/elixir_euler_blob_amr.jl
+++ b/examples/2d/elixir_euler_blob_amr.jl
@@ -51,7 +51,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_max=1.0,

--- a/examples/2d/elixir_euler_blob_mortar.jl
+++ b/examples/2d/elixir_euler_blob_mortar.jl
@@ -55,7 +55,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.7)
 

--- a/examples/2d/elixir_euler_density_wave.jl
+++ b/examples/2d/elixir_euler_density_wave.jl
@@ -42,7 +42,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.6)
 

--- a/examples/2d/elixir_euler_ec.jl
+++ b/examples/2d/elixir_euler_ec.jl
@@ -41,7 +41,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.0)
 

--- a/examples/2d/elixir_euler_kelvin_helmholtz_instability.jl
+++ b/examples/2d/elixir_euler_kelvin_helmholtz_instability.jl
@@ -48,7 +48,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=20,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.3)
 

--- a/examples/2d/elixir_euler_kelvin_helmholtz_instability_amr.jl
+++ b/examples/2d/elixir_euler_kelvin_helmholtz_instability_amr.jl
@@ -51,7 +51,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_max=1.0,

--- a/examples/2d/elixir_euler_nonperiodic.jl
+++ b/examples/2d/elixir_euler_nonperiodic.jl
@@ -54,7 +54,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.0)
 

--- a/examples/2d/elixir_euler_positivity.jl
+++ b/examples/2d/elixir_euler_positivity.jl
@@ -48,7 +48,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorLöhner(semi,
                                 variable=density_pressure)

--- a/examples/2d/elixir_euler_sedov_blast_wave.jl
+++ b/examples/2d/elixir_euler_sedov_blast_wave.jl
@@ -48,7 +48,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_max=0.5,

--- a/examples/2d/elixir_euler_shockcapturing.jl
+++ b/examples/2d/elixir_euler_shockcapturing.jl
@@ -48,7 +48,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.0)
 

--- a/examples/2d/elixir_euler_source_terms.jl
+++ b/examples/2d/elixir_euler_source_terms.jl
@@ -39,7 +39,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.0)
 

--- a/examples/2d/elixir_euler_vortex.jl
+++ b/examples/2d/elixir_euler_vortex.jl
@@ -43,7 +43,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.1)
 

--- a/examples/2d/elixir_euler_vortex_amr.jl
+++ b/examples/2d/elixir_euler_vortex_amr.jl
@@ -101,7 +101,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=50,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_controller = ControllerThreeLevel(semi, TrixiExtension.IndicatorVortex(semi),
                                       base_level=3,

--- a/examples/2d/elixir_euler_vortex_mortar.jl
+++ b/examples/2d/elixir_euler_vortex_mortar.jl
@@ -46,7 +46,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.4)
 

--- a/examples/2d/elixir_euler_vortex_mortar_shockcapturing.jl
+++ b/examples/2d/elixir_euler_vortex_mortar_shockcapturing.jl
@@ -57,7 +57,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.7)
 

--- a/examples/2d/elixir_euler_vortex_mortar_split.jl
+++ b/examples/2d/elixir_euler_vortex_mortar_split.jl
@@ -47,7 +47,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.4)
 

--- a/examples/2d/elixir_euler_vortex_shockcapturing.jl
+++ b/examples/2d/elixir_euler_vortex_shockcapturing.jl
@@ -53,7 +53,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.7)
 

--- a/examples/2d/elixir_hypdiff_harmonic_nonperiodic.jl
+++ b/examples/2d/elixir_hypdiff_harmonic_nonperiodic.jl
@@ -45,7 +45,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.0)
 

--- a/examples/2d/elixir_hypdiff_lax_friedrichs.jl
+++ b/examples/2d/elixir_hypdiff_lax_friedrichs.jl
@@ -43,7 +43,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.2)
 

--- a/examples/2d/elixir_hypdiff_nonperiodic.jl
+++ b/examples/2d/elixir_hypdiff_nonperiodic.jl
@@ -49,7 +49,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.0)
 

--- a/examples/2d/elixir_hypdiff_upwind.jl
+++ b/examples/2d/elixir_hypdiff_upwind.jl
@@ -43,7 +43,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.0)
 

--- a/examples/2d/elixir_mhd_alfven_wave.jl
+++ b/examples/2d/elixir_mhd_alfven_wave.jl
@@ -42,7 +42,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=10,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 cfl = 1.0
 stepsize_callback = StepsizeCallback(cfl=cfl)

--- a/examples/2d/elixir_mhd_alfven_wave_mortar.jl
+++ b/examples/2d/elixir_mhd_alfven_wave_mortar.jl
@@ -45,7 +45,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=10,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 cfl = 1.0
 stepsize_callback = StepsizeCallback(cfl=cfl)

--- a/examples/2d/elixir_mhd_blast_wave.jl
+++ b/examples/2d/elixir_mhd_blast_wave.jl
@@ -48,7 +48,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_max=0.5,

--- a/examples/2d/elixir_mhd_ec.jl
+++ b/examples/2d/elixir_mhd_ec.jl
@@ -39,7 +39,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=10,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 cfl = 1.0
 stepsize_callback = StepsizeCallback(cfl=cfl)

--- a/examples/2d/elixir_mhd_orszag_tang.jl
+++ b/examples/2d/elixir_mhd_orszag_tang.jl
@@ -48,7 +48,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_max=0.5,

--- a/examples/2d/elixir_mhd_rotor.jl
+++ b/examples/2d/elixir_mhd_rotor.jl
@@ -49,7 +49,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_max=0.5,

--- a/examples/3d/elixir_advection_amr.jl
+++ b/examples/3d/elixir_advection_amr.jl
@@ -43,7 +43,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_controller = ControllerThreeLevel(semi, IndicatorMax(semi, variable=first),
                                       base_level=4,

--- a/examples/3d/elixir_advection_basic.jl
+++ b/examples/3d/elixir_advection_basic.jl
@@ -38,7 +38,7 @@ analysis_callback = AnalysisCallback(semi, interval=100)
 
 # The SaveSolutionCallback allows to save the solution to a file in regular intervals
 save_solution = SaveSolutionCallback(interval=100,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 #
 # The StepsizeCallback handles the re-calculcation of the maximum Δt after each time step
 stepsize_callback = StepsizeCallback(cfl=1.2)

--- a/examples/3d/elixir_advection_extended.jl
+++ b/examples/3d/elixir_advection_extended.jl
@@ -64,7 +64,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 # The StepsizeCallback handles the re-calculcation of the maximum Δt after each time step
 stepsize_callback = StepsizeCallback(cfl=1.2)

--- a/examples/3d/elixir_advection_mortar.jl
+++ b/examples/3d/elixir_advection_mortar.jl
@@ -47,7 +47,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                    save_initial_solution=true,
                                    save_final_solution=true,
-                                   solution_variables=:primitive)
+                                   solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.2)
 

--- a/examples/3d/elixir_euler_amr.jl
+++ b/examples/3d/elixir_euler_amr.jl
@@ -42,7 +42,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_controller = ControllerThreeLevel(semi, IndicatorMax(semi, variable=first),
                                       base_level=4,

--- a/examples/3d/elixir_euler_blob_amr.jl
+++ b/examples/3d/elixir_euler_blob_amr.jl
@@ -46,7 +46,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=200,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorLöhner(semi,
                                 variable=density)

--- a/examples/3d/elixir_euler_density_pulse.jl
+++ b/examples/3d/elixir_euler_density_pulse.jl
@@ -42,7 +42,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.1)
 

--- a/examples/3d/elixir_euler_ec.jl
+++ b/examples/3d/elixir_euler_ec.jl
@@ -42,7 +42,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.3)
 

--- a/examples/3d/elixir_euler_eoc_test.jl
+++ b/examples/3d/elixir_euler_eoc_test.jl
@@ -43,7 +43,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.1)
 

--- a/examples/3d/elixir_euler_mortar.jl
+++ b/examples/3d/elixir_euler_mortar.jl
@@ -46,7 +46,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.6)
 

--- a/examples/3d/elixir_euler_sedov_blast_wave.jl
+++ b/examples/3d/elixir_euler_sedov_blast_wave.jl
@@ -55,7 +55,7 @@ save_restart = SaveRestartCallback(interval=10,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_max=1.0,

--- a/examples/3d/elixir_euler_shockcapturing.jl
+++ b/examples/3d/elixir_euler_shockcapturing.jl
@@ -53,7 +53,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.4)
 

--- a/examples/3d/elixir_euler_shockcapturing_amr.jl
+++ b/examples/3d/elixir_euler_shockcapturing_amr.jl
@@ -53,7 +53,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_smooth=false,

--- a/examples/3d/elixir_euler_source_terms.jl
+++ b/examples/3d/elixir_euler_source_terms.jl
@@ -43,7 +43,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=0.6)
 

--- a/examples/3d/elixir_euler_taylor_green_vortex.jl
+++ b/examples/3d/elixir_euler_taylor_green_vortex.jl
@@ -42,7 +42,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.4)
 

--- a/examples/3d/elixir_eulergravity_eoc_test.jl
+++ b/examples/3d/elixir_eulergravity_eoc_test.jl
@@ -63,7 +63,7 @@ save_restart = SaveRestartCallback(interval=100,
 save_solution = SaveSolutionCallback(interval=10,
                                    save_initial_solution=true,
                                    save_final_solution=true,
-                                   solution_variables=:primitive)
+                                   solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.1)
 

--- a/examples/3d/elixir_hypdiff_lax_friedrichs.jl
+++ b/examples/3d/elixir_hypdiff_lax_friedrichs.jl
@@ -43,7 +43,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=2.4)
 

--- a/examples/3d/elixir_hypdiff_nonperiodic.jl
+++ b/examples/3d/elixir_hypdiff_nonperiodic.jl
@@ -51,7 +51,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 stepsize_callback = StepsizeCallback(cfl=1.8)
 

--- a/examples/3d/elixir_mhd_alfven_wave.jl
+++ b/examples/3d/elixir_mhd_alfven_wave.jl
@@ -38,7 +38,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=10,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 cfl = 1.4
 stepsize_callback = StepsizeCallback(cfl=cfl)

--- a/examples/3d/elixir_mhd_alfven_wave_mortar.jl
+++ b/examples/3d/elixir_mhd_alfven_wave_mortar.jl
@@ -41,7 +41,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=10,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 cfl = 1.4
 stepsize_callback = StepsizeCallback(cfl=cfl)

--- a/examples/3d/elixir_mhd_ec.jl
+++ b/examples/3d/elixir_mhd_ec.jl
@@ -39,7 +39,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=10,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 cfl = 1.4
 stepsize_callback = StepsizeCallback(cfl=cfl)

--- a/examples/3d/elixir_mhd_orszag_tang.jl
+++ b/examples/3d/elixir_mhd_orszag_tang.jl
@@ -36,7 +36,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_solution = SaveSolutionCallback(interval=10,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 cfl = 1.1
 stepsize_callback = StepsizeCallback(cfl=cfl)

--- a/examples/paper-self-gravitating-gas-dynamics/elixir_euler_eoc_test.jl
+++ b/examples/paper-self-gravitating-gas-dynamics/elixir_euler_eoc_test.jl
@@ -36,7 +36,7 @@ stepsize_callback = StepsizeCallback(cfl=0.8)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 save_restart = SaveRestartCallback(interval=100,
                                    save_final_restart=true)

--- a/examples/paper-self-gravitating-gas-dynamics/elixir_eulergravity_eoc_test.jl
+++ b/examples/paper-self-gravitating-gas-dynamics/elixir_eulergravity_eoc_test.jl
@@ -60,7 +60,7 @@ stepsize_callback = StepsizeCallback(cfl=0.8)
 save_solution = SaveSolutionCallback(interval=10,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 save_restart = SaveRestartCallback(interval=100,
                                    save_final_restart=true)

--- a/examples/paper-self-gravitating-gas-dynamics/elixir_eulergravity_jeans_instability.jl
+++ b/examples/paper-self-gravitating-gas-dynamics/elixir_eulergravity_jeans_instability.jl
@@ -113,7 +113,7 @@ stepsize_callback = StepsizeCallback(cfl=1.0)
 save_solution = SaveSolutionCallback(interval=10,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 save_restart = SaveRestartCallback(interval=100,
                                    save_final_restart=true)

--- a/examples/paper-self-gravitating-gas-dynamics/elixir_eulergravity_sedov_blast_wave.jl
+++ b/examples/paper-self-gravitating-gas-dynamics/elixir_eulergravity_sedov_blast_wave.jl
@@ -85,7 +85,7 @@ stepsize_callback = StepsizeCallback(cfl=1.0)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 save_restart = SaveRestartCallback(interval=100,
                                    save_final_restart=true)

--- a/examples/paper-self-gravitating-gas-dynamics/elixir_hypdiff_eoc_test.jl
+++ b/examples/paper-self-gravitating-gas-dynamics/elixir_hypdiff_eoc_test.jl
@@ -47,7 +47,7 @@ stepsize_callback = StepsizeCallback(cfl=1.0)
 save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
-                                     solution_variables=:primitive)
+                                     solution_variables=cons2prim)
 
 analysis_interval = 500
 alive_callback = AliveCallback(analysis_interval=analysis_interval)

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -102,6 +102,8 @@ export initial_condition_poisson_nonperiodic, source_terms_poisson_nonperiodic, 
 export initial_condition_sedov_self_gravity, boundary_condition_sedov_self_gravity
 export initial_condition_eoc_test_coupled_euler_gravity, source_terms_eoc_test_coupled_euler_gravity, source_terms_eoc_test_euler
 
+export cons2cons, cons2prim
+
 export TreeMesh
 
 export DG,

--- a/src/auxiliary/precompile.jl
+++ b/src/auxiliary/precompile.jl
@@ -66,10 +66,10 @@ inf_timing = @snoopi tmin=0.01 begin
                                       interval=analysis_interval,
                                       extra_analysis_integrals=(entropy,))
 
-  # TODO: Taal decide, first AMR or save solution etc.
-  callbacks = CallbackSet(summary_callback, amr_callback, stepsize_callback,
+  callbacks = CallbackSet(summary_callback,
                           save_restart, save_solution,
-                          analysis_callback, alive_callback);
+                          analysis_callback, alive_callback,
+                          amr_callback, stepsize_callback);
 
 
   ###############################################################################
@@ -239,7 +239,8 @@ function _precompile_manual_()
     @assert Base.precompile(Tuple{Core.kwftype(typeof(Trixi.Type)),NamedTuple{(:glm_scale, :cfl),Tuple{RealT,RealT}},Type{GlmSpeedCallback}})
   end
   @assert Base.precompile(Tuple{Core.kwftype(typeof(Trixi.Type)),NamedTuple{(:interval, :save_final_restart),Tuple{Int,Bool}},Type{SaveRestartCallback}})
-  @assert Base.precompile(Tuple{Core.kwftype(typeof(Trixi.Type)),NamedTuple{(:interval, :save_initial_solution, :save_final_solution, :solution_variables),Tuple{Int,Bool,Bool,Symbol}},Type{SaveSolutionCallback}})
+  @assert Base.precompile(Tuple{Core.kwftype(typeof(Trixi.Type)),NamedTuple{(:interval, :save_initial_solution, :save_final_solution, :solution_variables),Tuple{Int,Bool,Bool,typeof(cons2cons)}},Type{SaveSolutionCallback}})
+  @assert Base.precompile(Tuple{Core.kwftype(typeof(Trixi.Type)),NamedTuple{(:interval, :save_initial_solution, :save_final_solution, :solution_variables),Tuple{Int,Bool,Bool,typeof(cons2prim)}},Type{SaveSolutionCallback}})
   for RealT in (Float64,), polydeg in 1:7
     nnodes_ = polydeg + 1
     nnodes_analysis = 2*polydeg + 1
@@ -257,7 +258,7 @@ function _precompile_manual_()
   for RealT in (Float64,), polydeg in 1:7
     nnodes_ = polydeg + 1
 
-    # 2D, serial
+    # 1D, serial
     @assert Base.precompile(Tuple{typeof(Trixi.init_boundaries),Array{Int,1},TreeMesh{1,Trixi.SerialTree{1}},Trixi.ElementContainer1D{RealT,1,polydeg}})
     @assert Base.precompile(Tuple{typeof(Trixi.init_interfaces),Array{Int,1},TreeMesh{1,Trixi.SerialTree{1}},Trixi.ElementContainer1D{RealT,1,polydeg}})
 

--- a/src/auxiliary/precompile.jl
+++ b/src/auxiliary/precompile.jl
@@ -55,7 +55,7 @@ inf_timing = @snoopi tmin=0.01 begin
   save_solution = SaveSolutionCallback(interval=100,
                                       save_initial_solution=true,
                                       save_final_solution=true,
-                                      solution_variables=:primitive)
+                                      solution_variables=cons2prim)
 
   save_restart = SaveRestartCallback(interval=100,
                                     save_final_restart=true)

--- a/src/auxiliary/special_elixirs.jl
+++ b/src/auxiliary/special_elixirs.jl
@@ -65,7 +65,7 @@ function convergence_test(mod::Module, elixir::AbstractString, iterations; kwarg
   end
 
   # number of variables
-  variablenames = varnames_cons(mod.equations)
+  variablenames = varnames(cons2cons, mod.equations)
   nvariables = length(variablenames)
 
   # Reshape errors to get a matrix where the i-th row represents the i-th iteration

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -110,32 +110,32 @@ function initialize!(cb::DiscreteCallback{Condition,Affect!}, u_ode, t, integrat
       @printf(io, "  %-14s", "time")
       @printf(io, "  %-14s", "dt")
       if :l2_error in analysis_errors
-        for v in varnames_cons(equations)
+        for v in varnames(cons2cons, equations)
           @printf(io, "   %-14s", "l2_" * v)
         end
       end
       if :linf_error in analysis_errors
-        for v in varnames_cons(equations)
+        for v in varnames(cons2cons, equations)
           @printf(io, "   %-14s", "linf_" * v)
         end
       end
       if :conservation_error in analysis_errors
-        for v in varnames_cons(equations)
+        for v in varnames(cons2cons, equations)
           @printf(io, "   %-14s", "cons_" * v)
         end
       end
       if :residual in analysis_errors
-        for v in varnames_cons(equations)
+        for v in varnames(cons2cons, equations)
           @printf(io, "   %-14s", "res_" * v)
         end
       end
       if :l2_error_primitive in analysis_errors
-        for v in varnames_prim(equations)
+        for v in varnames(cons2prim, equations)
           @printf(io, "   %-14s", "l2_" * v)
         end
       end
       if :linf_error_primitive in analysis_errors
-        for v in varnames_prim(equations)
+        for v in varnames(cons2prim, equations)
           @printf(io, "   %-14s", "linf_" * v)
         end
       end
@@ -236,7 +236,7 @@ function (analysis_callback::AnalysisCallback)(integrator)
             (:l2_error, :linf_error, :conservation_error, :residual))
         mpi_print(" Variable:    ")
         for v in eachvariable(equations)
-          mpi_isroot() && @printf("   %-14s", varnames_cons(equations)[v])
+          mpi_isroot() && @printf("   %-14s", varnames(cons2cons, equations)[v])
         end
         mpi_println()
       end
@@ -302,7 +302,7 @@ function (analysis_callback::AnalysisCallback)(integrator)
 
         mpi_print(" Variable:    ")
         for v in eachvariable(equations)
-          mpi_isroot() && @printf("   %-14s", varnames_prim(equations)[v])
+          mpi_isroot() && @printf("   %-14s", varnames(cons2prim, equations)[v])
         end
         mpi_println()
 

--- a/src/callbacks_step/save_restart_dg.jl
+++ b/src/callbacks_step/save_restart_dg.jl
@@ -9,7 +9,7 @@ function save_restart_file(u, time, dt, timestep,
 
   # Restart files always store conservative variables
   data = u
-  varnames = varnames_cons(equations)
+  varnames = varnames(cons2cons, equations)
 
   # Open file (clobber existing content)
   h5open(filename, "w") do file
@@ -61,7 +61,7 @@ function load_restart_file(mesh::SerialTreeMesh, equations, dg::DG, cache, resta
     end
 
     # Read data
-    varnames = varnames_cons(equations)
+    varnames = varnames(cons2cons, equations)
     for v in eachvariable(equations)
       # Check if variable name matches
       var = file["variables_$v"]
@@ -89,7 +89,7 @@ function save_restart_file(u, time, dt, timestep,
 
   # Restart files always store conservative variables
   data = u
-  varnames = varnames_cons(equations)
+  varnames = varnames(cons2cons, equations)
 
   # Calculate element and node counts by MPI rank
   element_size = nnodes(dg)^ndims(mesh)
@@ -172,7 +172,7 @@ function load_restart_file(mesh::ParallelTreeMesh, equations, dg::DG, cache, res
     end
 
     # Read data
-    varnames = varnames_cons(equations)
+    varnames = varnames(cons2cons, equations)
     for v in eachvariable(equations)
       # Check if variable name matches
       var = file["variables_$v"]

--- a/src/callbacks_step/save_restart_dg.jl
+++ b/src/callbacks_step/save_restart_dg.jl
@@ -9,7 +9,6 @@ function save_restart_file(u, time, dt, timestep,
 
   # Restart files always store conservative variables
   data = u
-  varnames = varnames(cons2cons, equations)
 
   # Open file (clobber existing content)
   h5open(filename, "w") do file
@@ -31,7 +30,7 @@ function save_restart_file(u, time, dt, timestep,
 
       # Add variable name as attribute
       var = file["variables_$v"]
-      attributes(var)["name"] = varnames[v]
+      attributes(var)["name"] = varnames(cons2cons, equations)[v]
     end
   end
 
@@ -61,12 +60,11 @@ function load_restart_file(mesh::SerialTreeMesh, equations, dg::DG, cache, resta
     end
 
     # Read data
-    varnames = varnames(cons2cons, equations)
     for v in eachvariable(equations)
       # Check if variable name matches
       var = file["variables_$v"]
-      if (name = read(attributes(var)["name"])) != varnames[v]
-        error("mismatch: variables_$v should be '$(varnames[v])', but found '$name'")
+      if (name = read(attributes(var)["name"])) != varnames(cons2cons, equations)[v]
+        error("mismatch: variables_$v should be '$(varnames(cons2cons, equations)[v])', but found '$name'")
       end
 
       # Read variable
@@ -89,7 +87,6 @@ function save_restart_file(u, time, dt, timestep,
 
   # Restart files always store conservative variables
   data = u
-  varnames = varnames(cons2cons, equations)
 
   # Calculate element and node counts by MPI rank
   element_size = nnodes(dg)^ndims(mesh)
@@ -126,7 +123,7 @@ function save_restart_file(u, time, dt, timestep,
 
       # Add variable name as attribute
       var = file["variables_$v"]
-      attributes(var)["name"] = varnames[v]
+      attributes(var)["name"] = varnames(cons2cons, equations)[v]
     end
   end
 
@@ -172,12 +169,11 @@ function load_restart_file(mesh::ParallelTreeMesh, equations, dg::DG, cache, res
     end
 
     # Read data
-    varnames = varnames(cons2cons, equations)
     for v in eachvariable(equations)
       # Check if variable name matches
       var = file["variables_$v"]
-      if (name = read(attributes(var)["name"])) != varnames[v]
-        error("mismatch: variables_$v should be '$(varnames[v])', but found '$name'")
+      if (name = read(attributes(var)["name"])) != varnames(cons2cons, equations)[v]
+        error("mismatch: variables_$v should be '$(varnames(cons2cons, equations)[v])', but found '$name'")
       end
 
       # Read variable

--- a/src/callbacks_step/save_solution.jl
+++ b/src/callbacks_step/save_solution.jl
@@ -1,21 +1,22 @@
 
-# TODO: Taal refactor, allow saving arbitrary functions of the conservative variables
-# TODO: Taal refactor, make solution_variables a function instead of a Symbol
 """
     SaveSolutionCallback(; interval=0,
                            save_initial_solution=true,
                            save_final_solution=true,
                            output_directory="out",
-                           solution_variables=:primitive)
+                           solution_variables=cons2prim)
 
-Save the current numerical solution every `interval` time steps.
+Save the current numerical solution every `interval` time steps. `solution_variables` can be any
+callable that converts the conservative variables at a single point to a set of solution variables.
+The first parameter passed to `solution_variables` will be the set of conservative variables and the
+second parameter is the equation struct.
 """
-mutable struct SaveSolutionCallback
+mutable struct SaveSolutionCallback{SolutionVariables}
   interval::Int
   save_initial_solution::Bool
   save_final_solution::Bool
   output_directory::String
-  solution_variables::Symbol
+  solution_variables::SolutionVariables
 end
 
 
@@ -46,7 +47,7 @@ function SaveSolutionCallback(; interval=0,
                                 save_initial_solution=true,
                                 save_final_solution=true,
                                 output_directory="out",
-                                solution_variables=:primitive)
+                                solution_variables=cons2prim)
   # when is the callback activated
   condition = (u, t, integrator) -> interval > 0 && ((integrator.iter % interval == 0) ||
                                                      (save_final_solution && isfinished(integrator)))

--- a/src/callbacks_step/save_solution.jl
+++ b/src/callbacks_step/save_solution.jl
@@ -52,6 +52,19 @@ function SaveSolutionCallback(; interval=0,
   condition = (u, t, integrator) -> interval > 0 && ((integrator.iter % interval == 0) ||
                                                      (save_final_solution && isfinished(integrator)))
 
+  # FIXME: Deprecations introduced in v0.3
+  if solution_variables isa Symbol
+    Base.depwarn("Providing the keyword argument `solution_variables` as a `Symbol` is deprecated." *
+                 "Use functions such as `cons2cons` or `cons2prim` instead.", :SaveSolutionCallback)
+    if solution_variables == :conservative
+      solution_variables = cons2cons
+    elseif solution_variables == :primitive
+      solution_variables = cons2prim
+    else
+      error("Unknown `solution_variables` $solution_variables.")
+    end
+  end
+
   solution_callback = SaveSolutionCallback(interval, save_initial_solution, save_final_solution,
                                            output_directory, solution_variables)
 

--- a/src/callbacks_step/save_solution_dg.jl
+++ b/src/callbacks_step/save_solution_dg.jl
@@ -76,17 +76,15 @@ function save_solution_file(u, time, dt, timestep,
   end
 
   # Convert to different set of variables if requested
-  if solution_variables === :conservative
+  if solution_variables === cons2cons
     data = u
-  elseif solution_variables === :primitive
+  else
     # Reinterpret the solution array as an array of conservative variables,
     # compute the primitive variables via broadcasting, and reinterpret the
     # result as a plain array of floating point numbers
     data = Array(reinterpret(eltype(u),
            solution_variables.(reinterpret(SVector{nvariables(equations),eltype(u)}, u),
                       Ref(equations))))
-  else
-    error("Unknown solution_variables $solution_variables")
   end
 
   # Calculate element and node counts by MPI rank

--- a/src/callbacks_step/save_solution_dg.jl
+++ b/src/callbacks_step/save_solution_dg.jl
@@ -15,7 +15,7 @@ function save_solution_file(u, time, dt, timestep,
   # Convert to primitive variables if requested
   if solution_variables === :conservative
     data = u
-    varnames = varnames_cons(equations)
+    varnames = varnames(cons2cons, equations)
   elseif solution_variables === :primitive
     # Reinterpret the solution array as an array of conservative variables,
     # compute the primitive variables via broadcasting, and reinterpret the
@@ -23,7 +23,7 @@ function save_solution_file(u, time, dt, timestep,
     data = Array(reinterpret(eltype(u),
            cons2prim.(reinterpret(SVector{nvariables(equations),eltype(u)}, u),
                       Ref(equations))))
-    varnames = varnames_prim(equations)
+    varnames = varnames(cons2prim, equations)
   else
     error("Unknown solution_variables $solution_variables")
   end
@@ -82,7 +82,7 @@ function save_solution_file(u, time, dt, timestep,
   # Convert to primitive variables if requested
   if solution_variables === :conservative
     data = u
-    varnames = varnames_cons(equations)
+    varnames = varnames(cons2cons, equations)
   elseif solution_variables === :primitive
     # Reinterpret the solution array as an array of conservative variables,
     # compute the primitive variables via broadcasting, and reinterpret the
@@ -90,7 +90,7 @@ function save_solution_file(u, time, dt, timestep,
     data = Array(reinterpret(eltype(u),
            cons2prim.(reinterpret(SVector{nvariables(equations),eltype(u)}, u),
                       Ref(equations))))
-    varnames = varnames_prim(equations)
+    varnames = varnames(cons2prim, equations)
   else
     error("Unknown solution_variables $solution_variables")
   end

--- a/src/callbacks_step/save_solution_dg.jl
+++ b/src/callbacks_step/save_solution_dg.jl
@@ -15,7 +15,7 @@ function save_solution_file(u, time, dt, timestep,
   # Convert to primitive variables if requested
   if solution_variables === :conservative
     data = u
-    varnames = varnames(cons2cons, equations)
+    varnames_ = varnames(cons2cons, equations)
   elseif solution_variables === :primitive
     # Reinterpret the solution array as an array of conservative variables,
     # compute the primitive variables via broadcasting, and reinterpret the
@@ -23,7 +23,7 @@ function save_solution_file(u, time, dt, timestep,
     data = Array(reinterpret(eltype(u),
            cons2prim.(reinterpret(SVector{nvariables(equations),eltype(u)}, u),
                       Ref(equations))))
-    varnames = varnames(cons2prim, equations)
+    varnames_ = varnames(cons2prim, equations)
   else
     error("Unknown solution_variables $solution_variables")
   end
@@ -48,7 +48,7 @@ function save_solution_file(u, time, dt, timestep,
 
       # Add variable name as attribute
       var = file["variables_$v"]
-      attributes(var)["name"] = varnames[v]
+      attributes(var)["name"] = varnames_[v]
     end
 
     # Store element variables
@@ -82,7 +82,7 @@ function save_solution_file(u, time, dt, timestep,
   # Convert to primitive variables if requested
   if solution_variables === :conservative
     data = u
-    varnames = varnames(cons2cons, equations)
+    varnames_ = varnames(cons2cons, equations)
   elseif solution_variables === :primitive
     # Reinterpret the solution array as an array of conservative variables,
     # compute the primitive variables via broadcasting, and reinterpret the
@@ -90,7 +90,7 @@ function save_solution_file(u, time, dt, timestep,
     data = Array(reinterpret(eltype(u),
            cons2prim.(reinterpret(SVector{nvariables(equations),eltype(u)}, u),
                       Ref(equations))))
-    varnames = varnames(cons2prim, equations)
+    varnames_ = varnames(cons2prim, equations)
   else
     error("Unknown solution_variables $solution_variables")
   end
@@ -135,7 +135,7 @@ function save_solution_file(u, time, dt, timestep,
 
       # Add variable name as attribute
       var = file["variables_$v"]
-      attributes(var)["name"] = varnames[v]
+      attributes(var)["name"] = varnames_[v]
     end
 
     # Store element variables

--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -9,8 +9,8 @@ end
 
 
 get_name(::CompressibleEulerEquations1D) = "CompressibleEulerEquations1D"
-varnames_cons(::CompressibleEulerEquations1D) = @SVector ["rho", "rho_v1", "rho_e"]
-varnames_prim(::CompressibleEulerEquations1D) = @SVector ["rho", "v1", "p"]
+varnames(::typeof(cons2cons), ::CompressibleEulerEquations1D) = @SVector ["rho", "rho_v1", "rho_e"]
+varnames(::typeof(cons2prim), ::CompressibleEulerEquations1D) = @SVector ["rho", "v1", "p"]
 
 
 """

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -10,8 +10,8 @@ end
 
 
 get_name(::CompressibleEulerEquations2D) = "CompressibleEulerEquations2D"
-varnames_cons(::CompressibleEulerEquations2D) = @SVector ["rho", "rho_v1", "rho_v2", "rho_e"]
-varnames_prim(::CompressibleEulerEquations2D) = @SVector ["rho", "v1", "v2", "p"]
+varnames(::typeof(cons2cons), ::CompressibleEulerEquations2D) = @SVector ["rho", "rho_v1", "rho_v2", "rho_e"]
+varnames(::typeof(cons2prim), ::CompressibleEulerEquations2D) = @SVector ["rho", "v1", "v2", "p"]
 
 
 # Set initial conditions at physical location `x` for time `t`

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -10,8 +10,8 @@ end
 
 
 get_name(::CompressibleEulerEquations3D) = "CompressibleEulerEquations3D"
-varnames_cons(::CompressibleEulerEquations3D) = @SVector ["rho", "rho_v1", "rho_v2", "rho_v3", "rho_e"]
-varnames_prim(::CompressibleEulerEquations3D) = @SVector ["rho", "v1", "v2", "v3", "p"]
+varnames(::typeof(cons2cons), ::CompressibleEulerEquations3D) = @SVector ["rho", "rho_v1", "rho_v2", "rho_v3", "rho_e"]
+varnames(::typeof(cons2prim), ::CompressibleEulerEquations3D) = @SVector ["rho", "v1", "v2", "v3", "p"]
 
 
 # Set initial conditions at physical location `x` for time `t`

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -71,11 +71,12 @@ end
 
 
 @inline cons2cons(u, ::AbstractEquations) = u
+function cons2prim(u, ::AbstractEquations) end
 @inline Base.first(u, ::AbstractEquations) = first(u)
 
 # `varnames_cons` and `varnames_prim` are deprecated
-@deprecate varnames_cons(equations) varnames(::typeof(cons2cons), equations)
-@deprecate varnames_prim(equations) varnames(::typeof(cons2prim), equations)
+@deprecate varnames_cons(equations) varnames(cons2cons, equations)
+@deprecate varnames_prim(equations) varnames(cons2prim, equations)
 
 
 ####################################################################################################

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -74,7 +74,7 @@ end
 function cons2prim(u, ::AbstractEquations) end
 @inline Base.first(u, ::AbstractEquations) = first(u)
 
-# `varnames_cons` and `varnames_prim` are deprecated
+# FIXME: Deprecations introduced in v0.3
 @deprecate varnames_cons(equations) varnames(cons2cons, equations)
 @deprecate varnames_prim(equations) varnames(cons2prim, equations)
 

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -25,7 +25,7 @@ function Base.show(io::IO, ::MIME"text/plain", equations::AbstractEquations)
     for variable in eachvariable(equations)
       summary_line(increment_indent(io),
                    "variable " * string(variable),
-                   varnames_cons(equations)[variable])
+                   varnames(cons2cons, equations)[variable])
     end
     summary_footer(io)
   end
@@ -72,6 +72,10 @@ end
 
 @inline cons2cons(u, ::AbstractEquations) = u
 @inline Base.first(u, ::AbstractEquations) = first(u)
+
+# `varnames_cons` and `varnames_prim` are deprecated
+@deprecate varnames_cons(equations) varnames(::typeof(cons2cons), equations)
+@deprecate varnames_prim(equations) varnames(::typeof(cons2prim), equations)
 
 
 ####################################################################################################

--- a/src/equations/hyperbolic_diffusion_1d.jl
+++ b/src/equations/hyperbolic_diffusion_1d.jl
@@ -26,8 +26,8 @@ end
 
 
 get_name(::HyperbolicDiffusionEquations1D) = "HyperbolicDiffusionEquations1D"
-varnames_cons(::HyperbolicDiffusionEquations1D) = @SVector ["phi", "q1"]
-varnames_prim(::HyperbolicDiffusionEquations1D) = @SVector ["phi", "q1"]
+varnames(::typeof(cons2cons), ::HyperbolicDiffusionEquations1D) = @SVector ["phi", "q1"]
+varnames(::typeof(cons2prim), ::HyperbolicDiffusionEquations1D) = @SVector ["phi", "q1"]
 default_analysis_errors(::HyperbolicDiffusionEquations1D) = (:l2_error, :linf_error, :residual)
 
 @inline function residual_steady_state(du, ::HyperbolicDiffusionEquations1D)

--- a/src/equations/hyperbolic_diffusion_2d.jl
+++ b/src/equations/hyperbolic_diffusion_2d.jl
@@ -20,8 +20,8 @@ end
 
 
 get_name(::HyperbolicDiffusionEquations2D) = "HyperbolicDiffusionEquations2D"
-varnames_cons(::HyperbolicDiffusionEquations2D) = @SVector ["phi", "q1", "q2"]
-varnames_prim(::HyperbolicDiffusionEquations2D) = @SVector ["phi", "q1", "q2"]
+varnames(::typeof(cons2cons), ::HyperbolicDiffusionEquations2D) = @SVector ["phi", "q1", "q2"]
+varnames(::typeof(cons2prim), ::HyperbolicDiffusionEquations2D) = @SVector ["phi", "q1", "q2"]
 default_analysis_errors(::HyperbolicDiffusionEquations2D)     = (:l2_error, :linf_error, :residual)
 
 @inline function residual_steady_state(du, ::HyperbolicDiffusionEquations2D)

--- a/src/equations/hyperbolic_diffusion_3d.jl
+++ b/src/equations/hyperbolic_diffusion_3d.jl
@@ -20,8 +20,8 @@ end
 
 
 get_name(::HyperbolicDiffusionEquations3D) = "HyperbolicDiffusionEquations3D"
-varnames_cons(::HyperbolicDiffusionEquations3D) = @SVector ["phi", "q1", "q2", "q3"]
-varnames_prim(::HyperbolicDiffusionEquations3D) = @SVector ["phi", "q1", "q2", "q3"]
+varnames(::typeof(cons2cons), ::HyperbolicDiffusionEquations3D) = @SVector ["phi", "q1", "q2", "q3"]
+varnames(::typeof(cons2prim), ::HyperbolicDiffusionEquations3D) = @SVector ["phi", "q1", "q2", "q3"]
 default_analysis_errors(::HyperbolicDiffusionEquations3D)     = (:l2_error, :linf_error, :residual)
 
 """

--- a/src/equations/ideal_glm_mhd_1d.jl
+++ b/src/equations/ideal_glm_mhd_1d.jl
@@ -12,8 +12,8 @@ end
 
 get_name(::IdealGlmMhdEquations1D) = "IdealGlmMhdEquations1D"
 have_nonconservative_terms(::IdealGlmMhdEquations1D) = Val(false)
-varnames_cons(::IdealGlmMhdEquations1D) = @SVector ["rho", "rho_v1", "rho_v2", "rho_v3", "rho_e", "B1", "B2", "B3"]
-varnames_prim(::IdealGlmMhdEquations1D) = @SVector ["rho", "v1", "v2", "v3", "p", "B1", "B2", "B3"]
+varnames(::typeof(cons2cons), ::IdealGlmMhdEquations1D) = @SVector ["rho", "rho_v1", "rho_v2", "rho_v3", "rho_e", "B1", "B2", "B3"]
+varnames(::typeof(cons2prim), ::IdealGlmMhdEquations1D) = @SVector ["rho", "v1", "v2", "v3", "p", "B1", "B2", "B3"]
 default_analysis_integrals(::IdealGlmMhdEquations1D)  = (entropy_timederivative, Val(:l2_divb), Val(:linf_divb))
 
 

--- a/src/equations/ideal_glm_mhd_2d.jl
+++ b/src/equations/ideal_glm_mhd_2d.jl
@@ -17,8 +17,8 @@ end
 
 get_name(::IdealGlmMhdEquations2D) = "IdealGlmMhdEquations2D"
 have_nonconservative_terms(::IdealGlmMhdEquations2D) = Val(true)
-varnames_cons(::IdealGlmMhdEquations2D) = @SVector ["rho", "rho_v1", "rho_v2", "rho_v3", "rho_e", "B1", "B2", "B3", "psi"]
-varnames_prim(::IdealGlmMhdEquations2D) = @SVector ["rho", "v1", "v2", "v3", "p", "B1", "B2", "B3", "psi"]
+varnames(::typeof(cons2cons), ::IdealGlmMhdEquations2D) = @SVector ["rho", "rho_v1", "rho_v2", "rho_v3", "rho_e", "B1", "B2", "B3", "psi"]
+varnames(::typeof(cons2prim), ::IdealGlmMhdEquations2D) = @SVector ["rho", "v1", "v2", "v3", "p", "B1", "B2", "B3", "psi"]
 default_analysis_integrals(::IdealGlmMhdEquations2D)  = (entropy_timederivative, Val(:l2_divb), Val(:linf_divb))
 
 

--- a/src/equations/ideal_glm_mhd_3d.jl
+++ b/src/equations/ideal_glm_mhd_3d.jl
@@ -17,8 +17,8 @@ end
 
 get_name(::IdealGlmMhdEquations3D) = "IdealGlmMhdEquations3D"
 have_nonconservative_terms(::IdealGlmMhdEquations3D) = Val(true)
-varnames_cons(::IdealGlmMhdEquations3D) = @SVector ["rho", "rho_v1", "rho_v2", "rho_v3", "rho_e", "B1", "B2", "B3", "psi"]
-varnames_prim(::IdealGlmMhdEquations3D) = @SVector ["rho", "v1", "v2", "v3", "p", "B1", "B2", "B3", "psi"]
+varnames(::typeof(cons2cons), ::IdealGlmMhdEquations3D) = @SVector ["rho", "rho_v1", "rho_v2", "rho_v3", "rho_e", "B1", "B2", "B3", "psi"]
+varnames(::typeof(cons2prim), ::IdealGlmMhdEquations3D) = @SVector ["rho", "v1", "v2", "v3", "p", "B1", "B2", "B3", "psi"]
 default_analysis_integrals(::IdealGlmMhdEquations3D)  = (entropy_timederivative, Val(:l2_divb), Val(:linf_divb))
 
 

--- a/src/equations/linear_scalar_advection_1d.jl
+++ b/src/equations/linear_scalar_advection_1d.jl
@@ -18,8 +18,8 @@ end
 
 
 get_name(::LinearScalarAdvectionEquation1D) = "LinearScalarAdvectionEquation1D"
-varnames_cons(::LinearScalarAdvectionEquation1D) = SVector("scalar")
-varnames_prim(::LinearScalarAdvectionEquation1D) = SVector("scalar")
+varnames(::typeof(cons2cons), ::LinearScalarAdvectionEquation1D) = SVector("scalar")
+varnames(::typeof(cons2prim), ::LinearScalarAdvectionEquation1D) = SVector("scalar")
 
 
 # Set initial conditions at physical location `x` for time `t`

--- a/src/equations/linear_scalar_advection_2d.jl
+++ b/src/equations/linear_scalar_advection_2d.jl
@@ -22,8 +22,8 @@ end
 
 
 get_name(::LinearScalarAdvectionEquation2D) = "LinearScalarAdvectionEquation2D"
-varnames_cons(::LinearScalarAdvectionEquation2D) = SVector("scalar")
-varnames_prim(::LinearScalarAdvectionEquation2D) = SVector("scalar")
+varnames(::typeof(cons2cons), ::LinearScalarAdvectionEquation2D) = SVector("scalar")
+varnames(::typeof(cons2prim), ::LinearScalarAdvectionEquation2D) = SVector("scalar")
 
 # Calculates translated coordinates `x` for a periodic domain
 function x_trans_periodic_2d(x, domain_length = SVector(2, 2), center = SVector(0, 0))

--- a/src/equations/linear_scalar_advection_3d.jl
+++ b/src/equations/linear_scalar_advection_3d.jl
@@ -22,8 +22,8 @@ end
 
 
 get_name(::LinearScalarAdvectionEquation3D) = "LinearScalarAdvectionEquation3D"
-varnames_cons(::LinearScalarAdvectionEquation3D) = SVector("scalar")
-varnames_prim(::LinearScalarAdvectionEquation3D) = SVector("scalar")
+varnames(::typeof(cons2cons), ::LinearScalarAdvectionEquation3D) = SVector("scalar")
+varnames(::typeof(cons2prim), ::LinearScalarAdvectionEquation3D) = SVector("scalar")
 
 
 # Set initial conditions at physical location `x` for time `t`


### PR DESCRIPTION
Instead of `:conservative` and `:primitive`, we now pass `cons2cons` and `cons2prim` to the `solution_variables` parameter in the `SaveSolutionCallback`. In addition, any two-parameter function `func` can now be passed, given that
* it has the signature `func(u, equations)` and
* that an overload `varnames(::typeof(func), equations)` exists.

Closes #174.