### PR TITLE
ignore error messages caused by module replacements in at-test_trixi_include

### DIFF
--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -113,21 +113,10 @@ macro test_nowarn_mod(expr)
         if !isempty(stderr_content)
           println("Content of `stderr`:\n", stderr_content)
         end
-        test_successful = isempty(stderr_content)
-        # we also ignore simple module redefinitions for convenience
-        if !test_successful
-          only_module_replacements = true
-          for line in split(stderr_content, '\n')
-            if !isempty(line) && match(r"WARNING: replacing module .+\.", line) === nothing
-              only_module_replacements = false
-              break
-            end
-          end
-          if only_module_replacements
-            test_successful = true
-          end
-        end
-        @test test_successful
+        # We also ignore simple module redefinitions for convenience. Thus, we
+        # check whether every line of `stderr_content` is of the form of a
+        # module replacement warning.
+        @test occursin(r"^(WARNING: replacing module .+\.\n)*$", stderr_content)
         ret
       finally
         rm(fname, force=true)


### PR DESCRIPTION
Thanks for reporting this, @erik-f. This closes #507. 

With the diff
```
diff --git a/examples/2d/elixir_advection_basic.jl b/examples/2d/elixir_advection_basic.jl
index 851d9429..888ab84d 100644
--- a/examples/2d/elixir_advection_basic.jl
+++ b/examples/2d/elixir_advection_basic.jl
@@ -2,6 +2,7 @@
 using OrdinaryDiffEq
 using Trixi
 
+module TestModule end
 ###############################################################################
 # semidiscretization of the linear advection equation
```
I get
```julia
julia> using Test, Trixi; include("test/test_trixi.jl")
@test_nowarn_mod (macro with 1 method)

julia> begin

       @testset "elixir_advection_basic.jl" begin
         @test_trixi_include(joinpath("examples/2d", "elixir_advection_basic.jl"),
           l2   = [9.14468177884088e-6],
           linf = [6.437440532947036e-5])
       end

       @testset "elixir_advection_basic.jl" begin
         @test_trixi_include(joinpath("examples/2d/", "elixir_advection_basic.jl"),
           l2   = [9.14468177884088e-6],
           linf = [6.437440532947036e-5])
       end

       end
[...]
Test Summary:             | Pass  Total
elixir_advection_basic.jl |    5      5
```