### PR TITLE
Some performance improvements for the initial refinement

### DIFF
--- a/docs/src/conventions.md
+++ b/docs/src/conventions.md
@@ -31,3 +31,12 @@ following naming conventions:
   element method, inside each element multiple **nodes** may be defined, which
   hold nodal information. The nodes are again a solver-specific component, just
   like the elements.
+
+
+## Variable names
+
+- Use descriptive names (using `snake_case` for variables/functions and `CamelCase` for types)
+- Use a suffix `_` as in `name_` for local variables that would otherwise hide existing symbols.
+- Use a prefix `_` as in `_name` to indicate internal methods/data that are "fragile" in the
+  sense that there's no guarantee that they might get changed without notice. These are also not
+  documented with a docstring (but maybe with comments using `#`).

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -37,7 +37,7 @@ using RecipesBase
 using Requires
 @reexport using StaticArrays: SVector
 using StaticArrays: MVector, MArray, SMatrix
-using TimerOutputs: @notimeit, @timeit_debug, TimerOutput, print_timer, reset_timer!
+using TimerOutputs: TimerOutputs, @notimeit, @timeit_debug, TimerOutput, print_timer, reset_timer!
 using UnPack: @unpack, @pack!
 
 # Tullio.jl makes use of LoopVectorization.jl via Requires.jl.

