### PR TITLE
flux plus dissipation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,14 +19,20 @@ for human readability.
 
 #### Changed
 
-#### Removed
+- `flux_lax_friedrichs(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations2D)` and
+  `flux_lax_friedrichs(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations3D)`
+  were actually using the logic of `flux_godunov`. Thus, they were renamed accordingly
+  in [#493](https://github.com/trixi-framework/Trixi.jl/pull/493). This is considered a bugfix
+  (released in Trixi v0.3.22).
 
 #### Deprecated
 
-- `calcflux` → `flux` (https://github.com/trixi-framework/Trixi.jl/pull/463)
+- `calcflux` → `flux` ([#463](https://github.com/trixi-framework/Trixi.jl/pull/463))
 - `flux_upwind` → `flux_godunov`
 - Providing the keyword argument `solution_variables` of `SaveSolutionCallback`
   as `Symbol` is deprecated in favor of using functions like `cons2cons` and
   `cons2prim`
 - `varnames_cons(equations)` → `varnames(cons2cons, equations)`
 - `varnames_prim(equations)` → `varnames(cons2prim, equations)`
+
+#### Removed

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,14 +14,14 @@ for human readability.
 - New systems of equations
   - multicomponent compressible Euler
   - acoustic perturbation equations
-  - Lattice-Boltzmann equations 
+  - Lattice-Boltzmann equations
 - New structured mesh type `StructuredMesh`
 
 #### Changed
 
 #### Removed
 
-### Deprecated
+#### Deprecated
 
 - `calcflux` → `flux` (https://github.com/trixi-framework/Trixi.jl/pull/463)
 - `flux_upwind` → `flux_godunov`

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@ for human readability.
   - acoustic perturbation equations
   - Lattice-Boltzmann equations
 - New structured mesh type `StructuredMesh`
+- Composable `FluxPlusDissipation` and `FluxLaxFriedrichs()`, `FluxHLL()` with adaptable
+  wave speed estimates were added in [#493](https://github.com/trixi-framework/Trixi.jl/pull/493)
 
 #### Changed
 

--- a/examples/2d/elixir_lbm_constant.jl
+++ b/examples/2d/elixir_lbm_constant.jl
@@ -9,7 +9,7 @@ equations = LatticeBoltzmannEquations2D(Ma=0.1, Re=Inf)
 
 initial_condition = initial_condition_constant
 
-surface_flux = flux_lax_friedrichs
+surface_flux = flux_godunov
 solver = DGSEM(3, surface_flux)
 
 coordinates_min = (-1, -1)
@@ -48,7 +48,7 @@ stepsize_callback = StepsizeCallback(cfl=1.0)
 collision_callback = LBMCollisionCallback()
 
 callbacks = CallbackSet(summary_callback,
-                        analysis_callback, alive_callback, 
+                        analysis_callback, alive_callback,
                         save_restart, save_solution,
                         stepsize_callback,
                         collision_callback)

--- a/examples/2d/elixir_lbm_couette.jl
+++ b/examples/2d/elixir_lbm_couette.jl
@@ -15,7 +15,7 @@ boundary_conditions = (
                        y_pos=boundary_condition_couette,
                       )
 
-surface_flux = flux_lax_friedrichs
+surface_flux = flux_godunov
 solver = DGSEM(3, surface_flux)
 
 coordinates_min = (0, 0)

--- a/examples/2d/elixir_lbm_lid_driven_cavity.jl
+++ b/examples/2d/elixir_lbm_lid_driven_cavity.jl
@@ -15,7 +15,7 @@ boundary_conditions = (
                        y_pos=boundary_condition_lid_driven_cavity,
                       )
 
-surface_flux = flux_lax_friedrichs
+surface_flux = flux_godunov
 solver = DGSEM(5, surface_flux)
 
 coordinates_min = (0, 0)
@@ -56,7 +56,7 @@ stepsize_callback = StepsizeCallback(cfl=1.0)
 collision_callback = LBMCollisionCallback()
 
 callbacks = CallbackSet(summary_callback,
-                        analysis_callback, alive_callback, 
+                        analysis_callback, alive_callback,
                         save_restart, save_solution,
                         stepsize_callback,
                         collision_callback)

--- a/examples/3d/elixir_lbm_constant.jl
+++ b/examples/3d/elixir_lbm_constant.jl
@@ -9,7 +9,7 @@ equations = LatticeBoltzmannEquations3D(Ma=0.1, Re=Inf)
 
 initial_condition = initial_condition_constant
 
-surface_flux = flux_lax_friedrichs
+surface_flux = flux_godunov
 solver = DGSEM(3, surface_flux)
 
 coordinates_min = (-1, -1, -1)
@@ -48,7 +48,7 @@ stepsize_callback = StepsizeCallback(cfl=1.0)
 collision_callback = LBMCollisionCallback()
 
 callbacks = CallbackSet(summary_callback,
-                        analysis_callback, alive_callback, 
+                        analysis_callback, alive_callback,
                         save_restart, save_solution,
                         stepsize_callback,
                         collision_callback)

--- a/examples/3d/elixir_lbm_taylor_green_vortex.jl
+++ b/examples/3d/elixir_lbm_taylor_green_vortex.jl
@@ -10,7 +10,7 @@ equations = LatticeBoltzmannEquations3D(Ma=0.1, Re=1600; L=L)
 
 initial_condition = initial_condition_taylor_green_vortex
 
-surface_flux = flux_lax_friedrichs
+surface_flux = flux_godunov
 solver = DGSEM(3, surface_flux)
 
 coordinates_min = (-pi*L, -pi*L, -pi*L)

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -85,7 +85,8 @@ export AcousticPerturbationEquations2D,
 
 export flux, flux_central, flux_lax_friedrichs, flux_hll, flux_hllc, flux_godunov,
        flux_chandrashekar, flux_ranocha, flux_derigs_etal, flux_kennedy_gruber, flux_shima_etal,
-       flux_ec
+       flux_ec,
+       FluxPlusDissipation, DissipationGlobalLaxFriedrichs
 
 export initial_condition_constant,
        initial_condition_gauss,

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -87,8 +87,8 @@ export flux, flux_central, flux_lax_friedrichs, flux_hll, flux_hllc, flux_goduno
        flux_chandrashekar, flux_ranocha, flux_derigs_etal, flux_kennedy_gruber, flux_shima_etal,
        flux_ec,
        FluxPlusDissipation, DissipationGlobalLaxFriedrichs, DissipationLocalLaxFriedrichs,
-       max_abs_speed_naive,
-       FluxLaxFriedrichs
+       FluxLaxFriedrichs, max_abs_speed_naive,
+       FluxHLL, min_max_speed_naive
 
 export initial_condition_constant,
        initial_condition_gauss,

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -86,7 +86,9 @@ export AcousticPerturbationEquations2D,
 export flux, flux_central, flux_lax_friedrichs, flux_hll, flux_hllc, flux_godunov,
        flux_chandrashekar, flux_ranocha, flux_derigs_etal, flux_kennedy_gruber, flux_shima_etal,
        flux_ec,
-       FluxPlusDissipation, DissipationGlobalLaxFriedrichs
+       FluxPlusDissipation, DissipationGlobalLaxFriedrichs, DissipationLocalLaxFriedrichs,
+       max_abs_speed_naive,
+       FluxLaxFriedrichs
 
 export initial_condition_constant,
        initial_condition_gauss,

--- a/src/equations/acoustic_perturbation_2d.jl
+++ b/src/equations/acoustic_perturbation_2d.jl
@@ -339,27 +339,6 @@ end
   λ_max = max(abs(v_ll), abs(v_rr)) + max(c_mean_ll, c_mean_rr)
 end
 
-function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::AcousticPerturbationEquations2D)
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
-  # Calculate v = v_prime + v_mean
-  v_prime_ll = u_ll[orientation]
-  v_prime_rr = u_rr[orientation]
-  v_mean_ll = u_ll[orientation + 3]
-  v_mean_rr = u_rr[orientation + 3]
-
-  v_ll = v_prime_ll + v_mean_ll
-  v_rr = v_prime_rr + v_mean_rr
-
-  c_mean_ll = u_ll[6]
-  c_mean_rr = u_rr[6]
-
-  speed = max(abs(v_ll), abs(v_rr)) + max(c_mean_ll, c_mean_rr)
-
-  return 0.5 * ( (f_ll + f_rr) - speed * (u_rr - u_ll) )
-end
-
 
 @inline have_constant_speed(::AcousticPerturbationEquations2D) = Val(false)
 

--- a/src/equations/acoustic_perturbation_2d.jl
+++ b/src/equations/acoustic_perturbation_2d.jl
@@ -322,6 +322,23 @@ end
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::AcousticPerturbationEquations2D)
+  # Calculate v = v_prime + v_mean
+  v_prime_ll = u_ll[orientation]
+  v_prime_rr = u_rr[orientation]
+  v_mean_ll = u_ll[orientation + 3]
+  v_mean_rr = u_rr[orientation + 3]
+
+  v_ll = v_prime_ll + v_mean_ll
+  v_rr = v_prime_rr + v_mean_rr
+
+  c_mean_ll = u_ll[6]
+  c_mean_rr = u_rr[6]
+
+  λ_max = max(abs(v_ll), abs(v_rr)) + max(c_mean_ll, c_mean_rr)
+end
+
 function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::AcousticPerturbationEquations2D)
   f_ll = flux(u_ll, orientation, equations)
   f_rr = flux(u_rr, orientation, equations)

--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -434,6 +434,25 @@ See also
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation as the
+# maximum velocity magnitude plus the maximum speed of sound
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::CompressibleEulerEquations1D)
+  rho_ll, rho_v1_ll, rho_e_ll = u_ll
+  rho_rr, rho_v1_rr, rho_e_rr = u_rr
+
+  # Calculate primitive variables and speed of sound
+  v1_ll = rho_v1_ll / rho_ll
+  v_mag_ll = abs(v1_ll)
+  p_ll = (equations.gamma - 1) * (rho_e_ll - 1/2 * rho_ll * v_mag_ll^2)
+  c_ll = sqrt(equations.gamma * p_ll / rho_ll)
+  v1_rr = rho_v1_rr / rho_rr
+  v_mag_rr = abs(v1_rr)
+  p_rr = (equations.gamma - 1) * (rho_e_rr - 1/2 * rho_rr * v_mag_rr^2)
+  c_rr = sqrt(equations.gamma * p_rr / rho_rr)
+
+  λ_max = max(v_mag_ll, v_mag_rr) + max(c_ll, c_rr)
+end
+
 function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::CompressibleEulerEquations1D)
   # Calculate primitive variables and speed of sound
   rho_ll, rho_v1_ll, rho_e_ll = u_ll

--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -453,32 +453,6 @@ end
   λ_max = max(v_mag_ll, v_mag_rr) + max(c_ll, c_rr)
 end
 
-function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::CompressibleEulerEquations1D)
-  # Calculate primitive variables and speed of sound
-  rho_ll, rho_v1_ll, rho_e_ll = u_ll
-  rho_rr, rho_v1_rr, rho_e_rr = u_rr
-
-  v1_ll = rho_v1_ll / rho_ll
-  v_mag_ll = abs(v1_ll)
-  p_ll = (equations.gamma - 1) * (rho_e_ll - 1/2 * rho_ll * v_mag_ll^2)
-  c_ll = sqrt(equations.gamma * p_ll / rho_ll)
-  v1_rr = rho_v1_rr / rho_rr
-  v_mag_rr = abs(v1_rr)
-  p_rr = (equations.gamma - 1) * (rho_e_rr - 1/2 * rho_rr * v_mag_rr^2)
-  c_rr = sqrt(equations.gamma * p_rr / rho_rr)
-
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
-  λ_max = max(v_mag_ll, v_mag_rr) + max(c_ll, c_rr)
-  f1 = 1/2 * (f_ll[1] + f_rr[1]) - 1/2 * λ_max * (rho_rr    - rho_ll)
-  f2 = 1/2 * (f_ll[2] + f_rr[2]) - 1/2 * λ_max * (rho_v1_rr - rho_v1_ll)
-  f3 = 1/2 * (f_ll[3] + f_rr[3]) - 1/2 * λ_max * (rho_e_rr  - rho_e_ll)
-
-  return SVector(f1, f2, f3)
-end
-
 
 function flux_hll(u_ll, u_rr, orientation, equations::CompressibleEulerEquations1D)
   # Calculate primitive variables and speed of sound

