### PR TITLE
improve the analysis callback (and reduce allocations significantly)

### DIFF
--- a/examples/3d/elixir_lbm_taylor_green_vortex.jl
+++ b/examples/3d/elixir_lbm_taylor_green_vortex.jl
@@ -51,7 +51,7 @@ stepsize_callback = StepsizeCallback(cfl=0.3)
 collision_callback = LBMCollisionCallback()
 
 callbacks = CallbackSet(summary_callback,
-                        analysis_callback, alive_callback, 
+                        analysis_callback, alive_callback,
                         save_restart, save_solution,
                         stepsize_callback,
                         collision_callback)
@@ -62,5 +62,6 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks, maxiters=1e5,
+            save_start=false, alias_u0=true);
 summary_callback() # print the timer summary

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -20,8 +20,8 @@ module Trixi
 using LinearAlgebra: dot
 using Printf: @printf, @sprintf, println
 
-import DiffEqBase: ODEProblem, ODESolution, get_du, u_modified!, set_proposed_dt!, terminate!,
-                   get_proposed_dt
+import DiffEqBase: ODEProblem, ODESolution, get_du, get_tmp_cache, u_modified!,
+                   set_proposed_dt!, terminate!, get_proposed_dt
 using DiffEqCallbacks: CallbackSet, DiscreteCallback
 using EllipsisNotation # ..
 using HDF5: h5open, attributes

--- a/src/auxiliary/mpi.jl
+++ b/src/auxiliary/mpi.jl
@@ -58,5 +58,15 @@ const MPI_IS_ROOT = Ref(true)
 
 @inline mpi_root() = 0
 
-@inline mpi_println(args...) = mpi_isroot() && println(args...)
-@inline mpi_print(args...) = mpi_isroot() && print(args...)
+@inline function mpi_println(args...)
+  if mpi_isroot()
+    println(args...)
+  end
+  return nothing
+end
+@inline function mpi_print(args...)
+  if mpi_isroot()
+    print(args...)
+  end
+  return nothing
+end

--- a/src/auxiliary/precompile.jl
+++ b/src/auxiliary/precompile.jl
@@ -276,16 +276,17 @@ function _precompile_manual_()
   @assert Base.precompile(Tuple{Core.kwftype(typeof(Trixi.Type)),NamedTuple{(:interval, :save_final_restart),Tuple{Int,Bool}},Type{SaveRestartCallback}})
   @assert Base.precompile(Tuple{Core.kwftype(typeof(Trixi.Type)),NamedTuple{(:interval, :save_initial_solution, :save_final_solution, :solution_variables),Tuple{Int,Bool,Bool,typeof(cons2cons)}},Type{SaveSolutionCallback}})
   @assert Base.precompile(Tuple{Core.kwftype(typeof(Trixi.Type)),NamedTuple{(:interval, :save_initial_solution, :save_final_solution, :solution_variables),Tuple{Int,Bool,Bool,typeof(cons2prim)}},Type{SaveSolutionCallback}})
-  for RealT in (Float64,), polydeg in 1:7
-    nnodes_ = polydeg + 1
-    nnodes_analysis = 2*polydeg + 1
-    @assert Base.precompile(Tuple{Type{AnalysisCallback},RealT,Int,Bool,String,String,Trixi.LobattoLegendreAnalyzer{RealT,nnodes_analysis,Array{RealT,2}},Array{Symbol,1},Tuple{typeof(Trixi.entropy_timederivative),typeof(entropy)},StaticArrays.SArray{Tuple{1},RealT,1,1}})
+  # TODO: AnalysisCallback?
+  # for RealT in (Float64,), polydeg in 1:7
+  #   nnodes_ = polydeg + 1
+  #   nnodes_analysis = 2*polydeg + 1
+    # @assert Base.precompile(Tuple{Type{AnalysisCallback},RealT,Int,Bool,String,String,Trixi.LobattoLegendreAnalyzer{RealT,nnodes_analysis,Array{RealT,2}},Array{Symbol,1},Tuple{typeof(Trixi.entropy_timederivative),typeof(entropy)},StaticArrays.SArray{Tuple{1},RealT,1,1}})
     # We would need to use all special cases instead of
     # Function,Trixi.AbstractVolumeIntegral
     # for equations_type in equations_types(RealT)
     #   @assert Base.precompile(Tuple{Core.kwftype(typeof(Trixi.Type)),NamedTuple{(:interval, :extra_analysis_integrals),Tuple{Int,Tuple{typeof(entropy)}}},Type{AnalysisCallback},equations_type,DG{RealT,LobattoLegendreBasis{RealT,nnodes_,Array{RealT,2},StaticArrays.SArray{Tuple{4,2},RealT,2,2*nnodes_},StaticArrays.SArray{Tuple{nnodes_,nnodes_},RealT,2,nnodes_^2}},Trixi.LobattoLegendreMortarL2{RealT,nnodes_,StaticArrays.SArray{Tuple{nnodes_,nnodes_},RealT,2,nnodes_^2}},Function,Trixi.AbstractVolumeIntegral}})
     # end
