### PR TITLE
timed testsets

### DIFF
--- a/test/test_special_elixirs.jl
+++ b/test/test_special_elixirs.jl
@@ -6,6 +6,8 @@ using Trixi
 
 import ForwardDiff
 
+include("test_trixi.jl")
+
 # Start with a clean environment: remove Trixi output directory if it exists
 outdir = "out"
 isdir(outdir) && rm(outdir, recursive=true)
@@ -16,27 +18,39 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples")
 
 @testset "Special elixirs" begin
   @testset "Convergence test" begin
-    mean_convergence = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "tree_2d_dgsem", "elixir_advection_extended.jl"), 3)
-    @test isapprox(mean_convergence[:l2], [4.0], rtol=0.01)
+    @timed_testset "tree_2d_dgsem" begin
+      mean_convergence = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "tree_2d_dgsem", "elixir_advection_extended.jl"), 3)
+      @test isapprox(mean_convergence[:l2], [4.0], rtol=0.01)
+    end
 
-    mean_convergence = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "structured_2d_dgsem", "elixir_advection_extended.jl"), 3)
-    @test isapprox(mean_convergence[:l2], [4.0], rtol=0.01)
+    @timed_testset "structured_2d_dgsem" begin
+      mean_convergence = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "structured_2d_dgsem", "elixir_advection_extended.jl"), 3)
+      @test isapprox(mean_convergence[:l2], [4.0], rtol=0.01)
+    end
 
-    mean_convergence = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "p4est_2d_dgsem", "elixir_euler_source_terms_nonperiodic_unstructured.jl"), 3)
-    @test isapprox(mean_convergence[:l2], [3.54, 3.50, 3.50, 3.52], rtol=0.01)
+    @timed_testset "p4est_2d_dgsem" begin
+      mean_convergence = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "p4est_2d_dgsem", "elixir_euler_source_terms_nonperiodic_unstructured.jl"), 3)
+      @test isapprox(mean_convergence[:l2], [3.54, 3.50, 3.50, 3.52], rtol=0.01)
+    end
 
-    mean_convergence = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "structured_3d_dgsem", "elixir_advection_basic.jl"), 2)
-    @test isapprox(mean_convergence[:l2], [4.0], rtol=0.01)
+    @timed_testset "structured_3d_dgsem" begin
+      mean_convergence = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "structured_3d_dgsem", "elixir_advection_basic.jl"), 2)
+      @test isapprox(mean_convergence[:l2], [4.0], rtol=0.01)
+    end
 
-    mean_convergence = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "p4est_3d_dgsem", "elixir_advection_unstructured_curved.jl"), 2, initial_refinement_level=1)
-    @test isapprox(mean_convergence[:l2], [3.31], rtol=0.01)
+    @timed_testset "p4est_3d_dgsem" begin
+      mean_convergence = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "p4est_3d_dgsem", "elixir_advection_unstructured_curved.jl"), 2, initial_refinement_level=1)
+      @test isapprox(mean_convergence[:l2], [3.31], rtol=0.01)
+    end
 
-    mean_convergence = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "paper_self_gravitating_gas_dynamics", "elixir_eulergravity_convergence.jl"), 2, tspan=(0.0, 0.1))
-    @test isapprox(mean_convergence[:l2], 4 * ones(4), atol=0.4)
+    @timed_testset "paper_self_gravitating_gas_dynamics" begin
+      mean_convergence = convergence_test(@__MODULE__, joinpath(EXAMPLES_DIR, "paper_self_gravitating_gas_dynamics", "elixir_eulergravity_convergence.jl"), 2, tspan=(0.0, 0.1))
+      @test isapprox(mean_convergence[:l2], 4 * ones(4), atol=0.4)
+    end
   end
 
 
-  @testset "Test linear structure (2D)" begin
+  @timed_testset "Test linear structure (2D)" begin
     trixi_include(@__MODULE__, joinpath(EXAMPLES_DIR, "tree_2d_dgsem", "elixir_advection_extended.jl"),
                   tspan=(0.0, 0.0), initial_refinement_level=2)
     A, b = linear_structure(semi)
@@ -58,7 +72,7 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples")
 
 
   @testset "Test Jacobian of DG (2D)" begin
-    @testset "Linear advection" begin
+    @timed_testset "Linear advection" begin
       trixi_include(@__MODULE__, joinpath(EXAMPLES_DIR, "tree_2d_dgsem", "elixir_advection_extended.jl"),
                     tspan=(0.0, 0.0), initial_refinement_level=2)
       A, _ = linear_structure(semi)
