### PR TITLE
Implement non-periodic boundaries with P4estMesh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.avi
 *.ogv
 *.mesh
+*.inp
 **/Manifest.toml
 out*/
 docs/build

--- a/examples/2d/elixir_euler_free_stream_p4est.jl
+++ b/examples/2d/elixir_euler_free_stream_p4est.jl
@@ -1,0 +1,77 @@
+
+using OrdinaryDiffEq
+using Trixi
+
+###############################################################################
+# semidiscretization of the compressible Euler equations
+
+equations = CompressibleEulerEquations2D(1.4)
+
+initial_condition = initial_condition_constant
+
+solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs)
+
+# Mapping as described in https://arxiv.org/abs/2012.12040, but reduced to 2D
+function mapping(xi_, eta_)
+  # Transform input variables between -1 and 1 onto [0,3]
+  xi = 1.5 * xi_ + 1.5
+  eta = 1.5 * eta_ + 1.5
+
+  y = eta + 3/8 * (cos(1.5 * pi * (2 * xi - 3)/3) *
+                   cos(0.5 * pi * (2 * eta - 3)/3))
+
+  x = xi + 3/8 * (cos(0.5 * pi * (2 * xi - 3)/3) *
+                  cos(2 * pi * (2 * y - 3)/3))
+
+  return SVector(x, y)
+end
+
+###############################################################################
+# Get the uncurved mesh from a file (downloads the file if not available locally)
+
+# Unstructured mesh with 48 cells of the square domain [-1, 1]^n
+mesh_file = joinpath(@__DIR__, "square_unstructured_1.inp")
+isfile(mesh_file) || download("https://gist.githubusercontent.com/efaulhaber/a075f8ec39a67fa9fad8f6f84342cbca/raw/a7206a02ed3a5d3cadacd8d9694ac154f9151db7/square_unstructured_1.inp",
+                              mesh_file)
+
+# Map the unstructured mesh with the mapping above
+mesh = P4estMesh(mesh_file, polydeg=3, mapping=mapping, initial_refinement_level=1)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                    boundary_conditions=Dict(
+                                      :all => BoundaryConditionDirichlet(initial_condition)
+                                    ))
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_solution = SaveSolutionCallback(interval=100,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=cons2prim)
+
+stepsize_callback = StepsizeCallback(cfl=2.0)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        save_solution,
+                        stepsize_callback)
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_nonperiodic_p4est.jl
+++ b/examples/2d/elixir_euler_nonperiodic_p4est.jl
@@ -1,0 +1,72 @@
+
+using OrdinaryDiffEq
+using Trixi
+
+###############################################################################
+# semidiscretization of the compressible Euler equations
+
+equations = CompressibleEulerEquations2D(1.4)
+
+initial_condition = initial_condition_convergence_test
+
+source_terms = source_terms_convergence_test
+
+# BCs must be passed as Dict
+boundary_condition = BoundaryConditionDirichlet(initial_condition)
+boundary_conditions = Dict(
+  :x_neg => boundary_condition,
+  :x_pos => boundary_condition,
+  :y_neg => boundary_condition,
+  :y_pos => boundary_condition
+)
+
+solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs)
+
+coordinates_min = (0.0, 0.0)
+coordinates_max = (2.0, 2.0)
+
+trees_per_dimension = (8, 8)
+
+mesh = P4estMesh(trees_per_dimension, polydeg=3,
+                 coordinates_min=coordinates_min, coordinates_max=coordinates_max,
+                 initial_refinement_level=1, periodicity=false)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                    source_terms=source_terms,
+                                    boundary_conditions=boundary_conditions)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 2.0)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_restart = SaveRestartCallback(interval=100,
+                                   save_final_restart=true)
+
+save_solution = SaveSolutionCallback(interval=100,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=cons2prim)
+
+stepsize_callback = StepsizeCallback(cfl=1.0)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        save_restart, save_solution,
+                        stepsize_callback)
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/examples/2d/elixir_euler_nonperiodic_p4est.jl
+++ b/examples/2d/elixir_euler_nonperiodic_p4est.jl
@@ -14,22 +14,20 @@ source_terms = source_terms_convergence_test
 # BCs must be passed as Dict
 boundary_condition = BoundaryConditionDirichlet(initial_condition)
 boundary_conditions = Dict(
-  :x_neg => boundary_condition,
-  :x_pos => boundary_condition,
-  :y_neg => boundary_condition,
-  :y_pos => boundary_condition
+  :all => boundary_condition
 )
 
 solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs)
 
-coordinates_min = (0.0, 0.0)
-coordinates_max = (2.0, 2.0)
+###############################################################################
+# Get the uncurved mesh from a file (downloads the file if not available locally)
 
-trees_per_dimension = (8, 8)
+# Unstructured mesh with 24 cells of the square domain [-1, 1]^n
+mesh_file = joinpath(@__DIR__, "square_unstructured_2.inp")
+isfile(mesh_file) || download("https://gist.githubusercontent.com/efaulhaber/63ff2ea224409e55ee8423b3a33e316a/raw/7db58af7446d1479753ae718930741c47a3b79b7/square_unstructured_2.inp",
+                              mesh_file)
 
