### PR TITLE
Fix computation on structured curved mesh with orientation-reversing mapping

### DIFF
--- a/src/callbacks_step/stepsize_dg2d.jl
+++ b/src/callbacks_step/stepsize_dg2d.jl
@@ -89,7 +89,7 @@ function max_dt(u, t, mesh::CurvedMesh{2},
       Ja21, Ja22     = get_contravariant_vector(2, contravariant_vectors, i, j, element)
       λ2_transformed = abs(Ja21 * λ1 + Ja22 * λ2)
 
-      inv_jacobian = inverse_jacobian[i, j, element]
+      inv_jacobian = abs(inverse_jacobian[i, j, element])
 
       max_λ1 = max(max_λ1, λ1_transformed * inv_jacobian)
       max_λ2 = max(max_λ2, λ2_transformed * inv_jacobian)
@@ -120,7 +120,7 @@ function max_dt(u, t, mesh::CurvedMesh{2},
       Ja21, Ja22     = get_contravariant_vector(2, contravariant_vectors, i, j, element)
       λ2_transformed = abs(Ja21 * max_λ1 + Ja22 * max_λ2)
 
-      inv_jacobian = inverse_jacobian[i, j, element]
+      inv_jacobian = abs(inverse_jacobian[i, j, element])
       max_scaled_speed = max(max_scaled_speed, inv_jacobian * (λ1_transformed + λ2_transformed))
     end
   end

--- a/src/callbacks_step/stepsize_dg3d.jl
+++ b/src/callbacks_step/stepsize_dg3d.jl
@@ -59,7 +59,7 @@ function max_dt(u, t, mesh::CurvedMesh{3},
       Ja31, Ja32, Ja33 = get_contravariant_vector(3, contravariant_vectors, i, j, k, element)
       λ3_transformed   = abs(Ja31 * λ1 + Ja32 * λ2 + Ja33 * λ3)
 
-      inv_jacobian = cache.elements.inverse_jacobian[i, j, k, element]
+      inv_jacobian = abs(cache.elements.inverse_jacobian[i, j, k, element])
 
       max_λ1 = max(max_λ1, inv_jacobian * λ1_transformed)
       max_λ2 = max(max_λ2, inv_jacobian * λ2_transformed)
@@ -92,7 +92,8 @@ function max_dt(u, t, mesh::CurvedMesh{3},
       Ja31, Ja32, Ja33 = get_contravariant_vector(3, contravariant_vectors, i, j, k, element)
       λ3_transformed   = abs(Ja31 * max_λ1 + Ja32 * max_λ2 + Ja33 * max_λ3)
 
-      inv_jacobian = cache.elements.inverse_jacobian[i, j, k, element]
+      inv_jacobian = abs(cache.elements.inverse_jacobian[i, j, k, element])
+
       max_scaled_speed = max(max_scaled_speed,
                              inv_jacobian * (λ1_transformed + λ2_transformed + λ3_transformed))
     end

--- a/src/solvers/dg_curved/dg.jl
+++ b/src/solvers/dg_curved/dg.jl
@@ -28,15 +28,25 @@ end
                                                   boundary_condition,
                                                   mesh::CurvedMesh, equations,dg::DG, cache,
                                                   direction, node_indices, surface_node_indices, element)
-  @unpack node_coordinates, contravariant_vectors = cache.elements
+  @unpack node_coordinates, contravariant_vectors, inverse_jacobian = cache.elements
   @unpack surface_flux = dg
 
   u_inner = get_node_vars(u, equations, dg, node_indices..., element)
   x = get_node_coords(node_coordinates, equations, dg, node_indices..., element)
 
+  # If the mapping is orientation-reversing, the contravariant vectors' orientation 
+  # is reversed as well. The normal vector must be oriented in the direction 
+  # from `left_element` to `right_element`, or the numerical flux will be computed
+  # incorrectly (downwind direction).
+  sign_jacobian = sign(inverse_jacobian[1, i, right_element])
+
   # Contravariant vector Ja^i is the normal vector
-  normal = get_contravariant_vector(orientation, contravariant_vectors, node_indices..., element)
-  flux = boundary_condition(u_inner, normal, direction, x, t, surface_flux, equations)
+  normal = sign_jacobian * get_contravariant_vector(orientation, contravariant_vectors, 
+                                                    node_indices..., element)
+
+  # If the mapping is orientation-reversing, the normal vector will be reversed (see above).
+  # However, the flux now has the wrong sign, since we need the physical flux in normal direction.
+  flux = sign_jacobian * boundary_condition(u_inner, normal, direction, x, t, surface_flux, equations)
 
   for v in eachvariable(equations)
     surface_flux_values[v, surface_node_indices..., direction, element] = flux[v]

--- a/src/solvers/dg_curved/dg.jl
+++ b/src/solvers/dg_curved/dg.jl
@@ -38,7 +38,7 @@ end
   # is reversed as well. The normal vector must be oriented in the direction 
   # from `left_element` to `right_element`, or the numerical flux will be computed
   # incorrectly (downwind direction).
-  sign_jacobian = sign(inverse_jacobian[1, node_indices..., element])
+  sign_jacobian = sign(inverse_jacobian[node_indices..., element])
 
   # Contravariant vector Ja^i is the normal vector
   normal = sign_jacobian * get_contravariant_vector(orientation, contravariant_vectors, 

--- a/src/solvers/dg_curved/dg.jl
+++ b/src/solvers/dg_curved/dg.jl
@@ -38,7 +38,7 @@ end
   # is reversed as well. The normal vector must be oriented in the direction 
   # from `left_element` to `right_element`, or the numerical flux will be computed
   # incorrectly (downwind direction).
-  sign_jacobian = sign(inverse_jacobian[1, i, right_element])
+  sign_jacobian = sign(inverse_jacobian[1, node_indices..., element])
 
   # Contravariant vector Ja^i is the normal vector
   normal = sign_jacobian * get_contravariant_vector(orientation, contravariant_vectors, 

--- a/src/solvers/dg_curved/dg_2d.jl
+++ b/src/solvers/dg_curved/dg_2d.jl
@@ -110,7 +110,7 @@ end
   end
 
   @unpack surface_flux = dg
-  @unpack contravariant_vectors = cache.elements
+  @unpack contravariant_vectors, inverse_jacobian = cache.elements
 
   right_direction = 2 * orientation
   left_direction = right_direction - 1
@@ -120,17 +120,30 @@ end
       u_ll = get_node_vars(u, equations, dg, nnodes(dg), i, left_element)
       u_rr = get_node_vars(u, equations, dg, 1,          i, right_element)
 
+      # If the mapping is orientation-reversing, the contravariant vectors' orientation 
+      # is reversed as well. The normal vector must be oriented in the direction 
+      # from `left_element` to `right_element`, or the numerical flux will be computed
+      # incorrectly (downwind direction).
+      sign_jacobian = sign(inverse_jacobian[1, i, right_element])
+
       # First contravariant vector Ja^1 as SVector
-      normal_vector = get_contravariant_vector(1, contravariant_vectors, 1, i, right_element)
+      normal_vector = sign_jacobian * get_contravariant_vector(1, contravariant_vectors,
+                                                               1, i, right_element)
     else # orientation == 2
       u_ll = get_node_vars(u, equations, dg, i, nnodes(dg), left_element)
       u_rr = get_node_vars(u, equations, dg, i, 1,          right_element)
 
+      # See above
+      sign_jacobian = sign(inverse_jacobian[i, 1, right_element])
+
       # Second contravariant vector Ja^2 as SVector
-      normal_vector = get_contravariant_vector(2, contravariant_vectors, i, 1, right_element)
+      normal_vector = sign_jacobian * get_contravariant_vector(2, contravariant_vectors,
+                                                               i, 1, right_element)
     end
 
-    flux = surface_flux(u_ll, u_rr, normal_vector, equations)
+    # If the mapping is orientation-reversing, the normal vector will be reversed (see above).
+    # However, the flux now has the wrong sign, since we need the physical flux in normal direction.
+    flux = sign_jacobian * surface_flux(u_ll, u_rr, normal_vector, equations)
 
     for v in eachvariable(equations)
       surface_flux_values[v, i, right_direction, left_element] = flux[v]

--- a/src/solvers/dg_curved/dg_3d.jl
+++ b/src/solvers/dg_curved/dg_3d.jl
@@ -136,23 +136,40 @@ end
       u_ll = get_node_vars(u, equations, dg, nnodes(dg), i, j, left_element)
       u_rr = get_node_vars(u, equations, dg, 1,          i, j, right_element)
 
+      # If the mapping is orientation-reversing, the contravariant vectors' orientation 
+      # is reversed as well. The normal vector must be oriented in the direction 
+      # from `left_element` to `right_element`, or the numerical flux will be computed
+      # incorrectly (downwind direction).
+      sign_jacobian = sign(inverse_jacobian[1, i, j, right_element])
+
       # First contravariant vector Ja^1 as SVector
-      normal = get_contravariant_vector(1, contravariant_vectors, 1, i, j, right_element)
+      normal = sign_jacobian * get_contravariant_vector(1, contravariant_vectors,
+                                                        1, i, j, right_element)
     elseif orientation == 2
       u_ll = get_node_vars(u, equations, dg, i, nnodes(dg), j, left_element)
       u_rr = get_node_vars(u, equations, dg, i, 1,          j, right_element)
 
+      # See above
+      sign_jacobian = sign(inverse_jacobian[i, 1, j, right_element])
+
       # Second contravariant vector Ja^2 as SVector
-      normal = get_contravariant_vector(2, contravariant_vectors, i, 1, j, right_element)
+      normal = sign_jacobian * get_contravariant_vector(2, contravariant_vectors,
+                                                        i, 1, j, right_element)
     else # orientation == 3
       u_ll = get_node_vars(u, equations, dg, i, j, nnodes(dg), left_element)
       u_rr = get_node_vars(u, equations, dg, i, j, 1,          right_element)
 
+      # See above
+      sign_jacobian = sign(inverse_jacobian[i, j, 1, right_element])
+
       # Third contravariant vector Ja^3 as SVector
-      normal = get_contravariant_vector(3, contravariant_vectors, i, j, 1, right_element)
+      normal = sign_jacobian * get_contravariant_vector(3, contravariant_vectors,
+                                                        i, j, 1, right_element)
     end
 
-    flux = surface_flux(u_ll, u_rr, normal, equations)
+    # If the mapping is orientation-reversing, the normal vector will be reversed (see above).
+    # However, the flux now has the wrong sign, since we need the physical flux in normal direction.
+    flux = sign_jacobian * surface_flux(u_ll, u_rr, normal, equations)
 
     for v in eachvariable(equations)
       surface_flux_values[v, i, j, right_direction, left_element] = flux[v]

--- a/src/solvers/dg_curved/dg_3d.jl
+++ b/src/solvers/dg_curved/dg_3d.jl
@@ -126,7 +126,7 @@ end
   end
 
   @unpack surface_flux = dg
-  @unpack contravariant_vectors = cache.elements
+  @unpack contravariant_vectors, inverse_jacobian = cache.elements
 
   right_direction = 2 * orientation
   left_direction = right_direction - 1


### PR DESCRIPTION
If the mapping is orientation-reversing, the Jacobian (and therefore the inverse Jacobian) will have a negative sign, which caused the time step calculation to fail.

Also, the contravariant vectors' orientation will be reversed as well. This is fine for the volume integral (since the inverse Jacobian will switch the sign again at the end of `rhs!`), but causes problems with the surface flux calculation.
Computing the surface flux in the opposite direction will calculate an incorrect numerical flux (downwind direction). This means that we need to switch the normal vector's sign, calculate the numerical flux, and then switch the sign again, since we need the physical flux in the normal direction (as said above, everything works with reversed sign).

Tests for orientation-reversing mappings will be added in #553.

@andrewwinters5000, could you please have a look at this?