### PR TITLE
Implement AMR with p4est

### DIFF
--- a/examples/2d/elixir_advection_amr_p4est_unstructured_flag.jl
+++ b/examples/2d/elixir_advection_amr_p4est_unstructured_flag.jl
@@ -1,4 +1,5 @@
 
+using Downloads: download
 using OrdinaryDiffEq
 using Trixi
 

--- a/examples/2d/elixir_advection_amr_p4est_unstructured_flag.jl
+++ b/examples/2d/elixir_advection_amr_p4est_unstructured_flag.jl
@@ -1,0 +1,92 @@
+
+using OrdinaryDiffEq
+using Trixi
+
+###############################################################################
+# semidiscretization of the linear advection equation
+
+advectionvelocity = (1.0, 1.0)
+# advectionvelocity = (0.2, -0.3)
+equations = LinearScalarAdvectionEquation2D(advectionvelocity)
+
+initial_condition = initial_condition_gauss
+
+boundary_condition = BoundaryConditionDirichlet(initial_condition)
+boundary_conditions = Dict(
+  :all => boundary_condition
+)
+
+solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs)
+
+# Deformed rectangle that looks like a waving flag,
+# lower and upper faces are sinus curves, left and right are vertical lines.
+f1(s) = SVector(-5.0, 5 * s - 5.0)
+f2(s) = SVector( 5.0, 5 * s + 5.0)
+f3(s) = SVector(5 * s, -5.0 + 5 * sin(0.5 * pi * s))
+f4(s) = SVector(5 * s,  5.0 + 5 * sin(0.5 * pi * s))
+faces = (f1, f2, f3, f4)
+
+Trixi.validate_faces(faces)
+mapping_flag = Trixi.transfinite_mapping(faces)
+
+# Unstructured mesh with 24 cells of the square domain [-1, 1]^n
+mesh_file = joinpath(@__DIR__, "square_unstructured_2.inp")
+isfile(mesh_file) || download("https://gist.githubusercontent.com/efaulhaber/63ff2ea224409e55ee8423b3a33e316a/raw/7db58af7446d1479753ae718930741c47a3b79b7/square_unstructured_2.inp",
+                              mesh_file)
+
+mesh = P4estMesh(mesh_file, polydeg=3,
+                 mapping=mapping_flag,
+                 initial_refinement_level=1)
+
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                    boundary_conditions=boundary_conditions)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 10.0)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval,
+                                     extra_analysis_integrals=(entropy,))
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_restart = SaveRestartCallback(interval=100,
+                                   save_final_restart=true)
+
+save_solution = SaveSolutionCallback(interval=1,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=cons2prim)
+
+amr_controller = ControllerThreeLevel(semi, IndicatorMax(semi, variable=first),
+                                      base_level=1,
+                                      med_level=2, med_threshold=0.1,
+                                      max_level=3, max_threshold=0.6)
+amr_callback = AMRCallback(semi, amr_controller,
+                           interval=5,
+                           adapt_initial_condition=true,
+                           adapt_initial_condition_only_refine=true)
+
+stepsize_callback = StepsizeCallback(cfl=1.6)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        save_restart, save_solution,
+                        amr_callback, stepsize_callback);
+
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+
+summary_callback() # print the timer summary

--- a/examples/2d/elixir_advection_amr_p4est_unstructured_flag.jl
+++ b/examples/2d/elixir_advection_amr_p4est_unstructured_flag.jl
@@ -27,6 +27,9 @@ f3(s) = SVector(5 * s, -5.0 + 5 * sin(0.5 * pi * s))
 f4(s) = SVector(5 * s,  5.0 + 5 * sin(0.5 * pi * s))
 faces = (f1, f2, f3, f4)
 
+# This creates a mapping that transforms [-1, 1]^2 to the domain with the faces defined above.
+# It generally doesn't work for meshes loaded from mesh files because these can be meshes
+# of arbitrary domains, but the mesh below is specifically built on the domain [-1, 1]^2.
 Trixi.validate_faces(faces)
 mapping_flag = Trixi.transfinite_mapping(faces)
 
@@ -61,7 +64,7 @@ alive_callback = AliveCallback(analysis_interval=analysis_interval)
 save_restart = SaveRestartCallback(interval=100,
                                    save_final_restart=true)
 
-save_solution = SaveSolutionCallback(interval=1,
+save_solution = SaveSolutionCallback(interval=100,
                                      save_initial_solution=true,
                                      save_final_solution=true,
                                      solution_variables=cons2prim)

--- a/examples/2d/elixir_advection_amr_p4est_unstructured_flag.jl
+++ b/examples/2d/elixir_advection_amr_p4est_unstructured_flag.jl
@@ -6,8 +6,8 @@ using Trixi
 ###############################################################################
 # semidiscretization of the linear advection equation
 
-advectionvelocity = (1.0, 1.0)
-# advectionvelocity = (0.2, -0.3)
+# advectionvelocity = (1.0, 1.0)
+advectionvelocity = (0.2, -0.3)
 equations = LinearScalarAdvectionEquation2D(advectionvelocity)
 
 initial_condition = initial_condition_gauss
@@ -75,7 +75,7 @@ amr_callback = AMRCallback(semi, amr_controller,
                            adapt_initial_condition=true,
                            adapt_initial_condition_only_refine=true)
 
-stepsize_callback = StepsizeCallback(cfl=1.6)
+stepsize_callback = StepsizeCallback(cfl=0.7)
 
 callbacks = CallbackSet(summary_callback,
                         analysis_callback, alive_callback,

--- a/examples/2d/elixir_advection_amr_p4est_unstructured_flag.jl
+++ b/examples/2d/elixir_advection_amr_p4est_unstructured_flag.jl
@@ -6,7 +6,6 @@ using Trixi
 ###############################################################################
 # semidiscretization of the linear advection equation
 
-# advectionvelocity = (1.0, 1.0)
 advectionvelocity = (0.2, -0.3)
 equations = LinearScalarAdvectionEquation2D(advectionvelocity)
 

--- a/examples/2d/elixir_advection_amr_solution_independent.jl
+++ b/examples/2d/elixir_advection_amr_solution_independent.jl
@@ -17,8 +17,8 @@ function IndicatorSolutionIndependent(semi)
   return IndicatorSolutionIndependent{typeof(cache)}(cache)
 end
 function (indicator::IndicatorSolutionIndependent)(u::AbstractArray{<:Any,4},
-                                             equations, dg, cache;
-                                             t, kwargs...)
+                                                   equations, dg, cache;
+                                                   t, kwargs...)
 
   mesh = indicator.cache.mesh
   alpha = indicator.cache.alpha

--- a/examples/2d/elixir_advection_amr_solution_independent.jl
+++ b/examples/2d/elixir_advection_amr_solution_independent.jl
@@ -86,8 +86,8 @@ initial_condition = initial_condition_gauss
 
 solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs)
 
-coordinates_min = (-5, -5)
-coordinates_max = ( 5,  5)
+coordinates_min = (-5.0, -5.0)
+coordinates_max = ( 5.0,  5.0)
 mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level=4,
                 n_cells_max=30_000)

--- a/examples/2d/elixir_advection_amr_solution_independent_p4est.jl
+++ b/examples/2d/elixir_advection_amr_solution_independent_p4est.jl
@@ -91,10 +91,12 @@ initial_condition = initial_condition_gauss
 
 solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs)
 
-coordinates_min = (-5, -5)
-coordinates_max = ( 5,  5)
+coordinates_min = (-5.0, -5.0)
+coordinates_max = ( 5.0,  5.0)
 