-mesh = P4estMesh(trees_per_dimension, polydeg=3,
-                 coordinates_min=coordinates_min, coordinates_max=coordinates_max,
-                 initial_refinement_level=1, periodicity=false)
+mesh = P4estMesh(mesh_file, initial_refinement_level=0)
 
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
                                     source_terms=source_terms,
@@ -39,7 +37,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 ###############################################################################
 # ODE solvers, callbacks etc.
 
-tspan = (0.0, 2.0)
+tspan = (0.0, 1.0)
 ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()

--- a/src/mesh/mesh_io.jl
+++ b/src/mesh/mesh_io.jl
@@ -141,10 +141,11 @@ function save_mesh_file(mesh::P4estMesh, output_directory)
   mkpath(output_directory)
 
   filename = joinpath(output_directory, "mesh.h5")
-  p4est_filename = joinpath(output_directory, "p4est_data")
+  p4est_filename = "p4est_data"
+  p4est_file = joinpath(output_directory, p4est_filename)
 
   # Save the complete connectivity/p4est data to disk.
-  p4est_save(p4est_filename, mesh.p4est, false)
+  p4est_save(p4est_file, mesh.p4est, false)
 
   # Open file (clobber existing content)
   h5open(filename, "w") do file
@@ -234,7 +235,7 @@ function load_mesh_serial(mesh_file::AbstractString; n_cells_max, RealT)
     end
     mesh = UnstructuredQuadMesh(mesh_filename; RealT=RealT, periodicity=periodicity_, unsaved_changes=false)
   elseif mesh_type == "P4estMesh"
-    p4est_file, tree_node_coordinates,
+    p4est_filename, tree_node_coordinates,
         nodes, boundary_names_ = h5open(mesh_file, "r") do file
       return read(attributes(file)["p4est_file"]),
              read(file["tree_node_coordinates"]),
@@ -243,6 +244,10 @@ function load_mesh_serial(mesh_file::AbstractString; n_cells_max, RealT)
     end
 
     boundary_names = boundary_names_ .|> Symbol
+
+    p4est_file = joinpath(dirname(mesh_file), p4est_filename)
+    # Prevent Julia crashes when p4est can't find the file
+    @assert isfile(p4est_file)
 
     conn_vec = Vector{Ptr{p4est_connectivity_t}}(undef, 1)
     p4est = p4est_load(p4est_file, C_NULL, 0, false, C_NULL, pointer(conn_vec))

--- a/src/mesh/p4est_mesh.jl
+++ b/src/mesh/p4est_mesh.jl
@@ -328,8 +328,8 @@ end
 # Calculate physical coordinates of each node.
 # This function assumes a structured mesh with trees in row order.
 # 2D version
-function calc_tree_node_coordinates!(node_coordinates::AbstractArray{RealT, 4},
-                                     nodes, mapping, trees_per_dimension) where RealT
+function calc_tree_node_coordinates!(node_coordinates::AbstractArray{<:Any, 4},
+                                     nodes, mapping, trees_per_dimension)
   linear_indices = LinearIndices(trees_per_dimension)
 
   # Get cell length in reference mesh