--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -454,40 +454,24 @@ end
 end
 
 
-function flux_hll(u_ll, u_rr, orientation, equations::CompressibleEulerEquations1D)
-  # Calculate primitive variables and speed of sound
+# Calculate minimum and maximum wave speeds for HLL-type fluxes
+@inline function min_max_speed_naive(u_ll, u_rr, orientation, equations::CompressibleEulerEquations1D)
   rho_ll, rho_v1_ll, rho_e_ll = u_ll
   rho_rr, rho_v1_rr, rho_e_rr = u_rr
 
+  # Calculate primitive variables and speed of sound
   v1_ll = rho_v1_ll / rho_ll
   p_ll = (equations.gamma - 1) * (rho_e_ll - 1/2 * rho_ll * v1_ll^2)
 
   v1_rr = rho_v1_rr / rho_rr
   p_rr = (equations.gamma - 1) * (rho_e_rr - 1/2 * rho_rr * v1_rr^2)
 
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
+  λ_min = v1_ll - sqrt(equations.gamma * p_ll / rho_ll)
+  λ_max = v1_rr + sqrt(equations.gamma * p_rr / rho_rr)
 
-  Ssl = v1_ll - sqrt(equations.gamma * p_ll / rho_ll)
-  Ssr = v1_rr + sqrt(equations.gamma * p_rr / rho_rr)
-
-  if Ssl >= 0.0 && Ssr > 0.0
-    f1 = f_ll[1]
-    f2 = f_ll[2]
-    f3 = f_ll[3]
-  elseif Ssr <= 0.0 && Ssl < 0.0
-    f1 = f_rr[1]
-    f2 = f_rr[2]
-    f3 = f_rr[3]
-  else
-    f1 = (Ssr*f_ll[1] - Ssl*f_rr[1] + Ssl*Ssr*(rho_rr[1]    - rho_ll[1]))/(Ssr - Ssl)
-    f2 = (Ssr*f_ll[2] - Ssl*f_rr[2] + Ssl*Ssr*(rho_v1_rr[1] - rho_v1_ll[1]))/(Ssr - Ssl)
-    f3 = (Ssr*f_ll[3] - Ssl*f_rr[3] + Ssl*Ssr*(rho_e_rr[1]  - rho_e_ll[1]))/(Ssr - Ssl)
-  end
-
-  return SVector(f1, f2, f3)
+  return λ_min, λ_max
 end
