### PR TITLE
Add simple rudimentary visualization for CurvedMesh

### DIFF
--- a/src/mesh/curved_mesh.jl
+++ b/src/mesh/curved_mesh.jl
@@ -150,6 +150,8 @@ end
 @inline Base.real(::CurvedMesh{NDIMS, RealT}) where {NDIMS, RealT} = RealT
 Base.size(mesh::CurvedMesh) = mesh.cells_per_dimension
 Base.size(mesh::CurvedMesh, i) = mesh.cells_per_dimension[i]
+Base.axes(mesh::CurvedMesh) = map(Base.OneTo, mesh.cells_per_dimension)
+Base.axes(mesh::CurvedMesh, i) = Base.OneTo(mesh.cells_per_dimension[i])
 
 
 function Base.show(io::IO, ::CurvedMesh{NDIMS, RealT}) where {NDIMS, RealT}

--- a/src/visualization/interpolate.jl
+++ b/src/visualization/interpolate.jl
@@ -312,7 +312,7 @@ function calc_vertices(coordinates, levels, length_level_0)
 end
 
 
-# Calculate the vertices for each mesh cell such that it can be visualized as a closed box for CurvedMesh
+# Calculate the vertices to plot each grid line for CurvedMesh
 #
 # Note: This is a low-level function that is not considered as part of Trixi's interface and may
 #       thus be changed in future releases.
@@ -327,6 +327,10 @@ function calc_vertices(node_coordinates, mesh)
   max_length = maximum(cells_per_dimension)
   n_nodes = size(node_coordinates, 2)
 
+  # Create output as two matrices `x` and `y`, each holding the node locations for each of the `n_lines` grid lines
+  # The # of rows in the matrices must be sufficient to store the longest dimension (`max_length`),
+  # and for each the node locations without doubling the corner nodes (`n_nodes-1`), plus the final node (`+1`)
+  # Rely on Plots.jl to ignore `NaN`s (i.e., they are not plotted) to handle shorter lines
   x = fill(NaN, max_length*(n_nodes-1)+1, n_lines)
   y = fill(NaN, max_length*(n_nodes-1)+1, n_lines)
 
@@ -334,10 +338,10 @@ function calc_vertices(node_coordinates, mesh)
   # Lines in x-direction
   # Bottom boundary
   i = 1
-  for element in axes(mesh, 1)
+  for cell_x in axes(mesh, 1)
     for node in 1:(n_nodes-1)
-      x[i, line_index] = node_coordinates[1, node, 1, linear_indices[element, 1]]
-      y[i, line_index] = node_coordinates[2, node, 1, linear_indices[element, 1]]
+      x[i, line_index] = node_coordinates[1, node, 1, linear_indices[cell_x, 1]]
+      y[i, line_index] = node_coordinates[2, node, 1, linear_indices[cell_x, 1]]
 
       i += 1
     end
@@ -369,10 +373,10 @@ function calc_vertices(node_coordinates, mesh)
   # Lines in y-direction
   # Left boundary
   i = 1
-  for element in axes(mesh, 2)
+  for cell_y in axes(mesh, 2)
     for node in 1:(n_nodes-1)
-      x[i, line_index] = node_coordinates[1, 1, node, linear_indices[1, element]]
-      y[i, line_index] = node_coordinates[2, 1, node, linear_indices[1, element]]
+      x[i, line_index] = node_coordinates[1, 1, node, linear_indices[1, cell_y]]
+      y[i, line_index] = node_coordinates[2, 1, node, linear_indices[1, cell_y]]
 
       i += 1
     end

--- a/src/visualization/interpolate.jl
+++ b/src/visualization/interpolate.jl
@@ -310,3 +310,52 @@ function calc_vertices(coordinates, levels, length_level_0)
 
   return x, y
 end
+
+
+# Calculate the vertices for each mesh cell such that it can be visualized as a closed box for CurvedMesh
+#
+# Note: This is a low-level function that is not considered as part of Trixi's interface and may
+#       thus be changed in future releases.
+function calc_vertices(node_coordinates)
+  @assert size(node_coordinates, 1) == 2 "only works in 2D"
+
+  # Initialize output arrays
+  n_elements = size(node_coordinates, 4)
+  n_nodes = size(node_coordinates, 2)
+  x = Matrix{Float64}(undef, 4*(n_nodes-1)+1, n_elements)
+  y = Matrix{Float64}(undef, 4*(n_nodes-1)+1, n_elements)
+
+  # Calculate vertices for all coordinates at once
+  for element_id in 1:n_elements
+    x[1, element_id] = node_coordinates[1, 1, 1, element_id]
+    y[1, element_id] = node_coordinates[2, 1, 1, element_id]
+
+    i = 2
+    # Bottom
+    for node in 2:n_nodes
+      x[i, element_id] = node_coordinates[1, node, 1, element_id]
+      y[i, element_id] = node_coordinates[2, node, 1, element_id]
+      i += 1
+    end
+    # Right
+    for node in 2:n_nodes
+      x[i, element_id] = node_coordinates[1, n_nodes, node, element_id]
+      y[i, element_id] = node_coordinates[2, n_nodes, node, element_id]
+      i += 1
+    end
+    # Top
+    for node in 2:n_nodes
+      x[i, element_id] = node_coordinates[1, n_nodes-node+1, n_nodes, element_id]
+      y[i, element_id] = node_coordinates[2, n_nodes-node+1, n_nodes, element_id]
+      i += 1
+    end
+    # Left
+    for node in 2:n_nodes
+      x[i, element_id] = node_coordinates[1, 1, n_nodes-node+1, element_id]
+      y[i, element_id] = node_coordinates[2, 1, n_nodes-node+1, element_id]
+      i += 1
+    end
+  end
+
+  return x, y
+end

