### PR TITLE
set `main` as main branch for Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,6 +7,7 @@
 # [number of additional OS] = 2 (Windows, MacOS)
 # parallel jobs in ci.yml
 codecov:
+  branch: main
   notify:
     after_n_builds: 20
 comment:


### PR DESCRIPTION
Partially addresses a problem reported in #654