### PR TITLE
remove superfluous AbstractVector annotations

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -36,7 +36,10 @@ makedocs(
     pages = [
         "Home" => "index.md",
         "Visualization" => "visualization.md",
-        "Conventions" => "conventions.md",
+        "Conventions" => [
+            "User-facing conventions" => "conventions_user.md",
+            "Internal conventions" => "conventions_internal.md",
+        ],
         "Meshes" => [
             "Tree mesh" => joinpath("meshes", "tree_mesh.md"),
             "Structured mesh" => joinpath("meshes", "structured_mesh.md"),

--- a/docs/src/conventions_internal.md
+++ b/docs/src/conventions_internal.md
@@ -1,0 +1,28 @@
+# Conventions used internally
+
+## Array types and wrapping
+
+To allow adaptive mesh refinement efficiently when using time integrators from
+[OrdinaryDiffEq](https://github.com/SciML/OrdinaryDiffEq.jl),
+Trixi allows to represent numerical solutions in two different ways. Some discussion
+can be found [online](https://github.com/SciML/OrdinaryDiffEq.jl/pull/1275) and
+in form of comments describing `Trixi.wrap_array` in the source code of Trixi.
+The flexibility introduced by this possible wrapping enables additional
+[performance optimizations](https://github.com/trixi-framework/Trixi.jl/pull/509).
+However, it comes at the cost of some additional abstractions (and needs to be
+used with caution, as described in the source code of Trixi). Thus, we use the
+following conventions to distinguish between arrays visible to the time integrator
+and wrapped arrays mainly used internally.
+
+- Arrays visible to the time integrator have a suffix `_ode`, e.g., `du_ode`, `u_ode`.
+- Wrapped arrays do not have a suffix, e.g., `du, u`.
+
+Methods either accept arrays visible to the time integrator or wrapped arrays
+based on the following rules.
+- When some solution is passed together with a semidiscretization `semi`, the
+  solution must be a `u_ode` that needs to be  wrapped via `wrap_array(u_ode, semi)`
+  for further processing.
+- When some solution is passed together with the `mesh, equations, solver, cache, ...`,
+  it is already wrapped via `wrap_array`.
+- Exceptions of this rule are possible, e.g. for AMR, but must be documented in
+  the code.

--- a/docs/src/conventions_user.md
+++ b/docs/src/conventions_user.md
@@ -1,4 +1,4 @@
-# [Conventions](@id conventions)
+# [User-facing conventions](@id conventions)
 
 ## Spatial dimensions and directions
 

--- a/examples/2d/elixir_advection_callbacks.jl
+++ b/examples/2d/elixir_advection_callbacks.jl
@@ -29,7 +29,7 @@ end
 # This method is called when the `ExampleStageCallback` is used as `stage_limiter!`
 # which gets called after every RK stage. There is no specific initialization
 # method for such `stage_limiter!`s in OrdinaryDiffEq.jl.
-function (example_stage_callback::ExampleStageCallback)(u_ode::AbstractVector, _, semi, t)
+function (example_stage_callback::ExampleStageCallback)(u_ode, _, semi, t)
 
   min_val, max_val = extrema(u_ode)
   push!(example_stage_callback.times, t)

--- a/src/callbacks_stage/positivity_zhang_shu.jl
+++ b/src/callbacks_stage/positivity_zhang_shu.jl
@@ -23,7 +23,7 @@ end
 
 
 function (limiter!::PositivityPreservingLimiterZhangShu)(
-    u_ode::AbstractVector, f, semi::AbstractSemidiscretization, t)
+    u_ode, f, semi::AbstractSemidiscretization, t)
   u = wrap_array(u_ode, semi)
   @timeit_debug timer() "positivity-preserving limiter" limiter_zhang_shu!(
     u, limiter!.thresholds, limiter!.variables, mesh_equations_solver_cache(semi)...)

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -167,6 +167,8 @@ end
                                              semi::SemidiscretizationHyperbolic,
                                              t, iter;
                                              kwargs...)
+  # Note that we don't `wrap_array` the vector `u_ode` to be able to `resize!`
+  # it when doing AMR while still dispatching on the `mesh` etc.
   amr_callback(u_ode, mesh_equations_solver_cache(semi)..., t, iter; kwargs...)
 end
 

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -251,7 +251,7 @@ function (analysis_callback::AnalysisCallback)(io, du, u, u_ode, t, semi)
   end
 
   # Calculate L2/Linf errors, which are also returned
-  l2_error, linf_error = calc_error_norms(u, t, analyzer, semi, cache_analysis)
+  l2_error, linf_error = calc_error_norms(u_ode, t, analyzer, semi, cache_analysis)
 
   if mpi_isroot()
     # L2 error
@@ -315,7 +315,7 @@ function (analysis_callback::AnalysisCallback)(io, du, u, u_ode, t, semi)
 
   # L2/L∞ errors of the primitive variables
   if :l2_error_primitive in analysis_errors || :linf_error_primitive in analysis_errors
-    l2_error_prim, linf_error_prim = calc_error_norms(cons2prim, u, t, analyzer, semi, cache_analysis)
+    l2_error_prim, linf_error_prim = calc_error_norms(cons2prim, u_ode, t, analyzer, semi, cache_analysis)
 
     if mpi_isroot()
       print(" Variable:    ")

--- a/src/callbacks_step/callbacks_step.jl
+++ b/src/callbacks_step/callbacks_step.jl
@@ -4,7 +4,7 @@
 get_element_variables!(element_variables, u, mesh, equations, solver, cache,
                        callback; kwargs...) = nothing
 
-@inline function get_element_variables!(element_variables, u_ode::AbstractVector,
+@inline function get_element_variables!(element_variables, u_ode,
                                         semi::AbstractSemidiscretization, cb::DiscreteCallback;
                                         kwargs...)
   mesh, equations, solver, cache = mesh_equations_solver_cache(semi)

--- a/src/callbacks_step/save_restart.jl
+++ b/src/callbacks_step/save_restart.jl
@@ -100,7 +100,7 @@ function (restart_callback::SaveRestartCallback)(integrator)
 end
 
 
-@inline function save_restart_file(u_ode::AbstractVector, t, dt, iter,
+@inline function save_restart_file(u_ode, t, dt, iter,
                                    semi::AbstractSemidiscretization, restart_callback)
   mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
   u = wrap_array(u_ode, mesh, equations, solver, cache)

--- a/src/callbacks_step/save_solution.jl
+++ b/src/callbacks_step/save_solution.jl
@@ -140,7 +140,7 @@ function (solution_callback::SaveSolutionCallback)(integrator)
 end
 
 
-@inline function save_solution_file(u_ode::AbstractVector, t, dt, iter,
+@inline function save_solution_file(u_ode, t, dt, iter,
                                     semi::AbstractSemidiscretization, solution_callback,
                                     element_variables=Dict{Symbol,Any}())
   mesh, equations, solver, cache = mesh_equations_solver_cache(semi)

--- a/src/callbacks_step/steady_state.jl
+++ b/src/callbacks_step/steady_state.jl
@@ -49,7 +49,7 @@ end
 
 
 # the condition
-function (steady_state_callback::SteadyStateCallback)(u_ode::AbstractVector, t, integrator)
+function (steady_state_callback::SteadyStateCallback)(u_ode, t, integrator)
   semi = integrator.p
 
   u  = wrap_array(u_ode, semi)

--- a/src/semidiscretization/semidiscretization.jl
+++ b/src/semidiscretization/semidiscretization.jl
@@ -11,14 +11,14 @@ end
 
 
 """
-    integrate_via_indices(func, u_ode::AbstractVector, semi::AbstractSemidiscretization, args...; normalize=true)
+    integrate_via_indices(func, u_ode, semi::AbstractSemidiscretization, args...; normalize=true)
 
 Call `func(u, i..., element, equations, solver, args...)` for all nodal indices `i..., element`
 and integrate the result using a quadrature associated with the semidiscretization `semi`.
 
 If `normalize` is true, the result is divided by the total volume of the computational domain.
 """
-function integrate_via_indices(func::Func, u_ode::AbstractVector, semi::AbstractSemidiscretization, args...; normalize=true) where {Func}
+function integrate_via_indices(func::Func, u_ode, semi::AbstractSemidiscretization, args...; normalize=true) where {Func}
   mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
 
   u = wrap_array(u_ode, mesh, equations, solver, cache)
@@ -26,14 +26,14 @@ function integrate_via_indices(func::Func, u_ode::AbstractVector, semi::Abstract
 end
 
 """
-    integrate([func=(u_node,equations)->u_node,] u_ode::AbstractVector, semi::AbstractSemidiscretization; normalize=true)
+    integrate([func=(u_node,equations)->u_node,] u_ode, semi::AbstractSemidiscretization; normalize=true)
 
 Call `func(u_node, equations)` for each vector of nodal variables `u_node` in `u_ode`
 and integrate the result using a quadrature associated with the semidiscretization `semi`.
 
 If `normalize` is true, the result is divided by the total volume of the computational domain.
 """
-function integrate(func::Func, u_ode::AbstractVector, semi::AbstractSemidiscretization; normalize=true) where {Func}
+function integrate(func::Func, u_ode, semi::AbstractSemidiscretization; normalize=true) where {Func}
   mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
 
   u = wrap_array(u_ode, mesh, equations, solver, cache)
@@ -112,7 +112,7 @@ end
 
 Same as [`compute_coefficients`](@ref) but stores the result in `u_ode`.
 """
-function compute_coefficients!(u_ode::AbstractVector, func, t, semi::AbstractSemidiscretization)
+function compute_coefficients!(u_ode, func, t, semi::AbstractSemidiscretization)
   u = wrap_array(u_ode, semi)
   # Call `compute_coefficients` defined by the solver
   compute_coefficients!(u, func, t, mesh_equations_solver_cache(semi)...)
@@ -240,7 +240,7 @@ end
 #   get_element_variables!(element_variables, ..)
 # is used to retrieve such up to date element variables, modifying
 # `element_variables::Dict{Symbol,Any}` in place.
-function get_element_variables!(element_variables, u_ode::AbstractVector, semi::AbstractSemidiscretization)
+function get_element_variables!(element_variables, u_ode, semi::AbstractSemidiscretization)
   u = wrap_array(u_ode, semi)
   get_element_variables!(element_variables, u, mesh_equations_solver_cache(semi)...)
 end
@@ -285,7 +285,7 @@ end
 # to avoid stochastic memory errors.
 #
 # Xref https://github.com/SciML/OrdinaryDiffEq.jl/pull/1275
-function wrap_array(u_ode::AbstractVector, semi::AbstractSemidiscretization)
+function wrap_array(u_ode, semi::AbstractSemidiscretization)
   wrap_array(u_ode, mesh_equations_solver_cache(semi)...)
 end
 
@@ -298,7 +298,7 @@ end
 # - nnodes(solver)
 # - real(solver)
 # - create_cache(mesh, equations, solver, RealT)
-# - wrap_array(u_ode::AbstractVector, mesh, equations, solver, cache)
+# - wrap_array(u_ode, mesh, equations, solver, cache)
 # - integrate(func, u, mesh, equations, solver, cache; normalize=true)
 # - integrate_via_indices(func, u, mesh, equations, solver, cache, args...; normalize=true)
 # - calc_error_norms(func, u, t, analyzer, mesh, equations, initial_condition, solver, cache, cache_analysis)

--- a/src/semidiscretization/semidiscretization_euler_gravity.jl
+++ b/src/semidiscretization/semidiscretization_euler_gravity.jl
@@ -222,7 +222,7 @@ end
 
 
 # TODO: Taal refactor, add some callbacks or so within the gravity update to allow investigating/optimizing it
-function update_gravity!(semi::SemidiscretizationEulerGravity, u_ode::AbstractVector)
+function update_gravity!(semi::SemidiscretizationEulerGravity, u_ode)
   @unpack semi_euler, semi_gravity, parameters, gravity_counter, cache = semi
 
   # Can be changed by AMR
@@ -413,7 +413,7 @@ end
 
 
 # TODO: Taal decide, where should specific parts like these be?
-@inline function save_solution_file(u_ode::AbstractVector, t, dt, iter,
+@inline function save_solution_file(u_ode, t, dt, iter,
                                     semi::SemidiscretizationEulerGravity, solution_callback,
                                     element_variables=Dict{Symbol,Any}())
 
@@ -431,7 +431,7 @@ end
 end
 
 
-@inline function (amr_callback::AMRCallback)(u_ode::AbstractVector,
+@inline function (amr_callback::AMRCallback)(u_ode,
                                              semi::SemidiscretizationEulerGravity,
                                              t, iter; kwargs...)
   passive_args = ((semi.cache.u_ode, mesh_equations_solver_cache(semi.semi_gravity)...),)

--- a/src/semidiscretization/semidiscretization_hyperbolic.jl
+++ b/src/semidiscretization/semidiscretization_hyperbolic.jl
@@ -167,6 +167,7 @@ end
 end
 
 
+#TODO
 function calc_error_norms(func, u_ode::AbstractVector, t, analyzer, semi::SemidiscretizationHyperbolic, cache_analysis)
   @unpack mesh, equations, initial_condition, solver, cache = semi
   u = wrap_array(u_ode, mesh, equations, solver, cache)
@@ -186,7 +187,7 @@ function compute_coefficients(t, semi::SemidiscretizationHyperbolic)
   compute_coefficients(semi.initial_condition, t, semi)
 end
 
-function compute_coefficients!(u_ode::AbstractVector, t, semi::SemidiscretizationHyperbolic)
+function compute_coefficients!(u_ode, t, semi::SemidiscretizationHyperbolic)
   compute_coefficients!(u_ode, semi.initial_condition, t, semi)
 end
 

--- a/src/semidiscretization/semidiscretization_hyperbolic.jl
+++ b/src/semidiscretization/semidiscretization_hyperbolic.jl
@@ -167,16 +167,9 @@ end
 end
 
 
-#TODO
 function calc_error_norms(func, u_ode::AbstractVector, t, analyzer, semi::SemidiscretizationHyperbolic, cache_analysis)
   @unpack mesh, equations, initial_condition, solver, cache = semi
   u = wrap_array(u_ode, mesh, equations, solver, cache)
-
-  calc_error_norms(func, u, t, analyzer, mesh, equations, initial_condition, solver, cache, cache_analysis)
-end
-
-function calc_error_norms(func, u, t, analyzer, semi::SemidiscretizationHyperbolic, cache_analysis)
-  @unpack mesh, equations, initial_condition, solver, cache = semi
 
   calc_error_norms(func, u, t, analyzer, mesh, equations, initial_condition, solver, cache, cache_analysis)
 end

--- a/src/visualization/adapt.jl
+++ b/src/visualization/adapt.jl
@@ -1,11 +1,11 @@
 """
-    adapt_to_mesh_level!(u_ode::AbstractVector, semi, level)
+    adapt_to_mesh_level!(u_ode, semi, level)
     adapt_to_mesh_level!(sol::Trixi.TrixiODESolution, level)
 
 Like [`adapt_to_mesh_level`](@ref), but modifies the solution and parts of the
 semidiscretization (mesh and caches) in place.
 """
-function adapt_to_mesh_level!(u_ode::AbstractVector, semi, level)
+function adapt_to_mesh_level!(u_ode, semi, level)
   # Create AMR callback with controller that refines everything towards a single level
   amr_controller = ControllerThreeLevel(semi, IndicatorMax(semi, variable=first), base_level=level)
   amr_callback = AMRCallback(semi, amr_controller, interval=0)
@@ -23,7 +23,7 @@ adapt_to_mesh_level!(sol::TrixiODESolution, level) = adapt_to_mesh_level!(sol.u[
 
 
 """
-    adapt_to_mesh_level(u_ode::AbstractVector, semi, level)
+    adapt_to_mesh_level(u_ode, semi, level)
     adapt_to_mesh_level(sol::Trixi.TrixiODESolution, level)
 
 Use the regular adaptive mesh refinement routines to adaptively refine/coarsen the solution `u_ode`
@@ -38,7 +38,7 @@ extracted as needed.
 
 See also: [`adapt_to_mesh_level!`](@ref)
 """
-function adapt_to_mesh_level(u_ode::AbstractVector, semi, level)
+function adapt_to_mesh_level(u_ode, semi, level)
   # Create new semidiscretization with copy of the current mesh
   mesh, _, _, _ = mesh_equations_solver_cache(semi)
   new_semi = remake(semi, mesh=deepcopy(mesh))

--- a/src/visualization/convert.jl
+++ b/src/visualization/convert.jl
@@ -124,8 +124,7 @@ end
 #
 # Note: This is a low-level function that is not considered as part of Trixi's interface and may
 #       thus be changed in future releases.
-function get_unstructured_data(u, semi, solution_variables)
-  mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
+function get_unstructured_data(u, solution_variables, mesh, equations, solver, cache)
 
   if solution_variables === cons2cons
     raw_data = u

--- a/src/visualization/plot_recipes.jl
+++ b/src/visualization/plot_recipes.jl
@@ -53,7 +53,7 @@ end
 
 
 """
-    PlotData2D(u, semi;
+    PlotData2D(u, semi [or mesh, equations, solver, cache];
                solution_variables=nothing,
                grid_lines=true, max_supported_level=11, nvisnodes=nothing,
                slice_axis=:z, slice_axis_intercept=0)
@@ -96,11 +96,15 @@ julia> plot(pd["scalar"]) # To plot only a single variable
 julia> plot!(getmesh(pd)) # To add grid lines to the plot
 ```
 """
-function PlotData2D(u, semi;
+
+PlotData2D(u_ode, semi; kwargs...) = PlotData2D(wrap_array(u_ode, semi),
+                                                mesh_equations_solver_cache(semi)...;
+                                                kwargs...)
+
+function PlotData2D(u, mesh::TreeMesh, equations, solver, cache;
                     solution_variables=nothing,
                     grid_lines=true, max_supported_level=11, nvisnodes=nothing,
                     slice_axis=:z, slice_axis_intercept=0)
-  mesh, equations, solver, _ = mesh_equations_solver_cache(semi)
   @assert ndims(mesh) in (2, 3) "unsupported number of dimensions $ndims (must be 2 or 3)"
   solution_variables_ = digest_solution_variables(equations, solution_variables)
 
@@ -111,7 +115,7 @@ function PlotData2D(u, semi;
   coordinates = mesh.tree.coordinates[:, leaf_cell_ids]
   levels = mesh.tree.levels[leaf_cell_ids]
 
-  unstructured_data = get_unstructured_data(u, semi, solution_variables_)
+  unstructured_data = get_unstructured_data(u, solution_variables_, mesh, equations, solver, cache)
   x, y, data, mesh_vertices_x, mesh_vertices_y = get_data_2d(center_level_0, length_level_0,
                                                              leaf_cell_ids, coordinates, levels,
                                                              ndims(mesh), unstructured_data,
@@ -127,30 +131,14 @@ function PlotData2D(u, semi;
 end
 
 
-"""
-    PlotData2D(u::AbstractArray{<:Any, 4}, semi::SemidiscretizationHyperbolic{<:Union{CurvedMesh,UnstructuredQuadMesh}};
-               solution_variables=nothing, kwargs...)
-
-Create a new `PlotData2D` object that can be used for visualizing 2D DGSEM solution data array
-`u` with `Plots.jl` for the mesh type `CurvedMesh` or `UnstructuredQuadMesh`. All relevant
-geometrical information is extracted from the semidiscretization `semi`. By default, the
-conservative variables from the solution are used for plotting. This can be changed by passing an
-appropriate conversion function to `solution_variables`.
-
-!!! warning "Experimental implementation"
-    This is an experimental feature and may change in future releases.
-
-"""
-function PlotData2D(u::AbstractArray{<:Any, 4},
-                    semi::SemidiscretizationHyperbolic{<:Union{CurvedMesh,UnstructuredQuadMesh}};
+function PlotData2D(u, mesh::Union{CurvedMesh,UnstructuredQuadMesh}, equations, solver, cache;
                     solution_variables=nothing, grid_lines=true, kwargs...)
-  mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
   @unpack node_coordinates = cache.elements
 
   @assert ndims(mesh) == 2 "unsupported number of dimensions $ndims (must be 2)"
   solution_variables_ = digest_solution_variables(equations, solution_variables)
 
-  unstructured_data = get_unstructured_data(u, semi, solution_variables_)
+  unstructured_data = get_unstructured_data(u, solution_variables_, mesh, equations, solver, cache)
 
   x = vec(view(node_coordinates, 1, ..))
   y = vec(view(node_coordinates, 2, ..))
@@ -174,18 +162,7 @@ end
 
 
 """
-    PlotData2D(u_ode::AbstractVector, semi; kwargs...)
-
-Create a `PlotData2D` object from a one-dimensional ODE solution `u_ode` and the semidiscretization
-`semi`.
-
-!!! warning "Experimental implementation"
-    This is an experimental feature and may change in future releases.
-"""
-PlotData2D(u_ode::AbstractVector, semi; kwargs...) = PlotData2D(wrap_array(u_ode, semi), semi; kwargs...)
-
-"""
-    PlotData2D(sol::Union{DiffEqBase.ODESolution,TimeIntegratorSolution}; kwargs...)
+    PlotData2D(sol; kwargs...)
 
 Create a `PlotData2D` object from a solution object created by either `OrdinaryDiffEq.solve!` (which
 returns a `DiffEqBase.ODESolution`) or Trixi's own `solve!` (which returns a
@@ -466,7 +443,8 @@ struct PlotData1D{Coordinates, Data, VariableNames, Vertices} <:AbstractPlotData
 end
 
 """
-    PlotData1D(u, semi; solution_variables=nothing, nvisnodes=nothing))
+    PlotData1D(u, semi [or mesh, equations, solver, cache];
+               solution_variables=nothing, nvisnodes=nothing)
 
 Create a new `PlotData1D` object that can be used for visualizing 1D DGSEM solution data array
 `u` with `Plots.jl`. All relevant geometrical information is extracted from the semidiscretization
@@ -478,21 +456,23 @@ function to `solution_variables`.
 twice the number of solution DG nodes are used for visualization, and if set to `0`,
 exactly the number of nodes in the DG elements are used.
 
-
-
 !!! warning "Experimental implementation"
     This is an experimental feature and may change in future releases.
 """
-function PlotData1D(u, semi; solution_variables=nothing, nvisnodes=nothing)
+PlotData1D(u_ode, semi; kwargs...) = PlotData1D(wrap_array(u_ode, semi),
+                                                mesh_equations_solver_cache(semi)...;
+                                                kwargs...)
 
-  mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
+function PlotData1D(u, mesh, equations, solver, cache;
+                    solution_variables=nothing, nvisnodes=nothing)
+
   @assert ndims(mesh) in (1) "unsupported number of dimensions $ndims (must be 1)"
   solution_variables_ = digest_solution_variables(equations, solution_variables)
 
   variable_names = SVector(varnames(solution_variables_, equations))
   original_nodes = cache.elements.node_coordinates
 
-  unstructured_data = get_unstructured_data(u, semi, solution_variables_)
+  unstructured_data = get_unstructured_data(u, solution_variables_, mesh, equations, solver, cache)
   x, data = get_data_1d(original_nodes, unstructured_data, nvisnodes)
 
   if ndims(mesh) == 1
@@ -505,18 +485,9 @@ function PlotData1D(u, semi; solution_variables=nothing, nvisnodes=nothing)
                     orientation_x)
 end
 
-"""
-    PlotData1D(u_ode::AbstractVector, semi)
-
-Create a `PlotData1D` object from a one-dimensional ODE solution `u_ode` and the semidiscretization
-`semi`.
-!!! warning "Experimental implementation"
-    This is an experimental feature and may change in future releases.
-"""
-PlotData1D(u_ode::AbstractVector, semi; kwargs...) = PlotData1D(wrap_array(u_ode, semi), semi; kwargs...)
 
 """
-    PlotData1D(sol::Union{DiffEqBase.ODESolution,TimeIntegratorSolution})
+    PlotData1D(sol; kwargs...)
 
 Create a `PlotData1D` object from a solution object created by either `OrdinaryDiffEq.solve!` (which
 returns a `DiffEqBase.ODESolution`) or Trixi's own `solve!` (which returns a

--- a/src/visualization/plot_recipes.jl
+++ b/src/visualization/plot_recipes.jl
@@ -143,7 +143,7 @@ function PlotData2D(u, mesh::Union{CurvedMesh,UnstructuredQuadMesh}, equations, 
   x = vec(view(node_coordinates, 1, ..))
   y = vec(view(node_coordinates, 2, ..))
 
-  data = [vec(unstructured_data[.., v]) for v in 1:nvariables(semi)]
+  data = [vec(unstructured_data[.., v]) for v in eachvariable(equations)]
 
   if grid_lines
     mesh_vertices_x, mesh_vertices_y = calc_vertices(node_coordinates, mesh)


### PR DESCRIPTION
These were okay to use for the `TreeMesh`es but are not really necessary. The rule should be as follows
- When some solution is passed together with the `semi`, it must be a `u_ode` that needs to be  wrapped via `wrap_array(u_ode, semi)` for further processing.
- When some solution is passed together with the `mesh, euqations, solver, cache, ...`, it is already wrapped via `wrap_array`.
- Exceptions of this rule are possible, e.g. for AMR, but must be documented in the code.

This should fix the problems @jlchan ran into several times while proting his great solvers to Trixi.