+
 
 """
     flux_hllc(u_ll, u_rr, orientation, equations::CompressibleEulerEquations2D)

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -838,35 +838,6 @@ end
   λ_max = max(v_mag_ll, v_mag_rr) + max(c_ll, c_rr)
 end
 
-function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::CompressibleEulerEquations2D)
-  # Calculate primitive variables and speed of sound
-  rho_ll, rho_v1_ll, rho_v2_ll, rho_e_ll = u_ll
-  rho_rr, rho_v1_rr, rho_v2_rr, rho_e_rr = u_rr
-
-  v1_ll = rho_v1_ll / rho_ll
-  v2_ll = rho_v2_ll / rho_ll
-  v_mag_ll = sqrt(v1_ll^2 + v2_ll^2)
-  p_ll = (equations.gamma - 1) * (rho_e_ll - 1/2 * rho_ll * v_mag_ll^2)
-  c_ll = sqrt(equations.gamma * p_ll / rho_ll)
-  v1_rr = rho_v1_rr / rho_rr
-  v2_rr = rho_v2_rr / rho_rr
-  v_mag_rr = sqrt(v1_rr^2 + v2_rr^2)
-  p_rr = (equations.gamma - 1) * (rho_e_rr - 1/2 * rho_rr * v_mag_rr^2)
-  c_rr = sqrt(equations.gamma * p_rr / rho_rr)
-
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
-  λ_max = max(v_mag_ll, v_mag_rr) + max(c_ll, c_rr)
-  f1 = 1/2 * (f_ll[1] + f_rr[1]) - 1/2 * λ_max * (rho_rr    - rho_ll)
-  f2 = 1/2 * (f_ll[2] + f_rr[2]) - 1/2 * λ_max * (rho_v1_rr - rho_v1_ll)
-  f3 = 1/2 * (f_ll[3] + f_rr[3]) - 1/2 * λ_max * (rho_v2_rr - rho_v2_ll)
-  f4 = 1/2 * (f_ll[4] + f_rr[4]) - 1/2 * λ_max * (rho_e_rr  - rho_e_ll)
-
-  return SVector(f1, f2, f3, f4)
-end
-
 
 function flux_hll(u_ll, u_rr, orientation, equations::CompressibleEulerEquations2D)
   # Calculate primitive variables and speed of sound

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -817,6 +817,25 @@ See also
 end
 
 
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::CompressibleEulerEquations2D)
+  # Calculate primitive variables and speed of sound
+  rho_ll, rho_v1_ll, rho_v2_ll, rho_e_ll = u_ll
+  rho_rr, rho_v1_rr, rho_v2_rr, rho_e_rr = u_rr
+
+  v1_ll = rho_v1_ll / rho_ll
+  v2_ll = rho_v2_ll / rho_ll
+  v_mag_ll = sqrt(v1_ll^2 + v2_ll^2)
+  p_ll = (equations.gamma - 1) * (rho_e_ll - 1/2 * rho_ll * v_mag_ll^2)
+  c_ll = sqrt(equations.gamma * p_ll / rho_ll)
+  v1_rr = rho_v1_rr / rho_rr
+  v2_rr = rho_v2_rr / rho_rr
+  v_mag_rr = sqrt(v1_rr^2 + v2_rr^2)
+  p_rr = (equations.gamma - 1) * (rho_e_rr - 1/2 * rho_rr * v_mag_rr^2)
+  c_rr = sqrt(equations.gamma * p_rr / rho_rr)
+
+  λ_max = max(v_mag_ll, v_mag_rr) + max(c_ll, c_rr)
+end
+
 function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::CompressibleEulerEquations2D)
   # Calculate primitive variables and speed of sound
   rho_ll, rho_v1_ll, rho_v2_ll, rho_e_ll = u_ll

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -839,11 +839,12 @@ end
 end
 
 
-function flux_hll(u_ll, u_rr, orientation, equations::CompressibleEulerEquations2D)
-  # Calculate primitive variables and speed of sound
+# Calculate minimum and maximum wave speeds for HLL-type fluxes
+@inline function min_max_speed_naive(u_ll, u_rr, orientation, equations::CompressibleEulerEquations2D)
   rho_ll, rho_v1_ll, rho_v2_ll, rho_e_ll = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, rho_e_rr = u_rr
 
+  # Calculate primitive variables and speed of sound
   v1_ll = rho_v1_ll / rho_ll
   v2_ll = rho_v2_ll / rho_ll
   p_ll = (equations.gamma - 1) * (rho_e_ll - 1/2 * rho_ll * (v1_ll^2 + v2_ll^2))
@@ -852,36 +853,15 @@ function flux_hll(u_ll, u_rr, orientation, equations::CompressibleEulerEquations
   v2_rr = rho_v2_rr / rho_rr
   p_rr = (equations.gamma - 1) * (rho_e_rr - 1/2 * rho_rr * (v1_rr^2 + v2_rr^2))
 
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
   if orientation == 1 # x-direction
-    Ssl = v1_ll - sqrt(equations.gamma * p_ll / rho_ll)
-    Ssr = v1_rr + sqrt(equations.gamma * p_rr / rho_rr)
+    λ_min = v1_ll - sqrt(equations.gamma * p_ll / rho_ll)
+    λ_max = v1_rr + sqrt(equations.gamma * p_rr / rho_rr)
   else # y-direction
-    Ssl = v2_ll - sqrt(equations.gamma * p_ll / rho_ll)
-    Ssr = v2_rr + sqrt(equations.gamma * p_rr / rho_rr)
+    λ_min = v2_ll - sqrt(equations.gamma * p_ll / rho_ll)
+    λ_max = v2_rr + sqrt(equations.gamma * p_rr / rho_rr)
   end
 
-  if Ssl >= 0.0 && Ssr > 0.0
-    f1 = f_ll[1]
-    f2 = f_ll[2]
-    f3 = f_ll[3]
-    f4 = f_ll[4]
-  elseif Ssr <= 0.0 && Ssl < 0.0
-    f1 = f_rr[1]
-    f2 = f_rr[2]
-    f3 = f_rr[3]
-    f4 = f_rr[4]
-  else
-    f1 = (Ssr*f_ll[1] - Ssl*f_rr[1] + Ssl*Ssr*(rho_rr[1]    - rho_ll[1]))/(Ssr - Ssl)
-    f2 = (Ssr*f_ll[2] - Ssl*f_rr[2] + Ssl*Ssr*(rho_v1_rr[1] - rho_v1_ll[1]))/(Ssr - Ssl)
-    f3 = (Ssr*f_ll[3] - Ssl*f_rr[3] + Ssl*Ssr*(rho_v2_rr[1] - rho_v2_ll[1]))/(Ssr - Ssl)
-    f4 = (Ssr*f_ll[4] - Ssl*f_rr[4] + Ssl*Ssr*(rho_e_rr[1]  - rho_e_ll[1]))/(Ssr - Ssl)
-  end
-
-  return SVector(f1, f2, f3, f4)
+  return λ_min, λ_max
 end
 
 

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -817,6 +817,8 @@ See also
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation as the
+# maximum velocity magnitude plus the maximum speed of sound
 @inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::CompressibleEulerEquations2D)
   # Calculate primitive variables and speed of sound
   rho_ll, rho_v1_ll, rho_v2_ll, rho_e_ll = u_ll

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -820,10 +820,10 @@ end
 # Calculate maximum wave speed for local Lax-Friedrichs-type dissipation as the
 # maximum velocity magnitude plus the maximum speed of sound
 @inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::CompressibleEulerEquations2D)
-  # Calculate primitive variables and speed of sound
   rho_ll, rho_v1_ll, rho_v2_ll, rho_e_ll = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, rho_e_rr = u_rr
 
+  # Calculate primitive variables and speed of sound
   v1_ll = rho_v1_ll / rho_ll
   v2_ll = rho_v2_ll / rho_ll
   v_mag_ll = sqrt(v1_ll^2 + v2_ll^2)

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -710,38 +710,6 @@ end
   λ_max = max(v_mag_ll, v_mag_rr) + max(c_ll, c_rr)
 end
 
-function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::CompressibleEulerEquations3D)
-  # Calculate primitive variables and speed of sound
-  rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll = u_ll
-  rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr = u_rr
-
-  v1_ll = rho_v1_ll / rho_ll
-  v2_ll = rho_v2_ll / rho_ll
-  v3_ll = rho_v3_ll / rho_ll
-  v_mag_ll = sqrt(v1_ll^2 + v2_ll^2 + v3_ll^2)
-  p_ll = (equations.gamma - 1) * (rho_e_ll - 1/2 * rho_ll * v_mag_ll^2)
-  c_ll = sqrt(equations.gamma * p_ll / rho_ll)
-  v1_rr = rho_v1_rr / rho_rr
-  v2_rr = rho_v2_rr / rho_rr
-  v3_rr = rho_v3_rr / rho_rr
-  v_mag_rr = sqrt(v1_rr^2 + v2_rr^2 + v3_rr^2)
-  p_rr = (equations.gamma - 1) * (rho_e_rr - 1/2 * rho_rr * v_mag_rr^2)
-  c_rr = sqrt(equations.gamma * p_rr / rho_rr)
-
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
-  λ_max = max(v_mag_ll, v_mag_rr) + max(c_ll, c_rr)
-  f1 = 1/2 * (f_ll[1] + f_rr[1]) - 1/2 * λ_max * (rho_rr    - rho_ll)
-  f2 = 1/2 * (f_ll[2] + f_rr[2]) - 1/2 * λ_max * (rho_v1_rr - rho_v1_ll)
-  f3 = 1/2 * (f_ll[3] + f_rr[3]) - 1/2 * λ_max * (rho_v2_rr - rho_v2_ll)
-  f4 = 1/2 * (f_ll[4] + f_rr[4]) - 1/2 * λ_max * (rho_v3_rr - rho_v3_ll)
-  f5 = 1/2 * (f_ll[5] + f_rr[5]) - 1/2 * λ_max * (rho_e_rr  - rho_e_ll)
-
-  return SVector(f1, f2, f3, f4, f5)
-end
-
 
 function flux_hll(u_ll, u_rr, orientation, equations::CompressibleEulerEquations3D)
   # Calculate primitive variables and speed of sound

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -687,6 +687,29 @@ See also
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation as the
+# maximum velocity magnitude plus the maximum speed of sound
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::CompressibleEulerEquations3D)
+  rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll = u_ll
+  rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr = u_rr
+
+  # Calculate primitive variables and speed of sound
+  v1_ll = rho_v1_ll / rho_ll
+  v2_ll = rho_v2_ll / rho_ll
+  v3_ll = rho_v3_ll / rho_ll
+  v_mag_ll = sqrt(v1_ll^2 + v2_ll^2 + v3_ll^2)
+  p_ll = (equations.gamma - 1) * (rho_e_ll - 1/2 * rho_ll * v_mag_ll^2)
+  c_ll = sqrt(equations.gamma * p_ll / rho_ll)
+  v1_rr = rho_v1_rr / rho_rr
+  v2_rr = rho_v2_rr / rho_rr
+  v3_rr = rho_v3_rr / rho_rr
+  v_mag_rr = sqrt(v1_rr^2 + v2_rr^2 + v3_rr^2)
+  p_rr = (equations.gamma - 1) * (rho_e_rr - 1/2 * rho_rr * v_mag_rr^2)
+  c_rr = sqrt(equations.gamma * p_rr / rho_rr)
+
+  λ_max = max(v_mag_ll, v_mag_rr) + max(c_ll, c_rr)
+end
+
 function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::CompressibleEulerEquations3D)
   # Calculate primitive variables and speed of sound
   rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll = u_ll

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -711,11 +711,12 @@ end
 end
 
 
-function flux_hll(u_ll, u_rr, orientation, equations::CompressibleEulerEquations3D)
-  # Calculate primitive variables and speed of sound
+# Calculate minimum and maximum wave speeds for HLL-type fluxes
+@inline function min_max_speed_naive(u_ll, u_rr, orientation, equations::CompressibleEulerEquations3D)
   rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr = u_rr
 
+  # Calculate primitive variables and speed of sound
   v1_ll = rho_v1_ll / rho_ll
   v2_ll = rho_v2_ll / rho_ll
   v3_ll = rho_v3_ll / rho_ll
@@ -726,46 +727,22 @@ function flux_hll(u_ll, u_rr, orientation, equations::CompressibleEulerEquations
   v3_rr = rho_v3_rr / rho_rr
   p_rr = (equations.gamma - 1) * (rho_e_rr - 1/2 * rho_rr * (v1_rr^2 + v2_rr^2 + v3_rr^2))
 
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
   if orientation == 1 # x-direction
-    Ssl = v1_ll - sqrt(equations.gamma * p_ll / rho_ll)
-    Ssr = v1_rr + sqrt(equations.gamma * p_rr / rho_rr)
+    λ_min = v1_ll - sqrt(equations.gamma * p_ll / rho_ll)
+    λ_max = v1_rr + sqrt(equations.gamma * p_rr / rho_rr)
   elseif orientation == 2 # y-direction
-    Ssl = v2_ll - sqrt(equations.gamma * p_ll / rho_ll)
-    Ssr = v2_rr + sqrt(equations.gamma * p_rr / rho_rr)
+    λ_min = v2_ll - sqrt(equations.gamma * p_ll / rho_ll)
+    λ_max = v2_rr + sqrt(equations.gamma * p_rr / rho_rr)
   else # z-direction
-    Ssl = v3_ll - sqrt(equations.gamma * p_ll / rho_ll)
-    Ssr = v3_rr + sqrt(equations.gamma * p_rr / rho_rr)
+    λ_min = v3_ll - sqrt(equations.gamma * p_ll / rho_ll)
+    λ_max = v3_rr + sqrt(equations.gamma * p_rr / rho_rr)
   end
 
-  if Ssl >= 0.0 && Ssr > 0.0
-    f1 = f_ll[1]
-    f2 = f_ll[2]
-    f3 = f_ll[3]
-    f4 = f_ll[4]
-    f5 = f_ll[5]
-  elseif Ssr <= 0.0 && Ssl < 0.0
-    f1 = f_rr[1]
-    f2 = f_rr[2]
-    f3 = f_rr[3]
-    f4 = f_rr[4]
-    f5 = f_rr[5]
-  else
-    f1 = (Ssr*f_ll[1] - Ssl*f_rr[1] + Ssl*Ssr*(rho_rr    - rho_ll))    / (Ssr - Ssl)
-    f2 = (Ssr*f_ll[2] - Ssl*f_rr[2] + Ssl*Ssr*(rho_v1_rr - rho_v1_ll)) / (Ssr - Ssl)
-    f3 = (Ssr*f_ll[3] - Ssl*f_rr[3] + Ssl*Ssr*(rho_v2_rr - rho_v2_ll)) / (Ssr - Ssl)
-    f4 = (Ssr*f_ll[4] - Ssl*f_rr[4] + Ssl*Ssr*(rho_v3_rr - rho_v3_ll)) / (Ssr - Ssl)
-    f5 = (Ssr*f_ll[5] - Ssl*f_rr[5] + Ssl*Ssr*(rho_e_rr  - rho_e_ll))  / (Ssr - Ssl)
-  end
-
-  return SVector(f1, f2, f3, f4, f5)
+  return λ_min, λ_max
 end
 
 
- """
+"""
     flux_hllc(u_ll, u_rr, orientation, equations::CompressibleEulerEquations3D)
 
 Computes the HLLC flux (HLL with Contact) for compressible Euler equations developed by E.F. Toro

--- a/src/equations/compressible_euler_multicomponent_2d.jl
+++ b/src/equations/compressible_euler_multicomponent_2d.jl
@@ -717,6 +717,32 @@ Entropy conserving two-point flux by
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::CompressibleEulerMulticomponentEquations2D)
+  rho_v1_ll, rho_v2_ll, rho_e_ll = u_ll
+  rho_v1_rr, rho_v2_rr, rho_e_rr = u_rr
+
+  # Calculate primitive variables and speed of sound
+  rho_ll   = density(u_ll, equations)
+  rho_rr   = density(u_rr, equations)
+  gamma_ll = totalgamma(u_ll, equations)
+  gamma_rr = totalgamma(u_rr, equations)
+
+  v1_ll = rho_v1_ll / rho_ll
+  v2_ll = rho_v2_ll / rho_ll
+  v_mag_ll = sqrt(v1_ll^2 + v2_ll^2)
+
+  p_ll = (gamma_ll - 1) * (rho_e_ll - 1/2 * rho_ll * v_mag_ll^2)
+  c_ll = sqrt(gamma_ll * p_ll / rho_ll)
+  v1_rr = rho_v1_rr / rho_rr
+  v2_rr = rho_v2_rr / rho_rr
+  v_mag_rr = sqrt(v1_rr^2 + v2_rr^2)
+  p_rr = (gamma_rr - 1) * (rho_e_rr - 1/2 * rho_rr * v_mag_rr^2)
+  c_rr = sqrt(gamma_rr * p_rr / rho_rr)
+
+  λ_max = max(v_mag_ll, v_mag_rr) + max(c_ll, c_rr)
+end
+
 function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::CompressibleEulerMulticomponentEquations2D)
   # Calculate primitive variables and speed of sound
   rho_v1_ll, rho_v2_ll, rho_e_ll = u_ll

--- a/src/equations/compressible_euler_multicomponent_2d.jl
+++ b/src/equations/compressible_euler_multicomponent_2d.jl
@@ -743,39 +743,6 @@ end
   λ_max = max(v_mag_ll, v_mag_rr) + max(c_ll, c_rr)
 end
 
-function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::CompressibleEulerMulticomponentEquations2D)
-  # Calculate primitive variables and speed of sound
-  rho_v1_ll, rho_v2_ll, rho_e_ll = u_ll
-  rho_v1_rr, rho_v2_rr, rho_e_rr = u_rr
-
-  rho_ll   = density(u_ll, equations)
-  rho_rr   = density(u_rr, equations)
-  gamma_ll = totalgamma(u_ll, equations)
-  gamma_rr = totalgamma(u_rr, equations)
-
-  v1_ll = rho_v1_ll / rho_ll
-  v2_ll = rho_v2_ll / rho_ll
-  v_mag_ll = sqrt(v1_ll^2 + v2_ll^2)
-
-  p_ll = (gamma_ll - 1) * (rho_e_ll - 1/2 * rho_ll * v_mag_ll^2)
-  c_ll = sqrt(gamma_ll * p_ll / rho_ll)
-  v1_rr = rho_v1_rr / rho_rr
-  v2_rr = rho_v2_rr / rho_rr
-  v_mag_rr = sqrt(v1_rr^2 + v2_rr^2)
-  p_rr = (gamma_rr - 1) * (rho_e_rr - 1/2 * rho_rr * v_mag_rr^2)
-  c_rr = sqrt(gamma_rr * p_rr / rho_rr)
-
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
-  λ_max = max(v_mag_ll, v_mag_rr) + max(c_ll, c_rr)
-
-  f  = SVector{nvariables(equations), real(equations)}(1/2 * (f_ll[i] + f_rr[i]) - 1/2 * λ_max * (u_rr[i] - u_ll[i]) for i = 1:nvariables(equations))
-
-  return f
-end
-
 
 @inline function max_abs_speeds(u, equations::CompressibleEulerMulticomponentEquations2D)
   rho_v1, rho_v2, rho_e = u

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -86,6 +86,7 @@ function cons2prim(u, ::AbstractEquations) end
 ####################################################################################################
 # Include files with actual implementations for different systems of equations.
 
+# Numerical flux formulations that are independent of the specific system of equations
 include("numerical_fluxes.jl")
 
 # Linear scalar advection

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -61,7 +61,7 @@ Given the conservative variables `u`, calculate the (physical) flux in spatial
 direction `orientation` for the coressponding set of governing `equations`
 `orientation` is `1`, `2`, and `3` for the x-, y-, and z-directions, respectively.
 """
