### PR TITLE
Add UnstructuredQuadMesh to `load_mesh_serial`

### DIFF
--- a/examples/2d/elixir_euler_unstructured_quad_basic.jl
+++ b/examples/2d/elixir_euler_unstructured_quad_basic.jl
@@ -53,6 +53,9 @@ analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
 
 alive_callback = AliveCallback(analysis_interval=analysis_interval)
 
+save_restart = SaveRestartCallback(interval=50,
+                                   save_final_restart=true)
+
 save_solution = SaveSolutionCallback(interval=10,
                                      save_initial_solution=true,
                                      save_final_solution=true)
@@ -62,6 +65,7 @@ stepsize_callback = StepsizeCallback(cfl=0.9)
 callbacks = CallbackSet(summary_callback,
                         analysis_callback,
                         alive_callback,
+                        save_restart,
                         save_solution,
                         stepsize_callback)
 

--- a/examples/2d/elixir_euler_unstructured_quad_basic_restart.jl
+++ b/examples/2d/elixir_euler_unstructured_quad_basic_restart.jl
@@ -5,7 +5,7 @@ using Trixi
 ###############################################################################
 # create a restart file
 
-trixi_include(@__MODULE__, joinpath(@__DIR__, "elixir_advection_extended.jl"))
+trixi_include(@__MODULE__, joinpath(@__DIR__, "elixir_euler_unstructured_quad_basic.jl"))
 
 
 ###############################################################################
@@ -14,12 +14,14 @@ trixi_include(@__MODULE__, joinpath(@__DIR__, "elixir_advection_extended.jl"))
 # Note: If you get a restart file from somewhere else, you need to provide
 # appropriate setups in the elixir loading a restart file
 
-restart_filename = joinpath("out", "restart_000040.h5")
+restart_filename = joinpath("out", "restart_000050.h5")
 mesh = load_mesh(restart_filename)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                    source_terms=source_terms,
+                                    boundary_conditions=boundary_conditions)
 
-tspan = (load_time(restart_filename), 2.0)
+tspan = (load_time(restart_filename), 1.0)
 ode = semidiscretize(semi, tspan, restart_filename);
 
 
@@ -30,3 +32,4 @@ sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
             save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary
+

--- a/src/callbacks_step/save_restart_dg.jl
+++ b/src/callbacks_step/save_restart_dg.jl
@@ -1,6 +1,7 @@
 
 function save_restart_file(u, time, dt, timestep,
-                           mesh::Union{SerialTreeMesh,CurvedMesh}, equations, dg::DG, cache,
+                           mesh::Union{SerialTreeMesh, CurvedMesh, UnstructuredQuadMesh},
+                           equations, dg::DG, cache,
                            restart_callback)
   @unpack output_directory = restart_callback
 
@@ -39,7 +40,8 @@ function save_restart_file(u, time, dt, timestep,
 end
 
 
-function load_restart_file(mesh::Union{SerialTreeMesh,CurvedMesh}, equations, dg::DG, cache, restart_file)
+function load_restart_file(mesh::Union{SerialTreeMesh,CurvedMesh,UnstructuredQuadMesh},
+                           equations, dg::DG, cache, restart_file)
 
   # allocate memory
   u_ode = allocate_coefficients(mesh, equations, dg, cache)
@@ -69,7 +71,6 @@ function load_restart_file(mesh::Union{SerialTreeMesh,CurvedMesh}, equations, dg
       end
 
       # Read variable
-      println("Reading variables_$v ($name)...")
       u[v, .., :] = read(file["variables_$v"])
     end
   end

--- a/src/mesh/mesh_io.jl
+++ b/src/mesh/mesh_io.jl
@@ -196,6 +196,11 @@ function load_mesh_serial(mesh_file::AbstractString; n_cells_max, RealT)
     end
 
     mesh = CurvedMesh(size, mapping; RealT=RealT, unsaved_changes=false, mapping_as_string=mapping_as_string)
+  elseif mesh_type == "UnstructuredQuadMesh"
+    mesh_filename = h5open(mesh_file, "r") do file
+      return read(attributes(file)["mesh_filename"])
+    end
+    mesh = UnstructuredQuadMesh(mesh_filename; RealT=RealT, periodicity=false, unsaved_changes=false)
   else
     error("Unknown mesh type!")
   end

--- a/src/mesh/mesh_io.jl
+++ b/src/mesh/mesh_io.jl
@@ -197,6 +197,8 @@ function load_mesh_serial(mesh_file::AbstractString; n_cells_max, RealT)
 
     mesh = CurvedMesh(size, mapping; RealT=RealT, unsaved_changes=false, mapping_as_string=mapping_as_string)
   elseif mesh_type == "UnstructuredQuadMesh"
+    # FIXME: This works for visualization purposes via Trixi2Vtk however one currently cannot
+    #        restrat an unstructured and periodic simulation
     mesh_filename = h5open(mesh_file, "r") do file
       return read(attributes(file)["mesh_filename"])
     end

--- a/test/test_examples_2d_unstructured_quad.jl
+++ b/test/test_examples_2d_unstructured_quad.jl
@@ -36,6 +36,12 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "2d")
       linf = [0.004476908674416524, 0.0052614635050272085, 0.004926298866533951, 0.018058026023565432],
       tspan = (0.0, 1.0))
   end
+
+  @testset "elixir_euler_unstructured_quad_basic_restart.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_unstructured_quad_basic_restart.jl"),
+      l2   = [0.0007258658867098887, 0.000676268065087451, 0.0006316238024054346, 0.0014729738442086392],
+      linf = [0.004476908674416524, 0.0052614635050272085, 0.004926298866533951, 0.018058026023565432])
+  end
 end
 
 end # module


### PR DESCRIPTION
Necessary structure to reconstruct the unstructured quadrilateral mesh for conversion to vtk via Trixi2Vtk