### PR TITLE
Speed up initial refinement during mesh generation

### DIFF
--- a/src/mesh/abstract_tree.jl
+++ b/src/mesh/abstract_tree.jl
@@ -255,7 +255,7 @@ end
 
 # Initialize the neighbors of child cell `child_id` based on parent cell `cell_id`
 function init_child_neighbors!(t::AbstractTree, cell_id, child, child_id)
-  t.neighbor_ids[:, child_id] .= 0
+  t.neighbor_ids[:, child_id] .= zero(eltype(t.neighbor_ids))
   for direction in eachdirection(t)
     # If neighbor is a sibling, establish one-sided connectivity
     # Note: two-sided is not necessary, as each sibling will do this

--- a/src/mesh/abstract_tree.jl
+++ b/src/mesh/abstract_tree.jl
@@ -296,12 +296,12 @@ end
 # Refine given cells without rebalancing tree.
 #
 # Note: After a call to this method the tree may be unbalanced!
-function refine_unbalanced!(t::AbstractTree, cell_ids)
+function refine_unbalanced!(t::AbstractTree, cell_ids, sorted_unique_cell_ids=sort(unique(cell_ids)))
   # Store actual ids refined cells (shifted due to previous insertions)
   refined = zeros(Int, length(cell_ids))
 
   # Loop over all cells that are to be refined
-  for (count, original_cell_id) in enumerate(sort(unique(cell_ids)))
+  for (count, original_cell_id) in enumerate(sorted_unique_cell_ids)
     # Determine actual cell id, taking into account previously inserted cells
     n_children = n_children_per_cell(t)
     cell_id = original_cell_id + (count - 1) * n_children

--- a/src/mesh/mesh.jl
+++ b/src/mesh/mesh.jl
@@ -115,9 +115,7 @@ end
 function initialize!(mesh::TreeMesh, initial_refinement_level,
                      refinement_patches, coarsening_patches)
   # Create initial refinement
-  @timeit_debug timer() "initial refinement" for _ in 1:initial_refinement_level
-    refine!(mesh.tree)
-  end
+  @timeit_debug timer() "initial refinement" refine_uniformly!(mesh.tree, initial_refinement_level)
 
   # Apply refinement patches
   @timeit_debug timer() "refinement patches" for patch in refinement_patches

--- a/src/mesh/parallel_tree.jl
+++ b/src/mesh/parallel_tree.jl
@@ -162,79 +162,18 @@ leaf_cells_by_rank(t::ParallelTree, rank) = filter_leaf_cells(t) do cell_id
 local_leaf_cells(t::ParallelTree) = leaf_cells_by_rank(t, mpi_rank())
 
 
-# Refine given cells without rebalancing tree.
-#
-# Note: After a call to this method the tree may be unbalanced!
-function refine_unbalanced!(t::ParallelTree, cell_ids)
-  # Store actual ids refined cells (shifted due to previous insertions)
-  refined = zeros(Int, length(cell_ids))
+# Set information for child cell `child_id` based on parent cell `cell_id` (except neighbors)
+function init_child!(t::ParallelTree, cell_id, child, child_id)
+  t.parent_ids[child_id] = cell_id
+  t.child_ids[child, cell_id] = child_id
+  t.child_ids[:, child_id] .= 0
+  t.levels[child_id] = t.levels[cell_id] + 1
+  t.coordinates[:, child_id] .= child_coordinates(
+      t, t.coordinates[:, cell_id], length_at_cell(t, cell_id), child)
+  t.original_cell_ids[child_id] = 0
+  t.mpi_ranks[child_id] = t.mpi_ranks[cell_id]
 
-  # Loop over all cells that are to be refined
-  for (count, original_cell_id) in enumerate(sort(unique(cell_ids)))
-    # Determine actual cell id, taking into account previously inserted cells
-    n_children = n_children_per_cell(t)
-    cell_id = original_cell_id + (count - 1) * n_children
-    refined[count] = cell_id
-
-    @assert !has_children(t, cell_id) "Non-leaf cell $cell_id cannot be refined"
-
-    # Insert new cells directly behind parent (depth-first)
-    insert!(t, cell_id + 1, n_children)
-
-    # Flip sign of refined cell such that we can easily find it later
-    t.original_cell_ids[cell_id] = -t.original_cell_ids[cell_id]
-
-    # Initialize child cells
-    for child in 1:n_children
-      # Set child information based on parent
-      child_id = cell_id + child
-      t.parent_ids[child_id] = cell_id
-      t.child_ids[child, cell_id] = child_id
-      t.neighbor_ids[:, child_id] .= 0
-      t.child_ids[:, child_id] .= 0
-      t.levels[child_id] = t.levels[cell_id] + 1
-      t.coordinates[:, child_id] .= child_coordinates(
-          t, t.coordinates[:, cell_id], length_at_cell(t, cell_id), child)
-      t.original_cell_ids[child_id] = 0
-      t.mpi_ranks[child_id] = t.mpi_ranks[cell_id]
-
-      # For determining neighbors, use neighbor connections of parent cell
-      for direction in eachdirection(t)
-        # If neighbor is a sibling, establish one-sided connectivity
-        # Note: two-sided is not necessary, as each sibling will do this
-        if has_sibling(child, direction)
-          adjacent = adjacent_child(child, direction)
-          neighbor_id = cell_id + adjacent
-
-          t.neighbor_ids[direction, child_id] = neighbor_id
-          continue
-        end
-
-        # Skip if original cell does have no neighbor in direction
-        if !has_neighbor(t, cell_id, direction)
-          continue
-        end
-
-        # Otherwise, check if neighbor has children - if not, skip again
-        neighbor_id = t.neighbor_ids[direction, cell_id]
-        if !has_children(t, neighbor_id)
-          continue
-        end
-
-        # Check if neighbor has corresponding child and if yes, establish connectivity
-        adjacent = adjacent_child(child, direction)
-        if has_child(t, neighbor_id, adjacent)
-          neighbor_child_id = t.child_ids[adjacent, neighbor_id]
-          opposite = opposite_direction(direction)
-
-          t.neighbor_ids[direction, child_id] = neighbor_child_id
-          t.neighbor_ids[opposite, neighbor_child_id] = child_id
-        end
-      end
-    end
-  end
-
-  return refined
+  return nothing
 end
 
 