-function flux(u, orientation, equations) end
+function flux end
 
 
 # set sensible default values that may be overwritten by specific equations

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -72,23 +72,6 @@ default_analysis_errors(::AbstractEquations)     = (:l2_error, :linf_error)
 default_analysis_integrals(::AbstractEquations)  = (entropy_timederivative,)
 
 
-"""
-    flux_central(u_ll, u_rr, orientation, equations::AbstractEquations)
-
-The classical central numerical flux `f((u_ll) + f(u_rr)) / 2`. When this flux is
-used as volume flux, the discretization is equivalent to the classical weak form
-DG method (except floating point errors).
-"""
-@inline function flux_central(u_ll, u_rr, orientation, equations::AbstractEquations)
-  # Calculate regular 1D fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
-  # Average regular fluxes
-  return 0.5 * (f_ll + f_rr)
-end
-
-
 @inline cons2cons(u, ::AbstractEquations) = u
 function cons2prim(u, ::AbstractEquations) end
 @inline Base.first(u, ::AbstractEquations) = first(u)
@@ -102,6 +85,8 @@ function cons2prim(u, ::AbstractEquations) end
 
 ####################################################################################################
 # Include files with actual implementations for different systems of equations.
+
+include("numerical_fluxes.jl")
 
 # Linear scalar advection
 abstract type AbstractLinearScalarAdvectionEquation{NDIMS, NVARS} <: AbstractEquations{NDIMS, NVARS} end

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -73,7 +73,7 @@ default_analysis_integrals(::AbstractEquations)  = (entropy_timederivative,)
 
 
 @inline cons2cons(u, ::AbstractEquations) = u
-function cons2prim(u, ::AbstractEquations) end
+function cons2prim#=(u, ::AbstractEquations)=# end
 @inline Base.first(u, ::AbstractEquations) = first(u)
 
 # FIXME: Deprecations introduced in v0.3

--- a/src/equations/hyperbolic_diffusion_1d.jl
+++ b/src/equations/hyperbolic_diffusion_1d.jl
@@ -205,16 +205,6 @@ end
   λ_max = sqrt(equations.nu * equations.inv_Tr)
 end
 
-@inline function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::HyperbolicDiffusionEquations1D)
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
-  λ_max = sqrt(equations.nu * equations.inv_Tr)
-
-  return 0.5 * (f_ll + f_rr - λ_max * (u_rr - u_ll))
-end
-
 
 @inline have_constant_speed(::HyperbolicDiffusionEquations1D) = Val(true)
 

--- a/src/equations/hyperbolic_diffusion_1d.jl
+++ b/src/equations/hyperbolic_diffusion_1d.jl
@@ -200,6 +200,11 @@ end
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::HyperbolicDiffusionEquations1D)
+  λ_max = sqrt(equations.nu * equations.inv_Tr)
+end
+
 @inline function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::HyperbolicDiffusionEquations1D)
   # Obtain left and right fluxes
   f_ll = flux(u_ll, orientation, equations)

--- a/src/equations/hyperbolic_diffusion_2d.jl
+++ b/src/equations/hyperbolic_diffusion_2d.jl
@@ -257,16 +257,6 @@ end
   λ_max = sqrt(equations.nu * equations.inv_Tr)
 end
 
-@inline function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::HyperbolicDiffusionEquations2D)
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
-  λ_max = sqrt(equations.nu * equations.inv_Tr)
-
-  return 0.5 * (f_ll + f_rr - λ_max * (u_rr - u_ll))
-end
-
 
 @inline function flux_godunov(u_ll, u_rr, orientation, equations::HyperbolicDiffusionEquations2D)
   # Obtain left and right fluxes

--- a/src/equations/hyperbolic_diffusion_2d.jl
+++ b/src/equations/hyperbolic_diffusion_2d.jl
@@ -252,6 +252,11 @@ end
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::HyperbolicDiffusionEquations2D)
+  λ_max = sqrt(equations.nu * equations.inv_Tr)
+end
+
 @inline function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::HyperbolicDiffusionEquations2D)
   # Obtain left and right fluxes
   f_ll = flux(u_ll, orientation, equations)

--- a/src/equations/hyperbolic_diffusion_3d.jl
+++ b/src/equations/hyperbolic_diffusion_3d.jl
@@ -236,6 +236,11 @@ end
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::HyperbolicDiffusionEquations3D)
+  λ_max = sqrt(equations.nu * equations.inv_Tr)
+end
+
 @inline function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::HyperbolicDiffusionEquations3D)
   # Obtain left and right fluxes
   f_ll = flux(u_ll, orientation, equations)

--- a/src/equations/hyperbolic_diffusion_3d.jl
+++ b/src/equations/hyperbolic_diffusion_3d.jl
@@ -241,16 +241,6 @@ end
   λ_max = sqrt(equations.nu * equations.inv_Tr)
 end
 
-@inline function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::HyperbolicDiffusionEquations3D)
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
-  λ_max = sqrt(equations.nu * equations.inv_Tr)
-
-  return 0.5 * (f_ll + f_rr - λ_max * (u_rr - u_ll))
-end
-
 
 @inline function flux_godunov(u_ll, u_rr, orientation, equations::HyperbolicDiffusionEquations3D)
   # Obtain left and right fluxes

--- a/src/equations/ideal_glm_mhd_1d.jl
+++ b/src/equations/ideal_glm_mhd_1d.jl
@@ -406,14 +406,14 @@ end
 
 
 """
-    flux_hll(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations2D)
+    min_max_speed_naive(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations1D)
 
-HLL flux for ideal GLM-MHD equations like that by
+Calculate minimum and maximum wave speeds for HLL-type fluxes as in
 - Li (2005)
   An HLLC Riemann solver for magneto-hydrodynamics
   [DOI: 10.1016/j.jcp.2004.08.020](https://doi.org/10.1016/j.jcp.2004.08.020)
 """
-function flux_hll(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations1D)
+@inline function min_max_speed_naive(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations1D)
   rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr = u_rr
 
@@ -432,47 +432,14 @@ function flux_hll(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations1D)
   mag_norm_rr = B1_rr^2 + B2_rr^2 + B3_rr^2
   p_rr = (equations.gamma - 1)*(rho_e_rr - 0.5*rho_rr*vel_norm_rr - 0.5*mag_norm_rr)
 
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
   # Approximate the left-most and right-most eigenvalues in the Riemann fan
   c_f_ll = calc_fast_wavespeed(u_ll, orientation, equations)
   c_f_rr = calc_fast_wavespeed(u_rr, orientation, equations)
   vel_roe, c_f_roe = calc_fast_wavespeed_roe(u_ll, u_rr, orientation, equations)
-  Ssl = min(v1_ll - c_f_ll, vel_roe - c_f_roe)
-  Ssr = max(v1_rr + c_f_rr, vel_roe + c_f_roe)
+  λ_min = min(v1_ll - c_f_ll, vel_roe - c_f_roe)
+  λ_max = max(v1_rr + c_f_rr, vel_roe + c_f_roe)
 
-  if Ssl >= 0.0 && Ssr > 0.0
-    f1 = f_ll[1]
-    f2 = f_ll[2]
-    f3 = f_ll[3]
-    f4 = f_ll[4]
-    f5 = f_ll[5]
-    f6 = f_ll[6]
-    f7 = f_ll[7]
-    f8 = f_ll[8]
-  elseif Ssr <= 0.0 && Ssl < 0.0
-    f1 = f_rr[1]
-    f2 = f_rr[2]
-    f3 = f_rr[3]
-    f4 = f_rr[4]
-    f5 = f_rr[5]
-    f6 = f_rr[6]
-    f7 = f_rr[7]
-    f8 = f_rr[8]
-  else
-    f1 = (Ssr * f_ll[1] - Ssl * f_rr[1] + Ssl * Ssr * (rho_rr[1]    - rho_ll[1]))    / (Ssr - Ssl)
-    f2 = (Ssr * f_ll[2] - Ssl * f_rr[2] + Ssl * Ssr * (rho_v1_rr[1] - rho_v1_ll[1])) / (Ssr - Ssl)
-    f3 = (Ssr * f_ll[3] - Ssl * f_rr[3] + Ssl * Ssr * (rho_v2_rr[1] - rho_v2_ll[1])) / (Ssr - Ssl)
-    f4 = (Ssr * f_ll[4] - Ssl * f_rr[4] + Ssl * Ssr * (rho_v3_rr[1] - rho_v3_ll[1])) / (Ssr - Ssl)
-    f5 = (Ssr * f_ll[5] - Ssl * f_rr[5] + Ssl * Ssr * (rho_e_rr[1]  - rho_e_ll[1]))  / (Ssr - Ssl)
-    f6 = (Ssr * f_ll[6] - Ssl * f_rr[6] + Ssl * Ssr * (B1_rr[1]     - B1_ll[1]))     / (Ssr - Ssl)
-    f7 = (Ssr * f_ll[7] - Ssl * f_rr[7] + Ssl * Ssr * (B2_rr[1]     - B2_ll[1]))     / (Ssr - Ssl)
-    f8 = (Ssr * f_ll[8] - Ssl * f_rr[8] + Ssl * Ssr * (B3_rr[1]     - B3_ll[1]))     / (Ssr - Ssl)
-  end
-
-  return SVector(f1, f2, f3, f4, f5, f6, f7, f8)
+  return λ_min, λ_max
 end
 
 

--- a/src/equations/ideal_glm_mhd_1d.jl
+++ b/src/equations/ideal_glm_mhd_1d.jl
@@ -404,40 +404,6 @@ end
   λ_max = max(v_mag_ll, v_mag_rr) + max(cf_ll, cf_rr)
 end
 