-mesh = P4estMesh((1, 1), polydeg=3,
+trees_per_dimension = (1, 1)
+
+mesh = P4estMesh(trees_per_dimension, polydeg=3,
                  coordinates_min=coordinates_min, coordinates_max=coordinates_max,
                  initial_refinement_level=4)
 

--- a/examples/2d/elixir_advection_amr_solution_independent_p4est.jl
+++ b/examples/2d/elixir_advection_amr_solution_independent_p4est.jl
@@ -1,0 +1,149 @@
+
+using OrdinaryDiffEq
+using Trixi
+
+# define new structs inside a module to allow re-evaluating the file
+module TrixiExtension
+
+using Trixi
+
+struct IndicatorSolutionIndependent{Cache<:NamedTuple} <: Trixi.AbstractIndicator
+  cache::Cache
+end
+function IndicatorSolutionIndependent(semi)
+  basis = semi.solver.basis
+  alpha = Vector{real(basis)}()
+  cache = (; semi.mesh, alpha)
+  return IndicatorSolutionIndependent{typeof(cache)}(cache)
+end
+function (indicator::IndicatorSolutionIndependent)(u::AbstractArray{<:Any,4},
+                                             equations, dg, cache;
+                                             t, kwargs...)
+
+  mesh = indicator.cache.mesh
+  alpha = indicator.cache.alpha
+  resize!(alpha, nelements(dg, cache))
+
+  #Predict the theoretical center.
+  advectionvelocity = (1.0, 1.0)
+  center = t.*advectionvelocity
+
+  inner_distance = 1
+  outer_distance = 1.85
+
+  #Iterate over all elements
+  for element in 1:length(alpha)
+    # Calculate periodic distance between cell and center.
+    # This requires an uncurved mesh!
+    coordinates = [0.5 * (cache.elements.node_coordinates[1, 1, 1, element] +
+                          cache.elements.node_coordinates[1, end, 1, element]),
+                   0.5 * (cache.elements.node_coordinates[2, 1, 1, element] +
+                          cache.elements.node_coordinates[2, 1, end, element])]
+
+    #The geometric shape of the amr should be preserved when the base_level is increased.
+    #This is done by looking at the original coordinates of each cell.
+    cell_coordinates = original_coordinates(coordinates, 5/8)
+    cell_distance = periodic_distance_2d(cell_coordinates, center, 10)
+    if cell_distance < (inner_distance+outer_distance)/2
+      cell_coordinates = original_coordinates(coordinates, 5/16)
+      cell_distance = periodic_distance_2d(cell_coordinates, center, 10)
+    end
+
+    #Set alpha according to cells position inside the circles.
+    target_level = (cell_distance < inner_distance) + (cell_distance < outer_distance)
+    alpha[element] = target_level/2
+  end
+  return alpha
+end
+
+# For periodic domains, distance between two points must take into account
+# periodic extensions of the domain
+function periodic_distance_2d(coordinates, center, domain_length)
+  dx = coordinates .- center
+  dx_shifted = abs.(dx .% domain_length)
+  dx_periodic = min.(dx_shifted, domain_length .- dx_shifted)
+  return sqrt(sum(dx_periodic.^2))
+end
+
+#This takes a cells coordinates and transforms them into the coordinates of a parent-cell it originally refined from.
+#It does it so that the parent-cell has given cell_length.
+function original_coordinates(coordinates, cell_length)
+  offset = coordinates .% cell_length
+  offset_sign = sign.(offset)
+  border = coordinates - offset
+  center = border + (offset_sign .* cell_length/2)
+  return center
+end
+
+end # module TrixiExtension
+
+import .TrixiExtension
+###############################################################################
+# semidiscretization of the linear advection equation
+
+advectionvelocity = (1.0, 1.0)
+# advectionvelocity = (0.2, -0.3)
+equations = LinearScalarAdvectionEquation2D(advectionvelocity)
+
+initial_condition = initial_condition_gauss
+
+solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs)
+
+coordinates_min = (-5, -5)
+coordinates_max = ( 5,  5)
+
+mesh = P4estMesh((1, 1), polydeg=3,
+                 coordinates_min=coordinates_min, coordinates_max=coordinates_max,
+                 initial_refinement_level=4)
+
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 10.0)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval,
+                                     extra_analysis_integrals=(entropy,))
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_restart = SaveRestartCallback(interval=100,
+                                   save_final_restart=true)
+
+save_solution = SaveSolutionCallback(interval=100,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=cons2prim)
+
+amr_controller = ControllerThreeLevel(semi, TrixiExtension.IndicatorSolutionIndependent(semi),
+                                      base_level=4,
+                                      med_level=5, med_threshold=0.1,
+                                      max_level=6, max_threshold=0.6)
+
+amr_callback = AMRCallback(semi, amr_controller,
+                           interval=5,
+                           adapt_initial_condition=true,
+                           adapt_initial_condition_only_refine=true)
+
+stepsize_callback = StepsizeCallback(cfl=1.6)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        save_restart, save_solution,
+                        amr_callback, stepsize_callback);
+
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/examples/2d/elixir_advection_amr_solution_independent_p4est.jl
+++ b/examples/2d/elixir_advection_amr_solution_independent_p4est.jl
@@ -35,10 +35,10 @@ function (indicator::IndicatorSolutionIndependent)(u::AbstractArray{<:Any,4},
   for element in 1:length(alpha)
     # Calculate periodic distance between cell and center.
     # This requires an uncurved mesh!
-    coordinates = [0.5 * (cache.elements.node_coordinates[1, 1, 1, element] +
-                          cache.elements.node_coordinates[1, end, 1, element]),
-                   0.5 * (cache.elements.node_coordinates[2, 1, 1, element] +
-                          cache.elements.node_coordinates[2, 1, end, element])]
+    coordinates = SVector(0.5 * (cache.elements.node_coordinates[1, 1, 1, element] +
+                                 cache.elements.node_coordinates[1, end, 1, element]),
+                          0.5 * (cache.elements.node_coordinates[2, 1, 1, element] +
+                                 cache.elements.node_coordinates[2, 1, end, element]))
 
     #The geometric shape of the amr should be preserved when the base_level is increased.
     #This is done by looking at the original coordinates of each cell.

--- a/examples/2d/elixir_advection_amr_solution_independent_p4est.jl
+++ b/examples/2d/elixir_advection_amr_solution_independent_p4est.jl
@@ -10,15 +10,17 @@ using Trixi
 struct IndicatorSolutionIndependent{Cache<:NamedTuple} <: Trixi.AbstractIndicator
   cache::Cache
 end
+
 function IndicatorSolutionIndependent(semi)
   basis = semi.solver.basis
   alpha = Vector{real(basis)}()
   cache = (; semi.mesh, alpha)
   return IndicatorSolutionIndependent{typeof(cache)}(cache)
 end
+
 function (indicator::IndicatorSolutionIndependent)(u::AbstractArray{<:Any,4},
-                                             equations, dg, cache;
-                                             t, kwargs...)
+                                                   equations, dg, cache;
+                                                   t, kwargs...)
 
   mesh = indicator.cache.mesh
   alpha = indicator.cache.alpha

--- a/examples/2d/elixir_advection_p4est_non_conforming_flag.jl
+++ b/examples/2d/elixir_advection_p4est_non_conforming_flag.jl
@@ -26,7 +26,7 @@ mesh = P4estMesh(trees_per_dimension, polydeg=3,
                  faces=(f1, f2, f3, f4),
                  initial_refinement_level=1)
 
-# Refine bottom left quadrant of each forest to level 4
+# Refine bottom left quadrant of each tree to level 4
 function refine_fn(p4est, which_tree, quadrant)
   if quadrant.x == 0 && quadrant.y == 0 && quadrant.level < 4
     # return true (refine)
@@ -37,7 +37,7 @@ function refine_fn(p4est, which_tree, quadrant)
   end
 end
 
-# Refine recursively until each bottom left quadrant of a forest has level 4
+# Refine recursively until each bottom left quadrant of a tree has level 4
 # The mesh will be rebalanced before the simulation starts
 refine_fn_c = @cfunction(refine_fn, Cint, (Ptr{Trixi.p4est_t}, Ptr{Trixi.p4est_topidx_t}, Ptr{Trixi.p4est_quadrant_t}))
 Trixi.p4est_refine(mesh.p4est, true, refine_fn_c, C_NULL)

--- a/examples/2d/elixir_advection_p4est_non_conforming_flag.jl
+++ b/examples/2d/elixir_advection_p4est_non_conforming_flag.jl
@@ -19,9 +19,9 @@ f2(s) = SVector( 1.0, s + 1.0)
 f3(s) = SVector(s, -1.0 + sin(0.5 * pi * s))
 f4(s) = SVector(s,  1.0 + sin(0.5 * pi * s))
 
+# Create P4estMesh with 3 x 2 trees and 6 x 4 elements
 trees_per_dimension = (3, 2)
 
-# Create P4estMesh with 3 x 2 trees and 6 x 4 elements
 mesh = P4estMesh(trees_per_dimension, polydeg=3,
                  faces=(f1, f2, f3, f4),
                  initial_refinement_level=1)

