### PR TITLE
bump compat bounds for OrdinaryDiffEq.jl; closes #453

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -11,6 +11,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Documenter = "0.26"
 MPI = "0.15, 0.16"
-OrdinaryDiffEq = "5.44 - 5.50"
+OrdinaryDiffEq = "5.44 - 5.50, 5.51.1"
 Plots = "1.9"
 SimpleMock = "1.2"


### PR DESCRIPTION
Waiting for https://github.com/SciML/OrdinaryDiffEq.jl/pull/1350