### PR TITLE
Add support for static non-conforming P4estMeshes (no AMR)

### DIFF
--- a/examples/2d/elixir_advection_p4est_non_conforming.jl
+++ b/examples/2d/elixir_advection_p4est_non_conforming.jl
@@ -1,0 +1,83 @@
+
+using OrdinaryDiffEq
+using P4est
+using Trixi
+
+
+# Refine bottom left quadrant of each forest to level 4
+function refine_fn(p4est, which_tree, quadrant)
+  if quadrant.x == 0 && quadrant.y == 0 && quadrant.level < 4
+    # return true (refine)
+    return Cint(1)
+  else
+    # return false (don't refine)
+    return Cint(0)
+  end
+end
+
+###############################################################################
+# semidiscretization of the linear advection equation
+
+advectionvelocity = (1.0, 1.0)
+equations = LinearScalarAdvectionEquation2D(advectionvelocity)
+
+# Create DG solver with polynomial degree = 3 and (local) Lax-Friedrichs/Rusanov flux as surface flux
+solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs)
+
+# Deformed rectangle that looks like a waving flag,
+# lower and upper faces are sinus curves, left and right are vertical lines.
+f1(s) = SVector(-1.0, s - 1.0)
+f2(s) = SVector( 1.0, s + 1.0)
+f3(s) = SVector(s, -1.0 + sin(0.5 * pi * s))
+f4(s) = SVector(s,  1.0 + sin(0.5 * pi * s))
+
+trees_per_dimension = (3, 2)
+
+# Create P4estMesh with 8 x 8 trees and 16 x 16 elements
+mesh = P4estMesh(trees_per_dimension, polydeg=3,
+                 faces=(f1, f2, f3, f4),
+                 initial_refinement_level=1)
+
+# Refine recursively until each bottom left quadrant of a forest has level 4
+# The mesh will be rebalanced before the simulation starts
+refine_fn_c = @cfunction(refine_fn, Cint, (Ptr{p4est_t}, Ptr{p4est_topidx_t}, Ptr{p4est_quadrant_t}))
+p4est_refine(mesh.p4est, true, refine_fn_c, C_NULL)
+
+# A semidiscretization collects data structures and functions for the spatial discretization
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test, solver)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+# Create ODE problem with time span from 0.0 to 1.0
+ode = semidiscretize(semi, (0.0, 0.2));
+
+# At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
+# and resets the timers
+summary_callback = SummaryCallback()
+
+# The AnalysisCallback allows to analyse the solution in regular intervals and prints the results
+analysis_callback = AnalysisCallback(semi, interval=100)
+
+# The SaveSolutionCallback allows to save the solution to a file in regular intervals
+save_solution = SaveSolutionCallback(interval=100,
+                                     solution_variables=cons2prim)
+
+# The StepsizeCallback handles the re-calculcation of the maximum Δt after each time step
+stepsize_callback = StepsizeCallback(cfl=1.6)
+
+# Create a CallbackSet to collect all callbacks such that they can be passed to the ODE solver
+callbacks = CallbackSet(summary_callback, analysis_callback, save_solution, stepsize_callback)
+
+
+###############################################################################
+# run the simulation
+
+# OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+
+# Print the timer summary
+summary_callback()

--- a/examples/2d/elixir_euler_free_stream_p4est.jl
+++ b/examples/2d/elixir_euler_free_stream_p4est.jl
@@ -1,4 +1,5 @@
 
+using Downloads: download
 using OrdinaryDiffEq
 using Trixi
 

--- a/examples/2d/elixir_euler_nonperiodic_p4est.jl
+++ b/examples/2d/elixir_euler_nonperiodic_p4est.jl
@@ -1,4 +1,5 @@
 
+using Downloads: download
 using OrdinaryDiffEq
 using Trixi
 

--- a/src/mesh/p4est_mesh.jl
+++ b/src/mesh/p4est_mesh.jl
@@ -303,7 +303,7 @@ end
 @inline Base.real(::P4estMesh{NDIMS, RealT}) where {NDIMS, RealT} = RealT
 
 @inline ntrees(mesh::P4estMesh) = mesh.p4est.trees.elem_count
-@inline ncells(mesh::P4estMesh) = mesh.p4est_mesh.local_num_quadrants
+@inline ncells(mesh::P4estMesh) = mesh.p4est.global_num_quadrants
 
 
 function Base.show(io::IO, mesh::P4estMesh)