--- a/examples/2d/elixir_advection_p4est_non_conforming_flag.jl
+++ b/examples/2d/elixir_advection_p4est_non_conforming_flag.jl
@@ -21,7 +21,7 @@ f4(s) = SVector(s,  1.0 + sin(0.5 * pi * s))
 
 trees_per_dimension = (3, 2)
 
-# Create P4estMesh with 8 x 8 trees and 16 x 16 elements
+# Create P4estMesh with 3 x 2 trees and 6 x 4 elements
 mesh = P4estMesh(trees_per_dimension, polydeg=3,
                  faces=(f1, f2, f3, f4),
                  initial_refinement_level=1)

--- a/examples/2d/elixir_advection_p4est_non_conforming_flag.jl
+++ b/examples/2d/elixir_advection_p4est_non_conforming_flag.jl
@@ -21,7 +21,6 @@ f4(s) = SVector(s,  1.0 + sin(0.5 * pi * s))
 
 # Create P4estMesh with 3 x 2 trees and 6 x 4 elements
 trees_per_dimension = (3, 2)
-
 mesh = P4estMesh(trees_per_dimension, polydeg=3,
                  faces=(f1, f2, f3, f4),
                  initial_refinement_level=1)

--- a/examples/2d/elixir_advection_p4est_non_conforming_flag_unstructured.jl
+++ b/examples/2d/elixir_advection_p4est_non_conforming_flag_unstructured.jl
@@ -1,4 +1,5 @@
 
+using Downloads: download
 using OrdinaryDiffEq
 using Trixi
 

--- a/examples/2d/elixir_advection_p4est_non_conforming_flag_unstructured.jl
+++ b/examples/2d/elixir_advection_p4est_non_conforming_flag_unstructured.jl
@@ -1,0 +1,95 @@
+
+using OrdinaryDiffEq
+using Trixi
+
+
+###############################################################################
+# semidiscretization of the linear advection equation
+
+advectionvelocity = (1.0, 1.0)
+equations = LinearScalarAdvectionEquation2D(advectionvelocity)
+
+initial_condition = initial_condition_convergence_test
+
+boundary_condition = BoundaryConditionDirichlet(initial_condition)
+boundary_conditions = Dict(
+  :all => boundary_condition
+)
+
+# Create DG solver with polynomial degree = 3 and (local) Lax-Friedrichs/Rusanov flux as surface flux
+solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs)
+
+# Deformed rectangle that looks like a waving flag,
+# lower and upper faces are sinus curves, left and right are vertical lines.
+f1(s) = SVector(-1.0, s - 1.0)
+f2(s) = SVector( 1.0, s + 1.0)
+f3(s) = SVector(s, -1.0 + sin(0.5 * pi * s))
+f4(s) = SVector(s,  1.0 + sin(0.5 * pi * s))
+faces = (f1, f2, f3, f4)
+
+Trixi.validate_faces(faces)
+mapping_flag = Trixi.transfinite_mapping(faces)
+
+# Unstructured mesh with 24 cells of the square domain [-1, 1]^n
+mesh_file = joinpath(@__DIR__, "square_unstructured_2.inp")
+isfile(mesh_file) || download("https://gist.githubusercontent.com/efaulhaber/63ff2ea224409e55ee8423b3a33e316a/raw/7db58af7446d1479753ae718930741c47a3b79b7/square_unstructured_2.inp",
+                              mesh_file)
+
+mesh = P4estMesh(mesh_file, polydeg=3,
+                 mapping=mapping_flag,
+                 initial_refinement_level=0)
+
+# Refine bottom left quadrant of each forest to level 3
+function refine_fn(p4est, which_tree, quadrant)
+  if quadrant.x == 0 && quadrant.y == 0 && quadrant.level < 3
+    # return true (refine)
+    return Cint(1)
+  else
+    # return false (don't refine)
+    return Cint(0)
+  end
+end
+
+# Refine recursively until each bottom left quadrant of a forest has level 4
+# The mesh will be rebalanced before the simulation starts
+refine_fn_c = @cfunction(refine_fn, Cint, (Ptr{Trixi.p4est_t}, Ptr{Trixi.p4est_topidx_t}, Ptr{Trixi.p4est_quadrant_t}))
+Trixi.p4est_refine(mesh.p4est, true, refine_fn_c, C_NULL)
+
+# A semidiscretization collects data structures and functions for the spatial discretization
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver, boundary_conditions=boundary_conditions)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+# Create ODE problem with time span from 0.0 to 1.0
+ode = semidiscretize(semi, (0.0, 0.2));
+
+# At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
+# and resets the timers
+summary_callback = SummaryCallback()
+
+# The AnalysisCallback allows to analyse the solution in regular intervals and prints the results
+analysis_callback = AnalysisCallback(semi, interval=100)
+
+# The SaveSolutionCallback allows to save the solution to a file in regular intervals
+save_solution = SaveSolutionCallback(interval=100,
+                                     solution_variables=cons2prim)
+
+# The StepsizeCallback handles the re-calculcation of the maximum Δt after each time step
+stepsize_callback = StepsizeCallback(cfl=1.6)
+
+# Create a CallbackSet to collect all callbacks such that they can be passed to the ODE solver
+callbacks = CallbackSet(summary_callback, analysis_callback, save_solution, stepsize_callback)
+
+
+###############################################################################
+# run the simulation
+
+# OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+
+# Print the timer summary
+summary_callback()

--- a/examples/2d/elixir_advection_p4est_non_conforming_flag_unstructured.jl
+++ b/examples/2d/elixir_advection_p4est_non_conforming_flag_unstructured.jl
@@ -40,7 +40,7 @@ mesh = P4estMesh(mesh_file, polydeg=3,
                  mapping=mapping_flag,
                  initial_refinement_level=0)
 
-# Refine bottom left quadrant of each forest to level 3
+# Refine bottom left quadrant of each tree to level 3
 function refine_fn(p4est, which_tree, quadrant)
   if quadrant.x == 0 && quadrant.y == 0 && quadrant.level < 3
     # return true (refine)
@@ -51,7 +51,7 @@ function refine_fn(p4est, which_tree, quadrant)
   end
 end
 
-# Refine recursively until each bottom left quadrant of a forest has level 4
+# Refine recursively until each bottom left quadrant of a tree has level 4
 # The mesh will be rebalanced before the simulation starts
 refine_fn_c = @cfunction(refine_fn, Cint, (Ptr{Trixi.p4est_t}, Ptr{Trixi.p4est_topidx_t}, Ptr{Trixi.p4est_quadrant_t}))
 Trixi.p4est_refine(mesh.p4est, true, refine_fn_c, C_NULL)

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -176,6 +176,8 @@ export PlotData1D, PlotData2D, getmesh, adapt_to_mesh_level!, adapt_to_mesh_leve
 function __init__()
   init_mpi()
 
+  init_p4est()
+
   # Enable features that depend on the availability of the Plots package
   @require Plots="91a5bcdd-55d7-5caf-9e0b-520d859cae80" begin
     using .Plots: plot, plot!, savefig

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -228,4 +228,6 @@ function init_p4est()
 
   # Initialize p4est with log level ERROR to prevent a lot of output in AMR simulations
   p4est_init(C_NULL, SC_LP_ERROR)
+
+  return nothing
 end

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -212,3 +212,20 @@ macro timed(timer_output, label, expr)
     val
   end
 end
