### PR TITLE
fluxes left and right

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -85,7 +85,7 @@ export AcousticPerturbationEquations2D,
 
 export flux, flux_central, flux_lax_friedrichs, flux_hll, flux_hllc, flux_godunov, flux_secret,
        flux_chandrashekar, flux_ranocha, flux_derigs_etal, flux_kennedy_gruber, flux_shima_etal,
-       flux_ec, FluxComparedToCentral,
+       flux_ec, FluxComparedToCentral, flux_left, flux_right,
        FluxPlusDissipation, DissipationGlobalLaxFriedrichs
 
 export initial_condition_constant,

--- a/src/equations/numerical_fluxes.jl
+++ b/src/equations/numerical_fluxes.jl
@@ -43,6 +43,39 @@ end
 
 
 """
+    flux_left(u_ll, u_rr, orientation, equations) = flux(u_ll, orientation, equations)
+
+This flux can be useful to construct upwind summation by parts (SBP) operators, cf.
+- Mattsson (2017),
+  Diagonal norm upwind SBP operators.
+  [DOI: 10.1016/j.jcp.2017.01.042](https://doi.org/10.1016/j.jcp.2017.01.042).
+- Ranocha, Mitsotakis, Ketcheson (2021),
+  A Broad Class of Conservative Numerical Methods for Dispersive Wave Equations.
+  [DOI: 10.4208/cicp.OA-2020-0119](https://doi.org/10.4208/cicp.OA-2020-0119).
+  [arXiv: 2006.14802 [math.NA]](https://arxiv.org/abs/2006.14802).
+"""
+@inline function flux_left(u_ll, u_rr, orientation, equations)
+  flux(u_ll, orientation, equations)
+end
+
+"""
+    flux_right(u_ll, u_rr, orientation, equations) = flux(u_rr, orientation, equations)
+
+This flux can be useful to construct upwind summation by parts (SBP) operators, cf.
+- Mattsson (2017),
+  Diagonal norm upwind SBP operators.
+  [DOI: 10.1016/j.jcp.2017.01.042](https://doi.org/10.1016/j.jcp.2017.01.042).
+- Ranocha, Mitsotakis, Ketcheson (2021),
+  A Broad Class of Conservative Numerical Methods for Dispersive Wave Equations.
+  [DOI: 10.4208/cicp.OA-2020-0119](https://doi.org/10.4208/cicp.OA-2020-0119).
+  [arXiv: 2006.14802 [math.NA]](https://arxiv.org/abs/2006.14802).
+"""
+@inline function flux_right(u_ll, u_rr, orientation, equations)
+  flux(u_rr, orientation, equations)
+end
+
+
+"""
     FluxPlusDissipation(numerical_flux, dissipation)
 
 Combine a `numerical_flux` with a `dissipation` operator to create a new numerical flux.


### PR DESCRIPTION
These can be used to construct upwind SBP operators. Using the standard central DGSEM volume integral and these fluxes at the interfaces results in upwind SBP operators, which are provably linearly stable for Burgers' equation.

Some numerical evidence is always nice:
```julia
julia> using Trixi, LinearAlgebra

julia> equations = InviscidBurgersEquation1D();

julia> mesh = TreeMesh((-1.0,), (1.0,), initial_refinement_level=4, n_cells_max=10^5);

julia> function initial_condition_linear_stability(x, t, equation::InviscidBurgersEquation1D)
         k = 1
         2 + sinpi(k * (x[1] - 0.7)) |> SVector
       end
initial_condition_linear_stability (generic function with 1 method)

julia> semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_linear_stability, DGSEM(7, Trixi.flux_left));

julia> u0 = compute_coefficients(0.0, semi); du = similar(u0); u = u0;

julia> for i in 1:10_000
           u = 2 .+ rand(size(u0)...); extrema(u)
           Trixi.rhs!(du, u, semi, 0.0); Trixi.integrate(du .* u, semi) |> first > 0 && (println("not globally entropy dissipative: ", Trixi.integrate(du .* u, semi) |> first))
           J = jacobian_ad_forward(semi, u0_ode=u); λ = eigvals(J); maximum(real, λ) > 1.0e-3 && (println("found it: ", maximum(real, λ)); break)
       end
not globally entropy dissipative: 0.017056003020276767
...
not globally entropy dissipative: 0.044736149974338724
```

Edit: And here is the spectrum at the initial condition

![tmp](https://user-images.githubusercontent.com/12693098/111486896-2d212f80-8738-11eb-9836-d57ea7738cb0.png)
