### PR TITLE
Make n_cells_max optional for load_mesh

### DIFF
--- a/examples/2d/elixir_advection_restart_curved.jl
+++ b/examples/2d/elixir_advection_restart_curved.jl
@@ -18,7 +18,7 @@ trixi_include(@__MODULE__, joinpath(@__DIR__, elixir_file))
 # appropriate setups in the elixir loading a restart file
 
 restart_filename = joinpath("out", restart_file)
-mesh = load_mesh(restart_filename, n_cells_max=0)
+mesh = load_mesh(restart_filename)
 
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 

--- a/examples/3d/elixir_advection_restart.jl
+++ b/examples/3d/elixir_advection_restart.jl
@@ -15,7 +15,7 @@ trixi_include(@__MODULE__, joinpath(@__DIR__, "elixir_advection_extended.jl"))
 # appropriate setups in the elixir loading a restart file
 
 restart_filename = joinpath("out", "restart_000040.h5")
-mesh = load_mesh(restart_filename, n_cells_max=30_000)
+mesh = load_mesh(restart_filename)
 
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 

--- a/examples/3d/elixir_advection_restart_curved.jl
+++ b/examples/3d/elixir_advection_restart_curved.jl
@@ -16,7 +16,7 @@ trixi_include(@__MODULE__, joinpath(@__DIR__, "elixir_advection_basic_curved.jl"
 # appropriate setups in the elixir loading a restart file
 
 restart_filename = joinpath("out", "restart_000017.h5")
-mesh = load_mesh(restart_filename, n_cells_max=0)
+mesh = load_mesh(restart_filename)
 
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test, solver)
 


### PR DESCRIPTION
Right now, every time a mesh is loaded from a mesh file, `n_cells_max` must be specified.
In many cases, one doesn't want to do any mesh refinement after a restart, so this only needs to be larger than the actual number of cells.
Another case where this is very annoying is in https://github.com/trixi-framework/Trixi2Vtk.jl/pull/31. We load meshes using the function `load_mesh` from Trixi, but we still need to specify `n_cells_max`. For this to work with every mesh, this number would need to be ridiculously large.

My suggestion is to add the default `n_cells_max=0`, and automatically use the maximum of `n_cells_max` and `n_cells` in the mesh file.
I don't see any reason why `load_mesh` should fail when `n_cells_max` is too small. It should just fail at the next refinement.