### PR TITLE
Allow passing nodes to calc_node_coordinates! of `P4estMesh`

### DIFF
--- a/src/solvers/dg_p4est/containers_2d.jl
+++ b/src/solvers/dg_p4est/containers_2d.jl
@@ -21,16 +21,16 @@ end
 function calc_node_coordinates!(node_coordinates,
                                 mesh::P4estMesh{2},
                                 basis::LobattoLegendreBasis)
+  # Hanging nodes will cause holes in the mesh if its polydeg is higher
+  # than the polydeg of the solver.
+  @assert length(nodes) >= length(mesh.nodes) "The solver can't have a lower polydeg than the mesh"
+
   calc_node_coordinates!(node_coordinates, mesh, basis.nodes)
 end
 
 function calc_node_coordinates!(node_coordinates,
                                 mesh::P4estMesh{2},
                                 nodes::AbstractVector)
-  # Hanging nodes will cause holes in the mesh if its polydeg is higher
-  # than the polydeg of the solver.
-  @assert length(nodes) >= length(mesh.nodes) "The solver can't have a lower polydeg than the mesh"
-
   # We use `StrideArray`s here since these buffers are used in performance-critical
   # places and the additional information passed to the compiler makes them faster
   # than native `Array`s.

--- a/src/solvers/dg_p4est/containers_2d.jl
+++ b/src/solvers/dg_p4est/containers_2d.jl
@@ -23,7 +23,7 @@ function calc_node_coordinates!(node_coordinates,
                                 basis::LobattoLegendreBasis)
   # Hanging nodes will cause holes in the mesh if its polydeg is higher
   # than the polydeg of the solver.
-  @assert length(nodes) >= length(mesh.nodes) "The solver can't have a lower polydeg than the mesh"
+  @assert length(basis.nodes) >= length(mesh.nodes) "The solver can't have a lower polydeg than the mesh"
 
   calc_node_coordinates!(node_coordinates, mesh, basis.nodes)
 end


### PR DESCRIPTION
The function `calc_node_coordinates!` of `P4estMesh` works for arbitrary nodes. In https://github.com/trixi-framework/Trixi.jl/pull/638#discussion_r649933567, it was changed to only accept a `LobattoLegendreBasis`, which breaks compatibility with Trixi2Vtk where coordinates of equidistant nodes need to be computed.