-function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations1D)
-  rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll = u_ll
-  rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr = u_rr
-
-  # Calculate velocities and fast magnetoacoustic wave speeds
-  # left
-  v1_ll = rho_v1_ll / rho_ll
-  v2_ll = rho_v2_ll / rho_ll
-  v3_ll = rho_v3_ll / rho_ll
-  v_mag_ll = sqrt(v1_ll^2 + v2_ll^2 + v3_ll^2)
-  cf_ll = calc_fast_wavespeed(u_ll, orientation, equations)
-  # right
-  v1_rr = rho_v1_rr / rho_rr
-  v2_rr = rho_v2_rr / rho_rr
-  v3_rr = rho_v3_rr / rho_rr
-  v_mag_rr = sqrt(v1_rr^2 + v2_rr^2 + v3_rr^2)
-  cf_rr = calc_fast_wavespeed(u_rr, orientation, equations)
-
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
-  λ_max = max(v_mag_ll, v_mag_rr) + max(cf_ll, cf_rr)
-  f1 = 1/2 * (f_ll[1] + f_rr[1]) - 1/2 * λ_max * (rho_rr    - rho_ll)
-  f2 = 1/2 * (f_ll[2] + f_rr[2]) - 1/2 * λ_max * (rho_v1_rr - rho_v1_ll)
-  f3 = 1/2 * (f_ll[3] + f_rr[3]) - 1/2 * λ_max * (rho_v2_rr - rho_v2_ll)
-  f4 = 1/2 * (f_ll[4] + f_rr[4]) - 1/2 * λ_max * (rho_v3_rr - rho_v3_ll)
-  f5 = 1/2 * (f_ll[5] + f_rr[5]) - 1/2 * λ_max * (rho_e_rr  - rho_e_ll)
-  f6 = 1/2 * (f_ll[6] + f_rr[6]) - 1/2 * λ_max * (B1_rr     - B1_ll)
-  f7 = 1/2 * (f_ll[7] + f_rr[7]) - 1/2 * λ_max * (B2_rr     - B2_ll)
-  f8 = 1/2 * (f_ll[8] + f_rr[8]) - 1/2 * λ_max * (B3_rr     - B3_ll)
-
-  return SVector(f1, f2, f3, f4, f5, f6, f7, f8)
-end
 
 """
     flux_hll(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations2D)

--- a/src/equations/ideal_glm_mhd_1d.jl
+++ b/src/equations/ideal_glm_mhd_1d.jl
@@ -382,6 +382,28 @@ function flux_derigs_etal(u_ll, u_rr, orientation, equations::IdealGlmMhdEquatio
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations1D)
+  rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll = u_ll
+  rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr = u_rr
+
+  # Calculate velocities and fast magnetoacoustic wave speeds
+  # left
+  v1_ll = rho_v1_ll / rho_ll
+  v2_ll = rho_v2_ll / rho_ll
+  v3_ll = rho_v3_ll / rho_ll
+  v_mag_ll = sqrt(v1_ll^2 + v2_ll^2 + v3_ll^2)
+  cf_ll = calc_fast_wavespeed(u_ll, orientation, equations)
+  # right
+  v1_rr = rho_v1_rr / rho_rr
+  v2_rr = rho_v2_rr / rho_rr
+  v3_rr = rho_v3_rr / rho_rr
+  v_mag_rr = sqrt(v1_rr^2 + v2_rr^2 + v3_rr^2)
+  cf_rr = calc_fast_wavespeed(u_rr, orientation, equations)
+
+  λ_max = max(v_mag_ll, v_mag_rr) + max(cf_ll, cf_rr)
+end
+
 function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations1D)
   rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr = u_rr

--- a/src/equations/ideal_glm_mhd_2d.jl
+++ b/src/equations/ideal_glm_mhd_2d.jl
@@ -349,6 +349,28 @@ function flux_derigs_etal(u_ll, u_rr, orientation, equations::IdealGlmMhdEquatio
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations2D)
+  rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll, psi_ll = u_ll
+  rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr, psi_rr = u_rr
+
+  # Calculate velocities and fast magnetoacoustic wave speeds
+  # left
+  v1_ll = rho_v1_ll / rho_ll
+  v2_ll = rho_v2_ll / rho_ll
+  v3_ll = rho_v3_ll / rho_ll
+  v_mag_ll = sqrt(v1_ll^2 + v2_ll^2 + v3_ll^2)
+  cf_ll = calc_fast_wavespeed(u_ll, orientation, equations)
+  # right
+  v1_rr = rho_v1_rr / rho_rr
+  v2_rr = rho_v2_rr / rho_rr
+  v3_rr = rho_v3_rr / rho_rr
+  v_mag_rr = sqrt(v1_rr^2 + v2_rr^2 + v3_rr^2)
+  cf_rr = calc_fast_wavespeed(u_rr, orientation, equations)
+
+  λ_max = max(v_mag_ll, v_mag_rr) + max(cf_ll, cf_rr)
+end
+
 function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations2D)
   rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll, psi_ll = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr, psi_rr = u_rr

--- a/src/equations/ideal_glm_mhd_2d.jl
+++ b/src/equations/ideal_glm_mhd_2d.jl
@@ -373,14 +373,14 @@ end
 
 
 """
-    flux_hll(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations2D)
+    min_max_speed_naive(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations2D)
 
-HLL flux for ideal GLM-MHD equations like that by
+Calculate minimum and maximum wave speeds for HLL-type fluxes as in
 - Li (2005)
   An HLLC Riemann solver for magneto-hydrodynamics
   [DOI: 10.1016/j.jcp.2004.08.020](https://doi.org/10.1016/j.jcp.2004.08.020)
 """
-function flux_hll(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations2D)
+@inline function min_max_speed_naive(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations2D)
   rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll, psi_ll = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr, psi_rr = u_rr
 
@@ -399,59 +399,24 @@ function flux_hll(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations2D)
   mag_norm_rr = B1_rr^2 + B2_rr^2 + B3_rr^2
   p_rr = (equations.gamma - 1)*(rho_e_rr - 0.5*rho_rr*vel_norm_rr - 0.5*mag_norm_rr - 0.5*psi_rr^2)
 
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
   # Approximate the left-most and right-most eigenvalues in the Riemann fan
   if orientation == 1 # x-direction
     c_f_ll = calc_fast_wavespeed(u_ll, orientation, equations)
     c_f_rr = calc_fast_wavespeed(u_rr, orientation, equations)
     vel_roe, c_f_roe = calc_fast_wavespeed_roe(u_ll, u_rr, orientation, equations)
-    Ssl = min(v1_ll - c_f_ll, vel_roe - c_f_roe)
-    Ssr = max(v1_rr + c_f_rr, vel_roe + c_f_roe)
+    λ_min = min(v1_ll - c_f_ll, vel_roe - c_f_roe)
+    λ_max = max(v1_rr + c_f_rr, vel_roe + c_f_roe)
   else # y-direction
     c_f_ll = calc_fast_wavespeed(u_ll, orientation, equations)
     c_f_rr = calc_fast_wavespeed(u_rr, orientation, equations)
     vel_roe, c_f_roe = calc_fast_wavespeed_roe(u_ll, u_rr, orientation, equations)
-    Ssl = min(v2_ll - c_f_ll, vel_roe - c_f_roe)
-    Ssr = max(v2_rr + c_f_rr, vel_roe + c_f_roe)
+    λ_min = min(v2_ll - c_f_ll, vel_roe - c_f_roe)
+    λ_max = max(v2_rr + c_f_rr, vel_roe + c_f_roe)
   end
 
-  if Ssl >= 0.0 && Ssr > 0.0
-    f1 = f_ll[1]
-    f2 = f_ll[2]
-    f3 = f_ll[3]
-    f4 = f_ll[4]
-    f5 = f_ll[5]
-    f6 = f_ll[6]
-    f7 = f_ll[7]
-    f8 = f_ll[8]
-    f9 = f_ll[9]
-  elseif Ssr <= 0.0 && Ssl < 0.0
-    f1 = f_rr[1]
-    f2 = f_rr[2]
-    f3 = f_rr[3]
-    f4 = f_rr[4]
-    f5 = f_rr[5]
-    f6 = f_rr[6]
-    f7 = f_rr[7]
-    f8 = f_rr[8]
-    f9 = f_rr[9]
-  else
-    f1 = (Ssr * f_ll[1] - Ssl * f_rr[1] + Ssl * Ssr * (rho_rr[1]    - rho_ll[1]))    / (Ssr - Ssl)
-    f2 = (Ssr * f_ll[2] - Ssl * f_rr[2] + Ssl * Ssr * (rho_v1_rr[1] - rho_v1_ll[1])) / (Ssr - Ssl)
-    f3 = (Ssr * f_ll[3] - Ssl * f_rr[3] + Ssl * Ssr * (rho_v2_rr[1] - rho_v2_ll[1])) / (Ssr - Ssl)
-    f4 = (Ssr * f_ll[4] - Ssl * f_rr[4] + Ssl * Ssr * (rho_v3_rr[1] - rho_v3_ll[1])) / (Ssr - Ssl)
-    f5 = (Ssr * f_ll[5] - Ssl * f_rr[5] + Ssl * Ssr * (rho_e_rr[1]  - rho_e_ll[1]))  / (Ssr - Ssl)
-    f6 = (Ssr * f_ll[6] - Ssl * f_rr[6] + Ssl * Ssr * (B1_rr[1]     - B1_ll[1]))     / (Ssr - Ssl)
-    f7 = (Ssr * f_ll[7] - Ssl * f_rr[7] + Ssl * Ssr * (B2_rr[1]     - B2_ll[1]))     / (Ssr - Ssl)
-    f8 = (Ssr * f_ll[8] - Ssl * f_rr[8] + Ssl * Ssr * (B3_rr[1]     - B3_ll[1]))     / (Ssr - Ssl)
-    f9 = (Ssr * f_ll[9] - Ssl * f_rr[9] + Ssl * Ssr * (psi_rr[1]    - psi_ll[1]))    / (Ssr - Ssl)
-  end
-
-  return SVector(f1, f2, f3, f4, f5, f6, f7, f8, f9)
+  return λ_min, λ_max
 end
+
 
 """
     noncons_interface_flux(u_left, u_right, orientation, mode, equations::IdealGlmMhdEquations2D)

--- a/src/equations/ideal_glm_mhd_2d.jl
+++ b/src/equations/ideal_glm_mhd_2d.jl
@@ -371,41 +371,6 @@ end
   λ_max = max(v_mag_ll, v_mag_rr) + max(cf_ll, cf_rr)
 end
 
-function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations2D)
-  rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll, psi_ll = u_ll
-  rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr, psi_rr = u_rr
-
-  # Calculate velocities and fast magnetoacoustic wave speeds
-  # left
-  v1_ll = rho_v1_ll / rho_ll
-  v2_ll = rho_v2_ll / rho_ll
-  v3_ll = rho_v3_ll / rho_ll
-  v_mag_ll = sqrt(v1_ll^2 + v2_ll^2 + v3_ll^2)
-  cf_ll = calc_fast_wavespeed(u_ll, orientation, equations)
-  # right
-  v1_rr = rho_v1_rr / rho_rr
-  v2_rr = rho_v2_rr / rho_rr
-  v3_rr = rho_v3_rr / rho_rr
-  v_mag_rr = sqrt(v1_rr^2 + v2_rr^2 + v3_rr^2)
-  cf_rr = calc_fast_wavespeed(u_rr, orientation, equations)
-
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
-  λ_max = max(v_mag_ll, v_mag_rr) + max(cf_ll, cf_rr)
-  f1 = 1/2 * (f_ll[1] + f_rr[1]) - 1/2 * λ_max * (rho_rr    - rho_ll)
-  f2 = 1/2 * (f_ll[2] + f_rr[2]) - 1/2 * λ_max * (rho_v1_rr - rho_v1_ll)
-  f3 = 1/2 * (f_ll[3] + f_rr[3]) - 1/2 * λ_max * (rho_v2_rr - rho_v2_ll)
-  f4 = 1/2 * (f_ll[4] + f_rr[4]) - 1/2 * λ_max * (rho_v3_rr - rho_v3_ll)
-  f5 = 1/2 * (f_ll[5] + f_rr[5]) - 1/2 * λ_max * (rho_e_rr  - rho_e_ll)
-  f6 = 1/2 * (f_ll[6] + f_rr[6]) - 1/2 * λ_max * (B1_rr     - B1_ll)
-  f7 = 1/2 * (f_ll[7] + f_rr[7]) - 1/2 * λ_max * (B2_rr     - B2_ll)
-  f8 = 1/2 * (f_ll[8] + f_rr[8]) - 1/2 * λ_max * (B3_rr     - B3_ll)
-  f9 = 1/2 * (f_ll[9] + f_rr[9]) - 1/2 * λ_max * (psi_rr    - psi_ll)
-
-  return SVector(f1, f2, f3, f4, f5, f6, f7, f8, f9)
-end
 
 """
     flux_hll(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations2D)

--- a/src/equations/ideal_glm_mhd_3d.jl
+++ b/src/equations/ideal_glm_mhd_3d.jl
@@ -345,42 +345,6 @@ end
   λ_max = max(v_mag_ll, v_mag_rr) + max(cf_ll, cf_rr)
 end
 
-function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations3D)
-  rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll, psi_ll = u_ll
-  rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr, psi_rr = u_rr
-
-  # Calculate velocities and fast magnetoacoustic wave speeds
-  # left
-  v1_ll = rho_v1_ll / rho_ll
-  v2_ll = rho_v2_ll / rho_ll
-  v3_ll = rho_v3_ll / rho_ll
-  v_mag_ll = sqrt(v1_ll^2 + v2_ll^2 + v3_ll^2)
-  cf_ll = calc_fast_wavespeed(u_ll, orientation, equations)
-  # right
-  v1_rr = rho_v1_rr / rho_rr
-  v2_rr = rho_v2_rr / rho_rr
-  v3_rr = rho_v3_rr / rho_rr
-  v_mag_rr = sqrt(v1_rr^2 + v2_rr^2 + v3_rr^2)
-  cf_rr = calc_fast_wavespeed(u_rr, orientation, equations)
-
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
-  λ_max = max(v_mag_ll, v_mag_rr) + max(cf_ll, cf_rr)
-  f1 = 1/2 * (f_ll[1] + f_rr[1]) - 1/2 * λ_max * (rho_rr    - rho_ll)
-  f2 = 1/2 * (f_ll[2] + f_rr[2]) - 1/2 * λ_max * (rho_v1_rr - rho_v1_ll)
-  f3 = 1/2 * (f_ll[3] + f_rr[3]) - 1/2 * λ_max * (rho_v2_rr - rho_v2_ll)
-  f4 = 1/2 * (f_ll[4] + f_rr[4]) - 1/2 * λ_max * (rho_v3_rr - rho_v3_ll)
-  f5 = 1/2 * (f_ll[5] + f_rr[5]) - 1/2 * λ_max * (rho_e_rr  - rho_e_ll)
-  f6 = 1/2 * (f_ll[6] + f_rr[6]) - 1/2 * λ_max * (B1_rr     - B1_ll)
-  f7 = 1/2 * (f_ll[7] + f_rr[7]) - 1/2 * λ_max * (B2_rr     - B2_ll)
-  f8 = 1/2 * (f_ll[8] + f_rr[8]) - 1/2 * λ_max * (B3_rr     - B3_ll)
-  f9 = 1/2 * (f_ll[9] + f_rr[9]) - 1/2 * λ_max * (psi_rr    - psi_ll)
-
-  return SVector(f1, f2, f3, f4, f5, f6, f7, f8, f9)
-end
-
 
 """
     flux_hll(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations3D)