--- a/src/visualization/plot_recipes.jl
+++ b/src/visualization/plot_recipes.jl
@@ -108,6 +108,19 @@ function PlotData2D(u, semi;
 end
 
 
+"""
+    PlotData2D(u::AbstractArray{<:Any, 4}, semi::SemidiscretizationHyperbolic{<:CurvedMesh};
+               solution_variables=cons2prim, kwargs...)
+
+Create a new `PlotData2D` object that can be used for visualizing 2D DGSEM solution data array
+`u` with `Plots.jl` for the mesh type `CurvedMesh`. All relevant geometrical information is extracted
+from the semidiscretization `semi`. By default, the conservative variables from the solution are used
+for plotting. This can be changed by passing an appropriate conversion function to `solution_variables`.
+
+!!! warning "Experimental implementation"
+    This is an experimental feature and may change in future releases.
+
+"""
 function PlotData2D(u::AbstractArray{<:Any, 4}, semi::SemidiscretizationHyperbolic{<:CurvedMesh};
                     solution_variables=cons2prim, kwargs...)
   mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
@@ -258,6 +271,9 @@ getmesh(pd::PlotData2D) = PlotMesh2D(pd)
 end
 
 
+# Visualize a single variable in a 2D plot. Only works for `scatter` right now.
+#
+# Note: This is an experimental feature and may be changed in future releases without notice.
 @recipe function f(pds::PlotDataSeries2D{<:PlotData2D{<:Any, <:AbstractVector{<:AbstractVector}}}) 
   @unpack plot_data, variable_id = pds
   @unpack x, y, data, variable_names = plot_data
@@ -306,6 +322,9 @@ end
 end
 
 
+# Visualize the mesh in a 2D plot
+#
+# Note: This is an experimental feature and may be changed in future releases without notice.
 @recipe function f(pm::PlotMesh2D{<:PlotData2D{<:Any, <:AbstractVector{<:AbstractVector}}})
   @unpack plot_data = pm
   @unpack x, y, mesh_vertices_x, mesh_vertices_y = plot_data

--- a/src/visualization/plot_recipes.jl
+++ b/src/visualization/plot_recipes.jl
@@ -122,7 +122,7 @@ for plotting. This can be changed by passing an appropriate conversion function 
 
 """
 function PlotData2D(u::AbstractArray{<:Any, 4}, semi::SemidiscretizationHyperbolic{<:CurvedMesh};
-                    solution_variables=cons2prim, kwargs...)
+                    solution_variables=cons2prim, grid_lines=true, kwargs...)
   mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
   @unpack node_coordinates = cache.elements
 
@@ -135,7 +135,12 @@ function PlotData2D(u::AbstractArray{<:Any, 4}, semi::SemidiscretizationHyperbol
 
   data = [vec(unstructured_data[.., v]) for v in 1:nvariables(semi)]
 
-  mesh_vertices_x, mesh_vertices_y = calc_vertices(node_coordinates, mesh)
+  if grid_lines
+    mesh_vertices_x, mesh_vertices_y = calc_vertices(node_coordinates, mesh)
+  else
+    mesh_vertices_x = Matrix{Float64}(undef, 0, 0)
+    mesh_vertices_y = Matrix{Float64}(undef, 0, 0)
+  end
 
   variable_names = SVector(varnames(solution_variables, equations))
 

--- a/src/visualization/plot_recipes.jl
+++ b/src/visualization/plot_recipes.jl
@@ -109,9 +109,7 @@ end
 
 
 function PlotData2D(u::AbstractArray{<:Any, 4}, semi::SemidiscretizationHyperbolic{<:CurvedMesh};
-                    solution_variables=cons2prim, grid_lines=true,
-                    max_supported_level=11, nvisnodes=nothing,
-                    slice_axis=:z, slice_axis_intercept=0)
+                    solution_variables=cons2prim, kwargs...)
   mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
   @unpack node_coordinates = cache.elements
 
@@ -124,7 +122,7 @@ function PlotData2D(u::AbstractArray{<:Any, 4}, semi::SemidiscretizationHyperbol
 
   data = [vec(unstructured_data[.., v]) for v in 1:nvariables(semi)]
 
-  mesh_vertices_x, mesh_vertices_y = calc_vertices(node_coordinates)
+  mesh_vertices_x, mesh_vertices_y = calc_vertices(node_coordinates, mesh)
 
   variable_names = SVector(varnames(solution_variables, equations))
 
@@ -319,9 +317,9 @@ end
   legend -->  :none
 
   # Set series properties
-  seriestype := :path
-  linecolor := :black
-  linewidth := 1
+  seriestype --> :path
+  linecolor --> :black
+  linewidth --> 1
 
   # Return data for plotting
   mesh_vertices_x, mesh_vertices_y

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -16,11 +16,17 @@ isdir(outdir) && rm(outdir, recursive=true)
 
 # Run various visualization tests
 @testset "Visualization tests" begin
-  # Run Trixi
-  @test_nowarn_debug trixi_include(@__MODULE__, joinpath(examples_dir(), "2d", "elixir_euler_blast_wave_amr.jl"),
-                                   tspan=(0,0.1))
+  # Run 2D tests with elixirs for both mesh types
+  test_examples_2d = Dict(
+    "TreeMesh" => "elixir_euler_blast_wave_amr.jl",
+    "CurvedMesh" => "elixir_euler_source_terms_waving_flag.jl"
+  )
 
-  @testset "PlotData2D, PlotDataSeries2D, PlotMesh2D" begin
+  @testset "PlotData2D, PlotDataSeries2D, PlotMesh2D with $mesh" for mesh in keys(test_examples_2d)
+    # Run Trixi
+    @test_nowarn_debug trixi_include(@__MODULE__, joinpath(examples_dir(), "2d", test_examples_2d[mesh]),
+                                     tspan=(0,0.1))
+
     # Constructor
     @test PlotData2D(sol) isa PlotData2D
     @test PlotData2D(sol; nvisnodes=0, grid_lines=false, solution_variables=cons2cons) isa PlotData2D
@@ -61,15 +67,15 @@ isdir(outdir) && rm(outdir, recursive=true)
     @test getmesh(pd).plot_data == pd
     @test_nowarn_debug show(stdout, getmesh(pd))
     println(stdout)
-  end
 
-  @testset "2D plot recipes" begin
-    pd = PlotData2D(sol)
-
-    @test_nowarn_debug plot(sol)
-    @test_nowarn_debug plot(pd)
-    @test_nowarn_debug plot(pd["p"])
-    @test_nowarn_debug plot(getmesh(pd))
+    @testset "2D plot recipes" begin
+      pd = PlotData2D(sol)
+  
+      @test_nowarn_debug plot(sol)
+      @test_nowarn_debug plot(pd)
+      @test_nowarn_debug plot(pd["p"])
+      @test_nowarn_debug plot(getmesh(pd))
+    end
   end
 
   @testset "PlotData1D, PlotDataSeries1D, PlotMesh1D" begin


### PR DESCRIPTION
To visualize curved mesh data, we adapted the visualization code to work with `CurvedMesh`.
However, we need to plot data in "Matlab style" where we specify nodes and data on these nodes and not just specify x- and y-values and data on the tensor product of these.

In particular, we want to write
```julia
heatmap([0, 1, 0, 1], [0, 0, 1, 1], [1, 2, 3, 4])
```
to plot the values 1, 2, 3 and 4 at the nodes `(0, 0)`, `(1, 0)`, `(0, 1)` and `(1, 1)` respectively.
For some reason, this is not possible with `Plots.jl` (at least we don't know of a way to do this) with heat maps, but it is with scatter plots like this:
```julia
scatter([0, 1, 0, 1], [0, 0, 1, 1], marker_z=[1, 2, 3, 4])
```
For now, we just implemented the visualization with scatter plots (that look a bit awkward to be fair), and we search for a way to do this with heat maps properly in the future.

Example plots look like this:
![grafik](https://user-images.githubusercontent.com/44124897/113574632-c8614280-961c-11eb-9436-5df204db8807.png)
![grafik](https://user-images.githubusercontent.com/44124897/113574662-d616c800-961c-11eb-9e10-56a1949fc156.png)
![grafik](https://user-images.githubusercontent.com/44124897/113574694-e9c22e80-961c-11eb-84bc-1ca1ae49f9fb.png)
![grafik](https://user-images.githubusercontent.com/44124897/113574733-f9da0e00-961c-11eb-9968-ade51d167fa4.png)
