### PR TITLE
remove DiffEqCallbacks as dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.3.13-pre"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
-DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -24,7 +23,6 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 DiffEqBase = "6.47"
-DiffEqCallbacks = "2.14"
 EllipsisNotation = "1.0"
 HDF5 = "0.14, 0.15"
 LinearMaps = "2.7, 3.0"

--- a/examples/2d/elixir_advection_callbacks.jl
+++ b/examples/2d/elixir_advection_callbacks.jl
@@ -7,7 +7,7 @@ using Trixi
 module TrixiExtensionExample
 
 using Trixi
-using DiffEqCallbacks: DiscreteCallback, u_modified!
+using OrdinaryDiffEq: DiscreteCallback, u_modified!
 
 # This is an example implementation for a simple stage callback (i.e., a callable
 # that is executed after each Runge-Kutta *stage*), which records some values
@@ -143,7 +143,7 @@ example_callback = TrixiExtensionExample.ExampleStepCallback(message="안녕하�
 stepsize_callback = StepsizeCallback(cfl=1.6)
 
 callbacks = CallbackSet(summary_callback,
-                        analysis_callback, alive_callback, 
+                        analysis_callback, alive_callback,
                         save_solution,
                         example_callback,
                         stepsize_callback)

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -23,10 +23,10 @@ using Printf: @printf, @sprintf, println
 # import @reexport now to make it available for further imports/exports
 using Reexport: @reexport
 
-import DiffEqBase: ODEProblem, ODESolution, ODEFunction,
+import DiffEqBase: CallbackSet, DiscreteCallback,
+                   ODEProblem, ODESolution, ODEFunction,
                    get_du, get_tmp_cache, u_modified!,
                    get_proposed_dt, set_proposed_dt!, terminate!
-using DiffEqCallbacks: CallbackSet, DiscreteCallback
 @reexport using EllipsisNotation # ..
 using HDF5: h5open, attributes
 using LinearMaps: LinearMap

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
@@ -10,7 +9,6 @@ SimpleMock = "a896ed2c-15a5-4479-b61d-a0e88e2a1d25"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-DiffEqCallbacks = "2.14"
 Documenter = "0.26"
 MPI = "0.15, 0.16"
 OrdinaryDiffEq = "5.44"


### PR DESCRIPTION
This will be beneficial in Julia v1.6 due to parallel precompilation. DiffEqCallbacks uses OrdinaryDiffEq as a dependency, which takes some time to precompile.