### PR TITLE
unstructured BCs

### DIFF
--- a/examples/2d/elixir_euler_unstructured_quad_basic.jl
+++ b/examples/2d/elixir_euler_unstructured_quad_basic.jl
@@ -12,11 +12,11 @@ initial_condition = initial_condition_convergence_test
 source_terms = source_terms_convergence_test
 
 boundary_condition_convergence_test = BoundaryConditionDirichlet(initial_condition)
-boundary_conditions = Dict( "Slant"  => boundary_condition_convergence_test,
-                            "Bezier" => boundary_condition_convergence_test,
-                            "Right"  => boundary_condition_convergence_test,
-                            "Bottom" => boundary_condition_convergence_test,
-                            "Top"    => boundary_condition_convergence_test )
+boundary_conditions = Dict( :Slant  => boundary_condition_convergence_test,
+                            :Bezier => boundary_condition_convergence_test,
+                            :Right  => boundary_condition_convergence_test,
+                            :Bottom => boundary_condition_convergence_test,
+                            :Top    => boundary_condition_convergence_test )
 
 ###############################################################################
 # Get the DG approximation space

--- a/examples/2d/elixir_euler_unstructured_quad_basic.jl
+++ b/examples/2d/elixir_euler_unstructured_quad_basic.jl
@@ -12,7 +12,7 @@ initial_condition = initial_condition_convergence_test
 source_terms = source_terms_convergence_test
 
 boundary_condition_convergence_test = BoundaryConditionDirichlet(initial_condition)
