### PR TITLE
LO & HO flux comparison

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -127,7 +127,7 @@ export TreeMesh
 export DG,
        DGSEM, LobattoLegendreBasis,
        VolumeIntegralWeakForm, VolumeIntegralFluxDifferencing,
-       VolumeIntegralLocalComparison,
+       VolumeIntegralLocalComparison, VolumeIntegralFluxComparison,
        VolumeIntegralPureLGLFiniteVolume,
        VolumeIntegralShockCapturingHG, IndicatorHennemannGassner,
        MortarL2

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -128,6 +128,7 @@ export DG,
        DGSEM, LobattoLegendreBasis,
        VolumeIntegralWeakForm, VolumeIntegralFluxDifferencing,
        VolumeIntegralLocalComparison, VolumeIntegralFluxComparison,
+       VolumeIntegralLocalFluxComparison,
        VolumeIntegralPureLGLFiniteVolume,
        VolumeIntegralShockCapturingHG, IndicatorHennemannGassner,
        MortarL2

--- a/src/solvers/dg/dg.jl
+++ b/src/solvers/dg/dg.jl
@@ -114,6 +114,29 @@ function Base.show(io::IO, ::MIME"text/plain", integral::VolumeIntegralFluxCompa
 end
 
 
+# TODO: It would be really nice if we could convert other volume integrals to
+#       the flux form required here easily...
+# TODO: This needs a better name...
+struct VolumeIntegralLocalFluxComparison{VolumeFlux일, VolumeFlux이} <: AbstractVolumeIntegral
+  volume_flux_일::VolumeFlux일
+  volume_flux_이::VolumeFlux이
+end
+
+function Base.show(io::IO, ::MIME"text/plain", integral::VolumeIntegralLocalFluxComparison)
+  @nospecialize integral # reduce precompilation time
+
+  if get(io, :compact, false)
+    show(io, integral)
+  else
+    setup = [
+            "volume flux 1" => integral.volume_flux_일,
+            "volume flux 2" => integral.volume_flux_이
+            ]
+    summary_box(io, "VolumeIntegralLocalFluxComparison", setup)
+  end
+end
+
+
 """
     VolumeIntegralShockCapturingHG
 

--- a/src/solvers/dg/dg.jl
+++ b/src/solvers/dg/dg.jl
@@ -94,9 +94,9 @@ end
 # TODO: It would be really nice if we could convert other volume integrals to
 #       the flux form required here easily...
 # TODO: This needs a better name...
-struct VolumeIntegralFluxComparison{VolumeFlux일, VolumeFlux이} <: AbstractVolumeIntegral
-  volume_flux_일::VolumeFlux일
-  volume_flux_이::VolumeFlux이
+struct VolumeIntegralFluxComparison{VolumeFlux_a, VolumeFlux_b} <: AbstractVolumeIntegral
+  volume_flux_a::VolumeFlux_a
+  volume_flux_b::VolumeFlux_b
 end
 
 function Base.show(io::IO, ::MIME"text/plain", integral::VolumeIntegralFluxComparison)
@@ -106,8 +106,8 @@ function Base.show(io::IO, ::MIME"text/plain", integral::VolumeIntegralFluxCompa
     show(io, integral)
   else
     setup = [
-            "volume flux 1" => integral.volume_flux_일,
-            "volume flux 2" => integral.volume_flux_이
+            "volume flux 1" => integral.volume_flux_a,
+            "volume flux 2" => integral.volume_flux_b
             ]
     summary_box(io, "VolumeIntegralFluxComparison", setup)
   end
@@ -117,9 +117,9 @@ end
 # TODO: It would be really nice if we could convert other volume integrals to
 #       the flux form required here easily...
 # TODO: This needs a better name...
-struct VolumeIntegralLocalFluxComparison{VolumeFlux일, VolumeFlux이} <: AbstractVolumeIntegral
-  volume_flux_일::VolumeFlux일
-  volume_flux_이::VolumeFlux이
+struct VolumeIntegralLocalFluxComparison{VolumeFluxA, VolumeFluxB} <: AbstractVolumeIntegral
+  volume_flux_a::VolumeFluxA
+  volume_flux_b::VolumeFluxB
 end
 
 function Base.show(io::IO, ::MIME"text/plain", integral::VolumeIntegralLocalFluxComparison)
@@ -129,8 +129,8 @@ function Base.show(io::IO, ::MIME"text/plain", integral::VolumeIntegralLocalFlux
     show(io, integral)
   else
     setup = [
-            "volume flux 1" => integral.volume_flux_일,
-            "volume flux 2" => integral.volume_flux_이
+            "volume flux a" => integral.volume_flux_a,
+            "volume flux b" => integral.volume_flux_b
             ]
     summary_box(io, "VolumeIntegralLocalFluxComparison", setup)
   end

--- a/src/solvers/dg/dg.jl
+++ b/src/solvers/dg/dg.jl
@@ -91,6 +91,29 @@ function Base.show(io::IO, ::MIME"text/plain", integral::VolumeIntegralLocalComp
 end
 
 
+# TODO: It would be really nice if we could convert other volume integrals to
+#       the flux form required here easily...
+# TODO: This needs a better name...
+struct VolumeIntegralFluxComparison{VolumeFlux일, VolumeFlux이} <: AbstractVolumeIntegral
+  volume_flux_일::VolumeFlux일
+  volume_flux_이::VolumeFlux이
+end
+
+function Base.show(io::IO, ::MIME"text/plain", integral::VolumeIntegralFluxComparison)
+  @nospecialize integral # reduce precompilation time
+
+  if get(io, :compact, false)
+    show(io, integral)
+  else
+    setup = [
+            "volume flux 1" => integral.volume_flux_일,
+            "volume flux 2" => integral.volume_flux_이
+            ]
+    summary_box(io, "VolumeIntegralFluxComparison", setup)
+  end
+end
+
+
 """
     VolumeIntegralShockCapturingHG
 

--- a/src/solvers/dg/dg_1d.jl
+++ b/src/solvers/dg/dg_1d.jl
@@ -73,6 +73,17 @@ function create_cache(mesh::TreeMesh{1}, equations, volume_integral::VolumeInteg
 end
 
 
+function create_cache(mesh::TreeMesh{1}, equations, volume_integral::VolumeIntegralLocalFluxComparison, dg::DG, uEltype)
+
+  have_nonconservative_terms(equations) !== Val(false) && error("Are you kidding me?")
+
+  FluxType = SVector{nvariables(equations), uEltype}
+  w_threaded = [Array{FluxType, 1}(undef, nnodes(dg)) for _ in 1:Threads.nthreads()]
+
+  return (; w_threaded)
+end
+
+
 function create_cache(mesh::TreeMesh{1}, equations,
                       volume_integral::VolumeIntegralShockCapturingHG, dg::DG, uEltype)
   element_ids_dg   = Int[]
@@ -348,6 +359,45 @@ end
       end
     end
     fluxes[i] = flux1
+  end
+end
+
+
+function calc_volume_integral!(du::AbstractArray{<:Any,3}, u,
+                               nonconservative_terms::Val{false}, equations,
+                               volume_integral::VolumeIntegralLocalFluxComparison,
+                               dg::DGSEM, cache)
+  @unpack volume_flux_일, volume_flux_이 = volume_integral
+  @unpack derivative_split = dg.basis
+  @unpack w_threaded = cache
+
+  @threaded for element in eachelement(dg, cache)
+    w = w_threaded[Threads.threadid()]
+
+    # compute entropy variables
+    for i in eachnode(dg)
+      u_node = get_node_vars(u, equations, dg, i, element)
+      w[i] = cons2entropy(u_node, equations)
+    end
+
+    # perform flux-differencing in symmetric form
+    for i in eachnode(dg)
+      u_i = get_node_vars(u, equations, dg, i, element)
+      du_i = zero(u_i)
+      for ii in eachnode(dg)
+        u_ii = get_node_vars(u, equations, dg, ii, element)
+        flux일 = volume_flux_일(u_i, u_ii, 1, equations)
+        flux이 = volume_flux_이(u_i, u_ii, 1, equations)
+        d_i_ii = derivative_split[i, ii]
+        b = -sign(d_i_ii) * dot(w[i] - w[ii], flux이 - flux일)
+        c = 1.0e-4 # TODO: magic constant determining linear and nonlinear stability 😠
+        hyp = hypot(b, c) # sqrt(b^2 + c^2) computed in a numerically stable way
+        # δ = (hyp - b) / hyp # add anti-dissipation as dissipation
+        δ = (hyp - b) / 2hyp # just use the more dissipative flux
+        du_i += d_i_ii * (flux일 + δ * (flux이 - flux일))
+      end
+      add_to_node_vars!(du, du_i, equations, dg, i, element)
+    end
   end
 end
 

--- a/src/solvers/dg/dg_1d.jl
+++ b/src/solvers/dg/dg_1d.jl
@@ -308,11 +308,20 @@ function calc_volume_integral!(du::AbstractArray{<:Any,3}, u,
     for i in eachindex(fluxes_일, fluxes_이)
       flux일 = fluxes_일[i]
       flux이 = fluxes_이[i]
-      if dot(w[i+1] - w[i], flux일 - flux이) <= 0
-        fluxes_일[i] = flux일 # flux일 is more dissipative
-      else
-        fluxes_일[i] = flux이 # flux이 is more dissipative
-      end
+      # if dot(w[i+1] - w[i], flux일 - flux이) <= 0
+      #   fluxes_일[i] = flux일 # flux일 is more dissipative
+      #   # fluxes_일[i] = 2 * flux일 - flux이 # flux일 is more dissipative
+      # else
+      #   fluxes_일[i] = flux이 # flux이 is more dissipative
+      #   # fluxes_일[i] = 2 * flux이 - flux일 # flux이 is more dissipative
+      # end
+      b = dot(w[i+1] - w[i], flux이 - flux일)
+      c = 1.0e-12
+      # hyp = sqrt(b^2 + c^2)
+      hyp = hypot(b, c) # sqrt(b^2 + c^2) computed in a numerically stable way
+      # δ = (hyp - b) / hyp # add anti-dissipation as dissipation
+      δ = (hyp - b) / 2hyp # just use the more dissipative flux
+      fluxes_일[i] = flux일 + δ * (flux이 - flux일)
     end
 
     # update volume contribution in locally conservative form

--- a/src/solvers/dg/dg_1d.jl
+++ b/src/solvers/dg/dg_1d.jl
@@ -327,7 +327,7 @@ function calc_volume_integral!(du::AbstractArray{<:Any,3}, u,
       #   # fluxes_a[i] = 2 * flux_b - flux_a # flux_b is more dissipative
       # end
       b = dot(w[i+1] - w[i], flux_b - flux_a)
-      c = 1.0e-12
+      c = 1.0e-7
       # hyp = sqrt(b^2 + c^2)
       hyp = hypot(b, c) # sqrt(b^2 + c^2) computed in a numerically stable way
       # δ = (hyp - b) / hyp # add anti-dissipation as dissipation

--- a/src/solvers/dg/dg_1d.jl
+++ b/src/solvers/dg/dg_1d.jl
@@ -351,11 +351,11 @@ end
 
   for i in eachindex(fluxes)
     flux1 = zero(eltype(fluxes))
-    for k in i+1:nnodes(dg)
-      uk = get_node_vars(u, equations, dg, k, element)
-      for l in 1:i
-        ul = get_node_vars(u, equations, dg, l, element)
-        flux1 += weights[l] * derivative_split[l,k] * volume_flux(ul, uk, 1, equations)
+    for iip in i+1:nnodes(dg)
+      uiip = get_node_vars(u, equations, dg, iip, element)
+      for iim in 1:i
+        uiim = get_node_vars(u, equations, dg, iim, element)
+        flux1 += weights[iim] * derivative_split[iim,iip] * volume_flux(uiim, uiip, 1, equations)
       end
     end
     fluxes[i] = flux1

--- a/src/solvers/dg/dg_3d.jl
+++ b/src/solvers/dg/dg_3d.jl
@@ -94,6 +94,17 @@ function create_cache(mesh::TreeMesh{3}, equations, volume_integral::VolumeInteg
 end
 
 
+function create_cache(mesh::TreeMesh{3}, equations, volume_integral::VolumeIntegralLocalFluxComparison, dg::DG, uEltype)
+
+  have_nonconservative_terms(equations) !== Val(false) && error("Are you kidding me?")
+
+  FluxType = SVector{nvariables(equations), uEltype}
+  w_threaded = [Array{FluxType, 3}(undef, nnodes(dg), nnodes(dg), nnodes(dg)) for _ in 1:Threads.nthreads()]
+
+  return (; w_threaded)
+end
+
+
 function create_cache(mesh::TreeMesh{3}, equations,
                       volume_integral::VolumeIntegralShockCapturingHG, dg::DG, uEltype)
   element_ids_dg   = Int[]
@@ -472,6 +483,75 @@ function calc_volume_integral!(du::AbstractArray{<:Any,5}, u,
         add_to_node_vars!(du, 2*du_ec_node-du_cen_node, equations, dg, i, j, k, element)
       end
     end
+  end
+end
+
+
+function calc_volume_integral!(du::AbstractArray{<:Any,5}, u,
+                               nonconservative_terms::Val{false}, equations,
+                               volume_integral::VolumeIntegralLocalFluxComparison,
+                               dg::DGSEM, cache)
+  @unpack volume_flux_a, volume_flux_b = volume_integral
+  @unpack derivative_split = dg.basis
+  @unpack w_threaded = cache
+
+  @threaded for element in eachelement(dg, cache)
+    w = w_threaded[Threads.threadid()]
+
+    # compute entropy variables
+    for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
+      u_node = get_node_vars(u, equations, dg, i, j, k, element)
+      w[i,j,k] = cons2entropy(u_node, equations)
+    end
+
+    # perform flux-differencing in symmetric form
+    for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
+      u_i = get_node_vars(u, equations, dg, i, j, k, element)
+      du_i = zero(u_i)
+      c = 1.0e-4 # TODO: magic constant determining linear and nonlinear stability 😠
+
+      # x
+      for ii in eachnode(dg)
+        u_ii = get_node_vars(u, equations, dg, ii, j, k, element)
+        flux_a = volume_flux_a(u_i, u_ii, 1, equations)
+        flux_b = volume_flux_b(u_i, u_ii, 1, equations)
+        d_i_ii = derivative_split[i, ii]
+        b = -sign(d_i_ii) * dot(w[i,j,k] - w[ii,j,k], flux_b - flux_a)
+        hyp = hypot(b, c) # sqrt(b^2 + c^2) computed in a numerically stable way
+        # δ = (hyp - b) / hyp # add anti-dissipation as dissipation
+        δ = (hyp - b) / 2hyp # just use the more dissipative flux
+        du_i += d_i_ii * (flux_a + δ * (flux_b - flux_a))
+      end
+
+      # y
+      for jj in eachnode(dg)
+        u_jj = get_node_vars(u, equations, dg, i, jj, k, element)
+        flux_a = volume_flux_a(u_i, u_jj, 2, equations)
+        flux_b = volume_flux_b(u_i, u_jj, 2, equations)
+        d_j_jj = derivative_split[j, jj]
+        b = -sign(d_j_jj) * dot(w[i,j,k] - w[i,jj,k], flux_b - flux_a)
+        hyp = hypot(b, c) # sqrt(b^2 + c^2) computed in a numerically stable way
+        # δ = (hyp - b) / hyp # add anti-dissipation as dissipation
+        δ = (hyp - b) / 2hyp # just use the more dissipative flux
+        du_i += d_j_jj * (flux_a + δ * (flux_b - flux_a))
+      end
+
+      # z
+      for kk in eachnode(dg)
+        u_kk = get_node_vars(u, equations, dg, i, j, kk, element)
+        flux_a = volume_flux_a(u_i, u_kk, 3, equations)
+        flux_b = volume_flux_b(u_i, u_kk, 3, equations)
+        d_k_kk = derivative_split[k, kk]
+        b = -sign(d_k_kk) * dot(w[i,j,k] - w[i,j,kk], flux_b - flux_a)
+        hyp = hypot(b, c) # sqrt(b^2 + c^2) computed in a numerically stable way
+        # δ = (hyp - b) / hyp # add anti-dissipation as dissipation
+        δ = (hyp - b) / 2hyp # just use the more dissipative flux
+        du_i += d_k_kk * (flux_a + δ * (flux_b - flux_a))
+      end
+
+      add_to_node_vars!(du, du_i, equations, dg, i, j, k, element)
+    end
+
   end
 end
 


### PR DESCRIPTION
# High-order flux comparison

This basically implement a version comparing the local entropy production based on local high-order fluxes as in the work of Fisher and Carpenter. Right now, it is restricted to 1D.

The density wave works in 1D.
```julia
julia> trixi_include("examples/1d/elixir_euler_density_wave.jl", 
           solver=DGSEM(5, flux_lax_friedrichs, VolumeIntegralFluxComparison(flux_central, flux_ranocha)), 
           initial_refinement_level=4, 
           tspan=(0.0, 100.0))
```

EOC does not seem to be too bad (but not necessarily with a similarly clear superconvergence as central DG).
```julia
julia> convergence_test("examples/1d/elixir_euler_source_terms.jl", 4, 
           solver=DGSEM(3, flux_lax_friedrichs, VolumeIntegralFluxComparison(flux_central, flux_ranocha)))
...
####################################################################################################
l2
rho                 rho_v1              rho_e               
error     EOC       error     EOC       error     EOC       
6.23e-06  -         3.65e-06  -         1.06e-05  -         
4.42e-07  3.82      2.83e-07  3.69      6.11e-07  4.11      
2.03e-08  4.45      1.69e-08  4.07      2.58e-08  4.57      
5.29e-10  5.26      4.32e-10  5.29      1.13e-09  4.51      

mean      4.51      mean      4.35      mean      4.39      
----------------------------------------------------------------------------------------------------
linf
rho                 rho_v1              rho_e               
error     EOC       error     EOC       error     EOC       
1.73e-05  -         1.23e-05  -         3.77e-05  -         
1.91e-06  3.18      1.13e-06  3.44      3.41e-06  3.47      
9.14e-08  4.38      8.09e-08  3.81      1.31e-07  4.71      
2.05e-09  5.48      1.82e-09  5.47      6.05e-09  4.43      

mean      4.35      mean      4.24      mean      4.20      
----------------------------------------------------------------------------------------------------
Dict{Symbol, Any} with 3 entries:
  :variables => ("rho", "rho_v1", "rho_e")
  :l2        => [4.50854, 4.34757, 4.39473]
  :linf      => [4.34864, 4.24124, 4.20194]

julia> convergence_test("examples/1d/elixir_euler_source_terms.jl", 4, 
           solver=DGSEM(4, flux_lax_friedrichs, VolumeIntegralFluxComparison(flux_central, flux_ranocha)))
...
####################################################################################################
l2
rho                 rho_v1              rho_e               
error     EOC       error     EOC       error     EOC       
1.07e-07  -         9.58e-08  -         1.25e-07  -         
3.87e-09  4.79      3.19e-09  4.91      4.76e-09  4.72      
1.14e-10  5.09      2.42e-11  7.04      2.02e-10  4.56      
6.30e-12  4.17      1.01e-12  4.58      1.08e-11  4.22      

mean      4.68      mean      5.51      mean      4.50      
----------------------------------------------------------------------------------------------------
linf
rho                 rho_v1              rho_e               
error     EOC       error     EOC       error     EOC       
2.88e-07  -         2.30e-07  -         7.54e-07  -         
1.67e-08  4.11      8.13e-09  4.82      3.52e-08  4.42      
5.83e-10  4.84      1.37e-10  5.90      1.36e-09  4.69      
3.27e-11  4.16      5.20e-12  4.71      6.71e-11  4.35      

mean      4.37      mean      5.14      mean      4.49      
----------------------------------------------------------------------------------------------------
Dict{Symbol, Any} with 3 entries:
  :variables => ("rho", "rho_v1", "rho_e")
  :l2        => [4.68368, 5.51074, 4.49975]
  :linf      => [4.36869, 5.14326, 4.48567]

julia> convergence_test("examples/1d/elixir_burgers_basic.jl", 4, 
           solver=DGSEM(3, flux_lax_friedrichs, VolumeIntegralFluxComparison(flux_central, flux_ec)))
...
####################################################################################################
l2
scalar              
error     EOC       
1.17e-04  -         
1.24e-05  3.24      
1.09e-06  3.51      
8.08e-08  3.75      

mean      3.50      
----------------------------------------------------------------------------------------------------
linf
scalar              
error     EOC       
4.71e-04  -         
7.03e-05  2.74      
8.26e-06  3.09      
8.10e-07  3.35      

mean      3.06      
----------------------------------------------------------------------------------------------------
Dict{Symbol, Any} with 3 entries:
  :variables => ("scalar",)
  :l2        => [3.49955]
  :linf      => [3.06089]

julia> convergence_test("examples/1d/elixir_burgers_basic.jl", 4, 
           solver=DGSEM(4, flux_lax_friedrichs, VolumeIntegralFluxComparison(flux_central, flux_ec)))
####################################################################################################
l2
scalar              
error     EOC       
3.83e-06  -         
1.40e-07  4.77      
4.91e-09  4.84      
3.79e-11  7.02      

mean      5.54      
----------------------------------------------------------------------------------------------------
linf
scalar              
error     EOC       
1.63e-05  -         
7.48e-07  4.45      
3.49e-08  4.42      
2.68e-10  7.02      

mean      5.30      
----------------------------------------------------------------------------------------------------
Dict{Symbol, Any} with 3 entries:
  :variables => ("scalar",)
  :l2        => [5.54138]
  :linf      => [5.29776]
```

Interestingly, we get linear stability for high wave numbers for the Burgers' example (where the element-based comparison results in eigenvalues with positive real parts)
```julia
julia> trixi_include("examples/1d/elixir_burgers_linear_stability.jl", solver=DGSEM(3, flux_lax_friedrichs, VolumeIntegralFluxComparison(flux_central, flux_ec)), k=20); J = jacobian_ad_forward(semi); λ = eigvals(J); maximum(real, λ)
...
-6.14732499940009e-15

julia> trixi_include("examples/1d/elixir_burgers_linear_stability.jl", solver=DGSEM(3, flux_lax_friedrichs, VolumeIntegralLocalComparison(VolumeIntegralFluxDifferencing(flux_ec))), k=20); J = jacobian_ad_forward(semi); λ = eigvals(J); maximum(real, λ)
...
1.1973486561303046
```
However, we get eigenvalues with positive real parts for low wave numbers (where the element-based comparison was linearly stable).
```julia
julia> trixi_include("examples/1d/elixir_burgers_linear_stability.jl", solver=DGSEM(3, flux_lax_friedrichs, VolumeIntegralFluxComparison(flux_central, flux_ec)), k=1); J = jacobian_ad_forward(semi); λ = eigvals(J); maximum(real, λ)
...
3.676973569222142e-5

julia> trixi_include("examples/1d/elixir_burgers_linear_stability.jl", solver=DGSEM(3, flux_lax_friedrichs, VolumeIntegralLocalComparison(VolumeIntegralFluxDifferencing(flux_ec))), k=1); J = jacobian_ad_forward(semi); λ = eigvals(J); maximum(real, λ)
...
4.349791949228003e-15
```


# Local flux comparison

I also implemented the version where each two-point flux is compared using the entropy dissipation approximation in 1D. It seems to be linearly stable for Burgers :partying_face: 
```julia
julia> max_real_parts = Float64[]; for k in 1:20
           trixi_include("examples/1d/elixir_burgers_linear_stability.jl", solver=DGSEM(3, flux_lax_friedrichs, VolumeIntegralLocalFluxComparison(flux_central, flux_ec)), k=k)
           J = jacobian_ad_forward(semi)
           λ = eigvals(J)
           push!(max_real_parts, maximum(real, λ))
       end; max_real_parts
...
20-element Vector{Float64}:
  7.200005926160668e-15
  5.78540884760829e-17
  4.573883974512219e-15
 -2.858537270733039e-14
  1.570066156412183e-14
 -2.4512827773735094e-14
  9.551606133757615e-15
 -1.1600666345571795e-14
  5.468429999665181e-15
  7.129369996859868e-15
  1.8724548290078468e-14
 -3.7759896354234164e-16
  1.8125874882377547e-14
 -3.574851120683754e-15
 -2.435780893289072e-15
  1.1847684231506737e-14
 -6.3674879231118985e-15
  4.764398278798727e-15
  3.6025714037562356e-15
 -3.010111919300141e-15
```
The density wave works in 1D.
```julia
julia> trixi_include("examples/1d/elixir_euler_density_wave.jl", 
           solver=DGSEM(5, flux_lax_friedrichs, VolumeIntegralLocalFluxComparison(flux_central, flux_ranocha)), 
           initial_refinement_level=4, 
           tspan=(0.0, 100.0))
```

However, the EOC is reduced significantly the more "discontinuous" the switch between the fluxes gets...