@@ -74,7 +88,7 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples")
       @test maximum(real, λ) < 10 * sqrt(eps(real(semi)))
     end
 
-    @testset "Compressible Euler equations" begin
+    @timed_testset "Compressible Euler equations" begin
       trixi_include(@__MODULE__, joinpath(EXAMPLES_DIR, "tree_2d_dgsem", "elixir_euler_density_wave.jl"),
                     tspan=(0.0, 0.0), initial_refinement_level=2)
 
@@ -93,7 +107,7 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples")
       @test_skip jacobian_ad_forward(semi)
     end
 
-    @testset "MHD" begin
+    @timed_testset "MHD" begin
       trixi_include(@__MODULE__, joinpath(EXAMPLES_DIR, "tree_2d_dgsem", "elixir_mhd_alfven_wave.jl"),
                     tspan=(0.0, 0.0), initial_refinement_level=1)
       @test_nowarn jacobian_ad_forward(semi)
@@ -105,7 +119,7 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples")
   end
 
 
-  @testset "Test linear structure (3D)" begin
+  @timed_testset "Test linear structure (3D)" begin
     trixi_include(@__MODULE__, joinpath(EXAMPLES_DIR, "tree_3d_dgsem", "elixir_advection_extended.jl"),
                   tspan=(0.0, 0.0), initial_refinement_level=1)
     A, b = linear_structure(semi)
@@ -114,7 +128,7 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples")
   end
 
 
-  @testset "Test Jacobian of DG (3D)" begin
+  @timed_testset "Test Jacobian of DG (3D)" begin
     trixi_include(@__MODULE__, joinpath(EXAMPLES_DIR, "tree_3d_dgsem", "elixir_advection_extended.jl"),
                   tspan=(0.0, 0.0), initial_refinement_level=1)
     A, _ = linear_structure(semi)
@@ -132,7 +146,7 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples")
 
 
   @testset "AD using ForwardDiff" begin
-    @testset "Euler equations 1D" begin
+    @timed_testset "Euler equations 1D" begin
       function entropy_at_final_time(k) # k is the wave number of the initial condition
         equations = CompressibleEulerEquations1D(1.4)
         mesh = TreeMesh((-1.0,), (1.0,), initial_refinement_level=3, n_cells_max=10^4)
@@ -161,7 +175,7 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples")
       ForwardDiff.derivative(entropy_at_final_time, 1.0) ≈ -0.4524664696235628
     end
 
-    @testset "Linear advection 2D" begin
+    @timed_testset "Linear advection 2D" begin
       function energy_at_final_time(k) # k is the wave number of the initial condition
         equations = LinearScalarAdvectionEquation2D(1.0, -0.3)
         mesh = TreeMesh((-1.0, -1.0), (1.0, 1.0), initial_refinement_level=3, n_cells_max=10^4)

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -131,11 +131,29 @@ end
 
 
 """
+    @timed_testset "name of the testset" #= code to test #=
+
+Similar to `@testset`, but wraps the execution of the testset using `@time`
+and prints the name of the testset after execution.
+"""
+macro timed_testset(name, expr)
+  @assert name isa String
+  quote
+    @time @testset $name $expr
+    flush(stdout)
+    @info("Testset " * $name * " finished.\n")
+    flush(stdout)
+  end
+end
+
+
+"""
     @trixi_testset "name of the testset" #= code to test #=
 
 Similar to `@testset`, but wraps the code inside a temporary module to avoid
 namespace pollution. It also `include`s this file again to provide the
-definition of `@test_trixi_include`.
+definition of `@test_trixi_include`. Moreover, it records the execution time
+of the testset similarly to [`timed_testset`](@ref).
 """
 macro trixi_testset(name, expr)
   @assert name isa String
@@ -161,7 +179,7 @@ macro trixi_testset(name, expr)
       catch
         nothing
       end
-      @testset $name $expr
+      @timed_testset $name $expr
     end
     nothing
   end


### PR DESCRIPTION
This should help us to identify tests that are particularly expensive in CI. For example, we get
```
657.933297 seconds (117.14 M allocations: 6.142 GiB, 0.48% gc time)
[ Info: Testset structured_3d_dgsem finished.
```
from one of the convergence tests in `test_special_elixirs.jl`.

Xref #372