-  end
+  # end
   @assert Base.precompile(Tuple{typeof(SummaryCallback)})
   # TODO: AMRCallback, ControllerThreeLevel, indicators
 

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -82,6 +82,13 @@ function Base.show(io::IO, mime::MIME"text/plain", cb::DiscreteCallback{Conditio
 end
 
 
+# The function below is used to control the output depending on whether or not AMR is enabled.
+"""
+    uses_amr(callback)
+
+Checks whether the provided callback or `CallbackSet` is an [`AMRCallback`](@ref)
+or contains one.
+"""
 uses_amr(cb) = false
 uses_amr(cb::DiscreteCallback{Condition,Affect!}) where {Condition, Affect!<:AMRCallback} = true
 uses_amr(callbacks::CallbackSet) = mapreduce(uses_amr, |, callbacks.discrete_callbacks)

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -82,6 +82,11 @@ function Base.show(io::IO, mime::MIME"text/plain", cb::DiscreteCallback{Conditio
 end
 
 
+uses_amr(cb) = false
+uses_amr(cb::DiscreteCallback{Condition,Affect!}) where {Condition, Affect!<:AMRCallback} = true
+uses_amr(callbacks::CallbackSet) = mapreduce(uses_amr, |, callbacks.discrete_callbacks)
+
+
 function get_element_variables!(element_variables, u, mesh, equations, solver, cache,
                                 amr_callback::AMRCallback; kwargs...)
   get_element_variables!(element_variables, u, mesh, equations, solver, cache,

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -188,7 +188,7 @@ function (analysis_callback::AnalysisCallback)(integrator)
     mpi_println(" #elements:      " * @sprintf("% 14d", nelements(solver, cache)))
 
     # Level information (only show for AMR)
-    print_amr_information(integrator.opts.callback, solver, cache)
+    print_amr_information(integrator.opts.callback, mesh, solver, cache)
     mpi_println()
 
     # Open file for appending and store time step and time information
@@ -347,7 +347,7 @@ end
 
 
 # Print level information only if AMR is enabled
-function print_amr_information(callbacks, solver, cache)
+function print_amr_information(callbacks, mesh, solver, cache)
 
   if uses_amr(callbacks)
     levels = Vector{Int}(undef, nelements(solver, cache))
@@ -397,7 +397,8 @@ end
 function (cb::DiscreteCallback{Condition,Affect!})(sol) where {Condition, Affect!<:AnalysisCallback}
   analysis_callback = cb.affect!
   semi = sol.prob.p
-  @unpack analyzer, cache_analysis = analysis_callback
+  @unpack analyzer = analysis_callback
+  cache_analysis = analysis_callback.cache
 
   l2_error, linf_error = calc_error_norms(sol.u[end], sol.t[end], analyzer, semi, cache_analysis)
   (; l2=l2_error, linf=linf_error)

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -204,10 +204,8 @@ function (analysis_callback::AnalysisCallback)(integrator)
     # Calculate current time derivative (needed for semidiscrete entropy time derivative, residual, etc.)
     du_ode = first(get_tmp_cache(integrator))
     @notimeit timer() rhs!(du_ode, integrator.u, semi, t)
-    GC.@preserve du_ode begin
-      du = wrap_array(du_ode, mesh, equations, solver, cache)
-      l2_error, linf_error = analysis_callback(io, du, u, integrator.u, t, semi)
-    end # GC.@preserve du_ode
+    du = wrap_array(du_ode, mesh, equations, solver, cache)
+    l2_error, linf_error = analysis_callback(io, du, u, integrator.u, t, semi)
 
     mpi_println("─"^100)
     mpi_println()

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -212,6 +212,9 @@ function (analysis_callback::AnalysisCallback)(integrator)
 
     # Add line break and close analysis file if it was opened
     if mpi_isroot() && analysis_callback.save_analysis
+      # This resolves a possible type instability introduced above, since `io`
+      # can either be an `IOStream` or `devnull`, but we know that it must be
+      # an `IOStream here`.
       println(io::IOStream)
       close(io::IOStream)
     end

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -376,6 +376,8 @@ end
 
 # Iterate over tuples of analysis integrals in a type-stable way using "lispy tuple programming".
 function analyze_integrals(analysis_integrals::NTuple{N,Any}, io, du, u, t, semi) where {N}
+
+  # Extract the first analysis integral and process it; keep the remaining to be processed later
   quantity = first(analysis_integrals)
   remaining_quantities = Base.tail(analysis_integrals)
 
@@ -387,6 +389,7 @@ function analyze_integrals(analysis_integrals::NTuple{N,Any}, io, du, u, t, semi
   end
   mpi_println()
 
+  # Recursively call this method with the unprocessed integrals
   analyze_integrals(remaining_quantities, io, du, u, t, semi)
   return nothing
 end

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -229,12 +229,8 @@ function (analysis_callback::AnalysisCallback)(integrator)
       io = devnull
     end
 
-    # the time derivative can be unassigned before the first step is made
-    if t == integrator.sol.prob.tspan[1]
-      du_ode = similar(integrator.u)
-    else
-      du_ode = get_du(integrator)
-    end
+    # Calculate current time derivative (needed for semidiscrete entropy time derivative, residual, etc.)
+    du_ode = first(get_tmp_cache(integrator))
     @notimeit timer() rhs!(du_ode, integrator.u, semi, t)
     GC.@preserve du_ode begin
       du = wrap_array(du_ode, mesh, equations, solver, cache)

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -228,6 +228,8 @@ function (analysis_callback::AnalysisCallback)(integrator)
 end
 
 
+# This method is just called internally from `(analysis_callback::AnalysisCallback)(integrator)`
+# and serves as a function barrier. Additionally, it makes the code easier to profile and optimize.
 function (analysis_callback::AnalysisCallback)(io, du, u, u_ode, t, semi)
   @unpack analyzer, analysis_errors, analysis_integrals = analysis_callback
   cache_analysis = analysis_callback.cache

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -206,7 +206,7 @@ function (analysis_callback::AnalysisCallback)(integrator)
     @notimeit timer() rhs!(du_ode, integrator.u, semi, t)
     GC.@preserve du_ode begin
       du = wrap_array(du_ode, mesh, equations, solver, cache)
-      l2_error, linf_error = analysis_callback(io, du, u, t, semi)
+      l2_error, linf_error = analysis_callback(io, du, u, integrator.u, t, semi)
     end # GC.@preserve du_ode
 
     mpi_println("─"^100)
@@ -227,7 +227,7 @@ function (analysis_callback::AnalysisCallback)(integrator)
 end
 
 
-function (analysis_callback::AnalysisCallback)(io, du, u, t, semi)
+function (analysis_callback::AnalysisCallback)(io, du, u, u_ode, t, semi)
   @unpack analyzer, analysis_errors, analysis_integrals = analysis_callback
   cache_analysis = analysis_callback.cache
   _, equations, _, _ = mesh_equations_solver_cache(semi)
@@ -272,7 +272,7 @@ function (analysis_callback::AnalysisCallback)(io, du, u, t, semi)
   # Conservation errror
   if :conservation_error in analysis_errors
     @unpack initial_state_integrals = analysis_callback
-    state_integrals = integrate(u, semi)
+    state_integrals = integrate(u_ode, semi)
 
     if mpi_isroot()
       print(" |∑U - ∑U₀|:  ")

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -353,10 +353,6 @@ function print_amr_information(callbacks, solver, cache)
   return nothing
 end
 
-uses_amr(cb) = false
-uses_amr(cb::DiscreteCallback{Condition,Affect!}) where {Condition, Affect!<:AMRCallback} = true
-uses_amr(callbacks::CallbackSet) = mapreduce(uses_amr, |, callbacks.discrete_callbacks)
-
 
 # Iterate over tuples of analysis integrals in a type-stable way using "lispy tuple programming".
 function analyze_integrals(analysis_integrals::NTuple{N,Any}, io, du, u, t, semi) where {N}

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -352,22 +352,23 @@ end
 # Print level information only if AMR is enabled
 function print_amr_information(callbacks, mesh, solver, cache)
 
-  if uses_amr(callbacks)
-    levels = Vector{Int}(undef, nelements(solver, cache))
-    min_level = typemax(Int)
-    max_level = typemin(Int)
-    for element in eachelement(solver, cache)
-      current_level = mesh.tree.levels[cache.elements.cell_ids[element]]
-      levels[element] = current_level
-      min_level = min(min_level, current_level)
-      max_level = max(max_level, current_level)
-    end
+  # Return early if there is nothing to print
+  uses_amr(callbacks) || return nothing
 
-    for level = max_level:-1:min_level+1
-      mpi_println(" ├── level $level:    " * @sprintf("% 14d", count(isequal(level), levels)))
-    end
-    mpi_println(" └── level $min_level:    " * @sprintf("% 14d", count(isequal(min_level), levels)))
+  levels = Vector{Int}(undef, nelements(solver, cache))
+  min_level = typemax(Int)
+  max_level = typemin(Int)
+  for element in eachelement(solver, cache)
+    current_level = mesh.tree.levels[cache.elements.cell_ids[element]]
+    levels[element] = current_level
+    min_level = min(min_level, current_level)
+    max_level = max(max_level, current_level)
   end
+
+  for level = max_level:-1:min_level+1
+    mpi_println(" ├── level $level:    " * @sprintf("% 14d", count(isequal(level), levels)))
+  end
+  mpi_println(" └── level $min_level:    " * @sprintf("% 14d", count(isequal(min_level), levels)))
 
   return nothing
 end

--- a/src/callbacks_step/analysis_dg1d.jl
+++ b/src/callbacks_step/analysis_dg1d.jl
@@ -49,9 +49,9 @@ function calc_error_norms(func, u::AbstractArray{<:Any,3}, t, analyzer,
 end
 
 
-function integrate_via_indices(func, u::AbstractArray{<:Any,3},
+function integrate_via_indices(func::Func, u::AbstractArray{<:Any,3},
                                mesh::TreeMesh{1}, equations, dg::DGSEM, cache,
-                               args...; normalize=true)
+                               args...; normalize=true) where {Func}
   @unpack weights = dg.basis
 
   # Initialize integral with zeros of the right shape
@@ -74,8 +74,8 @@ function integrate_via_indices(func, u::AbstractArray{<:Any,3},
   return integral
 end
 
-function integrate(func, u::AbstractArray{<:Any,3},
-                   mesh::TreeMesh{1}, equations, dg::DGSEM, cache; normalize=true)
+function integrate(func::Func, u::AbstractArray{<:Any,3},
+                   mesh::TreeMesh{1}, equations, dg::DGSEM, cache; normalize=true) where {Func}
   integrate_via_indices(u, mesh, equations, dg, cache; normalize=normalize) do u, i, element, equations, dg
     u_local = get_node_vars(u, equations, dg, i, element)
     return func(u_local, equations)

--- a/src/callbacks_step/analysis_dg1d.jl
+++ b/src/callbacks_step/analysis_dg1d.jl
@@ -1,15 +1,24 @@
 
-function calc_error_norms(func, u::AbstractArray{<:Any,3}, t, analyzer,
-                          mesh::TreeMesh{1}, equations, initial_condition,
-                          dg::DGSEM, cache)
-  @unpack vandermonde, weights = analyzer
-  @unpack node_coordinates = cache.elements
+function create_cache(::Type{AnalysisCallback}, analyzer,
+                      equations::AbstractEquations{1}, dg::DG, cache)
+  eltype_u = eltype_x = eltype(cache.elements.node_coordinates) # TODO: AD, needs to be adapted
 
   # pre-allocate buffers
-  u_local = zeros(eltype(u),
+  u_local = zeros(eltype_u,
                   nvariables(equations), nnodes(analyzer))
-  x_local = zeros(eltype(node_coordinates),
+  x_local = zeros(eltype_x,
                   ndims(equations), nnodes(analyzer))
+
+  return (; u_local, x_local)
+end
+
+
+function calc_error_norms(func, u::AbstractArray{<:Any,3}, t, analyzer,
+                          mesh::TreeMesh{1}, equations, initial_condition,
+                          dg::DGSEM, cache, cache_analysis)
+  @unpack vandermonde, weights = analyzer
+  @unpack node_coordinates = cache.elements
+  @unpack u_local, x_local = cache_analysis
 
   # Set up data structures
   l2_error   = zero(func(get_node_vars(u, equations, dg, 1, 1), equations))

--- a/src/callbacks_step/analysis_dg2d.jl
+++ b/src/callbacks_step/analysis_dg2d.jl
@@ -53,9 +53,9 @@ function calc_error_norms(func, u::AbstractArray{<:Any,4}, t, analyzer,
 end
 
 
-function integrate_via_indices(func, u::AbstractArray{<:Any,4},
+function integrate_via_indices(func::Func, u::AbstractArray{<:Any,4},
                                mesh::TreeMesh{2}, equations, dg::DGSEM, cache,
-                               args...; normalize=true)
+                               args...; normalize=true) where {Func}
   @unpack weights = dg.basis
 
   # Initialize integral with zeros of the right shape
@@ -78,8 +78,8 @@ function integrate_via_indices(func, u::AbstractArray{<:Any,4},
   return integral
 end
 
-function integrate(func, u::AbstractArray{<:Any,4},
-                   mesh::TreeMesh{2}, equations, dg::DGSEM, cache; normalize=true)
+function integrate(func::Func, u::AbstractArray{<:Any,4},
+                   mesh::TreeMesh{2}, equations, dg::DGSEM, cache; normalize=true) where {Func}
   integrate_via_indices(u, mesh, equations, dg, cache; normalize=normalize) do u, i, j, element, equations, dg
     u_local = get_node_vars(u, equations, dg, i, j, element)
     return func(u_local, equations)

--- a/src/callbacks_step/analysis_dg2d.jl
+++ b/src/callbacks_step/analysis_dg2d.jl
@@ -1,19 +1,28 @@
 
-function calc_error_norms(func, u::AbstractArray{<:Any,4}, t, analyzer,
-                          mesh::TreeMesh{2}, equations, initial_condition,
-                          dg::DGSEM, cache)
-  @unpack vandermonde, weights = analyzer
-  @unpack node_coordinates = cache.elements
+function create_cache(::Type{AnalysisCallback}, analyzer,
+                      equations::AbstractEquations{2}, dg::DG, cache)
+  eltype_u = eltype_x = eltype(cache.elements.node_coordinates) # TODO: AD, needs to be adapted
 
   # pre-allocate buffers
-  u_local = zeros(eltype(u),
+  u_local = zeros(eltype_u,
                   nvariables(equations), nnodes(analyzer), nnodes(analyzer))
   u_tmp1 = similar(u_local,
                    nvariables(equations), nnodes(analyzer), nnodes(dg))
-  x_local = zeros(eltype(node_coordinates),
+  x_local = zeros(eltype_x,
                   ndims(equations), nnodes(analyzer), nnodes(analyzer))
   x_tmp1 = similar(x_local,
                    ndims(equations), nnodes(analyzer), nnodes(dg))
+
+  return (; u_local, u_tmp1, x_local, x_tmp1)
+end
+
+
+function calc_error_norms(func, u::AbstractArray{<:Any,4}, t, analyzer,
+                          mesh::TreeMesh{2}, equations, initial_condition,
+                          dg::DGSEM, cache, cache_analysis)
+  @unpack vandermonde, weights = analyzer
+  @unpack node_coordinates = cache.elements
+  @unpack u_local, u_tmp1, x_local, x_tmp1 = cache_analysis
 
   # Set up data structures
   l2_error   = zero(func(get_node_vars(u, equations, dg, 1, 1, 1), equations))

--- a/src/callbacks_step/analysis_dg2d_parallel.jl
+++ b/src/callbacks_step/analysis_dg2d_parallel.jl
@@ -31,9 +31,9 @@ function calc_error_norms(func, u::AbstractArray{<:Any,4}, t, analyzer,
 end
 
 
-function integrate_via_indices(func, u::AbstractArray{<:Any,4},
+function integrate_via_indices(func::Func, u::AbstractArray{<:Any,4},
                                mesh::ParallelTreeMesh{2}, equations, dg::DGSEM, cache,
-                               args...; normalize=true)
+                               args...; normalize=true) where {Func}
   # call the method accepting a general `mesh::TreeMesh{2}`
   # TODO: MPI, we should improve this; maybe we should dispatch on `u`
   #       and create some MPI array type, overloading broadcasting and mapreduce etc.

--- a/src/callbacks_step/analysis_dg2d_parallel.jl
+++ b/src/callbacks_step/analysis_dg2d_parallel.jl
@@ -1,15 +1,16 @@
 
 function calc_error_norms(func, u::AbstractArray{<:Any,4}, t, analyzer,
                           mesh::ParallelTreeMesh{2}, equations, initial_condition,
-                          dg::DGSEM, cache)
+                          dg::DGSEM, cache, cache_analysis)
   # call the method accepting a general `mesh::TreeMesh{2}`
   # TODO: MPI, we should improve this; maybe we should dispatch on `u`
   #       and create some MPI array type, overloading broadcasting and mapreduce etc.
   #       Then, this specific array type should also work well with DiffEq etc.
   l2_error, linf_error = invoke(calc_error_norms,
     Tuple{typeof(func), typeof(u), typeof(t), typeof(analyzer), TreeMesh{2},
-          typeof(equations), typeof(initial_condition), typeof(dg), typeof(cache)},
-    func, u, t, analyzer, mesh, equations, initial_condition, dg, cache)
+          typeof(equations), typeof(initial_condition), typeof(dg), typeof(cache),
+          typeof(cache_analysis)},
+    func, u, t, analyzer, mesh, equations, initial_condition, dg, cache, cache_analysis)
 
   # Since the local L2 norm is already normalized and square-rooted, we need to undo this first
   total_volume = mesh.tree.length_level_0^ndims(mesh)

--- a/src/callbacks_step/analysis_dg3d.jl
+++ b/src/callbacks_step/analysis_dg3d.jl
@@ -57,9 +57,9 @@ function calc_error_norms(func, u::AbstractArray{<:Any,5}, t, analyzer,
 end
 
 
-function integrate_via_indices(func, u::AbstractArray{<:Any,5},
+function integrate_via_indices(func::Func, u::AbstractArray{<:Any,5},
                                mesh::TreeMesh{3}, equations, dg::DGSEM, cache,
-                               args...; normalize=true)
+                               args...; normalize=true) where {Func}
   @unpack weights = dg.basis
 
   # Initialize integral with zeros of the right shape
@@ -82,8 +82,8 @@ function integrate_via_indices(func, u::AbstractArray{<:Any,5},
   return integral
 end
 
-function integrate(func, u::AbstractArray{<:Any,5},
-                   mesh::TreeMesh{3}, equations, dg::DGSEM, cache; normalize=true)
+function integrate(func::Func, u::AbstractArray{<:Any,5},
+                   mesh::TreeMesh{3}, equations, dg::DGSEM, cache; normalize=true) where {Func}
   integrate_via_indices(u, mesh, equations, dg, cache; normalize=normalize) do u, i, j, k, element, equations, dg
     u_local = get_node_vars(u, equations, dg, i, j, k, element)
     return func(u_local, equations)

--- a/src/equations/lattice_boltzmann_3d.jl
+++ b/src/equations/lattice_boltzmann_3d.jl
@@ -26,8 +26,8 @@ The twenty-seven discrete velocity directions of the D3Q27 scheme are sorted as 
        │       │          │
     10 ┼   6   ┼ 15        ──── x
        │       │         ╱
-       └───┼───┘        ╱ 
-    20    12     26    z           
+       └───┼───┘        ╱
+    20    12     26    z
   ```
 * plane at `z = 0`:
   ```
@@ -36,7 +36,7 @@ The twenty-seven discrete velocity directions of the D3Q27 scheme are sorted as 
        │       │          │
      2 ┼  27   ┼ 1         ──── x
        │       │         ╱
-       └───┼───┘        ╱ 
+       └───┼───┘        ╱
      8     4     13    z
   ```
 * plane at `z = +1`:
@@ -46,7 +46,7 @@ The twenty-seven discrete velocity directions of the D3Q27 scheme are sorted as 
        │       │          │
     16 ┼   5   ┼ 9         ──── x
        │       │         ╱
-       └───┼───┘        ╱ 
+       └───┼───┘        ╱
     22    18     23    z
   ```
 Note that usually the velocities are numbered from `0` to `26`, where `0` corresponds to the zero
@@ -172,7 +172,7 @@ end
 
 
 get_name(::LatticeBoltzmannEquations3D) = "LatticeBoltzmannEquations3D"
-varnames(::typeof(cons2cons), equations::LatticeBoltzmannEquations3D) = ntuple(v -> "pdf"*string(v), nvariables(equations))
+varnames(::typeof(cons2cons), equations::LatticeBoltzmannEquations3D) = ntuple(v -> "pdf"*string(v), Val(nvariables(equations)))
 varnames(::typeof(cons2prim), equations::LatticeBoltzmannEquations3D) = varnames(cons2cons, equations)
 
 

--- a/src/semidiscretization/semidiscretization.jl
+++ b/src/semidiscretization/semidiscretization.jl
@@ -18,7 +18,7 @@ and integrate the result using a quadrature associated with the semidiscretizati
 
 If `normalize` is true, the result is divided by the total volume of the computational domain.
 """
-function integrate_via_indices(func, u_ode::AbstractVector, semi::AbstractSemidiscretization, args...; normalize=true)
+function integrate_via_indices(func::Func, u_ode::AbstractVector, semi::AbstractSemidiscretization, args...; normalize=true) where {Func}
   mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
 
   u = wrap_array(u_ode, mesh, equations, solver, cache)
@@ -33,7 +33,7 @@ and integrate the result using a quadrature associated with the semidiscretizati
 
 If `normalize` is true, the result is divided by the total volume of the computational domain.
 """
-function integrate(func, u_ode::AbstractVector, semi::AbstractSemidiscretization; normalize=true)
+function integrate(func::Func, u_ode::AbstractVector, semi::AbstractSemidiscretization; normalize=true) where {Func}
   mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
 
   u = wrap_array(u_ode, mesh, equations, solver, cache)

--- a/src/semidiscretization/semidiscretization.jl
+++ b/src/semidiscretization/semidiscretization.jl
@@ -46,13 +46,13 @@ end
 
 
 """
-    calc_error_norms([func=(u_node,equations)->u_node,] u_ode, t, analyzer, semi::AbstractSemidiscretization)
+    calc_error_norms([func=(u_node,equations)->u_node,] u_ode, t, analyzer, semi::AbstractSemidiscretization, cache_analysis)
 
 Calculate discrete L2 and L∞ error norms of `func` applied to each nodal variable `u_node` in `u_ode`.
 If no exact solution is available, "errors" are calculated using some reference state and can be useful
 for regression tests.
 """
-calc_error_norms(u_ode, t, analyzer, semi::AbstractSemidiscretization) = calc_error_norms(cons2cons, u_ode, t, analyzer, semi)
+calc_error_norms(u_ode, t, analyzer, semi::AbstractSemidiscretization, cache_analysis) = calc_error_norms(cons2cons, u_ode, t, analyzer, semi, cache_analysis)
 
 
 """
@@ -264,7 +264,7 @@ end
 # - wrap_array(u_ode::AbstractVector, mesh, equations, solver, cache)
 # - integrate(func, u, mesh, equations, solver, cache; normalize=true)
 # - integrate_via_indices(func, u, mesh, equations, solver, cache, args...; normalize=true)
-# - calc_error_norms(func, u, t, analyzer, mesh, equations, initial_condition, solver, cache)
+# - calc_error_norms(func, u, t, analyzer, mesh, equations, initial_condition, solver, cache, cache_analysis)
 # - allocate_coefficients(mesh, equations, solver, cache)
 # - compute_coefficients!(u, func, mesh, equations, solver, cache)
 # - rhs!(du, u, t, mesh, equations, initial_condition, boundary_conditions, source_terms, solver, cache)

--- a/src/semidiscretization/semidiscretization_euler_gravity.jl
+++ b/src/semidiscretization/semidiscretization_euler_gravity.jl
@@ -160,8 +160,8 @@ end
 end
 
 
-@inline function calc_error_norms(func, u, t, analyzer, semi::SemidiscretizationEulerGravity)
-  calc_error_norms(func, u, t, analyzer, semi.semi_euler)
+@inline function calc_error_norms(func, u, t, analyzer, semi::SemidiscretizationEulerGravity, cache_analysis)
+  calc_error_norms(func, u, t, analyzer, semi.semi_euler, cache_analysis)
 end
 
 

--- a/src/semidiscretization/semidiscretization_hyperbolic.jl
+++ b/src/semidiscretization/semidiscretization_hyperbolic.jl
@@ -140,17 +140,17 @@ end
 end
 
 
-function calc_error_norms(func, u_ode::AbstractVector, t, analyzer, semi::SemidiscretizationHyperbolic)
+function calc_error_norms(func, u_ode::AbstractVector, t, analyzer, semi::SemidiscretizationHyperbolic, cache_analysis)
   @unpack mesh, equations, initial_condition, solver, cache = semi
   u = wrap_array(u_ode, mesh, equations, solver, cache)
 
-  calc_error_norms(func, u, t, analyzer, mesh, equations, initial_condition, solver, cache)
+  calc_error_norms(func, u, t, analyzer, mesh, equations, initial_condition, solver, cache, cache_analysis)
 end
 
-function calc_error_norms(func, u, t, analyzer, semi::SemidiscretizationHyperbolic)
+function calc_error_norms(func, u, t, analyzer, semi::SemidiscretizationHyperbolic, cache_analysis)
   @unpack mesh, equations, initial_condition, solver, cache = semi
 
-  calc_error_norms(func, u, t, analyzer, mesh, equations, initial_condition, solver, cache)
+  calc_error_norms(func, u, t, analyzer, mesh, equations, initial_condition, solver, cache, cache_analysis)
 end
 
 

--- a/src/time_integration/methods_2N.jl
+++ b/src/time_integration/methods_2N.jl
@@ -165,6 +165,7 @@ end
 
 # get a cache where the RHS can be stored
 get_du(integrator::SimpleIntegrator2N) = integrator.du
+get_tmp_cache(integrator::SimpleIntegrator2N) = (integrator.u_tmp,)
 
 # some algorithms from DiffEq like FSAL-ones need to be informed when a callback has modified u
 u_modified!(integrator::SimpleIntegrator2N, ::Bool) = false

--- a/src/time_integration/methods_3Sstar.jl
+++ b/src/time_integration/methods_3Sstar.jl
@@ -203,6 +203,7 @@ end
 
 # get a cache where the RHS can be stored
 get_du(integrator::SimpleIntegrator3Sstar) = integrator.du
+get_tmp_cache(integrator::SimpleIntegrator3Sstar) = (integrator.u_tmp1, integrator.u_tmp2)
 
 # some algorithms from DiffEq like FSAL-ones need to be informed when a callback has modified u
 u_modified!(integrator::SimpleIntegrator3Sstar, ::Bool) = false


### PR DESCRIPTION
The analysis callback had some allocation problems, especially in 3D... It turned out that most of the were caused by type-instabilities created by integration methods that didn't specialize on the function that should be integrated. By fixing these and adding some further simplifications and performance improvements on top, the performance of the second run of
```julia
julia> trixi_include("examples/3d/elixir_lbm_taylor_green_vortex.jl", initial_refinement_level=4, maxiters=22)
```
with `julia --threads=6 --check-bounds=no` can be improved from 
```
 -------------------------------------------------------------------------------
            Trixi.jl                    Time                   Allocations      
                                ----------------------   -----------------------
        Tot / % measured:            10.8s / 76.1%           2.26GiB / 79.0%    

 Section                ncalls     time   %tot     avg     alloc   %tot      avg
 -------------------------------------------------------------------------------
 rhs!                      111    4.99s  60.7%  45.0ms   4.99MiB  0.27%  46.1KiB
   interface flux          111    1.16s  14.1%  10.4ms    603KiB  0.03%  5.43KiB
   prolong2interfaces      111    1.07s  13.1%  9.68ms    603KiB  0.03%  5.44KiB
   volume integral         111    865ms  10.5%  7.80ms    623KiB  0.03%  5.61KiB
   surface integral        111    844ms  10.3%  7.60ms    610KiB  0.03%  5.50KiB
   reset ∂u/∂t             111    547ms  6.66%  4.93ms     0.00B  0.00%    0.00B
   Jacobian                111    500ms  6.09%  4.51ms    611KiB  0.03%  5.50KiB
   prolong2boundaries      111   1.48ms  0.02%  13.3μs    599KiB  0.03%  5.40KiB
   prolong2mortars         111   1.02ms  0.01%  9.20μs    667KiB  0.04%  6.01KiB
   mortar flux             111    910μs  0.01%  8.19μs    667KiB  0.04%  6.01KiB
   boundary flux           111    104μs  0.00%   935ns     0.00B  0.00%    0.00B
   source terms            111   28.4μs  0.00%   256ns     0.00B  0.00%    0.00B
 I/O                         5    1.56s  18.9%   311ms    114MiB  6.26%  22.9MiB
 analyze solution            3    1.55s  18.9%   517ms   1.67GiB  93.5%   569MiB
 LBM collision              22    118ms  1.43%  5.35ms    120KiB  0.01%  5.44KiB
 calculate dt               23    244μs  0.00%  10.6μs     0.00B  0.00%    0.00B
 -------------------------------------------------------------------------------
```
on `lbm3d` to
```
 -------------------------------------------------------------------------------
            Trixi.jl                    Time                   Allocations      
                                ----------------------   -----------------------
        Tot / % measured:            9.93s / 76.8%            174MiB / 69.0%    

 Section                ncalls     time   %tot     avg     alloc   %tot      avg
 -------------------------------------------------------------------------------
 rhs!                      111    4.99s  65.5%  45.0ms   4.99MiB  4.16%  46.1KiB
   interface flux          111    1.16s  15.2%  10.5ms    603KiB  0.49%  5.43KiB
   prolong2interfaces      111    1.08s  14.2%  9.74ms    604KiB  0.49%  5.44KiB
   volume integral         111    868ms  11.4%  7.82ms    622KiB  0.51%  5.60KiB
   surface integral        111    847ms  11.1%  7.63ms    610KiB  0.50%  5.50KiB
   reset ∂u/∂t             111    531ms  6.97%  4.78ms     0.00B  0.00%    0.00B
   Jacobian                111    499ms  6.54%  4.49ms    611KiB  0.50%  5.51KiB
   prolong2boundaries      111   1.50ms  0.02%  13.5μs    599KiB  0.49%  5.40KiB
   prolong2mortars         111   1.01ms  0.01%  9.08μs    667KiB  0.54%  6.01KiB
   mortar flux             111    925μs  0.01%  8.33μs    667KiB  0.54%  6.01KiB
   boundary flux           111    104μs  0.00%   939ns     0.00B  0.00%    0.00B
   source terms            111   26.8μs  0.00%   241ns     0.00B  0.00%    0.00B
 I/O                         5    1.65s  21.6%   330ms    114MiB  95.2%  22.9MiB
 analyze solution            3    859ms  11.3%   286ms    630KiB  0.51%   210KiB
 LBM collision              22    125ms  1.64%  5.69ms    120KiB  0.10%  5.43KiB
 calculate dt               23    284μs  0.00%  12.4μs     0.00B  0.00%    0.00B
 -------------------------------------------------------------------------------
```
in this PR.