+
+
+"""
+    init_p4est()
+
+Initialize p4est by calling `p4est_init` and setting the log level to `SC_LP_ERROR`.
+This function will check if p4est is already initialized
+and if yes, do nothing, thus it is safe to call it multiple times.
+"""
+function init_p4est()
+  if p4est_package_id()[] >= 0
+    return nothing
+  end
+
+  # Initialize p4est with log level ERROR to prevent a lot of output in AMR simulations
+  p4est_init(C_NULL, SC_LP_ERROR)
+end

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -411,14 +411,20 @@ function (amr_callback::AMRCallback)(u_ode::AbstractVector, mesh::P4estMesh,
     # don't set it to has_changed since there can be changes from earlier calls
     mesh.unsaved_changes = true
 
-    if semi.boundary_conditions isa UnstructuredQuadSortedBoundaryTypes
-      # Reinitialize boundary types container because boundaries may have changed.
-      initialize!(semi.boundary_conditions, cache)
-    end
+    reinitialize_boundaries!(semi.boundary_conditions, cache)
   end
 
   # Return true if there were any cells coarsened or refined, otherwise false
   return has_changed
+end
+
+function reinitialize_boundaries!(boundary_conditions::UnstructuredQuadSortedBoundaryTypes, cache)
+  # Reinitialize boundary types container because boundaries may have changed.
+  initialize!(boundary_conditions, cache)
+end
+
+function reinitialize_boundaries!(boundary_conditions, cache)
+  return boundary_conditions
 end
 
 

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -222,8 +222,8 @@ function (amr_callback::AMRCallback)(u_ode::AbstractVector, mesh::TreeMesh,
     # refine mesh
     refined_original_cells = @timed timer() "mesh" refine!(mesh.tree, to_refine)
 
-    # Find all indices of elements whose cell ids are in cells_to_refine
-    elements_to_refine = findall(cell_id -> cell_id in cells_to_refine, cache.elements.cell_ids)
+    # Find all indices of elements whose cell ids are in refined_original_cells
+    elements_to_refine = findall(cell_id -> cell_id in refined_original_cells, cache.elements.cell_ids)
 
     # refine solver
     @timed timer() "solver" refine!(u_ode, adaptor, mesh, equations, dg, cache, elements_to_refine)
@@ -283,8 +283,8 @@ function (amr_callback::AMRCallback)(u_ode::AbstractVector, mesh::TreeMesh,
       end
     end
 
-    # Find all indices of elements whose cell ids are in child_cells_to_coarsen
-    elements_to_remove = findall(cell_id -> cell_id in child_cells_to_coarsen, cache.elements.cell_ids)
+    # Find all indices of elements whose cell ids are in removed_child_cells
+    elements_to_remove = findall(cell_id -> cell_id in removed_child_cells, cache.elements.cell_ids)
 
     # coarsen solver
     @timed timer() "solver" coarsen!(u_ode, adaptor, mesh, equations, dg, cache, elements_to_remove)

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -223,7 +223,7 @@ function (amr_callback::AMRCallback)(u_ode::AbstractVector, mesh::TreeMesh,
     refined_original_cells = @timed timer() "mesh" refine!(mesh.tree, to_refine)
 
     # Find all indices of elements whose cell ids are in refined_original_cells
-    elements_to_refine = findall(cell_id -> cell_id in refined_original_cells, cache.elements.cell_ids)
+    elements_to_refine = findall(in(refined_original_cells), cache.elements.cell_ids)
 
     # refine solver
     @timed timer() "solver" refine!(u_ode, adaptor, mesh, equations, dg, cache, elements_to_refine)
@@ -284,7 +284,7 @@ function (amr_callback::AMRCallback)(u_ode::AbstractVector, mesh::TreeMesh,
     end
 
     # Find all indices of elements whose cell ids are in removed_child_cells
-    elements_to_remove = findall(cell_id -> cell_id in removed_child_cells, cache.elements.cell_ids)
+    elements_to_remove = findall(in(removed_child_cells), cache.elements.cell_ids)
 
     # coarsen solver
     @timed timer() "solver" coarsen!(u_ode, adaptor, mesh, equations, dg, cache, elements_to_remove)

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -413,7 +413,7 @@ function (amr_callback::AMRCallback)(u_ode::AbstractVector, mesh::P4estMesh,
 
     if semi.boundary_conditions isa UnstructuredQuadSortedBoundaryTypes
       # Reinitialize boundary types container because boundaries may have changed.
-      initialize!(boundary_conditions, cache)
+      initialize!(semi.boundary_conditions, cache)
     end
   end
 

--- a/src/callbacks_step/amr_dg1d.jl
+++ b/src/callbacks_step/amr_dg1d.jl
@@ -1,18 +1,14 @@
 
 # Refine elements in the DG solver based on a list of cell_ids that should be refined
 function refine!(u_ode::AbstractVector, adaptor, mesh::TreeMesh{1},
-                 equations, dg::DGSEM, cache, cells_to_refine)
+                 equations, dg::DGSEM, cache, elements_to_refine)
   # Return early if there is nothing to do
-  if isempty(cells_to_refine)
+  if isempty(elements_to_refine)
     return
   end
 
   # Determine for each existing element whether it needs to be refined
   needs_refinement = falses(nelements(dg, cache))
-
-  # The "Ref(...)" is such that we can vectorize the search but not the array that is searched
-  elements_to_refine = searchsortedfirst.(Ref(cache.elements.cell_ids[1:nelements(dg, cache)]),
-                                          cells_to_refine)
   needs_refinement[elements_to_refine] .= true
 
   # Retain current solution data
@@ -119,17 +115,14 @@ end
 
 # Coarsen elements in the DG solver based on a list of cell_ids that should be removed
 function coarsen!(u_ode::AbstractVector, adaptor, mesh::TreeMesh{1},
-                  equations, dg::DGSEM, cache, child_cells_to_coarsen)
+                  equations, dg::DGSEM, cache, elements_to_remove)
   # Return early if there is nothing to do
-  if isempty(child_cells_to_coarsen)
+  if isempty(elements_to_remove)
     return
   end
 
   # Determine for each old element whether it needs to be removed
   to_be_removed = falses(nelements(dg, cache))
-  # The "Ref(...)" is such that we can vectorize the search but not the array that is searched
-  elements_to_remove = searchsortedfirst.(Ref(cache.elements.cell_ids[1:nelements(dg, cache)]),
-                                          child_cells_to_coarsen)
   to_be_removed[elements_to_remove] .= true
 
   # Retain current solution data

--- a/src/callbacks_step/amr_dg2d.jl
+++ b/src/callbacks_step/amr_dg2d.jl
@@ -100,18 +100,15 @@ end
 
 
 # Refine elements in the DG solver based on a list of cell_ids that should be refined
-function refine!(u_ode::AbstractVector, adaptor, mesh::TreeMesh{2},
-                 equations, dg::DGSEM, cache, cells_to_refine)
+function refine!(u_ode::AbstractVector, adaptor, mesh::Union{TreeMesh{2}, P4estMesh{2}},
+                 equations, dg::DGSEM, cache, elements_to_refine)
   # Return early if there is nothing to do
-  if isempty(cells_to_refine)
+  if isempty(elements_to_refine)
     return
   end
 
   # Determine for each existing element whether it needs to be refined
   needs_refinement = falses(nelements(dg, cache))
-
-  # Find all indices of elements whose cell ids are in cells_to_refine
-  elements_to_refine = findall(cell_id -> cell_id in cells_to_refine, cache.elements.cell_ids)
   needs_refinement[elements_to_refine] .= true
 
   # Retain current solution data
@@ -146,7 +143,7 @@ function refine!(u_ode::AbstractVector, adaptor, mesh::TreeMesh{2},
   end # GC.@preserve old_u_ode
 
   # Sanity check
-  if isperiodic(mesh.tree) && nmortars(cache.mortars) == 0 && !mpi_isparallel()
+  if mesh isa TreeMesh && isperiodic(mesh.tree) && nmortars(cache.mortars) == 0 && !mpi_isparallel()
     @assert ninterfaces(cache.interfaces) == ndims(mesh) * nelements(dg, cache) ("For $(ndims(mesh))D and periodic domains and conforming elements, the number of interfaces must be $(ndims(mesh)) times the number of elements")
   end
 
@@ -222,18 +219,15 @@ end
 
 
 # Coarsen elements in the DG solver based on a list of cell_ids that should be removed
-function coarsen!(u_ode::AbstractVector, adaptor, mesh::TreeMesh{2},
-                  equations, dg::DGSEM, cache, child_cells_to_coarsen)
+function coarsen!(u_ode::AbstractVector, adaptor, mesh::Union{TreeMesh{2}, P4estMesh{2}},
+                  equations, dg::DGSEM, cache, elements_to_remove)
   # Return early if there is nothing to do
-  if isempty(child_cells_to_coarsen)
+  if isempty(elements_to_remove)
     return
   end
 
   # Determine for each old element whether it needs to be removed
   to_be_removed = falses(nelements(dg, cache))
-
-  # Find all indices of elements whose cell ids are in child_cells_to_coarsen
-  elements_to_remove = findall(cell_id -> cell_id in child_cells_to_coarsen, cache.elements.cell_ids)
   to_be_removed[elements_to_remove] .= true
 
   # Retain current solution data
@@ -279,7 +273,7 @@ function coarsen!(u_ode::AbstractVector, adaptor, mesh::TreeMesh{2},
   end # GC.@preserve old_u_ode
 
   # Sanity check
-  if isperiodic(mesh.tree) && nmortars(cache.mortars) == 0 && !mpi_isparallel()
+  if mesh isa TreeMesh && isperiodic(mesh.tree) && nmortars(cache.mortars) == 0 && !mpi_isparallel()
     @assert ninterfaces(cache.interfaces) == ndims(mesh) * nelements(dg, cache) ("For $(ndims(mesh))D and periodic domains and conforming elements, the number of interfaces must be $(ndims(mesh)) times the number of elements")
   end
 
@@ -343,7 +337,7 @@ end
 
 
 # this method is called when an `ControllerThreeLevel` is constructed
-function create_cache(::Type{ControllerThreeLevel}, mesh::TreeMesh{2}, equations, dg::DG, cache)
+function create_cache(::Type{ControllerThreeLevel}, mesh::Union{TreeMesh{2}, P4estMesh{2}}, equations, dg::DG, cache)
 
   controller_value = Vector{Int}(undef, nelements(dg, cache))
   return (; controller_value)

--- a/src/callbacks_step/amr_dg3d.jl
+++ b/src/callbacks_step/amr_dg3d.jl
@@ -1,18 +1,14 @@
 
 # Refine elements in the DG solver based on a list of cell_ids that should be refined
 function refine!(u_ode::AbstractVector, adaptor, mesh::TreeMesh{3},
-                 equations, dg::DGSEM, cache, cells_to_refine)
+                 equations, dg::DGSEM, cache, elements_to_refine)
   # Return early if there is nothing to do
-  if isempty(cells_to_refine)
+  if isempty(elements_to_refine)
     return
   end
 
   # Determine for each existing element whether it needs to be refined
   needs_refinement = falses(nelements(dg, cache))
-
-  # The "Ref(...)" is such that we can vectorize the search but not the array that is searched
-  elements_to_refine = searchsortedfirst.(Ref(cache.elements.cell_ids[1:nelements(dg, cache)]),
-                                          cells_to_refine)
   needs_refinement[elements_to_refine] .= true
 
   # Retain current solution data
@@ -159,17 +155,14 @@ end
 
 # Coarsen elements in the DG solver based on a list of cell_ids that should be removed
 function coarsen!(u_ode::AbstractVector, adaptor, mesh::TreeMesh{3},
-                  equations, dg::DGSEM, cache, child_cells_to_coarsen)
+                  equations, dg::DGSEM, cache, elements_to_remove)
   # Return early if there is nothing to do
-  if isempty(child_cells_to_coarsen)
+  if isempty(elements_to_remove)
     return
   end
 
   # Determine for each old element whether it needs to be removed
   to_be_removed = falses(nelements(dg, cache))
-  # The "Ref(...)" is such that we can vectorize the search but not the array that is searched
-  elements_to_remove = searchsortedfirst.(Ref(cache.elements.cell_ids[1:nelements(dg, cache)]),
-                                          child_cells_to_coarsen)
   to_be_removed[elements_to_remove] .= true
 
   # Retain current solution data

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -377,6 +377,9 @@ function print_amr_information(callbacks, mesh::TreeMesh, solver, cache)
   return nothing
 end
 
+function print_amr_information(callbacks, mesh::CurvedMesh, solver, cache)
+  return nothing
+end
 
 # Print level information only if AMR is enabled
 function print_amr_information(callbacks, mesh::P4estMesh, solver, cache)

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -370,9 +370,9 @@ function print_amr_information(callbacks, mesh, solver, cache)
   end
 
   for level = max_level:-1:min_level+1
-    mpi_println(" ├── level $level:    " * @sprintf("% 14d", count(isequal(level), levels)))
+    mpi_println(" ├── level $level:    " * @sprintf("% 14d", count(==(level), levels)))
   end
-  mpi_println(" └── level $min_level:    " * @sprintf("% 14d", count(isequal(min_level), levels)))
+  mpi_println(" └── level $min_level:    " * @sprintf("% 14d", count(==(min_level), levels)))
 
   return nothing
 end

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -386,7 +386,7 @@ function print_amr_information(callbacks, mesh::P4estMesh, solver, cache)
   elements_per_level = zeros(P4EST_MAXLEVEL + 1)
 
   for tree in convert_sc_array(p4est_tree_t, mesh.p4est.trees)
-    @. elements_per_level += tree.quadrants_per_level
+    elements_per_level .+= tree.quadrants_per_level
   end
 
   min_level = findfirst(i -> i > 0, elements_per_level) - 1

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -385,7 +385,7 @@ function print_amr_information(callbacks, mesh::P4estMesh, solver, cache)
 
   elements_per_level = zeros(P4EST_MAXLEVEL + 1)
 
-  for tree in convert_sc_array(p4est_tree_t, mesh.p4est.trees)
+  for tree in unsafe_wrap_sc(p4est_tree_t, mesh.p4est.trees)
     elements_per_level .+= tree.quadrants_per_level
   end
 

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -390,13 +390,13 @@ function print_amr_information(callbacks, mesh::P4estMesh, solver, cache)
     @. elements_per_level += tree.quadrants_per_level
   end
 
-  min_level = findfirst(i -> i > 0, elements_per_level)
-  max_level = findlast(i -> i > 0, elements_per_level)
+  min_level = findfirst(i -> i > 0, elements_per_level) - 1
+  max_level = findlast(i -> i > 0, elements_per_level) - 1
 
   for level = max_level:-1:min_level+1
-    mpi_println(" ├── level $level:    " * @sprintf("% 14d", elements_per_level[level]))
+    mpi_println(" ├── level $level:    " * @sprintf("% 14d", elements_per_level[level + 1]))
   end
-  mpi_println(" └── level $min_level:    " * @sprintf("% 14d", elements_per_level[min_level]))
+  mpi_println(" └── level $min_level:    " * @sprintf("% 14d", elements_per_level[min_level + 1]))
 
   return nothing
 end

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -354,7 +354,7 @@ end
 
 
 # Print level information only if AMR is enabled
-function print_amr_information(callbacks, mesh::TreeMesh, solver, cache)
+function print_amr_information(callbacks, mesh, solver, cache)
 
   # Return early if there is nothing to print
   uses_amr(callbacks) || return nothing
@@ -374,10 +374,6 @@ function print_amr_information(callbacks, mesh::TreeMesh, solver, cache)
   end
   mpi_println(" └── level $min_level:    " * @sprintf("% 14d", count(isequal(min_level), levels)))
 
-  return nothing
-end
-
-function print_amr_information(callbacks, mesh::CurvedMesh, solver, cache)
   return nothing
 end
 

--- a/src/mesh/mesh_io.jl
+++ b/src/mesh/mesh_io.jl
@@ -258,10 +258,8 @@ function load_mesh_serial(mesh_file::AbstractString; n_cells_max, RealT)
 
     conn_vec = Vector{Ptr{p4est_connectivity_t}}(undef, 1)
     p4est = p4est_load(p4est_file, C_NULL, 0, false, C_NULL, pointer(conn_vec))
-    ghost = p4est_ghost_new(p4est, P4EST_CONNECT_FACE)
-    p4est_mesh = p4est_mesh_new(p4est, ghost, P4EST_CONNECT_FACE)
 
-    mesh = P4estMesh{ndims, RealT, ndims+2}(p4est, p4est_mesh, tree_node_coordinates,
+    mesh = P4estMesh{ndims, RealT, ndims+2}(p4est, tree_node_coordinates,
                                             nodes, boundary_names, "", false)
   else
     error("Unknown mesh type!")

--- a/src/mesh/mesh_io.jl
+++ b/src/mesh/mesh_io.jl
@@ -259,8 +259,8 @@ function load_mesh_serial(mesh_file::AbstractString; n_cells_max, RealT)
     conn_vec = Vector{Ptr{p4est_connectivity_t}}(undef, 1)
     p4est = p4est_load(p4est_file, C_NULL, 0, false, C_NULL, pointer(conn_vec))
 
-    mesh = P4estMesh{ndims, RealT, ndims+2}(p4est, tree_node_coordinates,
-                                            nodes, boundary_names, "", false)
+    mesh = P4estMesh{ndims}(p4est, tree_node_coordinates,
+                            nodes, boundary_names, "", false)
   else
     error("Unknown mesh type!")
   end

--- a/src/mesh/mesh_io.jl
+++ b/src/mesh/mesh_io.jl
@@ -136,12 +136,19 @@ end
 # of the mesh, like its size and the type of boundary mapping function.
 # Then, within Trixi2Vtk, the P4estMesh and its node coordinates are reconstructured from
 # these attributes for plotting purposes
-function save_mesh_file(mesh::P4estMesh, output_directory)
+function save_mesh_file(mesh::P4estMesh, output_directory, timestep=0)
   # Create output directory (if it does not exist)
   mkpath(output_directory)
 
-  filename = joinpath(output_directory, "mesh.h5")
-  p4est_filename = "p4est_data"
+  # Determine file name based on existence of meaningful time step
+  if timestep > 0
+    filename = joinpath(output_directory, @sprintf("mesh_%06d.h5", timestep))
+    p4est_filename = @sprintf("p4est_data_%06d", timestep)
+  else
+    filename = joinpath(output_directory, "mesh.h5")
+    p4est_filename = "p4est_data"
+  end
+
   p4est_file = joinpath(output_directory, p4est_filename)
 
   # Save the complete connectivity/p4est data to disk.

--- a/src/mesh/p4est_mesh.jl
+++ b/src/mesh/p4est_mesh.jl
@@ -530,7 +530,7 @@ function save_original_id_iter_volume(info, user_data)
   # Unpack quadrant's user data ([global quad ID, controller_value])
   ptr = Ptr{Int}(info.quad.p.user_data)
   # Save global quad ID
-  unsafe_store!(ptr, quad_id, 2)
+  unsafe_store!(ptr, quad_id, 1)
 
   return nothing
 end

--- a/src/mesh/p4est_mesh.jl
+++ b/src/mesh/p4est_mesh.jl
@@ -322,7 +322,7 @@ function Base.show(io::IO, ::MIME"text/plain", mesh::P4estMesh)
     setup = [
              "#trees" => ntrees(mesh),
              "current #cells" => ncells(mesh),
-             "polydeg" => length(mesh.nodes),
+             "polydeg" => length(mesh.nodes) - 1,
             ]
     summary_box(io, "P4estMesh{" * string(ndims(mesh)) * ", " * string(real(mesh)) * "}", setup)
   end

--- a/src/mesh/p4est_mesh.jl
+++ b/src/mesh/p4est_mesh.jl
@@ -505,7 +505,7 @@ function coarsen!(mesh::P4estMesh)
   # Find original ID of each cell that has been coarsened and then refined again.
   for refined_cell in refined_cells
     # i-th cell of the ones that have been created by coarsening has been refined again
-    i = findfirst(isequal(refined_cell), new_cells)
+    i = findfirst(==(refined_cell), new_cells)
 
     # Remove IDs of the 2^NDIMS cells that have been coarsened to this cell
     coarsened_cells[:, i] .= -1
@@ -631,7 +631,7 @@ function collect_new_cells(mesh)
   end
 
   # Changed cells are all that haven't been set to zero above
-  new_cells = findall(isequal(1), cell_is_new)
+  new_cells = findall(==(1), cell_is_new)
 
   return new_cells
 end

--- a/src/mesh/p4est_mesh.jl
+++ b/src/mesh/p4est_mesh.jl
@@ -631,7 +631,7 @@ function collect_new_cells(mesh)
   end
 
   # Changed cells are all that haven't been set to zero above
-  new_cells = cell_is_new[cell_is_new .> 0]
+  new_cells = findall(isequal(1), cell_is_new)
 
   return new_cells
 end

--- a/src/semidiscretization/semidiscretization_euler_gravity.jl
+++ b/src/semidiscretization/semidiscretization_euler_gravity.jl
@@ -435,6 +435,6 @@ end
                                              semi::SemidiscretizationEulerGravity,
                                              t, iter; kwargs...)
   passive_args = ((semi.cache.u_ode, mesh_equations_solver_cache(semi.semi_gravity)...),)
-  amr_callback(u_ode, mesh_equations_solver_cache(semi.semi_euler)..., t, iter;
+  amr_callback(u_ode, mesh_equations_solver_cache(semi.semi_euler)..., semi, t, iter;
                kwargs..., passive_args=passive_args)
 end

--- a/src/solvers/dg_p4est/containers.jl
+++ b/src/solvers/dg_p4est/containers.jl
@@ -339,8 +339,8 @@ end
 function count_interfaces_iter_face(info, user_data)
   if info.sides.elem_count == 2
     # Extract interface data
-    sides = (load_sc_array(p4est_iter_face_side_t, info.sides, 1),
-             load_sc_array(p4est_iter_face_side_t, info.sides, 2))
+    sides = (unsafe_load_sc(p4est_iter_face_side_t, info.sides, 1),
+             unsafe_load_sc(p4est_iter_face_side_t, info.sides, 2))
 
     if sides[1].is_hanging == 0 && sides[2].is_hanging == 0
       # No hanging nodes => normal interface
@@ -370,8 +370,8 @@ end
 function count_mortars_iter_face(info, user_data)
   if info.sides.elem_count == 2
     # Extract interface data
-    sides = (load_sc_array(p4est_iter_face_side_t, info.sides, 1),
-             load_sc_array(p4est_iter_face_side_t, info.sides, 2))
+    sides = (unsafe_load_sc(p4est_iter_face_side_t, info.sides, 1),
+             unsafe_load_sc(p4est_iter_face_side_t, info.sides, 2))
 
     if sides[1].is_hanging != 0 || sides[2].is_hanging != 0
       # Hanging nodes => mortar
@@ -431,8 +431,8 @@ function iterate_faces(mesh::P4estMesh, iter_face_c, user_data)
 end
 
 
-# Convert sc_array to Julia array of the specified type
-function convert_sc_array(::Type{T}, sc_array) where T
+# Convert sc_array of type T to Julia array
+function unsafe_wrap_sc(::Type{T}, sc_array) where T
   element_count = sc_array.elem_count
   element_size = sc_array.elem_size
 
@@ -442,7 +442,8 @@ function convert_sc_array(::Type{T}, sc_array) where T
 end
 
 
-function load_sc_array(::Type{T}, sc_array, i=1) where T
+# Load the ith element (1-indexed) of an sc array of type T
+function unsafe_load_sc(::Type{T}, sc_array, i=1) where T
   element_size = sc_array.elem_size
 
   @assert element_size == sizeof(T)

--- a/src/solvers/dg_p4est/containers.jl
+++ b/src/solvers/dg_p4est/containers.jl
@@ -339,14 +339,15 @@ end
 function count_interfaces_iter_face(info, user_data)
   if info.sides.elem_count == 2
     # Extract interface data
-    sides = convert_sc_array(p4est_iter_face_side_t, info.sides)
+    sides = (load_sc_array(p4est_iter_face_side_t, info.sides, 1),
+             load_sc_array(p4est_iter_face_side_t, info.sides, 2))
 
     if sides[1].is_hanging == 0 && sides[2].is_hanging == 0
       # No hanging nodes => normal interface
       # Unpack user_data = [interface_count] and increment interface_count
       ptr = Ptr{Int}(user_data)
-      data_array = unsafe_wrap(Array, ptr, 1)
-      data_array[1] += 1
+      id = unsafe_load(ptr)
+      unsafe_store!(ptr, id + 1)
     end
   end
 
@@ -358,8 +359,8 @@ function count_boundaries_iter_face(info, user_data)
   if info.sides.elem_count == 1
     # Unpack user_data = [boundary_count] and increment boundary_count
     ptr = Ptr{Int}(user_data)
-    data_array = unsafe_wrap(Array, ptr, 1)
-    data_array[1] += 1
+    id = unsafe_load(ptr)
+    unsafe_store!(ptr, id + 1)
   end
 
   return nothing
@@ -369,14 +370,15 @@ end
 function count_mortars_iter_face(info, user_data)
   if info.sides.elem_count == 2
     # Extract interface data
-    sides = convert_sc_array(p4est_iter_face_side_t, info.sides)
+    sides = (load_sc_array(p4est_iter_face_side_t, info.sides, 1),
+             load_sc_array(p4est_iter_face_side_t, info.sides, 2))
 
     if sides[1].is_hanging != 0 || sides[2].is_hanging != 0
       # Hanging nodes => mortar
       # Unpack user_data = [mortar_count] and increment mortar_count
       ptr = Ptr{Int}(user_data)
-      data_array = unsafe_wrap(Array, ptr, 1)
-      data_array[1] += 1
+      id = unsafe_load(ptr)
+      unsafe_store!(ptr, id + 1)
     end
   end
 

--- a/src/solvers/dg_p4est/containers.jl
+++ b/src/solvers/dg_p4est/containers.jl
@@ -440,6 +440,15 @@ function convert_sc_array(::Type{T}, sc_array) where T
 end
 
 
+function load_sc_array(::Type{T}, sc_array, i=1) where T
+  element_size = sc_array.elem_size
+
+  @assert element_size == sizeof(T)
+
+  return unsafe_wrap(T, sc_array.array + element_size * (i - 1))
+end
+
+
 # Convert Tuple node_indices to actual indices.
 # E.g., (:one, :i, :j) will be (1, i, j) for some i and j,
 # (:i, :end) will be (i, size[2]),

--- a/src/solvers/dg_p4est/containers_2d.jl
+++ b/src/solvers/dg_p4est/containers_2d.jl
@@ -246,7 +246,7 @@ function init_mortars_iter_face(info, user_data)
              trees[sides[2].treeid + 1].quadrants_offset]
 
   if sides[1].is_hanging == true
-    # Left is small, right is large
+    # Left is small (1), right is large (2)
     small_large = [1, 2]
 
     local_small_quad_ids = sides[1].is.hanging.quadid
@@ -257,7 +257,7 @@ function init_mortars_iter_face(info, user_data)
     @assert sides[2].is_hanging == false
     large_quad_id = offsets[2] + sides[2].is.full.quadid
   else # sides[2].is_hanging == true
-    # Left is large, right is small
+    # Left is large (2), right is small (1)
     small_large = [2, 1]
 
     local_small_quad_ids = sides[2].is.hanging.quadid
@@ -288,10 +288,10 @@ function init_mortars_iter_face(info, user_data)
     # For orientation == 1, the large side needs to be indexed backwards
     # relative to the mortar.
     if small_large[side] == 1 || orientation == 0
-      # Forward indexing
+      # Forward indexing for small side or orientation == 0
       i = :i
     else
-      # Backward indexing
+      # Backward indexing for large side with reversed orientation
       i = :i_backwards
     end
 

--- a/src/solvers/dg_p4est/containers_2d.jl
+++ b/src/solvers/dg_p4est/containers_2d.jl
@@ -31,11 +31,11 @@ function calc_node_coordinates!(node_coordinates,
   p4est_root_len = 1 << P4EST_MAXLEVEL
   p4est_quadrant_len(l) = 1 << (P4EST_MAXLEVEL - l)
 
-  trees = convert_sc_array(p4est_tree_t, mesh.p4est.trees)
+  trees = unsafe_wrap_sc(p4est_tree_t, mesh.p4est.trees)
 
   for tree in eachindex(trees)
     offset = trees[tree].quadrants_offset
-    quadrants = convert_sc_array(p4est_quadrant_t, trees[tree].quadrants)
+    quadrants = unsafe_wrap_sc(p4est_quadrant_t, trees[tree].quadrants)
 
     for i in eachindex(quadrants)
       element = offset + i
@@ -69,8 +69,8 @@ function init_interfaces_iter_face(info, user_data)
     return nothing
   end
 
-  sides = (load_sc_array(p4est_iter_face_side_t, info.sides, 1),
-           load_sc_array(p4est_iter_face_side_t, info.sides, 2))
+  sides = (unsafe_load_sc(p4est_iter_face_side_t, info.sides, 1),
+           unsafe_load_sc(p4est_iter_face_side_t, info.sides, 2))
 
   if sides[1].is_hanging == true || sides[2].is_hanging == true
     # Mortar, no normal interface
@@ -91,9 +91,9 @@ end
 
 # Function barrier for type stability
 function init_interfaces_iter_face_inner(info, sides, interfaces, interface_id, mesh)
-  # Global trees array, one-based indexing
-  trees = (load_sc_array(p4est_tree_t, mesh.p4est.trees, sides[1].treeid + 1),
-           load_sc_array(p4est_tree_t, mesh.p4est.trees, sides[2].treeid + 1))
+  # Load local trees from global trees array, one-based indexing
+  trees = (unsafe_load_sc(p4est_tree_t, mesh.p4est.trees, sides[1].treeid + 1),
+           unsafe_load_sc(p4est_tree_t, mesh.p4est.trees, sides[2].treeid + 1))
   # Quadrant numbering offsets of the quadrants at this interface
   offsets = SVector(trees[1].quadrants_offset,
                     trees[2].quadrants_offset)
@@ -179,9 +179,9 @@ end
 # Function barrier for type stability
 function init_boundaries_iter_face_inner(info, boundaries, boundary_id, mesh)
   # Extract boundary data
-  side = load_sc_array(p4est_iter_face_side_t, info.sides)
-  # Global trees array, one-based indexing
-  tree = load_sc_array(p4est_tree_t, mesh.p4est.trees, side.treeid + 1)
+  side = unsafe_load_sc(p4est_iter_face_side_t, info.sides)
+  # Load tree from global trees array, one-based indexing
+  tree = unsafe_load_sc(p4est_tree_t, mesh.p4est.trees, side.treeid + 1)
   # Quadrant numbering offset of this quadrant
   offset = tree.quadrants_offset
 
@@ -238,8 +238,8 @@ function init_mortars_iter_face(info, user_data)
     return nothing
   end
 
-  sides = (load_sc_array(p4est_iter_face_side_t, info.sides, 1),
-           load_sc_array(p4est_iter_face_side_t, info.sides, 2))
+  sides = (unsafe_load_sc(p4est_iter_face_side_t, info.sides, 1),
+           unsafe_load_sc(p4est_iter_face_side_t, info.sides, 2))
 
   if sides[1].is_hanging == false && sides[2].is_hanging == false
     # Normal interface, no mortar
@@ -260,9 +260,9 @@ end
 
 # Function barrier for type stability
 function init_mortars_iter_face_inner(info, sides, mortars, mortar_id, mesh)
-  # Global trees array, one-based indexing
-  trees = (load_sc_array(p4est_tree_t, mesh.p4est.trees, sides[1].treeid + 1),
-           load_sc_array(p4est_tree_t, mesh.p4est.trees, sides[2].treeid + 1))
+  # Load local trees from global trees array, one-based indexing
+  trees = (unsafe_load_sc(p4est_tree_t, mesh.p4est.trees, sides[1].treeid + 1),
+           unsafe_load_sc(p4est_tree_t, mesh.p4est.trees, sides[2].treeid + 1))
   # Quadrant numbering offsets of the quadrants at this interface
   offsets = SVector(trees[1].quadrants_offset,
                     trees[2].quadrants_offset)

--- a/src/solvers/dg_p4est/dg_2d.jl
+++ b/src/solvers/dg_p4est/dg_2d.jl
@@ -167,8 +167,8 @@ function prolong2mortars!(cache, u,
   size_ = (nnodes(dg), nnodes(dg))
 
   @threaded for mortar in eachmortar(dg, cache)
-    small_indices  = node_indices[1, mortar]
-    large_indices  = node_indices[2, mortar]
+    small_indices = node_indices[1, mortar]
+    large_indices = node_indices[2, mortar]
 
     # Copy solution small to small
     for pos in 1:2, i in eachnode(dg), v in eachvariable(equations)

--- a/src/solvers/dg_unstructured_quad/dg_2d.jl
+++ b/src/solvers/dg_unstructured_quad/dg_2d.jl
@@ -307,6 +307,12 @@ end
 function calc_boundary_flux!(cache, t, boundary_conditions,
                              mesh::Union{UnstructuredQuadMesh, P4estMesh},
                              equations, dg::DG)
+  if nboundaries(cache.boundaries) != nboundaries(boundary_conditions)
+    # When using AMR, the boundary container may have been resized.
+    # In this case, the boundary types container must be reinitialized as well.
+    initialize!(boundary_conditions, cache)
+  end
+
   @unpack boundary_condition_types, boundary_indices = boundary_conditions
 
   calc_boundary_flux_by_type!(cache, t, boundary_condition_types, boundary_indices,

--- a/src/solvers/dg_unstructured_quad/dg_2d.jl
+++ b/src/solvers/dg_unstructured_quad/dg_2d.jl
@@ -307,12 +307,6 @@ end
 function calc_boundary_flux!(cache, t, boundary_conditions,
                              mesh::Union{UnstructuredQuadMesh, P4estMesh},
                              equations, dg::DG)
-  if nboundaries(cache.boundaries) != nboundaries(boundary_conditions)
-    # When using AMR, the boundary container may have been resized.
-    # In this case, the boundary types container must be reinitialized as well.
-    initialize!(boundary_conditions, cache)
-  end
-
   @unpack boundary_condition_types, boundary_indices = boundary_conditions
 
   calc_boundary_flux_by_type!(cache, t, boundary_condition_types, boundary_indices,

--- a/src/solvers/dg_unstructured_quad/sort_boundary_conditions.jl
+++ b/src/solvers/dg_unstructured_quad/sort_boundary_conditions.jl
@@ -9,21 +9,38 @@ set by the user in the elixir file is also stored for printing.
 !!! warning "Experimental code"
     This boundary condition container is experimental and can change any time.
 """
-struct UnstructuredQuadSortedBoundaryTypes{N, BCs<:NTuple{N, Any}}
+mutable struct UnstructuredQuadSortedBoundaryTypes{N, BCs<:NTuple{N, Any}}
   boundary_condition_types::BCs # specific boundary condition type(s), e.g. BoundaryConditionWall
   boundary_indices::NTuple{N, Vector{Int}} # integer vectors containing global boundary indices
   boundary_dictionary::Dict{Symbol, Any} # boundary conditions as set by the user in the elixir file
 end
+
+@inline nboundaries(container::UnstructuredQuadSortedBoundaryTypes) = sum(container.boundary_indices .|> length)
 
 
 # constructor that "eats" the original boundary condition dictionary and sorts the information
 # from the `UnstructuredBoundaryContainer2D` in cache.boundaries according to the boundary types
 # and stores the associated global boundary indexing in NTuple
 function UnstructuredQuadSortedBoundaryTypes(boundary_conditions::Dict, cache)
+  # extract the unique boundary function routines from the dictionary
+  boundary_condition_types = Tuple(unique(collect(values(boundary_conditions))))
+  n_boundary_types = length(boundary_condition_types)
+  boundary_indices = ntuple(_ -> [], n_boundary_types)
+
+  container = UnstructuredQuadSortedBoundaryTypes{n_boundary_types, typeof(boundary_condition_types)}(
+    boundary_condition_types, boundary_indices, boundary_conditions)
+
+  initialize!(container, cache)
+end
+
+
+function initialize!(boundary_types_container::UnstructuredQuadSortedBoundaryTypes{N}, cache) where N
+  @unpack boundary_dictionary, boundary_condition_types = boundary_types_container
+
   unique_names = unique(cache.boundaries.name)
 
   # Verify that each Dict key is a valid boundary name
-  for key in keys(boundary_conditions)
+  for key in keys(boundary_dictionary)
     if !(key in unique_names)
       error("Key $(repr(key)) is not a valid boundary name")
     end
@@ -31,20 +48,16 @@ function UnstructuredQuadSortedBoundaryTypes(boundary_conditions::Dict, cache)
 
   # Verify that each boundary has a boundary condition
   for name in unique_names
-    if name !== Symbol("---") && !haskey(boundary_conditions, name)
+    if name !== Symbol("---") && !haskey(boundary_dictionary, name)
       error("No boundary condition specified for boundary $(repr(name))")
     end
   end
 
-  # extract the unique boundary function routines from the dictionary
-  boundary_condition_types = Tuple(unique(collect(values(boundary_conditions))))
-  n_boundary_types = length(boundary_condition_types)
-
   # pull and sort the indexing for each boundary type
-  _boundary_indices = Vector{Any}(nothing, n_boundary_types)
-  for j in 1:n_boundary_types
+  _boundary_indices = Vector{Any}(nothing, N)
+  for j in 1:N
     indices_for_current_type = Int[]
-    for (test_name, test_condition) in boundary_conditions
+    for (test_name, test_condition) in boundary_dictionary
       temp_indices = findall(x->x===test_name, cache.boundaries.name)
       if test_condition === boundary_condition_types[j]
         indices_for_current_type = vcat(indices_for_current_type, temp_indices)
@@ -54,12 +67,7 @@ function UnstructuredQuadSortedBoundaryTypes(boundary_conditions::Dict, cache)
   end
 
   # convert the work array with the boundary indices into a tuple
-  boundary_indices = Tuple(_boundary_indices)
+  boundary_types_container.boundary_indices = Tuple(_boundary_indices)
 
-  boundary_dictionary = boundary_conditions
-
-  return UnstructuredQuadSortedBoundaryTypes{n_boundary_types, typeof(boundary_condition_types)}(
-                                                                      boundary_condition_types,
-                                                                      boundary_indices,
-                                                                      boundary_dictionary)
+  return boundary_types_container
 end

--- a/src/solvers/dg_unstructured_quad/sort_boundary_conditions.jl
+++ b/src/solvers/dg_unstructured_quad/sort_boundary_conditions.jl
@@ -15,7 +15,7 @@ mutable struct UnstructuredQuadSortedBoundaryTypes{N, BCs<:NTuple{N, Any}}
   boundary_dictionary::Dict{Symbol, Any} # boundary conditions as set by the user in the elixir file
 end
 
-@inline nboundaries(container::UnstructuredQuadSortedBoundaryTypes) = sum(container.boundary_indices .|> length)
+@inline nboundaries(container::UnstructuredQuadSortedBoundaryTypes) = sum(length, container.boundary_indices)
 
 
 # constructor that "eats" the original boundary condition dictionary and sorts the information

--- a/test/test_examples_2d_p4est.jl
+++ b/test/test_examples_2d_p4est.jl
@@ -15,10 +15,28 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "2d")
       linf = [6.437440532947036e-5])
   end
 
-  @testset "elixir_advection_p4est_non_conforming.jl" begin
-    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_p4est_non_conforming.jl"),
+  @testset "elixir_advection_p4est_non_conforming_flag.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_p4est_non_conforming_flag.jl"),
       l2   = [4.634288969205318e-4],
       linf = [4.740692055057893e-3])
+  end
+
+  @testset "elixir_advection_p4est_non_conforming_flag_unstructured.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_p4est_non_conforming_flag_unstructured.jl"),
+      l2   = [3.038384623519386e-3],
+      linf = [6.324792487776842e-2])
+  end
+
+  @testset "elixir_advection_amr_solution_independent_p4est.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr_solution_independent_p4est.jl"),
+      l2   = [7.945073295691892e-5],
+      linf = [0.0007454287896710293])
+  end
+
+  @testset "elixir_advection_amr_p4est_unstructured_flag.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr_p4est_unstructured_flag.jl"),
+      l2   = [1.535436496965521e-3],
+      linf = [4.400105886102593e-2])
   end
 
   @testset "elixir_advection_restart_p4est.jl" begin

--- a/test/test_examples_2d_p4est.jl
+++ b/test/test_examples_2d_p4est.jl
@@ -35,8 +35,8 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "2d")
 
   @testset "elixir_advection_amr_p4est_unstructured_flag.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr_p4est_unstructured_flag.jl"),
-      l2   = [1.535436496965521e-3],
-      linf = [4.400105886102593e-2])
+      l2   = [1.29561551e-03],
+      linf = [3.92061383e-02])
   end
 
   @testset "elixir_advection_restart_p4est.jl" begin


### PR DESCRIPTION
Sixth point of #584.
AMR now works as usual by replacing `TreeMesh` with `P4estMesh`, and it produces pretty much the same results.
Additionally, it works with unstructured and curved meshes.

Convergence analysis with `elixir_advection_amr_solution_independent` (`polydeg=3`):
```
l2
scalar
error     EOC
7.95e-05  -
3.99e-06  4.32
1.95e-07  4.35
mean      4.33
----------------------------------------------------------------------------------------------------
linf
scalar
error     EOC
7.45e-04  -
6.57e-05  3.50
5.32e-06  3.63
mean      3.57
```