### PR TITLE
Adding broadcast multiply back into entropy2cons

### DIFF
--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -600,7 +600,7 @@ end
   
   # convert to entropy `-rho * s` used by Hughes, France, Mallet (1986)
   # instead of `-rho * s / (gamma - 1)`
-  V1, V2, V5 = w * (gamma - 1)
+  V1, V2, V5 = w .* (gamma - 1)
   
   # specific entropy, eq. (53)
   s = gamma - V1 + 0.5 * (V2^2) / V5

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -1058,7 +1058,7 @@ end
 
   # convert to entropy `-rho * s` used by Hughes, France, Mallet (1986)
   # instead of `-rho * s / (gamma - 1)`
-  V1, V2, V3, V5 = w * (gamma-1)
+  V1, V2, V3, V5 = w .* (gamma-1)
 
   # s = specific entropy, eq. (53)
   s = gamma - V1 + (V2^2 + V3^2)/(2*V5)

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -974,7 +974,7 @@ end
 
   # convert to entropy `-rho * s` used by Hughes, France, Mallet (1986)
   # instead of `-rho * s / (gamma - 1)`
-  V1,V2,V3,V4,V5 = w * (gamma-1) 
+  V1,V2,V3,V4,V5 = w .* (gamma-1) 
 
   # s = specific entropy, eq. (53)      
   V_square    = V2^2 + V3^2 + V4^2

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -482,10 +482,20 @@ Cassette.@context Ctx
       cons_vars = prim2cons(SVector(rho, v1, p),equations)
       entropy_vars = cons2entropy(cons_vars, equations)
       @test cons_vars ≈ entropy2cons(entropy_vars, equations)
+
+      # test tuple args
+      cons_vars = prim2cons((rho, v1, p),equations)
+      entropy_vars = cons2entropy(cons_vars, equations)
+      @test cons_vars ≈ entropy2cons(entropy_vars, equations)
     end
 
     let equations = CompressibleEulerEquations2D(1.4)
       cons_vars = prim2cons(SVector(rho,v1,v2,p),equations)
+      entropy_vars = cons2entropy(cons_vars,equations)
+      @test cons_vars ≈ entropy2cons(entropy_vars,equations)
+
+      # test tuple args
+      cons_vars = prim2cons((rho,v1,v2,p),equations)
       entropy_vars = cons2entropy(cons_vars,equations)
       @test cons_vars ≈ entropy2cons(entropy_vars,equations)
     end
@@ -494,6 +504,11 @@ Cassette.@context Ctx
       cons_vars = prim2cons(SVector(rho,v1,v2,v3,p),equations)
       entropy_vars = cons2entropy(cons_vars,equations)
       @test cons_vars ≈ entropy2cons(entropy_vars,equations)
+
+      # test tuple args
+      cons_vars = prim2cons((rho,v1,v2,v3,p),equations)
+      entropy_vars = cons2entropy(cons_vars,equations)
+      @test cons_vars ≈ entropy2cons(entropy_vars,equations)      
     end
   end
 

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -506,9 +506,9 @@ Cassette.@context Ctx
       @test cons_vars ≈ entropy2cons(entropy_vars,equations)
 
       # test tuple args
-      cons_vars = prim2cons((rho,v1,v2,v3,p),equations)
-      entropy_vars = cons2entropy(cons_vars,equations)
-      @test cons_vars ≈ entropy2cons(entropy_vars,equations)      
+      cons_vars = prim2cons((rho, v1, v2, v3, p), equations)
+      entropy_vars = cons2entropy(cons_vars, equations)
+      @test cons_vars ≈ entropy2cons(entropy_vars, equations)      
     end
   end
 

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -495,9 +495,9 @@ Cassette.@context Ctx
       @test cons_vars ≈ entropy2cons(entropy_vars,equations)
 
       # test tuple args
-      cons_vars = prim2cons((rho,v1,v2,p),equations)
-      entropy_vars = cons2entropy(cons_vars,equations)
-      @test cons_vars ≈ entropy2cons(entropy_vars,equations)
+      cons_vars = prim2cons((rho, v1, v2, p), equations)
+      entropy_vars = cons2entropy(cons_vars, equations)
+      @test cons_vars ≈ entropy2cons(entropy_vars, equations)
     end
 
     let equations = CompressibleEulerEquations3D(1.4)


### PR DESCRIPTION
This change adds broadcasts back into `entropy2cons` so that it works with both tuple and vector arguments. Right now, lines like https://github.com/trixi-framework/Trixi.jl/blob/8b029f82abf55ead51470a25067dfb3b80a7770f/src/equations/compressible_euler_2d.jl#L1061 break for tuple arguments. I just replaced this with `V1, V2, V3, V5 = w .* (gamma-1)`