### PR TITLE
Initial support for preprocessing plotting data

### DIFF
--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -92,6 +92,20 @@ There are several other keyword arguments that influence how the solution data
 is processed for visualization with the Plots package. A detailed explanation
 can be found in the docstring of the [`PlotData2D`](@ref) constructor.
 
+Another way to change the appearance of a plot is to convert the solution to a
+uniformly refined mesh before plotting. This can be helpful, e.g., when
+trying different settings for a simulation with adaptive mesh refinement,
+where one would like to ignore the mesh changes when comparing solutions. This
+is achieved with [`adapt_to_mesh_level`](@ref), which uses the mesh adaptation
+routines to adapt the solution to a uniform grid. For example, the AMR solution
+from above could be preprocessed with
+```julia
+julia> pd = PlotData2D(adapt_to_mesh_level(sol, 4)...)
+```
+When plotted together with the mesh, this will yield the following visualization:
+
+![plot-rho-uniform-mesh](https://user-images.githubusercontent.com/3637659/112101404-e0f64500-8ba6-11eb-9516-ad910c6813b2.png)
+
 
 ### Plotting 3D solutions
 It is possible to plot 2D slices from 3D simulation data with the same commands

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -161,7 +161,7 @@ export trixi_include, examples_dir, get_examples, default_example
 export convergence_test, jacobian_fd, jacobian_ad_forward, linear_structure
 
 # Visualization-related exports
-export PlotData1D, PlotData2D, getmesh
+export PlotData1D, PlotData2D, getmesh, adapt_to_level!
 
 
 function __init__()

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -161,7 +161,7 @@ export trixi_include, examples_dir, get_examples, default_example
 export convergence_test, jacobian_fd, jacobian_ad_forward, linear_structure
 
 # Visualization-related exports
-export PlotData1D, PlotData2D, getmesh, adapt_to_level!
+export PlotData1D, PlotData2D, getmesh, adapt_to_mesh_level!, adapt_to_mesh_level
 
 
 function __init__()

--- a/src/visualization/adapt.jl
+++ b/src/visualization/adapt.jl
@@ -1,0 +1,13 @@
+function adapt_to_level!(u_ode::AbstractVector, semi, level)
+  amr_controller = ControllerThreeLevel(semi, IndicatorMax(semi, variable=first), base_level=level)
+  amr_callback = AMRCallback(semi, amr_controller, interval=0)
+
+  has_changed = amr_callback.affect!(u_ode, semi, 0.0, 0)
+  while has_changed
+    has_changed = amr_callback.affect!(u_ode, semi, 0.0, 0)
+  end
+
+  return u_ode, semi
+end
+
+adapt_to_level!(sol::TrixiODESolution, level; kwargs...) = adapt_to_level!(sol.u[end], sol.prob.p, level; kwargs...)

--- a/src/visualization/adapt.jl
+++ b/src/visualization/adapt.jl
@@ -1,3 +1,19 @@
+"""
+    adapt_to_mesh_level!(u_ode::AbstractVector, semi, level)
+    adapt_to_mesh_level!(sol::Union{DiffEqBase.ODESolution,TimeIntegratorSolution}, level)
+
+Use the regular adaptive mesh refinement routines to adaptively refine/coarsen the solution `u_ode`
+with semidiscretization `semi` towards a uniformly refined grid with refinement level `level`. The
+solution and parts of the semidiscretization (mesh and caches) will be *modified in place*.
+
+A convenience method accepts an ODE solution object, from which solution and semidiscretization are
+extracted as needed.
+
+!!! warning "Experimental implementation"
+    This is an experimental feature and may change in future releases.
+
+See also: [`adapt_to_mesh_level`](@ref)
+"""
 function adapt_to_mesh_level!(u_ode::AbstractVector, semi, level)
   # Create AMR callback with controller that refines everything towards a single level
   amr_controller = ControllerThreeLevel(semi, IndicatorMax(semi, variable=first), base_level=level)
@@ -15,6 +31,22 @@ end
 adapt_to_mesh_level!(sol::TrixiODESolution, level) = adapt_to_mesh_level!(sol.u[end], sol.prob.p, level)
 
 
+"""
+    adapt_to_mesh_level(u_ode::AbstractVector, semi, level)
+    adapt_to_mesh_level(sol::Union{DiffEqBase.ODESolution,TimeIntegratorSolution}, level)
+
+Use the regular adaptive mesh refinement routines to adaptively refine/coarsen the solution `u_ode`
+with semidiscretization `semi` towards a uniformly refined grid with refinement level `level`. The
+solution and semidiscretization are copied such that the original objects remain *unaltered*.
+
+A convenience method accepts an ODE solution object, from which solution and semidiscretization are
+extracted as needed.
+
+!!! warning "Experimental implementation"
+    This is an experimental feature and may change in future releases.
+
+See also: [`adapt_to_mesh_level!`](@ref)
+"""
 function adapt_to_mesh_level(u_ode::AbstractVector, semi, level)
   # Create new semidiscretization with copy of the current mesh
   mesh, _, _, _ = mesh_equations_solver_cache(semi)

--- a/src/visualization/adapt.jl
+++ b/src/visualization/adapt.jl
@@ -1,18 +1,9 @@
 """
     adapt_to_mesh_level!(u_ode::AbstractVector, semi, level)
-    adapt_to_mesh_level!(sol::Union{DiffEqBase.ODESolution,TimeIntegratorSolution}, level)
+    adapt_to_mesh_level!(sol::Trixi.TrixiODESolution, level)
 
-Use the regular adaptive mesh refinement routines to adaptively refine/coarsen the solution `u_ode`
-with semidiscretization `semi` towards a uniformly refined grid with refinement level `level`. The
-solution and parts of the semidiscretization (mesh and caches) will be *modified in place*.
-
-A convenience method accepts an ODE solution object, from which solution and semidiscretization are
-extracted as needed.
-
-!!! warning "Experimental implementation"
-    This is an experimental feature and may change in future releases.
-
-See also: [`adapt_to_mesh_level`](@ref)
+Like [`adapt_to_mesh_level`](@ref), but modifies the solution and parts of the
+semidiscretization (mesh and caches) in place.
 """
 function adapt_to_mesh_level!(u_ode::AbstractVector, semi, level)
   # Create AMR callback with controller that refines everything towards a single level
@@ -33,7 +24,7 @@ adapt_to_mesh_level!(sol::TrixiODESolution, level) = adapt_to_mesh_level!(sol.u[
 
 """
     adapt_to_mesh_level(u_ode::AbstractVector, semi, level)
-    adapt_to_mesh_level(sol::Union{DiffEqBase.ODESolution,TimeIntegratorSolution}, level)
+    adapt_to_mesh_level(sol::Trixi.TrixiODESolution, level)
 
 Use the regular adaptive mesh refinement routines to adaptively refine/coarsen the solution `u_ode`
 with semidiscretization `semi` towards a uniformly refined grid with refinement level `level`. The

--- a/src/visualization/visualization.jl
+++ b/src/visualization/visualization.jl
@@ -1,3 +1,4 @@
 include("plot_recipes.jl")
 include("interpolate.jl")
 include("convert.jl")
+include("adapt.jl")

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -143,6 +143,13 @@ isdir(outdir) && rm(outdir, recursive=true)
     end
   end
 
+  @testset "adapt_to_mesh_level" begin
+    @test_nowarn_debug trixi_include(@__MODULE__, joinpath(examples_dir(), "1d", "elixir_euler_blast_wave.jl"),
+                                     tspan=(0,0.1))
+    @test PlotData1D(adapt_to_mesh_level(sol, 4)...) isa PlotData1D
+    @test PlotData1D(adapt_to_mesh_level!(sol, 4)...) isa PlotData1D
+  end
+
   @testset "plot 3D" begin
     @test_nowarn_debug trixi_include(@__MODULE__, joinpath(examples_dir(), "3d", "elixir_advection_basic.jl"),
                                      tspan=(0,0.1))

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -144,10 +144,16 @@ isdir(outdir) && rm(outdir, recursive=true)
   end
 
   @testset "adapt_to_mesh_level" begin
-    @test_nowarn_debug trixi_include(@__MODULE__, joinpath(examples_dir(), "1d", "elixir_euler_blast_wave.jl"),
+    @test_nowarn_debug trixi_include(@__MODULE__, joinpath(examples_dir(), "2d", "elixir_advection_basic.jl"),
                                      tspan=(0,0.1))
-    @test PlotData1D(adapt_to_mesh_level(sol, 4)...) isa PlotData1D
-    @test PlotData1D(adapt_to_mesh_level!(sol, 4)...) isa PlotData1D
+    @test adapt_to_mesh_level(sol, 5) isa Tuple
+
+    u_ode_level5, semi_level5 = adapt_to_mesh_level(sol, 5)
+    u_ode_level4, semi_level4 = adapt_to_mesh_level(u_ode_level5, semi_level5, 4)
+    @test isapprox(sol.u[end], u_ode_level4, atol=1e-13)
+
+    @test adapt_to_mesh_level!(sol, 5) isa Tuple
+    @test isapprox(sol.u[end], u_ode_level5, atol=1e-13)
   end
 
   @testset "plot 3D" begin


### PR DESCRIPTION
The idea is to allow certain preprocessing operations to be performed before creating a solution plot. Initially, we have support for plotting everything on a uniform mesh of a fixed refinement level. This is based on an idea by @gregorgassner. Comments & suggestions welcome!

### Run simulation and plot solution as it is
```julia
julia> trixi_include("examples/2d/elixir_advection_amr.jl")

julia> pd = PlotData2D(sol)

julia> plot(pd, seriescolor=:heat)

julia> plot!(getmesh(pd))
```
![image](https://user-images.githubusercontent.com/3637659/112008336-ad270b00-8b25-11eb-9d4e-95bae1b7db94.png)

### Run simulation and plot at coarser refinement level (level = 4)
```julia
julia> trixi_include("examples/2d/elixir_advection_amr.jl")

julia> pd = PlotData2D(adapt_to_mesh_level(sol, 4)...)

julia> plot(pd, seriescolor=:heat)

julia> plot!(getmesh(pd))
```
![image](https://user-images.githubusercontent.com/3637659/112008620-efe8e300-8b25-11eb-8698-5baa6ef25afc.png)

### Run simulation and plot at coarser refinement level (level = 6)
```julia
julia> trixi_include("examples/2d/elixir_advection_amr.jl")

julia> pd = PlotData2D(adapt_to_mesh_level(sol, 6)...)

julia> plot(pd, seriescolor=:heat)

julia> plot!(getmesh(pd))
```
![image](https://user-images.githubusercontent.com/3637659/112007959-61746180-8b25-11eb-9b4a-b7d04100b8c6.png)
