### PR TITLE
Allow convergence tests with lower `initial_refinement_level` than defined in the elixir

### DIFF
--- a/src/auxiliary/special_elixirs.jl
+++ b/src/auxiliary/special_elixirs.jl
@@ -46,7 +46,7 @@ function convergence_test(mod::Module, elixir::AbstractString, iterations; kwarg
   # Types of errors to be calcuated
   errors = Dict(:l2 => Float64[], :linf => Float64[])
 
-  initial_resolution = extract_initial_resolution(elixir)
+  initial_resolution = extract_initial_resolution(elixir, kwargs)
 
   # run simulations and extract errors
   for iter in 1:iterations
@@ -175,17 +175,29 @@ function find_assignment(expr, destination)
 end
 
 # searches the parameter that specifies the mesh reslution in the elixir
-function extract_initial_resolution(elixir)
+function extract_initial_resolution(elixir, kwargs)
   code = read(elixir, String)
   expr = Meta.parse("begin $code end")
 
   try
     # get the initial_refinement_level from the elixir
     initial_refinement_level = find_assignment(expr, :initial_refinement_level)
+
+    if haskey(kwargs, :initial_refinement_level)
+      return kwargs[:initial_refinement_level]
+    else
+      return initial_refinement_level
+    end
   catch e
     if isa(e, UndefVarError)
       # get cells_per_dimension from the elixir
       cells_per_dimension = eval(find_assignment(expr, :cells_per_dimension))
+
+      if haskey(kwargs, :cells_per_dimension)
+        return kwargs[:cells_per_dimension]
+      else
+        return cells_per_dimension
+      end
     else
       throw(e)
     end


### PR DESCRIPTION
This allows to do quicker convergence tests when the elixir already takes some time without increasing the resolution.

Example:
```
julia> convergence_test("examples/2d/elixir_advection_extended.jl", 3);
[...]
####################################################################################################
l2
scalar
error     EOC
9.14e-06  -
5.69e-07  4.01
3.55e-08  4.00

mean      4.00
----------------------------------------------------------------------------------------------------
linf
scalar
error     EOC
6.44e-05  -
4.11e-06  3.97
2.58e-07  3.99

mean      3.98
----------------------------------------------------------------------------------------------------

julia> convergence_test("examples/2d/elixir_advection_extended.jl", 7, initial_refinement_level=0);
[...]
####################################################################################################
l2
scalar
error     EOC
3.49e-01  -
4.40e-02  2.99
2.49e-03  4.14
1.48e-04  4.07
9.14e-06  4.02
5.69e-07  4.01
3.55e-08  4.00

mean      3.87
----------------------------------------------------------------------------------------------------
linf
scalar
error     EOC
8.06e-01  -
1.71e-01  2.24
1.30e-02  3.71
9.66e-04  3.75
6.44e-05  3.91
4.11e-06  3.97
2.58e-07  3.99

mean      3.60
----------------------------------------------------------------------------------------------------
```