### PR TITLE
rewrite mpi_parallel to reduce time-to-first-simulation

### DIFF
--- a/src/auxiliary/mpi.jl
+++ b/src/auxiliary/mpi.jl
@@ -55,7 +55,7 @@ const MPI_IS_ROOT = Ref(true)
 @inline mpi_isparallel() = MPI_IS_PARALLEL[]
 
 # This is not type-stable but that's okay since we want to get rid of it anyway
-# and it's not used in performance-critical parts. The alternativ we used before,
+# and it's not used in performance-critical parts. The alternative we used before,
 # calling something like `eval(:(mpi_parallel() = Val(true)))` in `init_mpi()`,
 # causes invalidations and slows down the first call to Trixi.
 mpi_parallel()::Union{Val{true}, Val{false}} = Val(mpi_isparallel())

--- a/src/auxiliary/mpi.jl
+++ b/src/auxiliary/mpi.jl
@@ -25,14 +25,6 @@ function init_mpi()
   MPI_IS_PARALLEL[] = MPI_SIZE[] > 1
   MPI_IS_SERIAL[] = !MPI_IS_PARALLEL[]
   MPI_IS_ROOT[] = MPI_IS_SERIAL[] || MPI_RANK[] == 0
-
-  # Initialize methods for dispatching on parallel execution
-  if MPI_IS_PARALLEL[]
-    eval(:(mpi_parallel() = Val(true)))
-  else
-    eval(:(mpi_parallel() = Val(false)))
-  end
-
   MPI_INITIALIZED[] = true
 
   return nothing
@@ -61,6 +53,12 @@ const MPI_IS_ROOT = Ref(true)
 @inline mpi_nranks() = MPI_SIZE[]
 
 @inline mpi_isparallel() = MPI_IS_PARALLEL[]
+
+# This is not type-stable but that's okay since we want to get rid of it anyway
+# and it's not used in performance-critical parts. The alternativ we used before,
+# calling something like `eval(:(mpi_parallel() = Val(true)))` in `init_mpi()`,
+# causes invalidations and slows down the first call to Trixi.
+mpi_parallel()::Union{Val{true}, Val{false}} = Val(mpi_isparallel())
 
 @inline mpi_isroot() = MPI_IS_ROOT[]
 

--- a/src/mesh/mesh_io.jl
+++ b/src/mesh/mesh_io.jl
@@ -1,7 +1,7 @@
 
 # Save current mesh with some context information as an HDF5 file.
 function save_mesh_file(mesh::TreeMesh, output_directory, timestep=0)
-  save_mesh_file(mesh, output_directory, timestep, mpi_parallel())
+  save_mesh_file(mesh, output_directory, timestep, mpi_parallel(mesh))
 end
 
 function save_mesh_file(mesh::TreeMesh, output_directory, timestep,


### PR DESCRIPTION
This cuts down the total time-to-first-simulation for the default example by nearly 1 second on my system.