--- a/src/equations/ideal_glm_mhd_3d.jl
+++ b/src/equations/ideal_glm_mhd_3d.jl
@@ -323,6 +323,28 @@ function flux_derigs_etal(u_ll, u_rr, orientation, equations::IdealGlmMhdEquatio
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations3D)
+  rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll, psi_ll = u_ll
+  rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr, psi_rr = u_rr
+
+  # Calculate velocities and fast magnetoacoustic wave speeds
+  # left
+  v1_ll = rho_v1_ll / rho_ll
+  v2_ll = rho_v2_ll / rho_ll
+  v3_ll = rho_v3_ll / rho_ll
+  v_mag_ll = sqrt(v1_ll^2 + v2_ll^2 + v3_ll^2)
+  cf_ll = calc_fast_wavespeed(u_ll, orientation, equations)
+  # right
+  v1_rr = rho_v1_rr / rho_rr
+  v2_rr = rho_v2_rr / rho_rr
+  v3_rr = rho_v3_rr / rho_rr
+  v_mag_rr = sqrt(v1_rr^2 + v2_rr^2 + v3_rr^2)
+  cf_rr = calc_fast_wavespeed(u_rr, orientation, equations)
+
+  λ_max = max(v_mag_ll, v_mag_rr) + max(cf_ll, cf_rr)
+end
+
 function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations3D)
   rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll, psi_ll = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr, psi_rr = u_rr

--- a/src/equations/ideal_glm_mhd_3d.jl
+++ b/src/equations/ideal_glm_mhd_3d.jl
@@ -347,14 +347,14 @@ end
 
 
 """
-    flux_hll(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations3D)
+    min_max_speed_naive(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations3D)
 
-HLL flux for ideal GLM-MHD equations like that by
+Calculate minimum and maximum wave speeds for HLL-type fluxes as in
 - Li (2005)
   An HLLC Riemann solver for magneto-hydrodynamics
   [DOI: 10.1016/j.jcp.2004.08.020](https://doi.org/10.1016/j.jcp.2004.08.020)
 """
-function flux_hll(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations3D)
+@inline function min_max_speed_naive(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations3D)
   rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll, psi_ll = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr, psi_rr = u_rr
 
@@ -373,64 +373,28 @@ function flux_hll(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations3D)
   mag_norm_rr = B1_rr^2 + B2_rr^2 + B3_rr^2
   p_rr = (equations.gamma - 1)*(rho_e_rr - 0.5*rho_rr*vel_norm_rr - 0.5*mag_norm_rr - 0.5*psi_rr^2)
 
-  # Obtain left and right fluxes
-  f_ll = flux(u_ll, orientation, equations)
-  f_rr = flux(u_rr, orientation, equations)
-
   # Approximate the left-most and right-most eigenvalues in the Riemann fan
   if orientation == 1 # x-direction
     c_f_ll = calc_fast_wavespeed(u_ll, orientation, equations)
     c_f_rr = calc_fast_wavespeed(u_rr, orientation, equations)
     vel_roe, c_f_roe = calc_fast_wavespeed_roe(u_ll, u_rr, orientation, equations)
-    Ssl = min(v1_ll - c_f_ll, vel_roe - c_f_roe)
-    Ssr = max(v1_rr + c_f_rr, vel_roe + c_f_roe)
+    λ_min = min(v1_ll - c_f_ll, vel_roe - c_f_roe)
+    λ_max = max(v1_rr + c_f_rr, vel_roe + c_f_roe)
   elseif orientation == 2 # y-direction
     c_f_ll = calc_fast_wavespeed(u_ll, orientation, equations)
     c_f_rr = calc_fast_wavespeed(u_rr, orientation, equations)
     vel_roe, c_f_roe = calc_fast_wavespeed_roe(u_ll, u_rr, orientation, equations)
-    Ssl = min(v2_ll - c_f_ll, vel_roe - c_f_roe)
-    Ssr = max(v2_rr + c_f_rr, vel_roe + c_f_roe)
+    λ_min = min(v2_ll - c_f_ll, vel_roe - c_f_roe)
+    λ_max = max(v2_rr + c_f_rr, vel_roe + c_f_roe)
   else # z-direction
     c_f_ll = calc_fast_wavespeed(u_ll, orientation, equations)
     c_f_rr = calc_fast_wavespeed(u_rr, orientation, equations)
     vel_roe, c_f_roe = calc_fast_wavespeed_roe(u_ll, u_rr, orientation, equations)
-    Ssl = min(v2_ll - c_f_ll, vel_roe - c_f_roe)
-    Ssr = max(v2_rr + c_f_rr, vel_roe + c_f_roe)
+    λ_min = min(v2_ll - c_f_ll, vel_roe - c_f_roe)
+    λ_max = max(v2_rr + c_f_rr, vel_roe + c_f_roe)
   end
 
-  if Ssl >= 0.0 && Ssr > 0.0
-    f1 = f_ll[1]
-    f2 = f_ll[2]
-    f3 = f_ll[3]
-    f4 = f_ll[4]
-    f5 = f_ll[5]
-    f6 = f_ll[6]
-    f7 = f_ll[7]
-    f8 = f_ll[8]
-    f9 = f_ll[9]
-  elseif Ssr <= 0.0 && Ssl < 0.0
-    f1 = f_rr[1]
-    f2 = f_rr[2]
-    f3 = f_rr[3]
-    f4 = f_rr[4]
-    f5 = f_rr[5]
-    f6 = f_rr[6]
-    f7 = f_rr[7]
-    f8 = f_rr[8]
-    f9 = f_rr[9]
-  else
-    f1 = (Ssr * f_ll[1] - Ssl * f_rr[1] + Ssl * Ssr * (rho_rr[1]    - rho_ll[1]))    / (Ssr - Ssl)
-    f2 = (Ssr * f_ll[2] - Ssl * f_rr[2] + Ssl * Ssr * (rho_v1_rr[1] - rho_v1_ll[1])) / (Ssr - Ssl)
-    f3 = (Ssr * f_ll[3] - Ssl * f_rr[3] + Ssl * Ssr * (rho_v2_rr[1] - rho_v2_ll[1])) / (Ssr - Ssl)
-    f4 = (Ssr * f_ll[4] - Ssl * f_rr[4] + Ssl * Ssr * (rho_v3_rr[1] - rho_v3_ll[1])) / (Ssr - Ssl)
-    f5 = (Ssr * f_ll[5] - Ssl * f_rr[5] + Ssl * Ssr * (rho_e_rr[1]  - rho_e_ll[1]))  / (Ssr - Ssl)
-    f6 = (Ssr * f_ll[6] - Ssl * f_rr[6] + Ssl * Ssr * (B1_rr[1]     - B1_ll[1]))     / (Ssr - Ssl)
-    f7 = (Ssr * f_ll[7] - Ssl * f_rr[7] + Ssl * Ssr * (B2_rr[1]     - B2_ll[1]))     / (Ssr - Ssl)
-    f8 = (Ssr * f_ll[8] - Ssl * f_rr[8] + Ssl * Ssr * (B3_rr[1]     - B3_ll[1]))     / (Ssr - Ssl)
-    f9 = (Ssr * f_ll[9] - Ssl * f_rr[9] + Ssl * Ssr * (psi_rr[1]    - psi_ll[1]))    / (Ssr - Ssl)
-  end
-
-  return SVector(f1, f2, f3, f4, f5, f6, f7, f8, f9)
+  return λ_min, λ_max
 end
 
 

--- a/src/equations/inviscid_burgers_1d.jl
+++ b/src/equations/inviscid_burgers_1d.jl
@@ -80,12 +80,6 @@ end
   λ_max = max(abs(u_L), abs(u_R))
 end
 
-function flux_lax_friedrichs(u_ll, u_rr, orientation, equation::InviscidBurgersEquation1D)
-  u_L = u_ll[1]
-  u_R = u_rr[1]
-
-  return SVector(0.5 * ( 0.5 * (u_L^2 + u_R^2) - max(abs(u_L), abs(u_R)) * (u_R - u_L) ))
-end
 
 @inline function max_abs_speeds(u, equation::InviscidBurgersEquation1D)
   return (abs(u[1]),)

--- a/src/equations/inviscid_burgers_1d.jl
+++ b/src/equations/inviscid_burgers_1d.jl
@@ -72,6 +72,14 @@ end
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::InviscidBurgersEquation1D)
+  u_L = u_ll[1]
+  u_R = u_rr[1]
+
+  λ_max = max(abs(u_L), abs(u_R))
+end
+
 function flux_lax_friedrichs(u_ll, u_rr, orientation, equation::InviscidBurgersEquation1D)
   u_L = u_ll[1]
   u_R = u_rr[1]

--- a/src/equations/lattice_boltzmann_2d.jl
+++ b/src/equations/lattice_boltzmann_2d.jl
@@ -353,13 +353,12 @@ end
 end
 
 
-# TODO: flux_lax_friedrichs is not of the usual form for this equation???
 # Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
 # @inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations2D)
 #   λ_max =
 # end
 
