### PR TITLE
cancel redundant CI workflows automatically

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -24,6 +24,7 @@ on:
       - 'utils/**'
   workflow_dispatch:
 
+# Cancel redundant CI tests automatically
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -24,6 +24,10 @@ on:
       - 'utils/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ on:
       - 'utils/**'
   workflow_dispatch:
 
+# Cancel redundant CI tests automatically
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ on:
       - 'utils/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     if: "!contains(github.event.head_commit.message, 'skip ci')"


### PR DESCRIPTION
If it works as expected, this can save us quite some CI time when a PR is updated frequently.