### PR TITLE
introduce at-threaded macro wrapping Base at-threads

### DIFF
--- a/docs/src/parallelization.md
+++ b/docs/src/parallelization.md
@@ -4,9 +4,9 @@
 Many compute-intensive loops in Trixi.jl are parallelized using the
 [multi-threading](https://docs.julialang.org/en/v1/manual/multi-threading/)
 support provided by Julia. You can recognize those loops by the
-`Threads.@threads` macro prefixed to them, e.g.,
+`@threaded` macro prefixed to them, e.g.,
 ```julia
-Threads.@threads for element in eachelement(dg, cache)
+@threaded for element in eachelement(dg, cache)
   ...
 end
 ```

--- a/examples/2d/elixir_euler_vortex_amr.jl
+++ b/examples/2d/elixir_euler_vortex_amr.jl
@@ -40,7 +40,7 @@ function (indicator_vortex::IndicatorVortex)(u::AbstractArray{<:Any,4},
     center = (t-domain_length, t-domain_length)
   end
 
-  @threaded for element in eachelement(dg, cache)
+  Threads.@threads for element in eachelement(dg, cache)
     cell_id = cache.elements.cell_ids[element]
     coordinates = (mesh.tree.coordinates[1, cell_id], mesh.tree.coordinates[2, cell_id])
     # use the negative radius as indicator since the AMR controller increases

--- a/examples/2d/elixir_euler_vortex_amr.jl
+++ b/examples/2d/elixir_euler_vortex_amr.jl
@@ -40,7 +40,7 @@ function (indicator_vortex::IndicatorVortex)(u::AbstractArray{<:Any,4},
     center = (t-domain_length, t-domain_length)
   end
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     cell_id = cache.elements.cell_ids[element]
     coordinates = (mesh.tree.coordinates[1, cell_id], mesh.tree.coordinates[2, cell_id])
     # use the negative radius as indicator since the AMR controller increases
@@ -115,7 +115,7 @@ amr_callback = AMRCallback(semi, amr_controller,
 stepsize_callback = StepsizeCallback(cfl=1.1)
 
 callbacks = CallbackSet(summary_callback,
-                        analysis_callback, alive_callback, 
+                        analysis_callback, alive_callback,
                         save_solution,
                         amr_callback, stepsize_callback)
 

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -126,3 +126,25 @@ julia> Trixi.get_name(Val(:test))
 """
 get_name(x) = string(x)
 get_name(::Val{x}) where x = string(x)
+
+
+
+"""
+    @threaded for ... end
+
+Basically the same as `Threads.@threads` with an additional check whether only
+one thread is used to reduce the overhead of serial execution.
+
+Some discussion can be found at https://discourse.julialang.org/t/overhead-of-threads-threads/53964
+"""
+macro threaded(expr)
+  # esc(quote ... end) as suggested in https://github.com/JuliaLang/julia/issues/23221
+  return esc(quote
+    if Threads.nthreads() == 1
+      $(expr)
+    else
+      Threads.@threads $(expr)
+    end
+  end)
+end
+

--- a/src/callbacks_stage/positivity_zhang_shu_dg1d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg1d.jl
@@ -4,7 +4,7 @@ function limiter_zhang_shu!(u::AbstractArray{<:Any,3},
                             mesh, equations, dg::DGSEM, cache)
   @unpack weights = dg.basis
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     # dermine minimum value
     value_min = typemax(eltype(u))
     for i in eachnode(dg)

--- a/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
@@ -4,7 +4,7 @@ function limiter_zhang_shu!(u::AbstractArray{<:Any,4},
                             mesh, equations, dg::DGSEM, cache)
   @unpack weights = dg.basis
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     # dermine minimum value
     value_min = typemax(eltype(u))
     for j in eachnode(dg), i in eachnode(dg)

--- a/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
@@ -4,7 +4,7 @@ function limiter_zhang_shu!(u::AbstractArray{<:Any,5},
                             mesh, equations, dg::DGSEM, cache)
   @unpack weights = dg.basis
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     # dermine minimum value
     value_min = typemax(eltype(u))
     for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -41,7 +41,7 @@ function AMRCallback(semi, controller, adaptor;
   amr_cache = (; to_refine, to_coarsen)
 
   amr_callback = AMRCallback{typeof(controller), typeof(adaptor), typeof(amr_cache)}(
-    controller, interval, adapt_initial_condition, adapt_initial_condition_only_refine, 
+    controller, interval, adapt_initial_condition, adapt_initial_condition_only_refine,
     dynamic_load_balancing, adaptor, amr_cache)
 
   DiscreteCallback(condition, amr_callback,
@@ -422,7 +422,7 @@ function (controller::ControllerThreeLevel)(u::AbstractArray{<:Any},
 
   alpha = controller.indicator(u, equations, dg, cache; kwargs...)
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     cell_id = cache.elements.cell_ids[element]
     current_level = mesh.tree.levels[cell_id]
 
@@ -548,7 +548,7 @@ function (controller::ControllerThreeLevelCombined)(u::AbstractArray{<:Any},
   alpha = controller.indicator_primary(u, equations, dg, cache; kwargs...)
   alpha_secondary = controller.indicator_secondary(u, equations, dg, cache)
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     cell_id = cache.elements.cell_ids[element]
     current_level = mesh.tree.levels[cell_id]
 

--- a/src/callbacks_step/lbm_collision_dg2d.jl
+++ b/src/callbacks_step/lbm_collision_dg2d.jl
@@ -1,7 +1,7 @@
-function apply_collision!(u::AbstractArray{<:Any,4}, dt, collision_op, 
+function apply_collision!(u::AbstractArray{<:Any,4}, dt, collision_op,
                           mesh, equations, dg::DG, cache)
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     for j in eachnode(dg), i in eachnode(dg)
       u_node = get_node_vars(u, equations, dg, i, j, element)
       update = collision_op(u_node, dt, equations)

--- a/src/callbacks_step/lbm_collision_dg3d.jl
+++ b/src/callbacks_step/lbm_collision_dg3d.jl
@@ -1,7 +1,7 @@
-function apply_collision!(u::AbstractArray{<:Any,5}, dt, collision_op, 
+function apply_collision!(u::AbstractArray{<:Any,5}, dt, collision_op,
                           mesh, equations, dg::DG, cache)
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
       u_node = get_node_vars(u, equations, dg, i, j, k, element)
       update = collision_op(u_node, dt, equations)

--- a/src/semidiscretization/semidiscretization_euler_gravity.jl
+++ b/src/semidiscretization/semidiscretization_euler_gravity.jl
@@ -285,7 +285,7 @@ function timestep_gravity_2N!(cache, u_euler, t, dt, gravity_parameters, semi_gr
     a_stage = a[stage]
     b_stage_dt = b[stage] * dt
     @timeit_debug timer() "Runge-Kutta step" begin
-      Threads.@threads for idx in eachindex(u_ode)
+      @threaded for idx in eachindex(u_ode)
         u_tmp1_ode[idx] = du_ode[idx] - u_tmp1_ode[idx] * a_stage
         u_ode[idx] += u_tmp1_ode[idx] * b_stage_dt
       end
@@ -339,7 +339,7 @@ function timestep_gravity_3Sstar!(cache, u_euler, t, dt, gravity_parameters, sem
     gamma3_stage  = gamma3[stage]
     beta_stage_dt = beta[stage] * dt
     @timeit_debug timer() "Runge-Kutta step" begin
-      Threads.@threads for idx in eachindex(u_ode)
+      @threaded for idx in eachindex(u_ode)
         u_tmp1_ode[idx] += delta_stage * u_ode[idx]
         u_ode[idx]       = (gamma1_stage * u_ode[idx] +
                             gamma2_stage * u_tmp1_ode[idx] +

--- a/src/solvers/dg/dg_2d_parallel.jl
+++ b/src/solvers/dg/dg_2d_parallel.jl
@@ -345,7 +345,7 @@ function prolong2mpiinterfaces!(cache, u::AbstractArray{<:Any,4},
                                 equations, dg::DG)
   @unpack mpi_interfaces = cache
 
-  Threads.@threads for interface in eachmpiinterface(dg, cache)
+  @threaded for interface in eachmpiinterface(dg, cache)
     local_element = mpi_interfaces.local_element_ids[interface]
 
     if mpi_interfaces.orientations[interface] == 1 # interface in x-direction
@@ -381,7 +381,7 @@ function calc_mpi_interface_flux!(surface_flux_values::AbstractArray{<:Any,4},
   @unpack surface_flux = dg
   @unpack u, local_element_ids, orientations, remote_sides = cache.mpi_interfaces
 
-  Threads.@threads for interface in eachmpiinterface(dg, cache)
+  @threaded for interface in eachmpiinterface(dg, cache)
     # Get local neighboring element
     element = local_element_ids[interface]
 

--- a/src/solvers/dg/indicators_1d.jl
+++ b/src/solvers/dg/indicators_1d.jl
@@ -35,7 +35,7 @@ function (indicator_hg::IndicatorHennemannGassner)(u::AbstractArray{<:Any,3},
   threshold = 0.5 * 10^(-1.8 * (nnodes(dg))^0.25)
   parameter_s = log((1 - 0.0001)/0.0001)
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     indicator  = indicator_threaded[Threads.threadid()]
     modal      = modal_threaded[Threads.threadid()]
 
@@ -128,7 +128,7 @@ function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any,3},
   @unpack alpha, indicator_threaded = löhner.cache
   resize!(alpha, nelements(dg, cache))
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     indicator = indicator_threaded[Threads.threadid()]
 
     # Calculate indicator variables at Gauss-Lobatto nodes
@@ -178,7 +178,7 @@ function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any,3},
   @unpack alpha, indicator_threaded = indicator_max.cache
   resize!(alpha, nelements(dg, cache))
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     indicator = indicator_threaded[Threads.threadid()]
 
     # Calculate indicator variables at Gauss-Lobatto nodes

--- a/src/solvers/dg/indicators_2d.jl
+++ b/src/solvers/dg/indicators_2d.jl
@@ -36,7 +36,7 @@ function (indicator_hg::IndicatorHennemannGassner)(u::AbstractArray{<:Any,4},
   threshold = 0.5 * 10^(-1.8 * (nnodes(dg))^0.25)
   parameter_s = log((1 - 0.0001)/0.0001)
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     indicator  = indicator_threaded[Threads.threadid()]
     modal      = modal_threaded[Threads.threadid()]
     modal_tmp1 = modal_tmp1_threaded[Threads.threadid()]
@@ -144,7 +144,7 @@ function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any,4},
   @unpack alpha, indicator_threaded = löhner.cache
   resize!(alpha, nelements(dg, cache))
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     indicator = indicator_threaded[Threads.threadid()]
 
     # Calculate indicator variables at Gauss-Lobatto nodes
@@ -202,7 +202,7 @@ function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any,4},
   @unpack alpha, indicator_threaded = indicator_max.cache
   resize!(alpha, nelements(dg, cache))
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     indicator = indicator_threaded[Threads.threadid()]
 
     # Calculate indicator variables at Gauss-Lobatto nodes

--- a/src/solvers/dg/indicators_3d.jl
+++ b/src/solvers/dg/indicators_3d.jl
@@ -38,7 +38,7 @@ function (indicator_hg::IndicatorHennemannGassner)(u::AbstractArray{<:Any,5},
   threshold = 0.5 * 10^(-1.8 * (nnodes(dg))^0.25)
   parameter_s = log((1 - 0.0001)/0.0001)
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     indicator  = indicator_threaded[Threads.threadid()]
     modal      = modal_threaded[Threads.threadid()]
     modal_tmp1 = modal_tmp1_threaded[Threads.threadid()]
@@ -154,7 +154,7 @@ function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any,5},
   @unpack alpha, indicator_threaded = löhner.cache
   resize!(alpha, nelements(dg, cache))
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     indicator = indicator_threaded[Threads.threadid()]
 
     # Calculate indicator variables at Gauss-Lobatto nodes
@@ -220,7 +220,7 @@ function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any,5},
   @unpack alpha, indicator_threaded = indicator_max.cache
   resize!(alpha, nelements(dg, cache))
 
-  Threads.@threads for element in eachelement(dg, cache)
+  @threaded for element in eachelement(dg, cache)
     indicator = indicator_threaded[Threads.threadid()]
 
     # Calculate indicator variables at Gauss-Lobatto nodes

--- a/src/time_integration/methods_2N.jl
+++ b/src/time_integration/methods_2N.jl
@@ -139,7 +139,7 @@ function solve!(integrator::SimpleIntegrator2N)
       a_stage    = alg.a[stage]
       b_stage_dt = alg.b[stage] * integrator.dt
       @timeit_debug timer() "Runge-Kutta step" begin
-        Threads.@threads for i in eachindex(integrator.u)
+        @threaded for i in eachindex(integrator.u)
           integrator.u_tmp[i] = integrator.du[i] - integrator.u_tmp[i] * a_stage
           integrator.u[i] += integrator.u_tmp[i] * b_stage_dt
         end

--- a/src/time_integration/methods_3Sstar.jl
+++ b/src/time_integration/methods_3Sstar.jl
@@ -174,7 +174,7 @@ function solve!(integrator::SimpleIntegrator3Sstar)
       gamma3_stage  = alg.gamma3[stage]
       beta_stage_dt = alg.beta[stage] * integrator.dt
       @timeit_debug timer() "Runge-Kutta step" begin
-        Threads.@threads for i in eachindex(integrator.u)
+        @threaded for i in eachindex(integrator.u)
           integrator.u_tmp1[i] += delta_stage * integrator.u[i]
           integrator.u[i]       = (gamma1_stage * integrator.u[i] +
                                    gamma2_stage * integrator.u_tmp1[i] +


### PR DESCRIPTION
This avoids overhead if only one thread is used.

This branch with `julia --check-bounds=no --threads=1`
```julia
julia> using BenchmarkTools, Trixi

julia> trixi_include("examples/2d/elixir_euler_ec.jl")
julia> trixi_include("examples/2d/elixir_euler_ec.jl") # after compilation
 -------------------------------------------------------------------------------
            Trixi.jl                    Time                   Allocations
                                ----------------------   -----------------------
        Tot / % measured:            335ms / 96.3%           4.23MiB / 86.6%

 Section                ncalls     time   %tot     avg     alloc   %tot      avg
 -------------------------------------------------------------------------------
 rhs!                      186    288ms  89.2%  1.55ms   27.9KiB  0.75%     154B
   volume integral         186    234ms  72.3%  1.26ms     0.00B  0.00%    0.00B
   interface flux          186   38.7ms  12.0%   208μs     0.00B  0.00%    0.00B
   prolong2interfaces      186   5.88ms  1.82%  31.6μs     0.00B  0.00%    0.00B
   surface integral        186   5.53ms  1.71%  29.7μs     0.00B  0.00%    0.00B
   reset ∂u/∂t             186   2.13ms  0.66%  11.4μs     0.00B  0.00%    0.00B
   Jacobian                186   2.01ms  0.62%  10.8μs     0.00B  0.00%    0.00B
   prolong2mortars         186   22.2μs  0.01%   119ns     0.00B  0.00%    0.00B
   prolong2boundaries      186   18.9μs  0.01%   102ns     0.00B  0.00%    0.00B
   mortar flux             186   17.6μs  0.01%  94.5ns     0.00B  0.00%    0.00B
   boundary flux           186   11.4μs  0.00%  61.2ns     0.00B  0.00%    0.00B
   source terms            186   7.61μs  0.00%  40.9ns     0.00B  0.00%    0.00B
 I/O                         5   21.3ms  6.58%  4.25ms   3.60MiB  98.4%   737KiB
 analyze solution            2   9.47ms  2.93%  4.74ms   31.3KiB  0.83%  15.6KiB
 calculate dt               38   4.14ms  1.28%   109μs     0.00B  0.00%    0.00B
 -------------------------------------------------------------------------------

julia> @benchmark Trixi.rhs!(
           $(similar(ode.u0)),
           $(copy(ode.u0)),
           $(semi),
           $(first(tspan)))
BenchmarkTools.Trial:
  memory estimate:  352 bytes
  allocs estimate:  7
  --------------
  minimum time:     1.414 ms (0.00% GC)
  median time:      1.455 ms (0.00% GC)
  mean time:        1.467 ms (0.00% GC)
  maximum time:     2.294 ms (0.00% GC)
  --------------
  samples:          3408
  evals/sample:     1
```
This branch with `julia --check-bounds=no --threads=2`
```julia
julia> using BenchmarkTools, Trixi

julia> trixi_include("examples/2d/elixir_euler_ec.jl")

julia> @benchmark Trixi.rhs!(
           $(similar(ode.u0)),
           $(copy(ode.u0)),
           $(semi),
           $(first(tspan)))
BenchmarkTools.Trial:
  memory estimate:  14.09 KiB
  allocs estimate:  95
  --------------
  minimum time:     752.246 μs (0.00% GC)
  median time:      780.327 μs (0.00% GC)
  mean time:        782.276 μs (0.08% GC)
  maximum time:     4.722 ms (81.53% GC)
  --------------
  samples:          6390
  evals/sample:     1
```

Current `master` with `julia --check-bounds=no --threads=1`
```julia
julia> using BenchmarkTools, Trixi

julia> trixi_include("examples/2d/elixir_euler_ec.jl")
julia> trixi_include("examples/2d/elixir_euler_ec.jl") # after compilation
 -------------------------------------------------------------------------------
            Trixi.jl                    Time                   Allocations
                                ----------------------   -----------------------
        Tot / % measured:            369ms / 94.4%           5.70MiB / 90.0%

 Section                ncalls     time   %tot     avg     alloc   %tot      avg
 -------------------------------------------------------------------------------
 rhs!                      186    328ms  94.4%  1.77ms   1.48MiB  28.9%  8.15KiB
   volume integral         186    251ms  72.0%  1.35ms    163KiB  3.10%     896B
   interface flux          186   44.1ms  12.7%   237μs    157KiB  2.99%     864B
   prolong2interfaces      186   14.2ms  4.09%  76.5μs    157KiB  2.99%     864B
   surface integral        186   10.8ms  3.10%  58.1μs    166KiB  3.15%     912B
   Jacobian                186   3.22ms  0.92%  17.3μs    163KiB  3.10%     896B
   reset ∂u/∂t             186   2.69ms  0.77%  14.5μs     0.00B  0.00%    0.00B
   prolong2boundaries      186    673μs  0.19%  3.62μs    157KiB  2.99%     864B
   mortar flux             186    635μs  0.18%  3.42μs    267KiB  5.09%  1.44KiB
   prolong2mortars         186    630μs  0.18%  3.39μs    259KiB  4.93%  1.39KiB
   source terms            186   30.3μs  0.01%   163ns     0.00B  0.00%    0.00B
   boundary flux           186   22.7μs  0.01%   122ns     0.00B  0.00%    0.00B
 analyze solution            2   9.49ms  2.73%  4.74ms   48.6KiB  0.93%  24.3KiB
 I/O                         5   5.77ms  1.66%  1.15ms   3.60MiB  70.2%   737KiB
 calculate dt               38   4.39ms  1.26%   115μs     0.00B  0.00%    0.00B
 -------------------------------------------------------------------------------

julia> @benchmark Trixi.rhs!(
           $(similar(ode.u0)),
           $(copy(ode.u0)),
           $(semi),
           $(first(tspan)))
BenchmarkTools.Trial:
  memory estimate:  8.34 KiB
  allocs estimate:  55
  --------------
  minimum time:     1.431 ms (0.00% GC)
  median time:      1.535 ms (0.00% GC)
  mean time:        1.584 ms (0.00% GC)
  maximum time:     3.490 ms (0.00% GC)
  --------------
  samples:          3155
  evals/sample:     1
```

Current `master` with `julia --check-bounds=no --threads=2`
```julia
julia> using BenchmarkTools, Trixi

julia> trixi_include("examples/2d/elixir_euler_ec.jl")

julia> @benchmark Trixi.rhs!(
           $(similar(ode.u0)),
           $(copy(ode.u0)),
           $(semi),
           $(first(tspan)))
BenchmarkTools.Trial:
  memory estimate:  14.09 KiB
  allocs estimate:  95
  --------------
  minimum time:     751.753 μs (0.00% GC)
  median time:      783.038 μs (0.00% GC)
  mean time:        792.170 μs (0.08% GC)
  maximum time:     5.009 ms (82.36% GC)
  --------------
  samples:          6310
  evals/sample:     1
```

See also https://discourse.julialang.org/t/overhead-of-threads-threads/53964