### PR TITLE
improve 2D mortar flux

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -17,7 +17,7 @@ module Trixi
 
 # Include other packages that are used in Trixi
 # (standard library packages first, other packages next, all of them sorted alphabetically)
-using LinearAlgebra: dot
+using LinearAlgebra: dot, mul!
 using Printf: @printf, @sprintf, println
 
 import DiffEqBase: ODEProblem, ODESolution, get_du, get_tmp_cache, u_modified!,

--- a/src/solvers/dg/dg_2d.jl
+++ b/src/solvers/dg/dg_2d.jl
@@ -1004,8 +1004,14 @@ end
   end
 
   for v in eachvariable(equations)
-    @views surface_flux_values[v, :, direction, large_element] .=
-      (mortar_l2.reverse_upper * fstar_upper[v, :] + mortar_l2.reverse_lower * fstar_lower[v, :])
+    # The code below is semantically equivalent to
+    # surface_flux_values[v, :, direction, large_element] .=
+    #   (mortar_l2.reverse_upper * fstar_upper[v, :] + mortar_l2.reverse_lower * fstar_lower[v, :])
+    # but faster and does not allocate.
+    @views mul!(surface_flux_values[v, :, direction, large_element],
+                mortar_l2.reverse_upper, fstar_upper[v, :])
+    @views mul!(surface_flux_values[v, :, direction, large_element],
+                mortar_l2.reverse_lower,  fstar_lower[v, :], true, true)
   end
   # TODO: Taal performance
   # The code above could be replaced by the following code. However, the relative efficiency

--- a/src/solvers/dg/dg_2d.jl
+++ b/src/solvers/dg/dg_2d.jl
@@ -1008,6 +1008,9 @@ end
     # surface_flux_values[v, :, direction, large_element] .=
     #   (mortar_l2.reverse_upper * fstar_upper[v, :] + mortar_l2.reverse_lower * fstar_lower[v, :])
     # but faster and does not allocate.
+    # Note that `true * some_float == some_float` in Julia, i.e. `true` acts as
+    # a universal `one`. Hence, the second `mul!` means "add the matrix-vector
+    # product to the current value of the destination".
     @views mul!(surface_flux_values[v, :, direction, large_element],
                 mortar_l2.reverse_upper, fstar_upper[v, :])
     @views mul!(surface_flux_values[v, :, direction, large_element],


### PR DESCRIPTION
When working on the gravity project, I realized that the mortar flux in 2D allocates a lot, at least with the versions of all packages I have on my system. This PR improves the performance of `julia --threads=1 --check-bounds=no` for `trixi_include("examples/paper-self-gravitating-gas-dynamics/elixir_eulergravity_sedov_blast_wave.jl")` from
```
 ---------------------------------------------------------------------------------
             Trixi.jl                     Time                   Allocations      
                                  ----------------------   -----------------------
         Tot / % measured:             58.0s / 95.5%           17.8GiB / 100%     

 Section                  ncalls     time   %tot     avg     alloc   %tot      avg
 ---------------------------------------------------------------------------------
 Euler solver              2.93k    24.8s  44.9%  8.47ms   2.70GiB  15.2%   967KiB
   rhs!                    2.93k    24.8s  44.9%  8.47ms   2.70GiB  15.2%   967KiB
     mortar flux           2.93k    1.78s  3.21%   606μs   2.67GiB  15.0%   954KiB
 gravity solver            2.93k    23.5s  42.5%  8.02ms   10.2GiB  57.2%  3.56MiB
   rhs!                    29.3k    37.9s  68.4%  1.29ms   20.3GiB  114%    728KiB
     mortar flux           14.7k    4.82s  8.72%   329μs   10.0GiB  56.1%   716KiB
 ---------------------------------------------------------------------------------
```
on `master` to 
```
 ---------------------------------------------------------------------------------
             Trixi.jl                     Time                   Allocations      
                                  ----------------------   -----------------------
         Tot / % measured:             53.8s / 95.2%           5.14GiB / 100%     

 Section                  ncalls     time   %tot     avg     alloc   %tot      avg
 ---------------------------------------------------------------------------------
 Euler solver              2.93k    24.2s  47.2%  8.25ms   41.2MiB  0.78%  14.4KiB
   rhs!                    2.93k    24.2s  47.2%  8.25ms   40.5MiB  0.77%  14.1KiB
     mortar flux           2.93k    947ms  1.85%   323μs   4.29MiB  0.08%  1.50KiB
 gravity solver            2.93k    20.1s  39.2%  6.84ms    211MiB  4.02%  73.8KiB
   rhs!                    29.3k    31.6s  61.8%  1.08ms    382MiB  7.27%  13.4KiB
     mortar flux           14.7k    1.62s  3.17%   111μs   20.6MiB  0.39%  1.44KiB
 ---------------------------------------------------------------------------------
```