### PR TITLE
Re-add `flag-name` to Coveralls action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
       - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: run-${{ matrix.test_number }}
           parallel: true
           path-to-lcov: ./lcov.info
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: run-${{ matrix.test_number }}
+          flag-name: run-${{ matrix.trixi_test }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}
           parallel: true
           path-to-lcov: ./lcov.info
 


### PR DESCRIPTION
It is required as per the [docs][1] and was again confirmed to be
necessary in a GitHub [issue][2] created by @erik-f.

[1]: https://github.com/marketplace/actions/coveralls-github-action#inputs
[2]: https://github.com/lemurheavy/coveralls-public/issues/1513#issuecomment-752789685