-function (f::FluxLaxFriedrichs)(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations2D)
+@inline function flux_godunov(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations2D)
   if orientation == 1
     v_alpha = equations.v_alpha1
   else

--- a/src/equations/lattice_boltzmann_2d.jl
+++ b/src/equations/lattice_boltzmann_2d.jl
@@ -75,7 +75,7 @@ struct LatticeBoltzmannEquations2D{RealT<:Real, CollisionOp} <: AbstractLatticeB
 end
 
 function LatticeBoltzmannEquations2D(; Ma, Re, collision_op=collision_bgk,
-                                    c=1, L=1, rho0=1, u0=nothing, nu=nothing)
+                                       c=1, L=1, rho0=1, u0=nothing, nu=nothing)
   # Sanity check that exactly one of Ma, u0 is not `nothing`
   if isnothing(Ma) && isnothing(u0)
     error("Mach number `Ma` and reference speed `u0` may not both be `nothing`")
@@ -352,6 +352,12 @@ end
   return v_alpha .* u
 end
 
+
+# TODO: flux_lax_friedrichs is not of the usual form for this equation???
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+# @inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations2D)
+#   λ_max =
+# end
 
 function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations2D)
   if orientation == 1

--- a/src/equations/lattice_boltzmann_2d.jl
+++ b/src/equations/lattice_boltzmann_2d.jl
@@ -359,7 +359,7 @@ end
 #   λ_max =
 # end
 
-function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations2D)
+function (f::FluxLaxFriedrichs)(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations2D)
   if orientation == 1
     v_alpha = equations.v_alpha1
   else

--- a/src/equations/lattice_boltzmann_3d.jl
+++ b/src/equations/lattice_boltzmann_3d.jl
@@ -238,13 +238,12 @@ end
 end
 
 
-# TODO: flux_lax_friedrichs is not of the usual form for this equation???
 # Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
 # @inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations3D)
 #   λ_max =
 # end
 
-function (f::FluxLaxFriedrichs)(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations3D)
+@inline function flux_godunov(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations3D)
   if orientation == 1 # x-direction
     v_alpha = equations.v_alpha1
   elseif orientation == 2 # y-direction

--- a/src/equations/lattice_boltzmann_3d.jl
+++ b/src/equations/lattice_boltzmann_3d.jl
@@ -238,6 +238,12 @@ end
 end
 
 
+# TODO: flux_lax_friedrichs is not of the usual form for this equation???
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+# @inline function max_abs_speed_naive(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations3D)
+#   λ_max =
+# end
+
 function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations3D)
   if orientation == 1 # x-direction
     v_alpha = equations.v_alpha1

--- a/src/equations/lattice_boltzmann_3d.jl
+++ b/src/equations/lattice_boltzmann_3d.jl
@@ -244,7 +244,7 @@ end
 #   λ_max =
 # end
 
-function flux_lax_friedrichs(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations3D)
+function (f::FluxLaxFriedrichs)(u_ll, u_rr, orientation, equations::LatticeBoltzmannEquations3D)
   if orientation == 1 # x-direction
     v_alpha = equations.v_alpha1
   elseif orientation == 2 # y-direction

--- a/src/equations/linear_scalar_advection_1d.jl
+++ b/src/equations/linear_scalar_advection_1d.jl
@@ -179,6 +179,11 @@ end
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equation::LinearScalarAdvectionEquation1D)
+  λ_max = abs(equation.advectionvelocity[orientation])
+end
+
 function flux_lax_friedrichs(u_ll, u_rr, orientation, equation::LinearScalarAdvectionEquation1D)
   a = equation.advectionvelocity[orientation]
   return 0.5 * ( a * (u_ll + u_rr) - abs(a) * (u_rr - u_ll) )

--- a/src/equations/linear_scalar_advection_1d.jl
+++ b/src/equations/linear_scalar_advection_1d.jl
@@ -184,12 +184,6 @@ end
   λ_max = abs(equation.advectionvelocity[orientation])
 end
 
-function flux_lax_friedrichs(u_ll, u_rr, orientation, equation::LinearScalarAdvectionEquation1D)
-  a = equation.advectionvelocity[orientation]
-  return 0.5 * ( a * (u_ll + u_rr) - abs(a) * (u_rr - u_ll) )
-end
-
-
 
 @inline have_constant_speed(::LinearScalarAdvectionEquation1D) = Val(true)
 

--- a/src/equations/linear_scalar_advection_2d.jl
+++ b/src/equations/linear_scalar_advection_2d.jl
@@ -244,12 +244,6 @@ end
   λ_max = abs(equation.advectionvelocity[orientation])
 end
 
-function flux_lax_friedrichs(u_ll, u_rr, orientation, equation::LinearScalarAdvectionEquation2D)
-  a = equation.advectionvelocity[orientation]
-  return 0.5 * ( a * (u_ll + u_rr) - abs(a) * (u_rr - u_ll) )
-end
-
-
 
 @inline have_constant_speed(::LinearScalarAdvectionEquation2D) = Val(true)
 

--- a/src/equations/linear_scalar_advection_2d.jl
+++ b/src/equations/linear_scalar_advection_2d.jl
@@ -239,6 +239,11 @@ end
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equation::LinearScalarAdvectionEquation2D)
+  λ_max = abs(equation.advectionvelocity[orientation])
+end
+
 function flux_lax_friedrichs(u_ll, u_rr, orientation, equation::LinearScalarAdvectionEquation2D)
   a = equation.advectionvelocity[orientation]
   return 0.5 * ( a * (u_ll + u_rr) - abs(a) * (u_rr - u_ll) )

--- a/src/equations/linear_scalar_advection_3d.jl
+++ b/src/equations/linear_scalar_advection_3d.jl
@@ -134,6 +134,11 @@ end
 end
 
 
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation, equation::LinearScalarAdvectionEquation3D)
+  λ_max = abs(equation.advectionvelocity[orientation])
+end
+
 function flux_lax_friedrichs(u_ll, u_rr, orientation, equation::LinearScalarAdvectionEquation3D)
   a = equation.advectionvelocity[orientation]
   return 0.5 * ( a * (u_ll + u_rr) - abs(a) * (u_rr - u_ll) )

--- a/src/equations/linear_scalar_advection_3d.jl
+++ b/src/equations/linear_scalar_advection_3d.jl
@@ -139,12 +139,6 @@ end
   λ_max = abs(equation.advectionvelocity[orientation])
 end
 
-function flux_lax_friedrichs(u_ll, u_rr, orientation, equation::LinearScalarAdvectionEquation3D)
-  a = equation.advectionvelocity[orientation]
-  return 0.5 * ( a * (u_ll + u_rr) - abs(a) * (u_rr - u_ll) )
-end
-
-
 
 @inline have_constant_speed(::LinearScalarAdvectionEquation3D) = Val(true)
 

--- a/src/equations/numerical_fluxes.jl
+++ b/src/equations/numerical_fluxes.jl
@@ -99,6 +99,11 @@ end
 Base.show(io::IO, f::FluxLaxFriedrichs) = print(io, "FluxLaxFriedrichs(", f.dissipation.max_abs_speed, ")")
 
 # TODO: Shall we deprecate `flux_lax_friedrichs`?
+"""
+    flux_lax_friedrichs
+
+See [`FluxLaxFriedrichs`](@ref).
+"""
 const flux_lax_friedrichs = FluxLaxFriedrichs()
 
 
@@ -121,6 +126,9 @@ FluxHLL() = FluxHLL(min_max_speed_naive)
 Simple and fast estimate of the minimal and maximal wave speed of the Riemann problem with
 left and right states `u_ll, u_rr`, usually based only on the local wave speeds associated to
 `u_ll` and `u_rr`.