-boundary_conditions = Dict( "Slant" => boundary_condition_convergence_test,
+boundary_conditions = Dict( "Slant"  => boundary_condition_convergence_test,
                             "Bezier" => boundary_condition_convergence_test,
                             "Right"  => boundary_condition_convergence_test,
                             "Bottom" => boundary_condition_convergence_test,

--- a/examples/2d/elixir_euler_unstructured_quad_free_stream.jl
+++ b/examples/2d/elixir_euler_unstructured_quad_free_stream.jl
@@ -11,13 +11,13 @@ equations = CompressibleEulerEquations2D(1.4)
 initial_condition = initial_condition_constant
 
 boundary_condition_free_stream = BoundaryConditionDirichlet(initial_condition)
-boundary_conditions = Dict( "Body"    => boundary_condition_free_stream,
-                            "Button1" => boundary_condition_free_stream,
-                            "Button2" => boundary_condition_free_stream,
-                            "Eye1"    => boundary_condition_free_stream,
-                            "Eye2"    => boundary_condition_free_stream,
-                            "Smile"   => boundary_condition_free_stream,
-                            "Bowtie"  => boundary_condition_free_stream )
+boundary_conditions = Dict( :Body    => boundary_condition_free_stream,
+                            :Button1 => boundary_condition_free_stream,
+                            :Button2 => boundary_condition_free_stream,
+                            :Eye1    => boundary_condition_free_stream,
+                            :Eye2    => boundary_condition_free_stream,
+                            :Smile   => boundary_condition_free_stream,
+                            :Bowtie  => boundary_condition_free_stream )
 
 ###############################################################################
 # Get the DG approximation space

--- a/examples/2d/elixir_euler_unstructured_quad_wall_bc.jl
+++ b/examples/2d/elixir_euler_unstructured_quad_wall_bc.jl
@@ -28,11 +28,11 @@ initial_condition = uniform_flow_state
 
 boundary_condition_uniform_flow = BoundaryConditionDirichlet(uniform_flow_state)
 boundary_condition_slip_wall = BoundaryConditionWall(boundary_state_slip_wall)
-boundary_conditions = Dict( "Bottom" => boundary_condition_uniform_flow,
-                            "Top"    => boundary_condition_uniform_flow,
-                            "Right"  => boundary_condition_uniform_flow,
-                            "Left"   => boundary_condition_uniform_flow,
-                            "Circle" => boundary_condition_slip_wall )
+boundary_conditions = Dict( :Bottom => boundary_condition_uniform_flow,
+                            :Top    => boundary_condition_uniform_flow,
+                            :Right  => boundary_condition_uniform_flow,
+                            :Left   => boundary_condition_uniform_flow,
+                            :Circle => boundary_condition_slip_wall )
 
 ###############################################################################
 # Get the DG approximation space

--- a/examples/2d/elixir_euler_unstructured_quad_wall_bc.jl
+++ b/examples/2d/elixir_euler_unstructured_quad_wall_bc.jl
@@ -8,7 +8,7 @@ using Trixi
 
 equations = CompressibleEulerEquations2D(1.4)
 
-function uniform_flow_state(x, t, equations)
+@inline function uniform_flow_state(x, t, equations::CompressibleEulerEquations2D)
 
   # set the freestream flow parameters
   rho_freestream = 1.0
@@ -16,8 +16,9 @@ function uniform_flow_state(x, t, equations)
   p_freestream = inv(equations.gamma)
 
   theta = pi / 90.0 # analogous with a two degree angle of attack
-  v1 = u_freestream * cos(theta)
-  v2 = u_freestream * sin(theta)
+  si, co = sincos(theta)
+  v1 = u_freestream * co
+  v2 = u_freestream * si
 
   prim = SVector(rho_freestream, v1, v2, p_freestream)
   return prim2cons(prim, equations)

--- a/src/solvers/dg_unstructured_quad/containers_2d.jl
+++ b/src/solvers/dg_unstructured_quad/containers_2d.jl
@@ -229,7 +229,7 @@ struct UnstructuredBoundaryContainer2D{RealT<:Real, uEltype<:Real, NVARS, POLYDE
   element_id      ::Vector{Int}       # [boundaries]
   element_side_id ::Vector{Int}       # [boundaries]
   node_coordinates::Array{RealT, 3}   # [ndims, nnodes, boundaries]
-  name            ::Vector{String}    # [boundaries]
+  name            ::Vector{Symbol}    # [boundaries]
 end
 
 
@@ -245,7 +245,7 @@ function UnstructuredBoundaryContainer2D{RealT, uEltype, NVARS, POLYDEG}(capacit
   element_id       = fill(typemin(Int), capacity)
   element_side_id  = fill(typemin(Int), capacity)
   node_coordinates = fill(nan_RealT, (2, n_nodes, capacity))
-  name             = fill("empty", capacity)
+  name             = fill(:empty, capacity)
 
   return UnstructuredBoundaryContainer2D{RealT, uEltype, NVARS, POLYDEG}(u, element_id, element_side_id,
                                                                          node_coordinates, name)

--- a/src/solvers/dg_unstructured_quad/containers_2d.jl
+++ b/src/solvers/dg_unstructured_quad/containers_2d.jl
@@ -195,16 +195,16 @@ function init_interfaces!(interfaces, edge_information, boundary_names, polydeg,
       primary_element = edge_information[3,j]
       # Note: This is a way to get the neighbour element number and local side from a square
       #       structured mesh where the element local surface numbering is right-handed
-      if boundary_names[primary_side, primary_element] == "Bottom"
+      if boundary_names[primary_side, primary_element] === :Bottom
         secondary_element = primary_element + (n_elements - convert(Int, sqrt(n_elements)))
         secondary_side    = 3
-      elseif boundary_names[primary_side, primary_element] == "Top"
+      elseif boundary_names[primary_side, primary_element] === :Top
         secondary_element = primary_element - (n_elements - convert(Int, sqrt(n_elements)))
         secondary_side    = 1
-      elseif boundary_names[primary_side, primary_element] == "Left"
+      elseif boundary_names[primary_side, primary_element] === :Left
         secondary_element = primary_element + (convert(Int, sqrt(n_elements)) - 1)
         secondary_side    = 2
-      elseif boundary_names[primary_side, primary_element] == "Right"
+      elseif boundary_names[primary_side, primary_element] === :Right
         secondary_element = primary_element - (convert(Int, sqrt(n_elements)) - 1)
         secondary_side    = 4
       end

--- a/src/solvers/dg_unstructured_quad/dg_2d.jl
+++ b/src/solvers/dg_unstructured_quad/dg_2d.jl
@@ -235,15 +235,22 @@ function calc_boundary_flux!(cache, t, boundary_conditions,
     boundary_condition = boundary_conditions[ name[boundary] ]
 
     # calc boundary flux on the current boundary interface
-    for j in eachnode(dg)
-      calc_boundary_flux!(surface_flux_values, t, boundary_condition, mesh, equations, dg, cache,
-                          j, side, element, boundary)
-    end
+    calc_boundary_flux!(surface_flux_values, t, boundary_condition, mesh, equations, dg, cache,
+                        side, element, boundary)
   end
 
   return nothing
 end
 
+# use a function barrier for now to improve type stability
+@noinline function calc_boundary_flux!(surface_flux_values, t, boundary_condition::BC,
+                                       mesh::UnstructuredQuadMesh, equations, dg::DG, cache,
+                                       side, element, boundary) where {BC}
+  for node in eachnode(dg)
+    calc_boundary_flux!(surface_flux_values, t, boundary_condition, mesh, equations, dg, cache,
+                        node, side, element, boundary)
+  end
+end
 
 # inlined version of the boundary flux calculation along a physical interface where the
 # boundary flux values are set according to a particular `boundary_condition` function


### PR DESCRIPTION
These are some first and minor performance improvements of the BCs for unstructured meshes. They only manifest for `elixir_euler_unstructured_quad_wall_bc.jl` since that's the only elixir with multiple BCs.

I used the following code with `julia --check-bounds=no --threads=1`
```julia
julia> trixi_include("examples/2d/elixir_euler_unstructured_quad_wall_bc.jl")

julia> du_ode = similar(ode.u0); du = Trixi.wrap_array(du_ode, semi); u_ode = copy(ode.u0); u = Trixi.wrap_array(u_ode, semi); Trixi.rhs!(du_ode, u_ode, semi, 0.0)

julia> @benchmark Trixi.calc_boundary_flux!(
           $(semi.cache),
           $(ode.tspan[1]),
           $(semi.boundary_conditions),
           $(mesh),
           $(equations),
           $(solver))
```

- Baseline 43497b20a9c8b368b3decc9c8e297767b2273a88
  ```
  BenchmarkTools.Trial:
    memory estimate:  82.50 KiB
    allocs estimate:  880
    --------------
    minimum time:     17.600 μs (0.00% GC)
    median time:      19.207 μs (0.00% GC)
    mean time:        31.350 μs (18.41% GC)
    maximum time:     7.938 ms (99.44% GC)
    --------------
    samples:          10000
    evals/sample:     1
  ```
- Improve `uniform_flow_state` 17a9f92ac6cdef6b59b751a4dbd53f3057a94033
  ```
  BenchmarkTools.Trial:
    memory estimate:  82.50 KiB
    allocs estimate:  880
    --------------
    minimum time:     16.781 μs (0.00% GC)
    median time:      17.519 μs (0.00% GC)
    mean time:        28.180 μs (17.80% GC)
    maximum time:     5.796 ms (99.35% GC)
    --------------
    samples:          10000
    evals/sample:     1
  ```
- Use `Symbol`s instead of `String`s for boundary names 87868b16e3b27b990b2f4e711b0a6aba2bd29bdb
  ```
  BenchmarkTools.Trial:
    memory estimate:  82.50 KiB
    allocs estimate:  880
    --------------
    minimum time:     16.273 μs (0.00% GC)
    median time:      17.082 μs (0.00% GC)
    mean time:        28.010 μs (18.19% GC)
    maximum time:     5.882 ms (99.42% GC)
    --------------
    samples:          10000
    evals/sample:     1
  ```
- Introduce a function barrier for boundary fluxes cfec9293826346eb9f840ef692c8ba818afe0b00
  ```
  BenchmarkTools.Trial:
    memory estimate:  22.50 KiB
    allocs estimate:  240
    --------------
    minimum time:     7.593 μs (0.00% GC)
    median time:      7.825 μs (0.00% GC)
    mean time:        9.900 μs (15.44% GC)
    maximum time:     1.610 ms (99.31% GC)
    --------------
    samples:          10000
    evals/sample:     4
  ```

Further performance improvements need some more experiments and probably a decision between at least two approaches suggested in #542 (sorting and earlier function barriers or function wrappers via `ccall`).