--- a/src/mesh/serial_tree.jl
+++ b/src/mesh/serial_tree.jl
@@ -145,78 +145,17 @@ function Base.show(io::IO, ::MIME"text/plain", t::SerialTree)
 end
 
 
-# Refine given cells without rebalancing tree.
-#
-# Note: After a call to this method the tree may be unbalanced!
-function refine_unbalanced!(t::SerialTree, cell_ids)
-  # Store actual ids refined cells (shifted due to previous insertions)
-  refined = zeros(Int, length(cell_ids))
+# Set information for child cell `child_id` based on parent cell `cell_id` (except neighbors)
+function init_child!(t::SerialTree, cell_id, child, child_id)
+  t.parent_ids[child_id] = cell_id
+  t.child_ids[child, cell_id] = child_id
+  t.child_ids[:, child_id] .= 0
+  t.levels[child_id] = t.levels[cell_id] + 1
+  t.coordinates[:, child_id] .= child_coordinates(
+      t, t.coordinates[:, cell_id], length_at_cell(t, cell_id), child)
+  t.original_cell_ids[child_id] = 0
 
-  # Loop over all cells that are to be refined
-  for (count, original_cell_id) in enumerate(sort(unique(cell_ids)))
-    # Determine actual cell id, taking into account previously inserted cells
-    n_children = n_children_per_cell(t)
-    cell_id = original_cell_id + (count - 1) * n_children
-    refined[count] = cell_id
-
-    @assert !has_children(t, cell_id) "Non-leaf cell $cell_id cannot be refined"
-
-    # Insert new cells directly behind parent (depth-first)
-    insert!(t, cell_id + 1, n_children)
-
-    # Flip sign of refined cell such that we can easily find it later
-    t.original_cell_ids[cell_id] = -t.original_cell_ids[cell_id]
-
-    # Initialize child cells
-    for child in 1:n_children
-      # Set child information based on parent
-      child_id = cell_id + child
-      t.parent_ids[child_id] = cell_id
-      t.child_ids[child, cell_id] = child_id
-      t.neighbor_ids[:, child_id] .= 0
-      t.child_ids[:, child_id] .= 0
-      t.levels[child_id] = t.levels[cell_id] + 1
-      t.coordinates[:, child_id] .= child_coordinates(
-          t, t.coordinates[:, cell_id], length_at_cell(t, cell_id), child)
-      t.original_cell_ids[child_id] = 0
-
-      # For determining neighbors, use neighbor connections of parent cell
-      for direction in eachdirection(t)
-        # If neighbor is a sibling, establish one-sided connectivity
-        # Note: two-sided is not necessary, as each sibling will do this
-        if has_sibling(child, direction)
-          adjacent = adjacent_child(child, direction)
-          neighbor_id = cell_id + adjacent
-
-          t.neighbor_ids[direction, child_id] = neighbor_id
-          continue
-        end
-
-        # Skip if original cell does have no neighbor in direction
-        if !has_neighbor(t, cell_id, direction)
-          continue
-        end
-
-        # Otherwise, check if neighbor has children - if not, skip again
-        neighbor_id = t.neighbor_ids[direction, cell_id]
-        if !has_children(t, neighbor_id)
-          continue
-        end
-
-        # Check if neighbor has corresponding child and if yes, establish connectivity
-        adjacent = adjacent_child(child, direction)
-        if has_child(t, neighbor_id, adjacent)
-          neighbor_child_id = t.child_ids[adjacent, neighbor_id]
-          opposite = opposite_direction(direction)
-
-          t.neighbor_ids[direction, child_id] = neighbor_child_id
-          t.neighbor_ids[opposite, neighbor_child_id] = child_id
-        end
-      end
-    end
-  end
-
-  return refined
+  return nothing
 end
 
 


### PR DESCRIPTION
Fixes #496.

Timing comparison (test code and results for `main` from #496):

Level | `main` | this branch
--: | --: | --:
9 | 46.2 s | 277 ms
10 | 799 s | 1.36 s