@@ -382,7 +382,7 @@ function calc_tree_node_coordinates!(node_coordinates::AbstractArray{RealT, 4},
   map_node_coordinates!(node_coordinates, mapping)
 end
 
-function map_node_coordinates!(node_coordinates::AbstractArray{RealT, 4}, mapping) where RealT
+function map_node_coordinates!(node_coordinates::AbstractArray{<:Any, 4}, mapping)
   for tree in axes(node_coordinates, 4),
       j in axes(node_coordinates, 3),
       i in axes(node_coordinates, 2)
@@ -394,6 +394,6 @@ function map_node_coordinates!(node_coordinates::AbstractArray{RealT, 4}, mappin
   return node_coordinates
 end
 
-function map_node_coordinates!(node_coordinates::AbstractArray{RealT, 4}, mapping::Nothing) where RealT
+function map_node_coordinates!(node_coordinates::AbstractArray{<:Any, 4}, mapping::Nothing)
   return node_coordinates
 end

--- a/src/mesh/p4est_mesh.jl
+++ b/src/mesh/p4est_mesh.jl
@@ -119,7 +119,7 @@ function P4estMesh(trees_per_dimension; polydeg,
   atexit(destroy_p4est_structs)
 
   # Non-periodic boundaries
-  boundary_names = Array{Symbol, 2}(undef, 4, prod(trees_per_dimension))
+  boundary_names = fill(Symbol("---"), 4, prod(trees_per_dimension))
   linear_indices = LinearIndices(trees_per_dimension)
 
   # Boundaries in x-direction

--- a/src/mesh/p4est_mesh.jl
+++ b/src/mesh/p4est_mesh.jl
@@ -388,7 +388,7 @@ function map_node_coordinates!(node_coordinates::AbstractArray{<:Any, 4}, mappin
       i in axes(node_coordinates, 2)
 
     node_coordinates[:, i, j, tree] .= mapping(node_coordinates[1, i, j, tree],
-                                                 node_coordinates[2, i, j, tree])
+                                               node_coordinates[2, i, j, tree])
   end
 
   return node_coordinates

--- a/src/mesh/p4est_mesh.jl
+++ b/src/mesh/p4est_mesh.jl
@@ -102,7 +102,7 @@ function P4estMesh(trees_per_dimension; polydeg,
 
   # p4est_connectivity_new_brick has trees in Morton order, so use our own function for this
   conn = connectivity_structured(trees_per_dimension..., periodicity)
-  p4est = p4est_new_ext(0, conn, 0, initial_refinement_level, false, 0, C_NULL, C_NULL)
+  p4est = p4est_new_ext(0, conn, 0, initial_refinement_level, true, 0, C_NULL, C_NULL)
 
   ghost = p4est_ghost_new(p4est, P4EST_CONNECT_FACE)
   p4est_mesh = p4est_mesh_new(p4est, ghost, P4EST_CONNECT_FACE)

--- a/src/mesh/p4est_mesh.jl
+++ b/src/mesh/p4est_mesh.jl
@@ -98,7 +98,7 @@ function P4estMesh(trees_per_dimension; polydeg,
   tree_node_coordinates = Array{RealT, NDIMS+2}(undef, NDIMS,
                                                 ntuple(_ -> length(nodes), NDIMS)...,
                                                 prod(trees_per_dimension))
-  calc_node_coordinates!(tree_node_coordinates, nodes, mapping, trees_per_dimension)
+  calc_tree_node_coordinates!(tree_node_coordinates, nodes, mapping, trees_per_dimension)
 
   # p4est_connectivity_new_brick has trees in Morton order, so use our own function for this
   conn = connectivity_structured(trees_per_dimension..., periodicity)
@@ -168,7 +168,7 @@ function P4estMesh(meshfile::String;
   tree_node_coordinates = Array{RealT, NDIMS+2}(undef, NDIMS,
                                                 ntuple(_ -> length(nodes), NDIMS)...,
                                                 n_trees)
-  calc_node_coordinates!(tree_node_coordinates, nodes, mapping, vertices, tree_to_vertex)
+  calc_tree_node_coordinates!(tree_node_coordinates, nodes, mapping, vertices, tree_to_vertex)
 
   p4est = p4est_new_ext(0, conn, 0, initial_refinement_level, true, 0, C_NULL, C_NULL)
   ghost = p4est_ghost_new(p4est, P4EST_CONNECT_FACE)
@@ -183,7 +183,7 @@ end
 
 # Create a new p4est_connectivity that represents a structured rectangle.
 # Similar to p4est_connectivity_new_brick, but doesn't use Morton order.
-# This order makes `calc_node_coordinates!` below and the calculation
+# This order makes `calc_tree_node_coordinates!` below and the calculation
 # of `boundary_names` above easier but is irrelevant otherwise.
 # TODO P4EST non-periodic
 function connectivity_structured(cells_x, cells_y, periodicity)
@@ -297,8 +297,8 @@ end
 # Calculate physical coordinates to which every node of the reference element is mapped
 # This function assumes a structured mesh with trees in row order.
 # 2D version
-function calc_node_coordinates!(node_coordinates::AbstractArray{RealT, 4},
-                                nodes, mapping, trees_per_dimension) where RealT
+function calc_tree_node_coordinates!(node_coordinates::AbstractArray{RealT, 4},
+                                     nodes, mapping, trees_per_dimension) where RealT
   linear_indices = LinearIndices(trees_per_dimension)
 
   # Get cell length in reference mesh
@@ -324,10 +324,9 @@ end
 # Calculate physical coordinates to which every node of the reference element is mapped
 # This function assumes a structured mesh with trees in row order.
 # 2D version
-function calc_node_coordinates!(node_coordinates::AbstractArray{RealT, 4},
-                                nodes, mapping,
-                                vertices::AbstractArray,
-                                tree_to_vertex) where RealT
+function calc_tree_node_coordinates!(node_coordinates::AbstractArray{RealT, 4},
+                                     nodes, mapping,
+                                     vertices, tree_to_vertex) where RealT
   nodes_in = [-1.0, 1.0]
   matrix = polynomial_interpolation_matrix(nodes_in, nodes)
   data_in = Array{RealT, 3}(undef, 2, 2, 2)

--- a/src/mesh/p4est_mesh.jl
+++ b/src/mesh/p4est_mesh.jl
@@ -221,15 +221,15 @@ function connectivity_structured(cells_x, cells_y, periodicity)
   # Vertices represent the coordinates of the forest. This is used by p4est
   # to write VTK files.
   # Trixi doesn't use p4est's coordinates, so the vertices can be empty.
-  num_vertices = 0
-  num_trees = cells_x * cells_y
+  n_vertices = 0
+  n_trees = cells_x * cells_y
   # No corner connectivity is needed
-  num_corners = 0
+  n_corners = 0
   vertices = C_NULL
   tree_to_vertex = C_NULL
 
-  tree_to_tree = Matrix{p4est_topidx_t}(undef, 4, num_trees)
-  tree_to_face = Matrix{Int8}(undef, 4, num_trees)
+  tree_to_tree = Matrix{p4est_topidx_t}(undef, 4, n_trees)
+  tree_to_face = Matrix{Int8}(undef, 4, n_trees)
 
   for cell_y in 1:cells_y, cell_x in 1:cells_x
     tree = linear_indices[cell_x, cell_y]
@@ -285,12 +285,14 @@ function connectivity_structured(cells_x, cells_y, periodicity)
   end
 
   tree_to_corner = C_NULL
+  # p4est docs: "in trivial cases it is just a pointer to a p4est_topix value of 0."
+  # We don't need corner connectivity, so this is a trivial case.
   ctt_offset = Array{p4est_topidx_t}([0])
 
   corner_to_tree = C_NULL
   corner_to_corner = C_NULL
 
-  p4est_connectivity_new_copy(num_vertices, num_trees, num_corners,
+  p4est_connectivity_new_copy(n_vertices, n_trees, n_corners,
                               vertices, tree_to_vertex,
                               tree_to_tree, tree_to_face,
                               tree_to_corner, ctt_offset,

--- a/src/mesh/p4est_mesh.jl
+++ b/src/mesh/p4est_mesh.jl
@@ -10,6 +10,8 @@ to manage trees and mesh refinement.
 mutable struct P4estMesh{NDIMS, RealT<:Real, NDIMSP2} <: AbstractMesh{NDIMS}
   p4est                 ::Ptr{p4est_t}
   p4est_mesh            ::Ptr{p4est_mesh_t}
+  # Coordinates at the nodes specified by the tensor product of `nodes` (NDIMS times).
+  # This specifies the geometry interpolation for each tree.
   tree_node_coordinates ::Array{RealT, NDIMSP2} # [dimension, i, j, k, tree]
   nodes                 ::Vector{RealT}
   boundary_names        ::Array{Symbol, 2}      # [face direction, tree]
@@ -379,12 +381,12 @@ function calc_tree_node_coordinates!(node_coordinates::AbstractArray{RealT, 4},
 end
 
 function map_node_coordinates!(node_coordinates::AbstractArray{RealT, 4}, mapping) where RealT
-  for n_tree in axes(node_coordinates, 4),
+  for tree in axes(node_coordinates, 4),
       j in axes(node_coordinates, 3),
       i in axes(node_coordinates, 2)
 
-    node_coordinates[:, i, j, n_tree] .= mapping(node_coordinates[1, i, j, n_tree],
-                                                 node_coordinates[2, i, j, n_tree])
+    node_coordinates[:, i, j, tree] .= mapping(node_coordinates[1, i, j, tree],
+                                                 node_coordinates[2, i, j, tree])
   end
 
   return node_coordinates

--- a/src/mesh/p4est_mesh.jl
+++ b/src/mesh/p4est_mesh.jl
@@ -10,9 +10,10 @@ to manage trees and mesh refinement.
 mutable struct P4estMesh{NDIMS, RealT<:Real, NDIMSP2} <: AbstractMesh{NDIMS}
   p4est                 ::Ptr{p4est_t}
   p4est_mesh            ::Ptr{p4est_mesh_t}
-  tree_node_coordinates ::Array{RealT, NDIMSP2} # [dimension, i, j, k, tree_id]
+  tree_node_coordinates ::Array{RealT, NDIMSP2} # [dimension, i, j, k, n_tree]
   nodes                 ::Vector{RealT}
   periodicity           ::NTuple{NDIMS, Bool}
+  boundary_names        ::Array{Symbol, 2}      # [face direction, n_tree]
   current_filename      ::String
   unsaved_changes       ::Bool
 end
@@ -101,7 +102,7 @@ function P4estMesh(trees_per_dimension; polydeg,
   calc_node_coordinates!(tree_node_coordinates, mapping, trees_per_dimension, nodes)
 
   # p4est_connectivity_new_brick has trees in Morton order, so use our own function for this
-  conn = connectivity_structured_periodic(trees_per_dimension...)
+  conn = connectivity_structured(trees_per_dimension..., periodicity)
   p4est = p4est_new_ext(0, conn, 0, initial_refinement_level, false, 0, C_NULL, C_NULL)
 
   ghost = p4est_ghost_new(p4est, P4EST_CONNECT_FACE)
@@ -117,16 +118,43 @@ function P4estMesh(trees_per_dimension; polydeg,
 
   atexit(destroy_p4est_structs)
 
-  return P4estMesh{NDIMS, RealT, NDIMS+2}(p4est, p4est_mesh, tree_node_coordinates,
-                                          nodes, periodicity, "", unsaved_changes)
+  # Non-periodic boundaries
+  boundary_names = Array{Symbol, 2}(undef, 4, prod(trees_per_dimension))
+  linear_indices = LinearIndices(trees_per_dimension)
+
+  # Boundaries in x-direction
+  if !periodicity[1]
+    for cell_y in 1:trees_per_dimension[2]
+      tree = linear_indices[1, cell_y]
+      boundary_names[1, tree] = :x_neg
+
+      tree = linear_indices[end, cell_y]
+      boundary_names[2, tree] = :x_pos
+    end
+  end
+
+  # Boundaries in y-direction
+  if !periodicity[2]
+    for cell_x in 1:trees_per_dimension[1]
+      tree = linear_indices[cell_x, 1]
+      boundary_names[3, tree] = :y_neg
+
+      tree = linear_indices[cell_x, end]
+      boundary_names[4, tree] = :y_pos
+    end
+  end
+
+  return P4estMesh{NDIMS, RealT, NDIMS+2}(p4est, p4est_mesh, tree_node_coordinates, nodes,
+                                          periodicity, boundary_names, "", unsaved_changes)
 end
 
 
-# Create a new p4est_connectivity that represents a structured rectangle with periodic boundaries.
-# Similar to p4est_connectivity_new_brick, but doesn't use Morton ordering.
-# This ordering makes `calc_node_coordinates!` below easier but is irrelevant otherwise.
+# Create a new p4est_connectivity that represents a structured rectangle.
+# Similar to p4est_connectivity_new_brick, but doesn't use Morton order.
+# This order makes `calc_node_coordinates!` below and the calculation
+# of `boundary_names` above easier but is irrelevant otherwise.
 # TODO P4EST non-periodic
-function connectivity_structured_periodic(cells_x, cells_y)
+function connectivity_structured(cells_x, cells_y, periodicity)
   linear_indices = LinearIndices((cells_x, cells_y))
 
   # Vertices represent the coordinates of the forest. This is used by p4est
@@ -139,22 +167,61 @@ function connectivity_structured_periodic(cells_x, cells_y)
   vertices = C_NULL
   tree_to_vertex = C_NULL
 
-  # Periodic boundaries
   tree_to_tree = Matrix{p4est_topidx_t}(undef, 4, num_trees)
+  tree_to_face = Matrix{Int8}(undef, 4, num_trees)
+
   for cell_y in 1:cells_y, cell_x in 1:cells_x
     tree = linear_indices[cell_x, cell_y]
-    # Subtract 1 because p4est uses zero-based indexing
-    tree_to_tree[1, tree] = linear_indices[mod(cell_x - 2, cells_x) + 1, cell_y] - 1
-    tree_to_tree[2, tree] = linear_indices[mod(cell_x, cells_x) + 1, cell_y] - 1
-    tree_to_tree[3, tree] = linear_indices[cell_x, mod(cell_y - 2, cells_y) + 1] - 1
-    tree_to_tree[4, tree] = linear_indices[cell_x, mod(cell_y, cells_y) + 1] - 1
-  end
 
-  tree_to_face = Matrix{Int8}(undef, 4, num_trees)
-  tree_to_face[1, :] .= 1
-  tree_to_face[2, :] .= 0
-  tree_to_face[3, :] .= 3
-  tree_to_face[4, :] .= 2
+    # Subtract 1 because p4est uses zero-based indexing
+    # Negative x-direction
+    if cell_x > 1
+      tree_to_tree[1, tree] = linear_indices[cell_x - 1, cell_y] - 1
+      tree_to_face[1, tree] = 1
+    elseif periodicity[1]
+      tree_to_tree[1, tree] = linear_indices[cells_x, cell_y] - 1
+      tree_to_face[1, tree] = 1
+    else # Non-periodic boundary, tree and face point to themselves (zero-based indexing)
+      tree_to_tree[1, tree] = tree - 1
+      tree_to_face[1, tree] = 0
+    end
+
+    # Positive x-direction
+    if cell_x < cells_x
+      tree_to_tree[2, tree] = linear_indices[cell_x + 1, cell_y] - 1
+      tree_to_face[2, tree] = 0
+    elseif periodicity[1]
+      tree_to_tree[2, tree] = linear_indices[1, cell_y] - 1
+      tree_to_face[2, tree] = 0
+    else # Non-periodic boundary, tree and face point to themselves (zero-based indexing)
+      tree_to_tree[2, tree] = tree - 1
+      tree_to_face[2, tree] = 1
+    end
+
+    # Negative x-direction
+    if cell_y > 1
+      tree_to_tree[3, tree] = linear_indices[cell_x, cell_y - 1] - 1
+      tree_to_face[3, tree] = 3
+    elseif periodicity[2]
+      tree_to_tree[3, tree] = linear_indices[cell_x, cells_y] - 1
+      tree_to_face[3, tree] = 3
+    else # Non-periodic boundary, tree and face point to themselves (zero-based indexing)
+      tree_to_tree[3, tree] = tree - 1
+      tree_to_face[3, tree] = 2
+    end
+
+    # Positive x-direction
+    if cell_y < cells_y
+      tree_to_tree[4, tree] = linear_indices[cell_x, cell_y + 1] - 1
+      tree_to_face[4, tree] = 2
+    elseif periodicity[2]
+      tree_to_tree[4, tree] = linear_indices[cell_x, 1] - 1
+      tree_to_face[4, tree] = 2
+    else # Non-periodic boundary, tree and face point to themselves (zero-based indexing)
+      tree_to_tree[4, tree] = tree - 1
+      tree_to_face[4, tree] = 3
+    end
+  end
 
   tree_to_corner = C_NULL
   ctt_offset = Array{p4est_topidx_t}([0])

--- a/src/solvers/dg_p4est/containers.jl
+++ b/src/solvers/dg_p4est/containers.jl
@@ -41,9 +41,9 @@ Base.eltype(::ElementContainerP4est{NDIMS, RealT, uEltype}) where {NDIMS, RealT,
 
 
 struct InterfaceContainerP4est{NDIMS, uEltype<:Real, NDIMSP2} <: AbstractContainer
-  u::Array{uEltype, NDIMSP2}                  # [primary/secondary, variables, i, j, n_interface]
-  element_ids::Matrix{Int}                    # [primary/secondary, n_interface]
-  node_indices::Matrix{NTuple{NDIMS, Symbol}} # [primary/secondary, n_interface]
+  u::Array{uEltype, NDIMSP2}                  # [primary/secondary, variable, i, j, interface]
+  element_ids::Matrix{Int}                    # [primary/secondary, interface]
+  node_indices::Matrix{NTuple{NDIMS, Symbol}} # [primary/secondary, interface]
 end
 
 # Create interface container and initialize interface data in `elements`.
@@ -70,10 +70,10 @@ end
 
 
 struct BoundaryContainerP4est{NDIMS, uEltype<:Real, NDIMSP1} <: AbstractContainer
-  u::Array{uEltype, NDIMSP1}                  # [variables, i, j, n_boundary]
-  element_ids::Vector{Int}                    # [n_boundary]
-  node_indices::Vector{NTuple{NDIMS, Symbol}} # [n_boundary]
-  name::Vector{Symbol}                        # [n_boundary]
+  u::Array{uEltype, NDIMSP1}                  # [variables, i, j, boundary]
+  element_ids::Vector{Int}                    # [boundary]
+  node_indices::Vector{NTuple{NDIMS, Symbol}} # [boundary]
+  name::Vector{Symbol}                        # [boundary]
 end
 
 # Create interface container and initialize interface data in `elements`.
@@ -132,8 +132,7 @@ function count_required_interfaces(mesh::P4estMesh)
   GC.@preserve user_data begin
     p4est_iterate(mesh.p4est,
                   C_NULL, # ghost layer
-                  # user data [interface_count]
-                  pointer(user_data),
+                  pointer(user_data), # user data [interface_count]
                   C_NULL, # iter_volume
                   iter_face_c, # iter_face
                   C_NULL) # iter_corner
@@ -150,8 +149,7 @@ function count_required_boundaries(mesh::P4estMesh)
   GC.@preserve user_data begin
     p4est_iterate(mesh.p4est,
                   C_NULL, # ghost layer
-                  # user data [boundary_count]
-                  pointer(user_data),
+                  pointer(user_data), # user data [boundary_count]
                   C_NULL, # iter_volume
                   iter_face_c, # iter_face
                   C_NULL) # iter_corner

--- a/src/solvers/dg_p4est/containers_2d.jl
+++ b/src/solvers/dg_p4est/containers_2d.jl
@@ -21,6 +21,10 @@ end
 function calc_node_coordinates!(node_coordinates,
                                 mesh::P4estMesh{2},
                                 nodes)
+  # Hanging nodes will cause holes in the mesh if its polydeg is higher
+  # than the polydeg of the solver.
+  @assert length(nodes) >= length(mesh.nodes) "The solver can't have a lower polydeg than the mesh"
+
   tmp1 = zeros(real(mesh), 2, length(nodes), length(mesh.nodes))
 
   # Macros from p4est

--- a/src/solvers/dg_p4est/containers_2d.jl
+++ b/src/solvers/dg_p4est/containers_2d.jl
@@ -86,12 +86,9 @@ function init_interfaces_iter_face(info, user_data)
   # Face at which the interface lies
   faces = [sides[1].face, sides[2].face]
 
-  quad_to_face = unsafe_wrap(Array, mesh.p4est_mesh.quad_to_face, 4 * ncells(mesh))
   # Relative orientation of the two cell faces,
   # 0 for aligned coordinates, 1 for reversed coordinates.
-  # `quad_to_face` has one entry for each quadrant's face, +1 for one-based indexing.
-  # The value in quad_to_face is `orientation * 4 + face`.
-  orientation = (quad_to_face[quad_ids[1] * 4 + faces[1] + 1] - faces[2]) / 4
+  orientation = info.orientation
 
   # Write data to interfaces container
   interfaces.element_ids[1, interface_id] = quad_ids[1] + 1

--- a/src/solvers/dg_p4est/dg.jl
+++ b/src/solvers/dg_p4est/dg.jl
@@ -4,8 +4,9 @@
 function create_cache(mesh::P4estMesh, equations::AbstractEquations, dg::DG, ::Any, ::Type{uEltype}) where {uEltype<:Real}
   elements = init_elements(mesh, equations, dg.basis, uEltype)
   interfaces = init_interfaces(mesh, equations, dg.basis, elements)
+  boundaries = init_boundaries(mesh, equations, dg.basis, elements)
 
-  cache = (; elements, interfaces)
+  cache = (; elements, interfaces, boundaries)
 
   return cache
 end

--- a/src/solvers/dg_p4est/dg_2d.jl
+++ b/src/solvers/dg_p4est/dg_2d.jl
@@ -3,33 +3,33 @@ function rhs!(du, u, t,
               initial_condition, boundary_conditions, source_terms,
               dg::DG, cache)
   # Reset du
-  @timeit_debug timer() "reset ∂u/∂t" du .= zero(eltype(du))
+  @timed timer() "reset ∂u/∂t" du .= zero(eltype(du))
 
   # Calculate volume integral
-  @timeit_debug timer() "volume integral" calc_volume_integral!(
+  @timed timer() "volume integral" calc_volume_integral!(
     du, u, mesh,
     have_nonconservative_terms(equations), equations,
     dg.volume_integral, dg, cache)
 
   # Prolong solution to interfaces
-  @timeit_debug timer() "prolong2interfaces" prolong2interfaces!(
+  @timed timer() "prolong2interfaces" prolong2interfaces!(
     cache, u, mesh, equations, dg)
 
   # Calculate interface fluxes
-  @timeit_debug timer() "interface flux" calc_interface_flux!(
+  @timed timer() "interface flux" calc_interface_flux!(
     cache.elements.surface_flux_values, mesh,
     equations, dg, cache)
 
   # Calculate surface integrals
-  @timeit_debug timer() "surface integral" calc_surface_integral!(
+  @timed timer() "surface integral" calc_surface_integral!(
     du, mesh, equations, dg, cache)
 
   # Apply Jacobian from mapping to reference element
-  @timeit_debug timer() "Jacobian" apply_jacobian!(
+  @timed timer() "Jacobian" apply_jacobian!(
     du, mesh, equations, dg, cache)
 
   # Calculate source terms
-  @timeit_debug timer() "source terms" calc_sources!(
+  @timed timer() "source terms" calc_sources!(
     du, u, t, source_terms, equations, dg, cache)
 
   return nothing

--- a/src/solvers/dg_unstructured_quad/dg_2d.jl
+++ b/src/solvers/dg_unstructured_quad/dg_2d.jl
@@ -216,13 +216,15 @@ end
 
 # TODO: Taal dimension agnostic
 function calc_boundary_flux!(cache, t, boundary_condition::BoundaryConditionPeriodic,
-                             mesh::UnstructuredQuadMesh, equations, dg::DG)
+                             mesh::Union{UnstructuredQuadMesh, P4estMesh}, equations, dg::DG)
   @assert isempty(eachboundary(dg, cache))
 end
 
 
+# Function barrier for type stability
 function calc_boundary_flux!(cache, t, boundary_conditions,
-                             mesh::UnstructuredQuadMesh, equations, dg::DG)
+                             mesh::Union{UnstructuredQuadMesh, P4estMesh},
+                             equations, dg::DG)
   @unpack boundary_condition_types, boundary_indices = boundary_conditions
 
   calc_boundary_flux_by_type!(cache, t, boundary_condition_types, boundary_indices,
@@ -235,7 +237,8 @@ end
 # in a type-stable way using "lispy tuple programming".
 function calc_boundary_flux_by_type!(cache, t, BCs::NTuple{N,Any},
                                      BC_indices::NTuple{N,Vector{Int}},
-                                     mesh::UnstructuredQuadMesh, equations, dg::DG) where {N}
+                                     mesh::Union{UnstructuredQuadMesh, P4estMesh},
+                                     equations, dg::DG) where {N}
   # Extract the boundary condition type and index vector
   boundary_condition = first(BCs)
   boundary_condition_indices = first(BC_indices)
@@ -255,8 +258,9 @@ end
 
 # terminate the type-stable iteration over tuples
 function calc_boundary_flux_by_type!(cache, t, BCs::Tuple{}, BC_indices::Tuple{},
-                                     mesh::UnstructuredQuadMesh, equations, dg::DG)
-  nothing
+                                     mesh::Union{UnstructuredQuadMesh, P4estMesh},
+                                     equations, dg::DG)
+  return nothing
 end
 
 

--- a/src/solvers/dg_unstructured_quad/sort_boundary_conditions.jl
+++ b/src/solvers/dg_unstructured_quad/sort_boundary_conditions.jl
@@ -20,6 +20,21 @@ end
 # from the `UnstructuredBoundaryContainer2D` in cache.boundaries according to the boundary types
 # and stores the associated global boundary indexing in NTuple
 function UnstructuredQuadSortedBoundaryTypes(boundary_conditions::Dict, cache)
+  unique_names = unique(cache.boundaries.name)
+
+  # Verify that each Dict key is a valid boundary name
+  for key in keys(boundary_conditions)
+    if !(key in unique_names)
+      error("Key $(repr(key)) is not a valid boundary name")
+    end
+  end
+
+  # Verify that each boundary has a boundary condition
+  for name in unique_names
+    if name !== Symbol("---") && !haskey(boundary_conditions, name)
+      error("No boundary condition specified for boundary $(repr(name))")
+    end
+  end
 
   # extract the unique boundary function routines from the dictionary
   boundary_condition_types = Tuple(unique(collect(values(boundary_conditions))))
@@ -44,7 +59,7 @@ function UnstructuredQuadSortedBoundaryTypes(boundary_conditions::Dict, cache)
   boundary_dictionary = boundary_conditions
 
   return UnstructuredQuadSortedBoundaryTypes{n_boundary_types, typeof(boundary_condition_types)}(
-                                                                         boundary_condition_types,
-                                                                         boundary_indices,
-                                                                         boundary_dictionary)
+                                                                      boundary_condition_types,
+                                                                      boundary_indices,
+                                                                      boundary_dictionary)
 end

--- a/test/test_examples_2d_p4est.jl
+++ b/test/test_examples_2d_p4est.jl
@@ -26,6 +26,12 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "2d")
       l2   = [2.3653424742684444e-6, 2.1388875095440695e-6, 2.1388875095548492e-6, 6.010896863397195e-6],
       linf = [1.4080465931654018e-5, 1.7579850587257084e-5, 1.7579850592586155e-5, 5.956893531156027e-5])
   end
+
+  @testset "elixir_euler_free_stream_curved.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_free_stream_curved.jl"),
+      l2   = [2.063350241405049e-15, 1.8571016296925367e-14, 3.1769447886391905e-14, 1.4104095258528071e-14],
+      linf = [1.9539925233402755e-14, 2.9791447087035294e-13, 6.502853810985698e-13, 2.7000623958883807e-13])
+  end
 end
 
 end # module

--- a/test/test_examples_2d_p4est.jl
+++ b/test/test_examples_2d_p4est.jl
@@ -20,6 +20,12 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "2d")
       l2   = [6.398955192910044e-6],
       linf = [3.474337336717426e-5])
   end
+
+  @testset "elixir_euler_nonperiodic_p4est.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_nonperiodic_p4est.jl"),
+      l2   = [2.3653424742684444e-6, 2.1388875095440695e-6, 2.1388875095548492e-6, 6.010896863397195e-6],
+      linf = [1.4080465931654018e-5, 1.7579850587257084e-5, 1.7579850592586155e-5, 5.956893531156027e-5])
+  end
 end
 
 end # module

--- a/test/test_examples_2d_p4est.jl
+++ b/test/test_examples_2d_p4est.jl
@@ -23,14 +23,14 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "2d")
 
   @testset "elixir_euler_nonperiodic_p4est.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_nonperiodic_p4est.jl"),
-      l2   = [2.3653424742684444e-6, 2.1388875095440695e-6, 2.1388875095548492e-6, 6.010896863397195e-6],
-      linf = [1.4080465931654018e-5, 1.7579850587257084e-5, 1.7579850592586155e-5, 5.956893531156027e-5])
+      l2   = [0.005689496253354319, 0.004522481295923261, 0.004522481295922983, 0.009971628336802528],
+      linf = [0.05125433503504517, 0.05343803272241532, 0.053438032722404216, 0.09032097668196482])
   end
 
-  @testset "elixir_euler_free_stream_curved.jl" begin
-    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_free_stream_curved.jl"),
+  @testset "elixir_euler_free_stream_p4est.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_free_stream_p4est.jl"),
       l2   = [2.063350241405049e-15, 1.8571016296925367e-14, 3.1769447886391905e-14, 1.4104095258528071e-14],
-      linf = [1.9539925233402755e-14, 2.9791447087035294e-13, 6.502853810985698e-13, 2.7000623958883807e-13])
+      linf = [1.9539925233402755e-14, 2.9791447087035294e-13, 4.636291350834654e-13, 4.956035581926699e-13])
   end
 end
 

--- a/test/test_special_elixirs.jl
+++ b/test/test_special_elixirs.jl
@@ -22,6 +22,9 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples")
     mean_eoc = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "2d", "elixir_advection_extended_curved.jl"), 3)
     @test isapprox(mean_eoc[:l2], [4.0], rtol=0.01)
 
+    mean_eoc = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "2d", "elixir_euler_nonperiodic_p4est.jl"), 3)
+    @test isapprox(mean_eoc[:l2], [3.54, 3.50, 3.50, 3.52], rtol=0.01)
+
     mean_eoc = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "3d", "elixir_advection_basic_curved.jl"), 2)
     @test isapprox(mean_eoc[:l2], [4.0], rtol=0.01)
 


### PR DESCRIPTION
Fourth point of #584. I added non-periodic boundary conditions. I can read uncurved, unstructured, conforming Abaqus mesh files now, and I can map the mesh to some curved domain, so I can create unstructured, curved meshes.

Thanks, @andrewwinters5000, for implementing the unstructured boundary stuff. I could reuse most of it, and I added a check to make sure that the BC `Dict` doesn't contain too few or too many keys.

![grafik](https://user-images.githubusercontent.com/44124897/119347955-822f7380-bc9c-11eb-9429-251991d69a67.png)