--- a/src/solvers/dg_p4est/containers.jl
+++ b/src/solvers/dg_p4est/containers.jl
@@ -41,9 +41,9 @@ Base.eltype(::ElementContainerP4est{NDIMS, RealT, uEltype}) where {NDIMS, RealT,
 
 
 struct InterfaceContainerP4est{NDIMS, uEltype<:Real, NDIMSP2} <: AbstractContainer
-  u::Array{uEltype, NDIMSP2}                  # [primary/secondary, variable, i, j, interface]
-  element_ids::Matrix{Int}                    # [primary/secondary, interface]
-  node_indices::Matrix{NTuple{NDIMS, Symbol}} # [primary/secondary, interface]
+  u::Array{uEltype, NDIMSP2}                    # [primary/secondary, variable, i, j, interface]
+  element_ids::Array{Int, 2}                    # [primary/secondary, interface]
+  node_indices::Array{NTuple{NDIMS, Symbol}, 2} # [primary/secondary, interface]
 end
 
 # Create interface container and initialize interface data.
@@ -56,8 +56,8 @@ function init_interfaces(mesh::P4estMesh, equations, basis,
   u = Array{uEltype, NDIMS+2}(undef, 2, nvariables(equations),
                               ntuple(_ -> nnodes(basis), NDIMS-1)...,
                               n_interfaces)
-  element_ids = Matrix{Int}(undef, 2, n_interfaces)
-  node_indices = Matrix{NTuple{NDIMS, Symbol}}(undef, 2, n_interfaces)
+  element_ids = Array{Int, 2}(undef, 2, n_interfaces)
+  node_indices = Array{NTuple{NDIMS, Symbol}, 2}(undef, 2, n_interfaces)
 
   interfaces = InterfaceContainerP4est{NDIMS, uEltype, NDIMS+2}(u, element_ids, node_indices)
 
@@ -102,8 +102,8 @@ end
 
 struct MortarContainerP4est{NDIMS, uEltype<:Real, NDIMSP1, NDIMSP3} <: AbstractContainer
   u::Array{uEltype, NDIMSP3}       # [small/large side, variable, position, i, j, mortar]
-  element_ids::Matrix{Int}         # [position, mortar]
-  node_indices::Matrix{NTuple{NDIMS, Symbol}} # [small/large, mortar]
+  element_ids::Array{Int, 2}       # [position, mortar]
+  node_indices::Array{NTuple{NDIMS, Symbol}, 2} # [small/large, mortar]
 end
 
 # Create mortar container and initialize mortar data.
@@ -118,8 +118,8 @@ function init_mortars(mesh::P4estMesh, equations, basis,
                               2^(NDIMS-1),
                               ntuple(_ -> nnodes(basis), NDIMS-1)...,
                               n_mortars)
-  element_ids = Matrix{Int}(undef, 2^(NDIMS-1) + 1, n_mortars)
-  node_indices = Matrix{NTuple{NDIMS, Symbol}}(undef, 2, n_mortars)
+  element_ids = Array{Int, 2}(undef, 2^(NDIMS-1) + 1, n_mortars)
+  node_indices = Array{NTuple{NDIMS, Symbol}, 2}(undef, 2, n_mortars)
 
   mortars = MortarContainerP4est{NDIMS, uEltype, NDIMS+1, NDIMS+3}(u, element_ids,
                                                                       node_indices)

--- a/src/solvers/dg_p4est/containers.jl
+++ b/src/solvers/dg_p4est/containers.jl
@@ -100,6 +100,31 @@ end
 @inline nboundaries(boundaries::BoundaryContainerP4est) = length(boundaries.element_ids)
 
 
+# Container data structure (structure-of-arrays style) for DG L2 mortars
+#
+# The positions used in `element_ids` are 1:3 (in 2D) or 1:5 (in 3D), where 1:2 (in 2D)
+# or 1:4 (in 3D) are the small elements numbered in z-order and 3 or 5 is the large element.
+# The solution values on the mortar element are saved in `u`, where `position` is the number
+# of the small element that corresponds to the respective part of the mortar element.
+# The first dimension `small/large side` takes 1 for small side and 2 for large side.
+#
+# Illustration of the positions in `element_ids` in 3D, where ξ and η are the local coordinates
+# of the mortar element, which are precisely the local coordinates that span
+# the surface of the smaller side.
+# Note that the orientation in the physical space is completely irrelevant here.
+#   /---------------------------\  /----------------------------\
+#   |             |             |  |                            |
+#   |    small    |    small    |  |                            |
+#   |      3      |      4      |  |                            |
+#   |             |             |  |           large            |
+#   |-------------|-------------|  |             5              |
+# η |             |             |  |                            |
+#   |    small    |    small    |  |                            |
+# ^ |      1      |      2      |  |                            |
+# | |             |             |  |                            |
+# | \---------------------------/  \----------------------------/
+# |
+# ⋅----> ξ
 struct MortarContainerP4est{NDIMS, uEltype<:Real, NDIMSP1, NDIMSP3} <: AbstractContainer
   u::Array{uEltype, NDIMSP3}       # [small/large side, variable, position, i, j, mortar]
   element_ids::Array{Int, 2}       # [position, mortar]

--- a/src/solvers/dg_p4est/containers.jl
+++ b/src/solvers/dg_p4est/containers.jl
@@ -101,8 +101,7 @@ end
 
 
 struct MortarContainerP4est{NDIMS, uEltype<:Real, NDIMSP1, NDIMSP3} <: AbstractContainer
-  u::Array{uEltype, NDIMSP3}       # [small/large side, position, variable, i, j, mortar]
-  u_large::Array{uEltype, NDIMSP1} # [variable, i, j, mortar]
+  u::Array{uEltype, NDIMSP3}       # [small/large side, variable, position, i, j, mortar]
   element_ids::Matrix{Int}         # [position, mortar]
   node_indices::Matrix{NTuple{NDIMS, Symbol}} # [small/large, mortar]
 end
@@ -114,19 +113,15 @@ function init_mortars(mesh::P4estMesh, equations, basis,
   # Initialize container
   n_mortars = count_required_mortars(mesh)
 
-  u = Array{uEltype, NDIMS+3}(undef, 3, 2^(NDIMS-1),
+  u = Array{uEltype, NDIMS+3}(undef, 2,
                               nvariables(equations),
+                              2^(NDIMS-1),
                               ntuple(_ -> nnodes(basis), NDIMS-1)...,
                               n_mortars)
-  u_large = Array{uEltype, NDIMS+1}(undef,
-                                    nvariables(equations),
-                                    ntuple(_ -> nnodes(basis), NDIMS-1)...,
-                                    n_mortars)
-  element_ids = Matrix{Int}(undef, 2^(NDIMS-1), n_mortars)
+  element_ids = Matrix{Int}(undef, 2^(NDIMS-1) + 1, n_mortars)
   node_indices = Matrix{NTuple{NDIMS, Symbol}}(undef, 2, n_mortars)
 
-  mortars = MortarContainerP4est{NDIMS, uEltype, NDIMS+1, NDIMS+3}(u, u_large,
-                                                                      element_ids,
+  mortars = MortarContainerP4est{NDIMS, uEltype, NDIMS+1, NDIMS+3}(u, element_ids,
                                                                       node_indices)
 
   init_mortars!(mortars, mesh)

--- a/src/solvers/dg_p4est/containers_2d.jl
+++ b/src/solvers/dg_p4est/containers_2d.jl
@@ -249,7 +249,7 @@ function init_mortars_iter_face(info, user_data)
     # Left is small, right is large
     small_large = [1, 2]
 
-    local_small_quad_ids = unsafe_wrap(Array, sides[1].is.hanging.quadid, 2)
+    local_small_quad_ids = sides[1].is.hanging.quadid
     # Global IDs of the two small quads
     small_quad_ids = offsets[1] .+ local_small_quad_ids
 
@@ -260,7 +260,7 @@ function init_mortars_iter_face(info, user_data)
     # Left is large, right is small
     small_large = [2, 1]
 
-    local_small_quad_ids = unsafe_wrap(Array, sides[2].is.hanging.quadid, 2)
+    local_small_quad_ids = sides[2].is.hanging.quadid
     # Global IDs of the two small quads
     small_quad_ids = offsets[2] .+ local_small_quad_ids
 

--- a/src/solvers/dg_p4est/containers_2d.jl
+++ b/src/solvers/dg_p4est/containers_2d.jl
@@ -246,6 +246,9 @@ function init_mortars_iter_face(info, user_data)
              trees[sides[2].treeid + 1].quadrants_offset]
 
   if sides[1].is_hanging == true
+    # Left is small, right is large
+    small_large = [1, 2]
+
     local_small_quad_ids = unsafe_wrap(Array, sides[1].is.hanging.quadid, 2)
     # Global IDs of the two small quads
     small_quad_ids = offsets[1] .+ local_small_quad_ids
@@ -254,6 +257,9 @@ function init_mortars_iter_face(info, user_data)
     @assert sides[2].is_hanging == false
     large_quad_id = offsets[2] + sides[2].is.full.quadid
   else # sides[2].is_hanging == true
+    # Left is large, right is small
+    small_large = [2, 1]
+
     local_small_quad_ids = unsafe_wrap(Array, sides[2].is.hanging.quadid, 2)
     # Global IDs of the two small quads
     small_quad_ids = offsets[2] .+ local_small_quad_ids
@@ -278,10 +284,10 @@ function init_mortars_iter_face(info, user_data)
   orientation = info.orientation
 
   for side in 1:2
-    # Align interface in positive coordinate direction of primary element.
-    # For orientation == 1, the secondary element needs to be indexed backwards
-    # relative to the interface.
-    if side == 1 || orientation == 0
+    # Align mortar in positive coordinate direction of small side.
+    # For orientation == 1, the large side needs to be indexed backwards
+    # relative to the mortar.
+    if small_large[side] == 1 || orientation == 0
       # Forward indexing
       i = :i
     else
@@ -291,16 +297,16 @@ function init_mortars_iter_face(info, user_data)
 
     if faces[side] == 0
       # Index face in negative x-direction
-      mortars.node_indices[side, mortar_id] = (:one, i)
+      mortars.node_indices[small_large[side], mortar_id] = (:one, i)
     elseif faces[side] == 1
       # Index face in positive x-direction
-      mortars.node_indices[side, mortar_id] = (:end, i)
+      mortars.node_indices[small_large[side], mortar_id] = (:end, i)
     elseif faces[side] == 2
       # Index face in negative y-direction
-      mortars.node_indices[side, mortar_id] = (i, :one)
+      mortars.node_indices[small_large[side], mortar_id] = (i, :one)
     else # faces[side] == 3
       # Index face in positive y-direction
-      mortars.node_indices[side, mortar_id] = (i, :end)
+      mortars.node_indices[small_large[side], mortar_id] = (i, :end)
     end
   end
 

--- a/src/solvers/dg_p4est/containers_2d.jl
+++ b/src/solvers/dg_p4est/containers_2d.jl
@@ -69,6 +69,13 @@ function init_interfaces_iter_face(info, user_data)
     return nothing
   end
 
+  sides = convert_sc_array(p4est_iter_face_side_t, info.sides)
+
+  if sides[1].is_hanging == true || sides[2].is_hanging == true
+    # Mortar, no normal interface
+    return nothing
+  end
+
   # Unpack user_data = [interfaces, interface_id, mesh] and increment interface_id
   ptr = Ptr{Any}(user_data)
   data_array = unsafe_wrap(Array, ptr, 3)
@@ -77,32 +84,27 @@ function init_interfaces_iter_face(info, user_data)
   data_array[2] += 1
   mesh = data_array[3]
 
-  # Extract interface data
-  sides = convert_sc_array(p4est_iter_face_side_t, info.sides)
   # Global trees array
   trees = convert_sc_array(p4est_tree_t, mesh.p4est.trees)
   # Quadrant numbering offsets of the quadrants at this interface, one-based indexing
   offsets = [trees[sides[1].treeid + 1].quadrants_offset,
              trees[sides[2].treeid + 1].quadrants_offset]
 
-  if sides[1].is_hanging != 0 || sides[2].is_hanging != 0
-    error("Hanging nodes are not supported yet")
-  end
-
   local_quad_ids = [sides[1].is.full.quadid, sides[2].is.full.quadid]
   # Global IDs of the neighboring quads
   quad_ids = offsets + local_quad_ids
+
+  # Write data to interfaces container
+  # p4est uses zero-based indexing; convert to one-based indexing
+  interfaces.element_ids[1, interface_id] = quad_ids[1] + 1
+  interfaces.element_ids[2, interface_id] = quad_ids[2] + 1
+
   # Face at which the interface lies
   faces = [sides[1].face, sides[2].face]
 
   # Relative orientation of the two cell faces,
   # 0 for aligned coordinates, 1 for reversed coordinates.
   orientation = info.orientation
-
-  # Write data to interfaces container
-  # p4est uses zero-based indexing; convert to one-based indexing
-  interfaces.element_ids[1, interface_id] = quad_ids[1] + 1
-  interfaces.element_ids[2, interface_id] = quad_ids[2] + 1
 
   # Iterate over primary and secondary element
   for side in 1:2
@@ -135,21 +137,12 @@ function init_interfaces_iter_face(info, user_data)
   return nothing
 end
 
-
 function init_interfaces!(interfaces, mesh::P4estMesh{2})
-  # Let p4est iterate over all interfaces and extract interface data to interface container
+  # Let p4est iterate over all interfaces and call init_interfaces_iter_face
   iter_face_c = @cfunction(init_interfaces_iter_face, Cvoid, (Ptr{p4est_iter_face_info_t}, Ptr{Cvoid}))
   user_data = [interfaces, 1, mesh]
 
-  GC.@preserve user_data begin
-    p4est_iterate(mesh.p4est,
-                  C_NULL, # ghost layer
-                  # user data [interfaces, interface_id, mesh]
-                  pointer(user_data),
-                  C_NULL, # iter_volume
-                  iter_face_c, # iter_face
-                  C_NULL) # iter_corner
-  end
+  iterate_faces(mesh, iter_face_c, user_data)
 
   return interfaces
 end
@@ -179,17 +172,18 @@ function init_boundaries_iter_face(info, user_data)
   offset = trees[sides[1].treeid + 1].quadrants_offset
 
   # Verify before accessing is.full, but this should never happen
-  @assert sides[1].is_hanging == 0
+  @assert sides[1].is_hanging == false
 
   local_quad_id = sides[1].is.full.quadid
   # Global ID of this quad
   quad_id = offset + local_quad_id
-  # Face at which the boundary lies
-  face = sides[1].face
 
   # Write data to boundaries container
   # p4est uses zero-based indexing; convert to one-based indexing
   boundaries.element_ids[boundary_id] = quad_id + 1
+
+  # Face at which the boundary lies
+  face = sides[1].face
 
   if face == 0
     # Index face in negative x-direction
@@ -211,21 +205,113 @@ function init_boundaries_iter_face(info, user_data)
   return nothing
 end
 
-
 function init_boundaries!(boundaries, mesh::P4estMesh{2})
-  # Let p4est iterate over all interfaces and extract boundary data to boundary container
+  # Let p4est iterate over all interfaces and call init_boundaries_iter_face
   iter_face_c = @cfunction(init_boundaries_iter_face, Cvoid, (Ptr{p4est_iter_face_info_t}, Ptr{Cvoid}))
   user_data = [boundaries, 1, mesh]
 
-  GC.@preserve user_data begin
-    p4est_iterate(mesh.p4est,
-                  C_NULL, # ghost layer
-                  # user data [interfaces, boundary_id, mesh]
-                  pointer(user_data),
-                  C_NULL, # iter_volume
-                  iter_face_c, # iter_face
-                  C_NULL) # iter_corner
-  end
+  iterate_faces(mesh, iter_face_c, user_data)
 
   return boundaries
+end
+
+
+# Iterate over all interfaces and extract mortar data to mortar container
+# This function will be passed to p4est in init_mortars! below
+function init_mortars_iter_face(info, user_data)
+  if info.sides.elem_count != 2
+    # Not an inner interface
+    return nothing
+  end
+
+  sides = convert_sc_array(p4est_iter_face_side_t, info.sides)
+
+  if sides[1].is_hanging == false && sides[2].is_hanging == false
+    # Normal interface, no mortar
+    return nothing
+  end
+
+  # Unpack user_data = [mortars, mortar_id, mesh] and increment mortar_id
+  ptr = Ptr{Any}(user_data)
+  data_array = unsafe_wrap(Array, ptr, 3)
+  mortars = data_array[1]
+  mortar_id = data_array[2]
+  data_array[2] += 1
+  mesh = data_array[3]
+
+  # Global trees array
+  trees = convert_sc_array(p4est_tree_t, mesh.p4est.trees)
+  # Quadrant numbering offsets of the quadrants at this interface, one-based indexing
+  offsets = [trees[sides[1].treeid + 1].quadrants_offset,
+             trees[sides[2].treeid + 1].quadrants_offset]
+
+  if sides[1].is_hanging == true
+    local_small_quad_ids = unsafe_wrap(Array, sides[1].is.hanging.quadid, 2)
+    # Global IDs of the two small quads
+    small_quad_ids = offsets[1] .+ local_small_quad_ids
+
+    # Just be sure before accessing is.full
+    @assert sides[2].is_hanging == false
+    large_quad_id = offsets[2] + sides[2].is.full.quadid
+  else # sides[2].is_hanging == true
+    local_small_quad_ids = unsafe_wrap(Array, sides[2].is.hanging.quadid, 2)
+    # Global IDs of the two small quads
+    small_quad_ids = offsets[2] .+ local_small_quad_ids
+
+    # Just be sure before accessing is.full
+    @assert sides[1].is_hanging == false
+    large_quad_id = offsets[1] + sides[1].is.full.quadid
+  end
+
+  # Write data to mortar container, 1 and 2 are the small elements
+  # p4est uses zero-based indexing; convert to one-based indexing
+  mortars.element_ids[1, mortar_id] = small_quad_ids[1] + 1
+  mortars.element_ids[2, mortar_id] = small_quad_ids[2] + 1
+  # 3 is the large element
+  mortars.element_ids[3, mortar_id] = large_quad_id + 1
+
+  # Face at which the interface lies
+  faces = [sides[1].face, sides[2].face]
+
+  # Relative orientation of the two cell faces,
+  # 0 for aligned coordinates, 1 for reversed coordinates.
+  orientation = info.orientation
+
+  for side in 1:2
+    # Align interface in positive coordinate direction of primary element.
+    # For orientation == 1, the secondary element needs to be indexed backwards
+    # relative to the interface.
+    if side == 1 || orientation == 0
+      # Forward indexing
+      i = :i
+    else
+      # Backward indexing
+      i = :i_backwards
+    end
+
+    if faces[side] == 0
+      # Index face in negative x-direction
+      mortars.node_indices[side, mortar_id] = (:one, i)
+    elseif faces[side] == 1
+      # Index face in positive x-direction
+      mortars.node_indices[side, mortar_id] = (:end, i)
+    elseif faces[side] == 2
+      # Index face in negative y-direction
+      mortars.node_indices[side, mortar_id] = (i, :one)
+    else # faces[side] == 3
+      # Index face in positive y-direction
+      mortars.node_indices[side, mortar_id] = (i, :end)
+    end
+  end
+
+  return nothing
+end
+
+function init_mortars!(mortars, mesh::P4estMesh{2})
+  iter_face_c = @cfunction(init_mortars_iter_face, Cvoid, (Ptr{p4est_iter_face_info_t}, Ptr{Cvoid}))
+  user_data = [mortars, 1, mesh]
+
+  iterate_faces(mesh, iter_face_c, user_data)
+
+  return mortars
 end

--- a/src/solvers/dg_p4est/dg.jl
+++ b/src/solvers/dg_p4est/dg.jl
@@ -2,12 +2,15 @@
 # It constructs the basic `cache` used throughout the simulation to compute
 # the RHS etc.
 function create_cache(mesh::P4estMesh, equations::AbstractEquations, dg::DG, ::Any, ::Type{uEltype}) where {uEltype<:Real}
-  elements = init_elements(mesh, equations, dg.basis, uEltype)
+  elements   = init_elements(mesh, equations, dg.basis, uEltype)
   interfaces = init_interfaces(mesh, equations, dg.basis, elements)
   boundaries = init_boundaries(mesh, equations, dg.basis, elements)
   mortars    = init_mortars(   mesh, equations, dg.basis, elements)
 
   cache = (; elements, interfaces, boundaries, mortars)
+
+  # Add specialized parts of the cache required to compute the volume integral etc.
+  cache = (;cache..., create_cache(mesh, equations, dg.mortar, uEltype)...)
 
   return cache
 end

--- a/src/solvers/dg_p4est/dg.jl
+++ b/src/solvers/dg_p4est/dg.jl
@@ -5,8 +5,9 @@ function create_cache(mesh::P4estMesh, equations::AbstractEquations, dg::DG, ::A
   elements = init_elements(mesh, equations, dg.basis, uEltype)
   interfaces = init_interfaces(mesh, equations, dg.basis, elements)
   boundaries = init_boundaries(mesh, equations, dg.basis, elements)
+  mortars    = init_mortars(   mesh, equations, dg.basis, elements)
 
-  cache = (; elements, interfaces, boundaries)
+  cache = (; elements, interfaces, boundaries, mortars)
 
   return cache
 end

--- a/src/solvers/dg_p4est/dg.jl
+++ b/src/solvers/dg_p4est/dg.jl
@@ -5,7 +5,7 @@ function create_cache(mesh::P4estMesh, equations::AbstractEquations, dg::DG, ::A
   elements   = init_elements(mesh, equations, dg.basis, uEltype)
   interfaces = init_interfaces(mesh, equations, dg.basis, elements)
   boundaries = init_boundaries(mesh, equations, dg.basis, elements)
-  mortars    = init_mortars(   mesh, equations, dg.basis, elements)
+  mortars    = init_mortars(mesh, equations, dg.basis, elements)
 
   cache = (; elements, interfaces, boundaries, mortars)
 

--- a/src/solvers/dg_p4est/dg.jl
+++ b/src/solvers/dg_p4est/dg.jl
@@ -2,6 +2,13 @@
 # It constructs the basic `cache` used throughout the simulation to compute
 # the RHS etc.
 function create_cache(mesh::P4estMesh, equations::AbstractEquations, dg::DG, ::Any, ::Type{uEltype}) where {uEltype<:Real}
+  # Make sure to balance the p4est before creating any containers
+  # in case someone has tampered with the p4est after creating the mesh
+  p4est_balance(mesh.p4est, P4EST_CONNECT_FACE, C_NULL)
+  # Due to a bug in p4est, the forest needs to be rebalanced twice sometimes
+  # See https://github.com/cburstedde/p4est/issues/112
+  p4est_balance(mesh.p4est, P4EST_CONNECT_FACE, C_NULL)
+
   elements   = init_elements(mesh, equations, dg.basis, uEltype)
   interfaces = init_interfaces(mesh, equations, dg.basis, elements)
   boundaries = init_boundaries(mesh, equations, dg.basis, elements)

--- a/src/solvers/dg_p4est/dg_2d.jl
+++ b/src/solvers/dg_p4est/dg_2d.jl
@@ -237,8 +237,8 @@ function calc_mortar_flux!(surface_flux_values,
       set_node_vars!(fstar[pos], flux_, equations, dg, i)
     end
 
-    mortar_fluxes_to_elements!(surface_flux_values, mortar_l2,
-                               mesh, equations, dg, cache,
+    mortar_fluxes_to_elements!(surface_flux_values,
+                               mesh, equations, mortar_l2, dg, cache,
                                mortar, fstar)
   end
 

--- a/src/solvers/dg_p4est/dg_2d.jl
+++ b/src/solvers/dg_p4est/dg_2d.jl
@@ -247,9 +247,9 @@ end
 
 
 @inline function mortar_fluxes_to_elements!(surface_flux_values,
+                                            mesh::P4estMesh{2}, equations,
                                             mortar_l2::LobattoLegendreMortarL2,
-                                            mesh::P4estMesh{2}, equations, dg::DGSEM, cache,
-                                            mortar, fstar)
+                                            dg::DGSEM, cache, mortar, fstar)
   @unpack element_ids, node_indices = cache.mortars
 
   small_indices  = node_indices[1, mortar]

--- a/src/solvers/dg_p4est/dg_2d.jl
+++ b/src/solvers/dg_p4est/dg_2d.jl
@@ -7,10 +7,6 @@ function create_cache(mesh::P4estMesh{2}, equations, mortar_l2::LobattoLegendreM
   fstar_lower_threaded = MA2d[MA2d(undef) for _ in 1:Threads.nthreads()]
   u_threaded =           MA2d[MA2d(undef) for _ in 1:Threads.nthreads()]
 
-  # A2d = Array{uEltype, 2}
-  # fstar_upper_threaded = [A2d(undef, nvariables(equations), nnodes(mortar_l2)) for _ in 1:Threads.nthreads()]
-  # fstar_lower_threaded = [A2d(undef, nvariables(equations), nnodes(mortar_l2)) for _ in 1:Threads.nthreads()]
-
   (; fstar_upper_threaded, fstar_lower_threaded, u_threaded)
 end
 
@@ -211,7 +207,6 @@ function calc_mortar_flux!(surface_flux_values,
                            mesh::P4estMesh{2},
                            nonconservative_terms::Val{false}, equations,
                            mortar_l2::LobattoLegendreMortarL2, dg::DG, cache)
-  # @unpack neighbor_ids, u_lower, u_upper, orientations = cache.mortars
   @unpack u, element_ids, node_indices = cache.mortars
   @unpack fstar_upper_threaded, fstar_lower_threaded = cache
   @unpack surface_flux = dg

--- a/src/solvers/dg_tree/dg_2d.jl
+++ b/src/solvers/dg_tree/dg_2d.jl
@@ -901,7 +901,8 @@ function calc_mortar_flux!(surface_flux_values,
     calc_fstar!(fstar_upper, equations, dg, u_upper, mortar, orientation)
     calc_fstar!(fstar_lower, equations, dg, u_lower, mortar, orientation)
 
-    mortar_fluxes_to_elements!(surface_flux_values, equations, mortar_l2, dg, cache,
+    mortar_fluxes_to_elements!(surface_flux_values, mortar_l2,
+                               mesh, equations, dg, cache,
                                mortar, fstar_upper, fstar_lower)
   end
 
@@ -961,7 +962,8 @@ function calc_mortar_flux!(surface_flux_values,
 
     @. fstar_upper += noncons_diamond_upper
     @. fstar_lower += noncons_diamond_lower
-    mortar_fluxes_to_elements!(surface_flux_values, equations, mortar_l2, dg, cache,
+    mortar_fluxes_to_elements!(surface_flux_values, mortar_l2,
+                               mesh, equations, dg, cache,
                                mortar, fstar_upper, fstar_lower)
   end
 
@@ -984,8 +986,9 @@ end
   return nothing
 end
 
-@inline function mortar_fluxes_to_elements!(surface_flux_values::AbstractArray{<:Any,4}, equations,
-                                            mortar_l2::LobattoLegendreMortarL2, dg::DGSEM, cache,
+@inline function mortar_fluxes_to_elements!(surface_flux_values,
+                                            mortar_l2::LobattoLegendreMortarL2,
+                                            mesh::TreeMesh{2}, equations, dg::DGSEM, cache,
                                             mortar, fstar_upper, fstar_lower)
   large_element = cache.mortars.neighbor_ids[3, mortar]
   upper_element = cache.mortars.neighbor_ids[2, mortar]

--- a/src/solvers/dg_tree/dg_2d.jl
+++ b/src/solvers/dg_tree/dg_2d.jl
@@ -987,8 +987,9 @@ end
 end
 
 @inline function mortar_fluxes_to_elements!(surface_flux_values,
+                                            mesh::TreeMesh{2}, equations,
                                             mortar_l2::LobattoLegendreMortarL2,
-                                            mesh::TreeMesh{2}, equations, dg::DGSEM, cache,
+                                            dg::DGSEM, cache,
                                             mortar, fstar_upper, fstar_lower)
   large_element = cache.mortars.neighbor_ids[3, mortar]
   upper_element = cache.mortars.neighbor_ids[2, mortar]

--- a/src/solvers/dg_tree/dg_2d.jl
+++ b/src/solvers/dg_tree/dg_2d.jl
@@ -113,7 +113,7 @@ end
 # TODO: Taal discuss/refactor timer, allowing users to pass a custom timer?
 
 function rhs!(du, u, t,
-              mesh::TreeMesh{2}, equations,
+              mesh::Union{TreeMesh{2}, P4estMesh{2}}, equations,
               initial_condition, boundary_conditions, source_terms,
               dg::DG, cache)
   # Reset du

--- a/src/solvers/dg_tree/dg_2d.jl
+++ b/src/solvers/dg_tree/dg_2d.jl
@@ -901,8 +901,8 @@ function calc_mortar_flux!(surface_flux_values,
     calc_fstar!(fstar_upper, equations, dg, u_upper, mortar, orientation)
     calc_fstar!(fstar_lower, equations, dg, u_lower, mortar, orientation)
 
-    mortar_fluxes_to_elements!(surface_flux_values, mortar_l2,
-                               mesh, equations, dg, cache,
+    mortar_fluxes_to_elements!(surface_flux_values,
+                               mesh, equations, mortar_l2, dg, cache,
                                mortar, fstar_upper, fstar_lower)
   end
 
@@ -962,8 +962,8 @@ function calc_mortar_flux!(surface_flux_values,
 
     @. fstar_upper += noncons_diamond_upper
     @. fstar_lower += noncons_diamond_lower
-    mortar_fluxes_to_elements!(surface_flux_values, mortar_l2,
-                               mesh, equations, dg, cache,
+    mortar_fluxes_to_elements!(surface_flux_values,
+                               mesh, equations, mortar_l2, dg, cache,
                                mortar, fstar_upper, fstar_lower)
   end
 

--- a/src/solvers/dg_tree/dg_3d.jl
+++ b/src/solvers/dg_tree/dg_3d.jl
@@ -924,7 +924,8 @@ function calc_mortar_flux!(surface_flux_values,
     calc_fstar!(fstar_lower_left,  equations, dg, u_lower_left,  mortar, orientation)
     calc_fstar!(fstar_lower_right, equations, dg, u_lower_right, mortar, orientation)
 
-    mortar_fluxes_to_elements!(surface_flux_values, equations, mortar_l2, dg, cache, mortar,
+    mortar_fluxes_to_elements!(surface_flux_values, mortar_l2,
+                               mesh, equations, dg, cache, mortar,
                                fstar_upper_left, fstar_upper_right,
                                fstar_lower_left, fstar_lower_right,
                                fstar_tmp1)
@@ -1033,7 +1034,8 @@ function calc_mortar_flux!(surface_flux_values,
     for j in eachnode(dg), i in eachnode(dg), v in eachvariable(equations)
       fstar_lower_right[v, i, j] += noncons_diamond_lower_right[v, i, j]
     end
-    mortar_fluxes_to_elements!(surface_flux_values, equations, mortar_l2, dg, cache, mortar,
+    mortar_fluxes_to_elements!(surface_flux_values, mortar_l2,
+                               mesh, equations, dg, cache, mortar,
                                fstar_upper_left, fstar_upper_right,
                                fstar_lower_left, fstar_lower_right,
                                fstar_tmp1)
@@ -1058,8 +1060,10 @@ end
   return nothing
 end
 
-@inline function mortar_fluxes_to_elements!(surface_flux_values::AbstractArray{<:Any,5}, equations,
-                                            mortar_l2::LobattoLegendreMortarL2, dg::DGSEM, cache, mortar,
+@inline function mortar_fluxes_to_elements!(surface_flux_values,
+                                            mortar_l2::LobattoLegendreMortarL2,
+                                            mesh::TreeMesh{3}, equations, dg::DGSEM, cache,
+                                            mortar,
                                             fstar_upper_left, fstar_upper_right,
                                             fstar_lower_left, fstar_lower_right,
                                             fstar_tmp1)

--- a/src/solvers/dg_tree/dg_3d.jl
+++ b/src/solvers/dg_tree/dg_3d.jl
@@ -1061,8 +1061,9 @@ end
 end
 
 @inline function mortar_fluxes_to_elements!(surface_flux_values,
+                                            mesh::TreeMesh{3}, equations,
                                             mortar_l2::LobattoLegendreMortarL2,
-                                            mesh::TreeMesh{3}, equations, dg::DGSEM, cache,
+                                            dg::DGSEM, cache,
                                             mortar,
                                             fstar_upper_left, fstar_upper_right,
                                             fstar_lower_left, fstar_lower_right,

--- a/src/solvers/dg_tree/dg_3d.jl
+++ b/src/solvers/dg_tree/dg_3d.jl
@@ -924,8 +924,8 @@ function calc_mortar_flux!(surface_flux_values,
     calc_fstar!(fstar_lower_left,  equations, dg, u_lower_left,  mortar, orientation)
     calc_fstar!(fstar_lower_right, equations, dg, u_lower_right, mortar, orientation)
 
-    mortar_fluxes_to_elements!(surface_flux_values, mortar_l2,
-                               mesh, equations, dg, cache, mortar,
+    mortar_fluxes_to_elements!(surface_flux_values,
+                               mesh, equations, mortar_l2, dg, cache, mortar,
                                fstar_upper_left, fstar_upper_right,
                                fstar_lower_left, fstar_lower_right,
                                fstar_tmp1)
@@ -1034,8 +1034,8 @@ function calc_mortar_flux!(surface_flux_values,
     for j in eachnode(dg), i in eachnode(dg), v in eachvariable(equations)
       fstar_lower_right[v, i, j] += noncons_diamond_lower_right[v, i, j]
     end
-    mortar_fluxes_to_elements!(surface_flux_values, mortar_l2,
-                               mesh, equations, dg, cache, mortar,
+    mortar_fluxes_to_elements!(surface_flux_values,
+                               mesh, equations, mortar_l2, dg, cache, mortar,
                                fstar_upper_left, fstar_upper_right,
                                fstar_lower_left, fstar_lower_right,
                                fstar_tmp1)

--- a/test/test_examples_2d_p4est.jl
+++ b/test/test_examples_2d_p4est.jl
@@ -36,7 +36,9 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "2d")
   @testset "elixir_euler_free_stream_p4est.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_free_stream_p4est.jl"),
       l2   = [2.063350241405049e-15, 1.8571016296925367e-14, 3.1769447886391905e-14, 1.4104095258528071e-14],
-      linf = [1.9539925233402755e-14, 2.9791447087035294e-13, 4.636291350834654e-13, 4.956035581926699e-13])
+      linf = [1.9539925233402755e-14, 2.9791447087035294e-13, 4.636291350834654e-13, 4.956035581926699e-13],
+      atol = 5e-13, # required to make CI tests pass on macOS
+    )
   end
 end
 

--- a/test/test_examples_2d_p4est.jl
+++ b/test/test_examples_2d_p4est.jl
@@ -1,4 +1,4 @@
-module TestExamples2DCurved
+module TestExamples2dP4est
 
 using Test
 using Trixi
@@ -13,6 +13,12 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "2d")
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_basic_p4est.jl"),
       l2   = [9.14468177884088e-6],
       linf = [6.437440532947036e-5])
+  end
+
+  @testset "elixir_advection_p4est_non_conforming.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_p4est_non_conforming.jl"),
+      l2   = [4.634288969205318e-4],
+      linf = [4.740692055057893e-3])
   end
 
   @testset "elixir_advection_restart_p4est.jl" begin

--- a/test/test_examples_2d_part1.jl
+++ b/test/test_examples_2d_part1.jl
@@ -30,6 +30,9 @@ isdir(outdir) && rm(outdir, recursive=true)
 
   # Unstructured curved mesh
   include("test_examples_2d_unstructured_quad.jl")
+
+  # P4estMesh
+  include("test_examples_2d_p4est.jl")
 end
 
 # Coverage test for all initial conditions


### PR DESCRIPTION
Fifth point of #584.
This is basically an intermediate PR while I am nearly done with AMR. This makes the big AMR PR easier to review (hopefully).
I don't have any tests for non-conforming meshes here, but I can assure you that it works.
Tests will be added with AMR.