--- a/src/auxiliary/containers.jl
+++ b/src/auxiliary/containers.jl
@@ -21,7 +21,7 @@ function copy_data!(target::AbstractArray, source::AbstractArray,
     end
   else
     # In this case we need to copy backward (right-to-left) to prevent overwriting data
-    for i in reverse(0:(count-1)), j in 1:block_size
+    for i in (count-1):-1:0, j in 1:block_size
       target[block_size*(destination+i-1) + j] = source[block_size*(first+i-1) + j]
     end
   end

--- a/src/callbacks_step/summary.jl
+++ b/src/callbacks_step/summary.jl
@@ -189,6 +189,7 @@ function (cb::DiscreteCallback{Condition,Affect!})(io::IO=stdout) where {Conditi
 
   mpi_isroot() || return nothing
 
+  TimerOutputs.complement!(timer())
   print_timer(io, timer(), title="Trixi.jl",
               allocations=true, linechars=:unicode, compact=false)
   println(io)

--- a/src/mesh/abstract_tree.jl
+++ b/src/mesh/abstract_tree.jl
@@ -96,7 +96,17 @@ opposite_direction(direction::Int) = direction + 1 - 2 * ((direction + 1) % 2)
 #   6       +     -     +
 #   7       -     +     +
 #   8       +     +     +
-child_sign(child::Int, dim::Int) = 1 - 2 * (div(child + 2^(dim - 1) - 1, 2^(dim-1)) % 2)
+# child_sign(child::Int, dim::Int) = 1 - 2 * (div(child + 2^(dim - 1) - 1, 2^(dim-1)) % 2)
+# Since we use only a fixed number of dimensions, we use a lookup table for improved performance.
+const _child_signs = [-1 -1 -1;
+                      +1 -1 -1;
+                      -1 +1 -1;
+                      +1 +1 -1;
+                      -1 -1 +1;
+                      +1 -1 +1;
+                      -1 +1 +1;
+                      +1 +1 +1]
+child_sign(child::Int, dim::Int) = _child_signs[child, dim]
 
 
 # For each child position (1 to 8) and a given direction (from 1 to 6), return

--- a/src/mesh/abstract_tree.jl
+++ b/src/mesh/abstract_tree.jl
@@ -57,7 +57,6 @@ isperiodic(t::AbstractTree, dimension) = t.periodicity[dimension]
 # Auxiliary methods for often-required calculations
 # Number of potential child cells
 n_children_per_cell(::AbstractTree{NDIMS}) where NDIMS = 2^NDIMS
-n_children_per_cell(dims::Integer) = 2^dims
 
 # Number of directions
 #

--- a/src/mesh/parallel_tree.jl
+++ b/src/mesh/parallel_tree.jl
@@ -165,12 +165,12 @@ local_leaf_cells(t::ParallelTree) = leaf_cells_by_rank(t, mpi_rank())
 # Refine given cells without rebalancing tree.
 #
 # Note: After a call to this method the tree may be unbalanced!
-function refine_unbalanced!(t::ParallelTree, cell_ids)
+function refine_unbalanced!(t::ParallelTree, cell_ids, sorted_unique_cell_ids=sort(unique(cell_ids)))
   # Store actual ids refined cells (shifted due to previous insertions)
   refined = zeros(Int, length(cell_ids))
 
   # Loop over all cells that are to be refined
-  for (count, original_cell_id) in enumerate(sort(unique(cell_ids)))
+  for (count, original_cell_id) in enumerate(sorted_unique_cell_ids)
     # Determine actual cell id, taking into account previously inserted cells
     n_children = n_children_per_cell(t)
     cell_id = original_cell_id + (count - 1) * n_children

--- a/src/mesh/parallel_tree.jl
+++ b/src/mesh/parallel_tree.jl
@@ -97,7 +97,7 @@ function init!(t::ParallelTree, center::AbstractArray{Float64}, length::Real, pe
   t.parent_ids[1] = 0
   t.child_ids[:, 1] .= 0
   t.levels[1] = 0
-  t.coordinates[:, 1] .= t.center_level_0
+  set_cell_coordinates!(t, t.center_level_0, 1)
   t.original_cell_ids[1] = 0
   t.mpi_ranks[1] = typemin(Int)
 
@@ -193,8 +193,10 @@ function refine_unbalanced!(t::ParallelTree, cell_ids, sorted_unique_cell_ids=so
       t.neighbor_ids[:, child_id] .= 0
       t.child_ids[:, child_id] .= 0
       t.levels[child_id] = t.levels[cell_id] + 1
-      t.coordinates[:, child_id] .= child_coordinates(
-          t, t.coordinates[:, cell_id], length_at_cell(t, cell_id), child)
+
+      set_cell_coordinates!(t,
+        child_coordinates(t, cell_coordinates(t, cell_id), length_at_cell(t, cell_id), child),
+        child_id)
       t.original_cell_ids[child_id] = 0
       t.mpi_ranks[child_id] = t.mpi_ranks[cell_id]
 

--- a/src/mesh/serial_tree.jl
+++ b/src/mesh/serial_tree.jl
@@ -95,7 +95,7 @@ function init!(t::SerialTree, center::AbstractArray{Float64}, length::Real, peri
   t.parent_ids[1] = 0
   t.child_ids[:, 1] .= 0
   t.levels[1] = 0
-  t.coordinates[:, 1] .= t.center_level_0
+  set_cell_coordinates!(t, t.center_level_0, 1)
   t.original_cell_ids[1] = 0
 
   # Set neighbor ids: for each periodic direction, the level-0 cell is its own neighbor
@@ -176,8 +176,9 @@ function refine_unbalanced!(t::SerialTree, cell_ids, sorted_unique_cell_ids=sort
       t.neighbor_ids[:, child_id] .= 0
       t.child_ids[:, child_id] .= 0
       t.levels[child_id] = t.levels[cell_id] + 1
-      t.coordinates[:, child_id] .= child_coordinates(
-          t, @view(t.coordinates[:, cell_id]), length_at_cell(t, cell_id), child)
+      set_cell_coordinates!(t,
+        child_coordinates(t, cell_coordinates(t, cell_id), length_at_cell(t, cell_id), child),
+        child_id)
       t.original_cell_ids[child_id] = 0
 
       # For determining neighbors, use neighbor connections of parent cell

--- a/src/mesh/serial_tree.jl
+++ b/src/mesh/serial_tree.jl
@@ -148,12 +148,12 @@ end
 # Refine given cells without rebalancing tree.
 #
 # Note: After a call to this method the tree may be unbalanced!
-function refine_unbalanced!(t::SerialTree, cell_ids)
+function refine_unbalanced!(t::SerialTree, cell_ids, sorted_unique_cell_ids=sort(unique(cell_ids)))
   # Store actual ids refined cells (shifted due to previous insertions)
   refined = zeros(Int, length(cell_ids))
 
   # Loop over all cells that are to be refined
-  for (count, original_cell_id) in enumerate(sort(unique(cell_ids)))
+  for (count, original_cell_id) in enumerate(sorted_unique_cell_ids)
     # Determine actual cell id, taking into account previously inserted cells
     n_children = n_children_per_cell(t)
     cell_id = original_cell_id + (count - 1) * n_children
@@ -177,7 +177,7 @@ function refine_unbalanced!(t::SerialTree, cell_ids)
       t.child_ids[:, child_id] .= 0
       t.levels[child_id] = t.levels[cell_id] + 1
       t.coordinates[:, child_id] .= child_coordinates(
-          t, t.coordinates[:, cell_id], length_at_cell(t, cell_id), child)
+          t, @view(t.coordinates[:, cell_id]), length_at_cell(t, cell_id), child)
       t.original_cell_ids[child_id] = 0
 
       # For determining neighbors, use neighbor connections of parent cell

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -23,7 +23,6 @@ isdir(outdir) && rm(outdir, recursive=true)
       @test Trixi.has_any_neighbor(t, 1, 1) == true
       @test Trixi.isperiodic(t, 1) == true
       @test Trixi.n_children_per_cell(t) == 2
-      @test Trixi.n_children_per_cell(2) == 4
       @test Trixi.n_directions(t) == 2
     end
 


### PR DESCRIPTION
These are some performance improvements for the implementation of the initial refinement. Please find below some performance measurements (after running the code once to trigger compilation).

On `main` with `julia --threads=1`
```julia
julia> using Revise, BenchmarkTools; using Trixi

julia> begin
              Trixi.reset_timer!(Trixi.timer())
              equations = LinearScalarAdvectionEquation2D(1.0, -0.3)
              mesh = TreeMesh((-1.0, -1.0), (1.0, 1.0), n_cells_max=10^5, initial_refinement_level=8)
              solver = DGSEM(3)
              semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test, solver)
              # Trixi.TimerOutputs.complement!(Trixi.timer())
              Trixi.print_timer(Trixi.timer())
        end
 ─────────────────────────────────────────────────────────────────────────────
                                      Time                   Allocations      
                              ──────────────────────   ───────────────────────
       Tot / % measured:           4.04s / 99.5%            289MiB / 86.7%    

 Section              ncalls     time   %tot     avg     alloc   %tot      avg
 ─────────────────────────────────────────────────────────────────────────────
 initial refinement        1    4.01s   100%   4.01s    240MiB  96.0%   240MiB
 creation                  1   2.53ms  0.06%  2.53ms   9.92MiB  3.96%  9.92MiB
 refinement patches        1    241ns  0.00%   241ns     0.00B  0.00%    0.00B
 coarsening patches        1   85.0ns  0.00%  85.0ns     0.00B  0.00%    0.00B
 ─────────────────────────────────────────────────────────────────────────────

julia> begin
              Trixi.reset_timer!(Trixi.timer())
              equations = LinearScalarAdvectionEquation2D(1.0, -0.3)
              mesh = TreeMesh((-1.0, -1.0), (1.0, 1.0), n_cells_max=10^6, initial_refinement_level=9)
              solver = DGSEM(3)
              semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test, solver)
              # Trixi.TimerOutputs.complement!(Trixi.timer())
              Trixi.print_timer(Trixi.timer())
        end
 ─────────────────────────────────────────────────────────────────────────────
                                      Time                   Allocations      
                              ──────────────────────   ───────────────────────
       Tot / % measured:           60.9s / 100%            1.19GiB / 87.3%    

 Section              ncalls     time   %tot     avg     alloc   %tot      avg
 ─────────────────────────────────────────────────────────────────────────────
 initial refinement        1    60.8s   100%   60.8s   0.94GiB  90.7%  0.94GiB
 creation                  1   26.7ms  0.04%  26.7ms   99.2MiB  9.35%  99.2MiB
 refinement patches        1    251ns  0.00%   251ns     0.00B  0.00%    0.00B
 coarsening patches        1   91.0ns  0.00%  91.0ns     0.00B  0.00%    0.00B
 ─────────────────────────────────────────────────────────────────────────────
```

On `main` with `julia --threads=1 --check-bounds=no`
```julia
julia> using Revise, BenchmarkTools; using Trixi

julia> begin
              Trixi.reset_timer!(Trixi.timer())
              equations = LinearScalarAdvectionEquation2D(1.0, -0.3)
              mesh = TreeMesh((-1.0, -1.0), (1.0, 1.0), n_cells_max=10^5, initial_refinement_level=8)
              solver = DGSEM(3)
              semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test, solver)
              # Trixi.TimerOutputs.complement!(Trixi.timer())
              Trixi.print_timer(Trixi.timer())
        end
 ─────────────────────────────────────────────────────────────────────────────
                                      Time                   Allocations      
                              ──────────────────────   ───────────────────────
       Tot / % measured:           3.26s / 99.4%            289MiB / 86.7%    

 Section              ncalls     time   %tot     avg     alloc   %tot      avg
 ─────────────────────────────────────────────────────────────────────────────
 initial refinement        1    3.24s   100%   3.24s    240MiB  96.0%   240MiB
 creation                  1   2.27ms  0.07%  2.27ms   9.92MiB  3.96%  9.92MiB
 refinement patches        1    290ns  0.00%   290ns     0.00B  0.00%    0.00B
 coarsening patches        1   91.0ns  0.00%  91.0ns     0.00B  0.00%    0.00B
 ─────────────────────────────────────────────────────────────────────────────

julia> begin
              Trixi.reset_timer!(Trixi.timer())
              equations = LinearScalarAdvectionEquation2D(1.0, -0.3)
              mesh = TreeMesh((-1.0, -1.0), (1.0, 1.0), n_cells_max=10^6, initial_refinement_level=9)
              solver = DGSEM(3)
              semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test, solver)
              # Trixi.TimerOutputs.complement!(Trixi.timer())
              Trixi.print_timer(Trixi.timer())
        end
 ─────────────────────────────────────────────────────────────────────────────
                                      Time                   Allocations      
                              ──────────────────────   ───────────────────────
       Tot / % measured:           47.3s / 100%            1.19GiB / 87.3%    

 Section              ncalls     time   %tot     avg     alloc   %tot      avg
 ─────────────────────────────────────────────────────────────────────────────
 initial refinement        1    47.1s   100%   47.1s   0.94GiB  90.7%  0.94GiB
 creation                  1   26.3ms  0.06%  26.3ms   99.2MiB  9.35%  99.2MiB
 refinement patches        1    310ns  0.00%   310ns     0.00B  0.00%    0.00B
 coarsening patches        1   92.0ns  0.00%  92.0ns     0.00B  0.00%    0.00B
 ─────────────────────────────────────────────────────────────────────────────
```

In this PR with `julia --threads=1`
```julia
julia> using Revise, BenchmarkTools; using Trixi

julia> begin
              Trixi.reset_timer!(Trixi.timer())
              equations = LinearScalarAdvectionEquation2D(1.0, -0.3)
              mesh = TreeMesh((-1.0, -1.0), (1.0, 1.0), n_cells_max=10^5, initial_refinement_level=8)
              solver = DGSEM(3)
              semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test, solver)
              Trixi.TimerOutputs.complement!(Trixi.timer())
              Trixi.print_timer(Trixi.timer())
        end
 ───────────────────────────────────────────────────────────────────────────────────
                                            Time                   Allocations      
                                    ──────────────────────   ───────────────────────
          Tot / % measured:              3.70s / 99.4%           50.1MiB / 23.0%    

 Section                    ncalls     time   %tot     avg     alloc   %tot      avg
 ───────────────────────────────────────────────────────────────────────────────────
 initial refinement              1    3.67s   100%   3.67s   1.61MiB  14.0%  1.61MiB
   refine!                       8    3.67s   100%   459ms   1.22MiB  10.6%   156KiB
     refine_unbalanced!          8    3.67s   100%   459ms    171KiB  1.45%  21.4KiB
     rebalance!                  8    387μs  0.01%  48.4μs    694KiB  5.88%  86.8KiB
     ~refine!~                   8    230μs  0.01%  28.8μs    381KiB  3.23%  47.7KiB
   collect all leaf cells        8    284μs  0.01%  35.5μs    400KiB  3.39%  50.0KiB
   ~initial refinement~          1   4.00μs  0.00%  4.00μs   1.66KiB  0.01%  1.66KiB
 creation                        1   2.40ms  0.07%  2.40ms   9.92MiB  86.0%  9.92MiB
 refinement patches              1    161ns  0.00%   161ns     0.00B  0.00%    0.00B
 coarsening patches              1   84.0ns  0.00%  84.0ns     0.00B  0.00%    0.00B
 ───────────────────────────────────────────────────────────────────────────────────

julia> begin
              Trixi.reset_timer!(Trixi.timer())
              equations = LinearScalarAdvectionEquation2D(1.0, -0.3)
              mesh = TreeMesh((-1.0, -1.0), (1.0, 1.0), n_cells_max=10^6, initial_refinement_level=9)
              solver = DGSEM(3)
              semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test, solver)
              Trixi.TimerOutputs.complement!(Trixi.timer())
              Trixi.print_timer(Trixi.timer())
        end
 ───────────────────────────────────────────────────────────────────────────────────
                                            Time                   Allocations      
                                    ──────────────────────   ───────────────────────
          Tot / % measured:              60.7s / 100%             260MiB / 40.6%    

 Section                    ncalls     time   %tot     avg     alloc   %tot      avg
 ───────────────────────────────────────────────────────────────────────────────────
 initial refinement              1    60.5s   100%   60.5s   6.32MiB  5.99%  6.32MiB
   refine!                       9    60.5s   100%   6.72s   4.77MiB  4.52%   542KiB
     refine_unbalanced!          9    60.5s   100%   6.72s    684KiB  0.63%  75.9KiB
     rebalance!                  9   1.56ms  0.00%   174μs   2.68MiB  2.54%   305KiB
     ~refine!~                   9    918μs  0.00%   102μs   1.42MiB  1.34%   161KiB
   collect all leaf cells        9   1.14ms  0.00%   127μs   1.56MiB  1.48%   177KiB
   ~initial refinement~          1   5.69μs  0.00%  5.69μs   1.66KiB  0.00%  1.66KiB
 creation                        1   25.6ms  0.04%  25.6ms   99.2MiB  94.0%  99.2MiB
 refinement patches              1    184ns  0.00%   184ns     0.00B  0.00%    0.00B
 coarsening patches              1   91.0ns  0.00%  91.0ns     0.00B  0.00%    0.00B
 ───────────────────────────────────────────────────────────────────────────────────
```

In this PR with `julia --threads=1 --check-bounds=no`
```julia
julia> using Revise, BenchmarkTools; using Trixi

julia> begin
              Trixi.reset_timer!(Trixi.timer())
              equations = LinearScalarAdvectionEquation2D(1.0, -0.3)
              mesh = TreeMesh((-1.0, -1.0), (1.0, 1.0), n_cells_max=10^5, initial_refinement_level=8)
              solver = DGSEM(3)
              semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test, solver)
              Trixi.TimerOutputs.complement!(Trixi.timer())
              Trixi.print_timer(Trixi.timer())
        end
 ───────────────────────────────────────────────────────────────────────────────────
                                            Time                   Allocations      
                                    ──────────────────────   ───────────────────────
          Tot / % measured:              2.90s / 99.3%           50.1MiB / 23.0%    

 Section                    ncalls     time   %tot     avg     alloc   %tot      avg
 ───────────────────────────────────────────────────────────────────────────────────
 initial refinement              1    2.88s   100%   2.88s   1.61MiB  14.0%  1.61MiB
   refine!                       8    2.88s   100%   359ms   1.22MiB  10.6%   156KiB
     refine_unbalanced!          8    2.88s   100%   359ms    171KiB  1.45%  21.4KiB
     rebalance!                  8    201μs  0.01%  25.1μs    694KiB  5.88%  86.8KiB
     ~refine!~                   8    144μs  0.01%  18.1μs    381KiB  3.23%  47.7KiB
   collect all leaf cells        8    184μs  0.01%  23.0μs    400KiB  3.39%  50.0KiB
   ~initial refinement~          1   4.99μs  0.00%  4.99μs   1.66KiB  0.01%  1.66KiB
 creation                        1    842μs  0.03%   842μs   9.92MiB  86.0%  9.92MiB
 refinement patches              1    222ns  0.00%   222ns     0.00B  0.00%    0.00B
 coarsening patches              1   80.0ns  0.00%  80.0ns     0.00B  0.00%    0.00B
 ───────────────────────────────────────────────────────────────────────────────────

julia> begin
              Trixi.reset_timer!(Trixi.timer())
              equations = LinearScalarAdvectionEquation2D(1.0, -0.3)
              mesh = TreeMesh((-1.0, -1.0), (1.0, 1.0), n_cells_max=10^6, initial_refinement_level=9)
              solver = DGSEM(3)
              semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test, solver)
              Trixi.TimerOutputs.complement!(Trixi.timer())
              Trixi.print_timer(Trixi.timer())
        end
 ───────────────────────────────────────────────────────────────────────────────────
                                            Time                   Allocations      
                                    ──────────────────────   ───────────────────────
          Tot / % measured:              45.8s / 100%             260MiB / 40.6%    

 Section                    ncalls     time   %tot     avg     alloc   %tot      avg
 ───────────────────────────────────────────────────────────────────────────────────
 initial refinement              1    45.6s   100%   45.6s   6.32MiB  5.99%  6.32MiB
   refine!                       9    45.6s   100%   5.07s   4.77MiB  4.52%   542KiB
     refine_unbalanced!          9    45.6s   100%   5.07s    684KiB  0.63%  75.9KiB
     rebalance!                  9    959μs  0.00%   107μs   2.68MiB  2.54%   305KiB
     ~refine!~                   9    623μs  0.00%  69.3μs   1.42MiB  1.34%   161KiB
   collect all leaf cells        9    765μs  0.00%  85.0μs   1.56MiB  1.48%   177KiB
   ~initial refinement~          1   7.61μs  0.00%  7.61μs   1.66KiB  0.00%  1.66KiB
 creation                        1   12.4ms  0.03%  12.4ms   99.2MiB  94.0%  99.2MiB
 refinement patches              1    202ns  0.00%   202ns     0.00B  0.00%    0.00B
 coarsening patches              1   80.0ns  0.00%  80.0ns     0.00B  0.00%    0.00B
 ───────────────────────────────────────────────────────────────────────────────────
```

Thus, we have a performance improvement (without bounds checking) of

- ca. 11% for `initial_refinement_level=8`
- ca. 4% for `initial_refinement_level=9`

These changes are purely minor performance improvements of the code without algorithmic changes. As far as I know, we need some algorithmic changes to avoid moving as much data around when refining bigger meshes to attack #496.