### PR TITLE
make influence on latency more clear

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -39,7 +39,7 @@ let
   SUITE["latency"]["default_example"] = @benchmarkable run(
     `$(Base.julia_cmd()) -e 'using Trixi; trixi_include(default_example())'`) seconds=60
   for polydeg in [3, 7]
-    command = "using Trixi; trixi_include(joinpath(examples_dir(), \"2d\", \"elixir_advection_extended.jl\"), polydeg=$(polydeg), save_restart=TrivialCallback(), save_solution=TrivialCallback(), cfl=0.1)"
+    command = "using Trixi; trixi_include(joinpath(examples_dir(), \"2d\", \"elixir_advection_extended.jl\"), tspan=(0.0, 1.0e-10), polydeg=$(polydeg), save_restart=TrivialCallback(), save_solution=TrivialCallback())"
     SUITE["latency"]["polydeg_$polydeg"] = @benchmarkable run($`$(Base.julia_cmd()) -e $command`) seconds=60
   end
 end


### PR DESCRIPTION
By not running a full simulation, we reduce the time necessary to run the benchmark and make the effect on latency more clear.