### PR TITLE
Prepare load_mesh_serial to be used in Trixi2Vtk and fix CurvedMesh restart for 1D and 3D

### DIFF
--- a/examples/3d/elixir_advection_basic_curved.jl
+++ b/examples/3d/elixir_advection_basic_curved.jl
@@ -39,11 +39,15 @@ analysis_callback = AnalysisCallback(semi, interval=100)
 save_solution = SaveSolutionCallback(interval=100,
                                      solution_variables=cons2prim)
 
+# The SaveRestartCallback allows to save a file from which a Trixi simulation can be restarted
+save_restart = SaveRestartCallback(interval=100,
+                                   save_final_restart=true)
+
 # The StepsizeCallback handles the re-calculcation of the maximum Δt after each time step
 stepsize_callback = StepsizeCallback(cfl=1.2)
 
 # Create a CallbackSet to collect all callbacks such that they can be passed to the ODE solver
-callbacks = CallbackSet(summary_callback, analysis_callback, save_solution, stepsize_callback)
+callbacks = CallbackSet(summary_callback, analysis_callback, save_solution, save_restart, stepsize_callback)
 
 
 ###############################################################################

--- a/examples/3d/elixir_advection_restart_curved.jl
+++ b/examples/3d/elixir_advection_restart_curved.jl
@@ -1,0 +1,33 @@
+
+using OrdinaryDiffEq
+using Trixi
+
+###############################################################################
+# create a restart file
+
+trixi_include(@__MODULE__, joinpath(@__DIR__, "elixir_advection_basic_curved.jl"), 
+              cells_per_dimension=(4, 4, 4))
+
+
+###############################################################################
+# adapt the parameters that have changed compared to "elixir_advection_extended.jl"
+
+# Note: If you get a restart file from somewhere else, you need to provide
+# appropriate setups in the elixir loading a restart file
+
+restart_filename = joinpath("out", "restart_000017.h5")
+mesh = load_mesh(restart_filename, n_cells_max=0)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test, solver)
+
+tspan = (load_time(restart_filename), 2.0)
+ode = semidiscretize(semi, tspan, restart_filename);
+
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/test/test_examples_3d_curved.jl
+++ b/test/test_examples_3d_curved.jl
@@ -29,6 +29,12 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "3d")
       linf = [0.005554857853361295])
   end
 
+  @testset "elixir_advection_restart_curved.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_restart_curved.jl"),
+      l2   = [0.0281388160824776],
+      linf = [0.08740635193023694])
+  end
+
   @testset "elixir_euler_source_terms_curved.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms_curved.jl"),
       l2   = [0.01032310150257373, 0.009728768969448439, 0.009728768969448494, 0.009728768969448388, 0.015080412597559597],


### PR DESCRIPTION
We would like to use the function `load_mesh_serial` from Trixi in Trixi2Vtk. However, this function takes a restart file as argument, which we don't have in Trixi2Vtk. This is also not necessary since the mesh file is extracted from the restart file immediately.

I changed the functions `load_mesh_serial` and `load_mesh_parallel` to take the mesh file as argument.
Also, loading a curved mesh in 1D and 3D didn't work, so I fixed this as well and added a 3D restart test for `CurvedMesh`.