### PR TITLE
Add test with different geometry and solver polydeg

### DIFF
--- a/examples/2d/elixir_advection_p4est_non_conforming_flag.jl
+++ b/examples/2d/elixir_advection_p4est_non_conforming_flag.jl
@@ -9,8 +9,8 @@ using Trixi
 advectionvelocity = (1.0, 1.0)
 equations = LinearScalarAdvectionEquation2D(advectionvelocity)
 
-# Create DG solver with polynomial degree = 3 and (local) Lax-Friedrichs/Rusanov flux as surface flux
-solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs)
+# Create DG solver with polynomial degree = 4 and (local) Lax-Friedrichs/Rusanov flux as surface flux
+solver = DGSEM(polydeg=4, surface_flux=flux_lax_friedrichs)
 
 # Deformed rectangle that looks like a waving flag,
 # lower and upper faces are sinus curves, left and right are vertical lines.
@@ -19,9 +19,10 @@ f2(s) = SVector( 1.0, s + 1.0)
 f3(s) = SVector(s, -1.0 + sin(0.5 * pi * s))
 f4(s) = SVector(s,  1.0 + sin(0.5 * pi * s))
 
-# Create P4estMesh with 3 x 2 trees and 6 x 4 elements
+# Create P4estMesh with 3 x 2 trees and 6 x 4 elements,
+# approximate the geometry with a smaller polydeg for testing.
 trees_per_dimension = (3, 2)
-mesh = P4estMesh(trees_per_dimension, polydeg=3,
+mesh = P4estMesh(trees_per_dimension, polydeg=2,
                  faces=(f1, f2, f3, f4),
                  initial_refinement_level=1)
 

--- a/test/test_examples_2d_p4est.jl
+++ b/test/test_examples_2d_p4est.jl
@@ -17,8 +17,8 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "2d")
 
   @testset "elixir_advection_p4est_non_conforming_flag.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_p4est_non_conforming_flag.jl"),
-      l2   = [4.634288969205318e-4],
-      linf = [4.740692055057893e-3])
+      l2   = [2.58174252995893e-5],
+      linf = [2.65115939055204e-4])
   end
 
   @testset "elixir_advection_p4est_non_conforming_flag_unstructured.jl" begin


### PR DESCRIPTION
There are two non-AMR non-conforming tests, one structured, and one unstructured. I changed the structured one to use different solver and mesh polydegs.
In non-numerical programs, I like to test every single feature with an isolated unit test. However, since these are integration tests that already take long to finish, I'd prefer just changing a test instead of adding another one.