+- Amiram Harten, Peter D. Lax, Bram van Leer (1983)
+  On Upstream Differencing and Godunov-Type Schemes for Hyperbolic Conservation Laws
+  [DOI: 10.1137/1025002](https://doi.org/10.1137/1025002)
 """
 function min_max_speed_naive end
 
@@ -145,4 +153,9 @@ end
 Base.show(io::IO, numflux::FluxHLL) = print(io, "FluxHLL(", numflux.min_max_speed, ")")
 
 # TODO: Shall we deprecate `flux_hll`?
+"""
+    flux_hll
+
+See [`FluxHLL`](@ref).
+"""
 const flux_hll = FluxHLL()

--- a/src/equations/numerical_fluxes.jl
+++ b/src/equations/numerical_fluxes.jl
@@ -1,0 +1,50 @@
+
+# This file contains general numerical fluxes that are not specific to certain equations
+
+"""
+    flux_central(u_ll, u_rr, orientation, equations::AbstractEquations)
+
+The classical central numerical flux `f((u_ll) + f(u_rr)) / 2`. When this flux is
+used as volume flux, the discretization is equivalent to the classical weak form
+DG method (except floating point errors).
+"""
+@inline function flux_central(u_ll, u_rr, orientation, equations::AbstractEquations)
+  # Calculate regular 1D fluxes
+  f_ll = flux(u_ll, orientation, equations)
+  f_rr = flux(u_rr, orientation, equations)
+
+  # Average regular fluxes
+  return 0.5 * (f_ll + f_rr)
+end
+
+
+"""
+    FluxPlusDissipation(numerical_flux, dissipation)
+
+Combine a `numerical_flux` with a `dissipation` operator to create a new numerical flux.
+"""
+struct FluxPlusDissipation{NumericalFlux, Dissipation}
+  numerical_flux::NumericalFlux
+  dissipation::Dissipation
+end
+
+@inline function (numflux::FluxPlusDissipation{NumericalFlux, Dissipation})(u_ll, u_rr, orientation, equations) where {NumericalFlux, Dissipation}
+  @unpack numerical_flux, dissipation = numflux
+
+  return numerical_flux(u_ll, u_rr, orientation, equations) + dissipation(u_ll, u_rr, orientation, equations)
+end
+
+
+"""
+    DissipationGlobalLaxFriedrichs(λ)
+
+Create a global Lax-Friedrichs dissipation operator with dissipation coefficient `λ`.
+"""
+struct DissipationGlobalLaxFriedrichs{RealT}
+  λ::RealT
+end
+
+@inline function (dissipation::DissipationGlobalLaxFriedrichs)(u_ll, u_rr, orientation, equations)
+  @unpack λ = dissipation
+  return -λ/2 * (u_rr - u_ll)
+end

--- a/src/equations/numerical_fluxes.jl
+++ b/src/equations/numerical_fluxes.jl
@@ -135,9 +135,9 @@ function min_max_speed_naive end
 @inline function (numflux::FluxHLL)(u_ll, u_rr, orientation, equations)
   λ_min, λ_max = numflux.min_max_speed(u_ll, u_rr, orientation, equations)
 
-  if λ_min >= 0 && λ_max >= 0
+  if λ_min >= 0 && λ_max > 0
     return flux(u_ll, orientation, equations)
-  elseif λ_max <= 0 && λ_min <= 0
+  elseif λ_max <= 0 && λ_min < 0
     return flux(u_rr, orientation, equations)
   else
     f_ll = flux(u_ll, orientation, equations)

--- a/src/equations/numerical_fluxes.jl
+++ b/src/equations/numerical_fluxes.jl
@@ -28,7 +28,7 @@ struct FluxPlusDissipation{NumericalFlux, Dissipation}
   dissipation::Dissipation
 end
 
-@inline function (numflux::FluxPlusDissipation{NumericalFlux, Dissipation})(u_ll, u_rr, orientation, equations) where {NumericalFlux, Dissipation}
+@inline function (numflux::FluxPlusDissipation)(u_ll, u_rr, orientation, equations)
   @unpack numerical_flux, dissipation = numflux
 
   return numerical_flux(u_ll, u_rr, orientation, equations) + dissipation(u_ll, u_rr, orientation, equations)
@@ -63,7 +63,7 @@ end
 
 DissipationLocalLaxFriedrichs() = DissipationLocalLaxFriedrichs(max_abs_speed_naive)
 
-@inline function (dissipation::DissipationLocalLaxFriedrichs{MaxAbsSpeed})(u_ll, u_rr, orientation, equations) where {MaxAbsSpeed}
+@inline function (dissipation::DissipationLocalLaxFriedrichs)(u_ll, u_rr, orientation, equations)
   λ = dissipation.max_abs_speed(u_ll, u_rr, orientation, equations)
   return -0.5 * λ * (u_rr - u_ll)
 end

--- a/src/equations/numerical_fluxes.jl
+++ b/src/equations/numerical_fluxes.jl
@@ -100,4 +100,4 @@ end
 Base.string(f::FluxLaxFriedrichs) = "FluxLaxFriedrichs(" * string(f.dissipation.max_abs_speed) * ")"
 
 # TODO: Shall we deprecate `flux_lax_friedrichs`?
-# const flux_lax_friedrichs = FluxLaxFriedrichs()
+const flux_lax_friedrichs = FluxLaxFriedrichs()

--- a/src/equations/numerical_fluxes.jl
+++ b/src/equations/numerical_fluxes.jl
@@ -34,6 +34,8 @@ end
   return numerical_flux(u_ll, u_rr, orientation, equations) + dissipation(u_ll, u_rr, orientation, equations)
 end
 
+Base.string(f::FluxPlusDissipation) = "FluxPlusDissipation(" * string(f.numerical_flux) * ", " * string(f.dissipation) * ")"
+
 
 """
     DissipationGlobalLaxFriedrichs(λ)
@@ -48,6 +50,8 @@ end
   @unpack λ = dissipation
   return -λ/2 * (u_rr - u_ll)
 end
+
+Base.string(d::DissipationGlobalLaxFriedrichs) = "DissipationGlobalLaxFriedrichs(" * string(d.λ) * ")"
 
 
 """
@@ -68,6 +72,8 @@ DissipationLocalLaxFriedrichs() = DissipationLocalLaxFriedrichs(max_abs_speed_na
   return -0.5 * λ * (u_rr - u_ll)
 end
 
+Base.string(d::DissipationLocalLaxFriedrichs) = "DissipationLocalLaxFriedrichs(" * string(d.max_abs_speed) * ")"
+
 
 """
     max_abs_speed_naive(u_ll, u_rr, orientation, equations)
@@ -78,6 +84,8 @@ Simple and fast estimate of the maximal wave speed of the Riemann problem with l
 function max_abs_speed_naive end
 
 
+# const FluxLaxFriedrichs = FluxPlusDissipation{typeof(flux_central), Dissipation} where {Dissipation<:DissipationLocalLaxFriedrichs}
+const FluxLaxFriedrichs{MaxAbsSpeed} = FluxPlusDissipation{typeof(flux_central), DissipationLocalLaxFriedrichs{MaxAbsSpeed}}
 """
     FluxLaxFriedrichs(max_abs_speed=max_abs_speed_naive)
 
@@ -88,3 +96,8 @@ Local Lax-Friedrichs (Rusanov) flux with maximum wave speed estimate provided by
 function FluxLaxFriedrichs(max_abs_speed=max_abs_speed_naive)
   FluxPlusDissipation(flux_central, DissipationLocalLaxFriedrichs(max_abs_speed))
 end
+
+Base.string(f::FluxLaxFriedrichs) = "FluxLaxFriedrichs(" * string(f.dissipation.max_abs_speed) * ")"
+
+# TODO: Shall we deprecate `flux_lax_friedrichs`?
+# const flux_lax_friedrichs = FluxLaxFriedrichs()

--- a/src/equations/numerical_fluxes.jl
+++ b/src/equations/numerical_fluxes.jl
@@ -34,7 +34,7 @@ end
   return numerical_flux(u_ll, u_rr, orientation, equations) + dissipation(u_ll, u_rr, orientation, equations)
 end
 
-Base.string(f::FluxPlusDissipation) = "FluxPlusDissipation(" * string(f.numerical_flux) * ", " * string(f.dissipation) * ")"
+Base.show(io::IO, f::FluxPlusDissipation) = print(io, "FluxPlusDissipation(",  f.numerical_flux, ", ", f.dissipation, ")")
 
 
 """
@@ -51,7 +51,7 @@ end
   return -λ/2 * (u_rr - u_ll)
 end
 
-Base.string(d::DissipationGlobalLaxFriedrichs) = "DissipationGlobalLaxFriedrichs(" * string(d.λ) * ")"
+Base.show(io::IO, d::DissipationGlobalLaxFriedrichs) = print(io, "DissipationGlobalLaxFriedrichs(", d.λ, ")")
 
 
 """
@@ -72,7 +72,7 @@ DissipationLocalLaxFriedrichs() = DissipationLocalLaxFriedrichs(max_abs_speed_na
   return -0.5 * λ * (u_rr - u_ll)
 end
 
-Base.string(d::DissipationLocalLaxFriedrichs) = "DissipationLocalLaxFriedrichs(" * string(d.max_abs_speed) * ")"
+Base.show(io::IO, d::DissipationLocalLaxFriedrichs) = print(io, "DissipationLocalLaxFriedrichs(", d.max_abs_speed, ")")
 
 
 """
@@ -96,7 +96,7 @@ function FluxLaxFriedrichs(max_abs_speed=max_abs_speed_naive)
   FluxPlusDissipation(flux_central, DissipationLocalLaxFriedrichs(max_abs_speed))
 end
 
-Base.string(f::FluxLaxFriedrichs) = "FluxLaxFriedrichs(" * string(f.dissipation.max_abs_speed) * ")"
+Base.show(io::IO, f::FluxLaxFriedrichs) = print(io, "FluxLaxFriedrichs(", f.dissipation.max_abs_speed, ")")
 
 # TODO: Shall we deprecate `flux_lax_friedrichs`?
 const flux_lax_friedrichs = FluxLaxFriedrichs()
@@ -142,7 +142,7 @@ function min_max_speed_naive end
   end
 end
 
-Base.string(numflux::FluxHLL) = "FluxHLL(" * string(numflux.min_max_speed) * ")"
+Base.show(io::IO, numflux::FluxHLL) = print(io, "FluxHLL(", numflux.min_max_speed, ")")
 
 # TODO: Shall we deprecate `flux_hll`?
 const flux_hll = FluxHLL()

--- a/src/solvers/dg/dg_2d.jl
+++ b/src/solvers/dg/dg_2d.jl
@@ -828,31 +828,23 @@ function prolong2mortars!(cache, u::AbstractArray{<:Any,4}, equations,
       leftright = 1
       if cache.mortars.orientations[mortar] == 1
         # L2 mortars in x-direction
-        # u_large = view(u, :, nnodes(dg), :, large_element)
-        # element_solutions_to_mortars!(cache, mortar_l2, leftright, mortar, u_large)
-        element_solutions_to_mortars!(cache, mortar_l2, leftright, mortar,
-                                      view(u, :, nnodes(dg), :, large_element))
+        u_large = view(u, :, nnodes(dg), :, large_element)
+        element_solutions_to_mortars!(cache, mortar_l2, leftright, mortar, u_large)
       else
         # L2 mortars in y-direction
-        # u_large = view(u, :, :, nnodes(dg), large_element)
-        # element_solutions_to_mortars!(cache, mortar_l2, leftright, mortar, u_large)
-        element_solutions_to_mortars!(cache, mortar_l2, leftright, mortar,
-                                      view(u, :, :, nnodes(dg), large_element))
+        u_large = view(u, :, :, nnodes(dg), large_element)
+        element_solutions_to_mortars!(cache, mortar_l2, leftright, mortar, u_large)
       end
     else # large_sides[mortar] == 2 -> large element on right side
       leftright = 2
       if cache.mortars.orientations[mortar] == 1
         # L2 mortars in x-direction
-        # u_large = view(u, :, 1, :, large_element)
-        # element_solutions_to_mortars!(cache, mortar_l2, leftright, mortar, u_large)
-        element_solutions_to_mortars!(cache, mortar_l2, leftright, mortar,
-                                      view(u, :, 1, :, large_element))
+        u_large = view(u, :, 1, :, large_element)
+        element_solutions_to_mortars!(cache, mortar_l2, leftright, mortar, u_large)
       else
         # L2 mortars in y-direction
-        # u_large = view(u, :, :, 1, large_element)
-        # element_solutions_to_mortars!(cache, mortar_l2, leftright, mortar, u_large)
-        element_solutions_to_mortars!(cache, mortar_l2, leftright, mortar,
-                                      view(u, :, :, 1, large_element))
+        u_large = view(u, :, :, 1, large_element)
+        element_solutions_to_mortars!(cache, mortar_l2, leftright, mortar, u_large)
       end
     end
   end

--- a/test/test_paper-self-gravitating-gas-dynamics.jl
+++ b/test/test_paper-self-gravitating-gas-dynamics.jl
@@ -73,15 +73,15 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
 
   @testset "elixir_eulergravity_jeans_instability.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_eulergravity_jeans_instability.jl"),
-      l2   = [10733.63378538114, 13356.780607423452, 1.6721408750434403e-6, 26834.076821148774],
-      linf = [15194.296424901113, 18881.481685044182, 6.809717915492584e-6, 37972.99700513482],
+      l2   = [10733.63378538114, 13356.780607423452, 1.6722844879795038e-6, 26834.076821148774],
+      linf = [15194.296424901113, 18881.481685044182, 6.809726988008751e-6, 37972.99700513482],
       tspan = (0.0, 0.1))
   end
 
   @testset "elixir_eulergravity_jeans_instability.jl with RK3S*" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_eulergravity_jeans_instability.jl"),
-      l2   = [10734.598193238024, 13358.217234481384, 1.9105446886104614e-6, 26836.487841241516],
-      linf = [15195.661004798487, 18883.512035906537, 7.864715319982429e-6, 37976.408478975296],
+      l2   = [10734.598193238024, 13358.217234481384, 1.911011743371934e-6, 26836.487841241516],
+      linf = [15195.661004798487, 18883.512035906537, 7.867948710816926e-6, 37976.408478975296],
       tspan = (0.0, 0.1),
       parameters=ParametersEulerGravity(background_density=1.5e7,
                                         gravitational_constant=6.674e-8,


### PR DESCRIPTION
This PR shall allow us to parameterize numerical flux functions by converting them into callable `struct`s. This will allow us to use different wave speed estimates for LLF and HLL type fluxes, cf. #134. In addition, a general `FluxPlusDissipation` is introduced, allowing us to combine arbitrary central-type numerical fluxes with arbitrary dissipation operators.

TODO:
- [x] Adapt all equations/dimensions except lattice Boltzmann
- [x] Adapt `LatticeBoltzmannEquations2D`, `LatticeBoltzmannEquations3D`
- [x] Introduce `min_max_speed_naive` for `FluxHLL`
- [x] Add entries to NEWS.md

Left for future PRs after discussion at the next Trixi meeting (tracked in #494):
- Deprecate `flux_lax_friedrichs, flux_hll`?
- Adapt other numerical fluxes to the same look & feel for consistency, e.g. `FluxCentral()`?
- Add more sophisticated wave speed estimates

Closes #492