### PR TITLE
curved ec performance

### DIFF
--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -269,7 +269,7 @@ end
 
 
 """
-    function flux_shima_etal(u_ll, u_rr, orientation, equations::CompressibleEulerEquations1D)
+    flux_shima_etal(u_ll, u_rr, orientation, equations::CompressibleEulerEquations1D)
 
 This flux is is a modification of the original kinetic energy preserving two-point flux by
 - Yuichi Kuya, Kosuke Totani and Soshi Kawai (2018)

--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -385,7 +385,7 @@ See also
 - Hendrik Ranocha (2020)
   Entropy Conserving and Kinetic Energy Preserving Numerical Methods for
   the Euler Equations Using Summation-by-Parts Operators
-[Proceedings of ICOSAHOM 2018](https://doi.org/10.1007/978-3-030-39647-3_42)
+  [Proceedings of ICOSAHOM 2018](https://doi.org/10.1007/978-3-030-39647-3_42)
 """
 @inline function flux_ranocha(u_ll, u_rr, orientation::Integer, equations::CompressibleEulerEquations1D)
   # Unpack left and right state

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -722,7 +722,8 @@ end
 
 
 """
-    flux_kennedy_gruber(u_ll, u_rr, orientation, equations::CompressibleEulerEquations2D)
+    flux_kennedy_gruber(u_ll, u_rr, orientation_or_normal_direction,
+                        equations::CompressibleEulerEquations2D)
 
 Kinetic energy preserving two-point flux by
 - Kennedy and Gruber (2008)
@@ -760,8 +761,10 @@ Kinetic energy preserving two-point flux by
   return SVector(f1, f2, f3, f4)
 end
 
-@inline function flux_kennedy_gruber(u_ll, u_rr, normal_direction::AbstractVector, equations::CompressibleEulerEquations3D)
+@inline function flux_kennedy_gruber(u_ll, u_rr, normal_direction::AbstractVector, equations::CompressibleEulerEquations2D)
   # Unpack left and right state
+  rho_e_ll = last(u_ll)
+  rho_e_rr = last(u_rr)
   rho_ll, v1_ll, v2_ll, p_ll = cons2prim(u_ll, equations)
   rho_rr, v1_rr, v2_rr, p_rr = cons2prim(u_rr, equations)
 
@@ -769,16 +772,15 @@ end
   rho_avg = 0.5 * (rho_ll + rho_rr)
   v1_avg  = 0.5 * (v1_ll + v1_rr)
   v2_avg  = 0.5 * (v2_ll + v2_rr)
-  v3_avg  = 0.5 * (v3_ll + v3_rr)
-  v_dot_n_avg = v1_avg * normal_direction[1] + v2_avg * normal_direction[2] + v3_avg * normal_direction[3]
+  v_dot_n_avg = v1_avg * normal_direction[1] + v2_avg * normal_direction[2]
   p_avg = 0.5 * (p_ll + p_rr)
-  e_avg = 0.5 * (rho_e_ll/rho_ll + rho_e_rr/rho_rr)
+  e_avg = 0.5 * (rho_e_ll / rho_ll + rho_e_rr / rho_rr)
 
   # Calculate fluxes depending on normal_direction
   f1 = rho_avg * v_dot_n_avg
   f2 = f1 * v1_avg + p_avg * normal_direction[1]
   f3 = f1 * v2_avg + p_avg * normal_direction[2]
-  Float64 = f1 * e_avg + p_avg * v_dot_n_avg
+  f4 = f1 * e_avg + p_avg * v_dot_n_avg
 
   return SVector(f1, f2, f3, f4)
 end
@@ -830,7 +832,8 @@ end
 
 
 """
-    flux_ranocha(u_ll, u_rr, orientation_or_normal_direction, equations::CompressibleEulerEquations2D)
+    flux_ranocha(u_ll, u_rr, orientation_or_normal_direction,
+                 equations::CompressibleEulerEquations2D)
 
 Entropy conserving and kinetic energy preserving two-point flux by
 - Hendrik Ranocha (2018)

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -760,6 +760,29 @@ Kinetic energy preserving two-point flux by
   return SVector(f1, f2, f3, f4)
 end
 
+@inline function flux_kennedy_gruber(u_ll, u_rr, normal_direction::AbstractVector, equations::CompressibleEulerEquations3D)
+  # Unpack left and right state
+  rho_ll, v1_ll, v2_ll, p_ll = cons2prim(u_ll, equations)
+  rho_rr, v1_rr, v2_rr, p_rr = cons2prim(u_rr, equations)
+
+  # Average each factor of products in flux
+  rho_avg = 0.5 * (rho_ll + rho_rr)
+  v1_avg  = 0.5 * (v1_ll + v1_rr)
+  v2_avg  = 0.5 * (v2_ll + v2_rr)
+  v3_avg  = 0.5 * (v3_ll + v3_rr)
+  v_dot_n_avg = v1_avg * normal_direction[1] + v2_avg * normal_direction[2] + v3_avg * normal_direction[3]
+  p_avg = 0.5 * (p_ll + p_rr)
+  e_avg = 0.5 * (rho_e_ll/rho_ll + rho_e_rr/rho_rr)
+
+  # Calculate fluxes depending on normal_direction
+  f1 = rho_avg * v_dot_n_avg
+  f2 = f1 * v1_avg + p_avg * normal_direction[1]
+  f3 = f1 * v2_avg + p_avg * normal_direction[2]
+  Float64 = f1 * e_avg + p_avg * v_dot_n_avg
+
+  return SVector(f1, f2, f3, f4)
+end
+
 
 """
     flux_chandrashekar(u_ll, u_rr, orientation, equations::CompressibleEulerEquations2D)

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -714,7 +714,7 @@ end
   f1 = rho_avg * v_dot_n_avg
   f2 = f1 * v1_avg + p_avg * normal_direction[1]
   f3 = f1 * v2_avg + p_avg * normal_direction[2]
-  f4 = ( f1 * velocity_square_avg + p_avg * v_dot_n_avg * equations.inv_gamma_minus_1
+  f4 = ( f1 * velocity_square_avg + p_avg * v_dot_n_avg * equations.inv_gamma_minus_one
         + 0.5 * (p_ll * v_dot_n_rr + p_rr * v_dot_n_ll) )
 
   return SVector(f1, f2, f3, f4)

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -500,7 +500,8 @@ end
 
 
 """
-    function flux_shima_etal(u_ll, u_rr, orientation, equations::CompressibleEulerEquations3D)
+    flux_shima_etal(u_ll, u_rr, orientation_or_normal_direction,
+                    equations::CompressibleEulerEquations3D)
 
 This flux is is a modification of the original kinetic energy preserving two-point flux by
 - Yuichi Kuya, Kosuke Totani and Soshi Kawai (2018)
@@ -550,6 +551,33 @@ The modification is in the energy flux to guarantee pressure equilibrium and was
     f4 = rho_avg * v3_avg * v3_avg + p_avg
     f5 = p_avg*v3_avg * equations.inv_gamma_minus_one + rho_avg*v3_avg*kin_avg + pv3_avg
   end
+
+  return SVector(f1, f2, f3, f4, f5)
+end
+
+@inline function flux_shima_etal(u_ll, u_rr, normal_direction::AbstractVector, equations::CompressibleEulerEquations3D)
+  # Unpack left and right state
+  rho_ll, v1_ll, v2_ll, v3_ll, p_ll = cons2prim(u_ll, equations)
+  rho_rr, v1_rr, v2_rr, v3_rr, p_rr = cons2prim(u_rr, equations)
+  v_dot_n_ll = v1_ll * normal_direction[1] + v2_ll * normal_direction[2] + v3_ll * normal_direction[3]
+  v_dot_n_rr = v1_rr * normal_direction[1] + v2_rr * normal_direction[2] + v3_rr * normal_direction[3]
+
+  # Average each factor of products in flux
+  rho_avg = 1/2 * (rho_ll + rho_rr)
+  v1_avg  = 1/2 * ( v1_ll +  v1_rr)
+  v2_avg  = 1/2 * ( v2_ll +  v2_rr)
+  v3_avg  = 1/2 * ( v3_ll +  v3_rr)
+  v_dot_n_avg = 1/2 * (v_dot_n_ll + v_dot_n_rr)
+  p_avg   = 1/2 * (  p_ll +   p_rr)
+  velocity_square_avg = 0.5 * (v1_ll*v1_rr + v2_ll*v2_rr + v3_ll*v3_rr)
+
+  # Calculate fluxes depending on normal_direction
+  f1 = rho_avg * v_dot_n_avg
+  f2 = f1 * v1_avg + p_avg * normal_direction[1]
+  f3 = f1 * v2_avg + p_avg * normal_direction[2]
+  f4 = f1 * v3_avg + p_avg * normal_direction[3]
+  f5 = ( f1 * velocity_square_avg + p_avg * v_dot_n_avg * equations.inv_gamma_minus_1
+        + 0.5 * (p_ll * v_dot_n_rr + p_rr * v_dot_n_ll) )
 
   return SVector(f1, f2, f3, f4, f5)
 end

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -634,6 +634,8 @@ end
 
 @inline function flux_kennedy_gruber(u_ll, u_rr, normal_direction::AbstractVector, equations::CompressibleEulerEquations3D)
   # Unpack left and right state
+  rho_e_ll = last(u_ll)
+  rho_e_rr = last(u_rr)
   rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr = u_rr
 
@@ -652,7 +654,7 @@ end
   v_dot_n_avg = v1_avg * normal_direction[1] + v2_avg * normal_direction[2] + v3_avg * normal_direction[3]
   p_avg = 0.5 * ((equations.gamma - 1) * (rho_e_ll - 0.5 * rho_ll * (v1_ll^2 + v2_ll^2 + v3_ll^2)) +
                  (equations.gamma - 1) * (rho_e_rr - 0.5 * rho_rr * (v1_rr^2 + v2_rr^2 + v3_rr^2)))
-  e_avg = 0.5 * (rho_e_ll/rho_ll + rho_e_rr/rho_rr)
+  e_avg = 0.5 * (rho_e_ll / rho_ll + rho_e_rr / rho_rr)
 
   # Calculate fluxes depending on normal_direction
   f1 = rho_avg * v_dot_n_avg
@@ -721,7 +723,8 @@ end
 
 
 """
-    flux_ranocha(u_ll, u_rr, orientation_or_normal_direction, equations::CompressibleEulerEquations3D)
+    flux_ranocha(u_ll, u_rr, orientation_or_normal_direction,
+                 equations::CompressibleEulerEquations3D)
 
 Entropy conserving and kinetic energy preserving two-point flux by
 - Hendrik Ranocha (2018)

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -576,7 +576,7 @@ end
   f2 = f1 * v1_avg + p_avg * normal_direction[1]
   f3 = f1 * v2_avg + p_avg * normal_direction[2]
   f4 = f1 * v3_avg + p_avg * normal_direction[3]
-  f5 = ( f1 * velocity_square_avg + p_avg * v_dot_n_avg * equations.inv_gamma_minus_1
+  f5 = ( f1 * velocity_square_avg + p_avg * v_dot_n_avg * equations.inv_gamma_minus_one
         + 0.5 * (p_ll * v_dot_n_rr + p_rr * v_dot_n_ll) )
 
   return SVector(f1, f2, f3, f4, f5)

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -584,7 +584,8 @@ end
 
 
 """
-    flux_kennedy_gruber(u_ll, u_rr, orientation, equations::CompressibleEulerEquations3D)
+    flux_kennedy_gruber(u_ll, u_rr, orientation_or_normal_direction,
+                        equations::CompressibleEulerEquations3D)
 
 Kinetic energy preserving two-point flux by
 - Kennedy and Gruber (2008)

--- a/src/equations/ideal_glm_mhd_2d.jl
+++ b/src/equations/ideal_glm_mhd_2d.jl
@@ -431,7 +431,8 @@ end
 
 
 """
-    flux_hindenlang(u_ll, u_rr, orientation_or_normal_direction, equations::IdealGlmMhdEquations2D)
+    flux_hindenlang(u_ll, u_rr, orientation_or_normal_direction,
+                    equations::IdealGlmMhdEquations2D)
 
 Entropy conserving and kinetic energy preserving two-point flux of
 Hindenlang (2019), extending [`flux_ranocha`](@ref) to the MHD equations.
@@ -515,7 +516,8 @@ Hindenlang (2019), extending [`flux_ranocha`](@ref) to the MHD equations.
   return SVector(f1, f2, f3, f4, f5, f6, f7, f8, f9)
 end
 
-@inline function flux_hindenlang(u_ll, u_rr, normal_direction::AbstractVector, equations::IdealGlmMhdEquations2D)
+@inline function flux_hindenlang(u_ll, u_rr, normal_direction::AbstractVector,
+                                 equations::IdealGlmMhdEquations2D)
   # Unpack left and right states
   rho_ll, v1_ll, v2_ll, v3_ll, p_ll, B1_ll, B2_ll, B3_ll, psi_ll = cons2prim(u_ll, equations)
   rho_rr, v1_rr, v2_rr, v3_rr, p_rr, B1_rr, B2_rr, B3_rr, psi_rr = cons2prim(u_rr, equations)

--- a/src/equations/ideal_glm_mhd_3d.jl
+++ b/src/equations/ideal_glm_mhd_3d.jl
@@ -416,7 +416,8 @@ end
 
 
 """
-    flux_hindenlang(u_ll, u_rr, orientation_or_normal_direction, equations::IdealGlmMhdEquations3D)
+    flux_hindenlang(u_ll, u_rr, orientation_or_normal_direction,
+                    equations::IdealGlmMhdEquations3D)
 
 Entropy conserving and kinetic energy preserving two-point flux of
 Hindenlang (2019), extending [`flux_ranocha`](@ref) to the MHD equations.

--- a/src/solvers/dgsem_structured/dg_3d.jl
+++ b/src/solvers/dgsem_structured/dg_3d.jl
@@ -221,17 +221,15 @@ end
     # x direction
     for ii in (i+1):nnodes(dg)
       u_node_ii = get_node_vars(u, equations, dg, ii, j, k, element)
-      flux1 = volume_flux(u_node, u_node_ii, 1, equations)
-      flux2 = volume_flux(u_node, u_node_ii, 2, equations)
-      flux3 = volume_flux(u_node, u_node_ii, 3, equations)
       # pull the contravariant vectors and compute the average
       Ja11_node_ii, Ja12_node_ii, Ja13_node_ii = get_contravariant_vector(1, contravariant_vectors,
                                                                           ii, j, k, element)
       Ja11_avg = 0.5 * (Ja11_node + Ja11_node_ii)
       Ja12_avg = 0.5 * (Ja12_node + Ja12_node_ii)
       Ja13_avg = 0.5 * (Ja13_node + Ja13_node_ii)
-      # compute the contravariant sharp flux
-      fluxtilde1 = Ja11_avg * flux1 + Ja12_avg * flux2 + Ja13_avg * flux3
+      # compute the contravariant sharp flux in the direction of the
+      # averaged contravariant vector
+      fluxtilde1 = volume_flux(u_node, u_node_ii, SVector(Ja11_avg, Ja12_avg, Ja13_avg), equations)
       multiply_add_to_node_vars!(du, alpha * derivative_split[i, ii], fluxtilde1, equations, dg, i,  j, k, element)
       multiply_add_to_node_vars!(du, alpha * derivative_split[ii, i], fluxtilde1, equations, dg, ii, j, k, element)
     end
@@ -239,17 +237,15 @@ end
     # y direction
     for jj in (j+1):nnodes(dg)
       u_node_jj = get_node_vars(u, equations, dg, i, jj, k, element)
-      flux1 = volume_flux(u_node, u_node_jj, 1, equations)
-      flux2 = volume_flux(u_node, u_node_jj, 2, equations)
-      flux3 = volume_flux(u_node, u_node_jj, 3, equations)
       # pull the contravariant vectors and compute the average
       Ja21_node_jj, Ja22_node_jj, Ja23_node_jj = get_contravariant_vector(2, contravariant_vectors,
                                                                           i, jj, k, element)
       Ja21_avg = 0.5 * (Ja21_node + Ja21_node_jj)
       Ja22_avg = 0.5 * (Ja22_node + Ja22_node_jj)
       Ja23_avg = 0.5 * (Ja23_node + Ja23_node_jj)
-      # compute the contravariant sharp flux
-      fluxtilde2 = Ja21_avg * flux1 + Ja22_avg * flux2 + Ja23_avg * flux3
+      # compute the contravariant sharp flux in the direction of the
+      # averaged contravariant vector
+      fluxtilde2 = volume_flux(u_node, u_node_jj, SVector(Ja21_avg, Ja22_avg, Ja23_avg), equations)
       multiply_add_to_node_vars!(du, alpha * derivative_split[j, jj], fluxtilde2, equations, dg, i, j,  k, element)
       multiply_add_to_node_vars!(du, alpha * derivative_split[jj, j], fluxtilde2, equations, dg, i, jj, k, element)
     end
@@ -257,17 +253,15 @@ end
     # z direction
     for kk in (k+1):nnodes(dg)
       u_node_kk = get_node_vars(u, equations, dg, i, j, kk, element)
-      flux1 = volume_flux(u_node, u_node_kk, 1, equations)
-      flux2 = volume_flux(u_node, u_node_kk, 2, equations)
-      flux3 = volume_flux(u_node, u_node_kk, 3, equations)
       # pull the contravariant vectors and compute the average
       Ja31_node_kk, Ja32_node_kk, Ja33_node_kk = get_contravariant_vector(3, contravariant_vectors,
                                                                           i, j, kk, element)
       Ja31_avg = 0.5 * (Ja31_node + Ja31_node_kk)
       Ja32_avg = 0.5 * (Ja32_node + Ja32_node_kk)
       Ja33_avg = 0.5 * (Ja33_node + Ja33_node_kk)
-      # compute the contravariant sharp flux
-      fluxtilde3 = Ja31_avg * flux1 + Ja32_avg * flux2 + Ja33_avg * flux3
+      # compute the contravariant sharp flux in the direction of the
+      # averaged contravariant vector
+      fluxtilde3 = volume_flux(u_node, u_node_kk, SVector(Ja31_avg, Ja32_avg, Ja33_avg), equations)
       multiply_add_to_node_vars!(du, alpha * derivative_split[k, kk], fluxtilde3, equations, dg, i, j, k,  element)
       multiply_add_to_node_vars!(du, alpha * derivative_split[kk, k], fluxtilde3, equations, dg, i, j, kk, element)
     end

--- a/src/solvers/dgsem_structured/dg_3d.jl
+++ b/src/solvers/dgsem_structured/dg_3d.jl
@@ -204,14 +204,14 @@ end
     u_node = get_node_vars(u, equations, dg, i, j, k, element)
 
     # pull the contravariant vectors in each coordinate direction
-    Ja11_node, Ja12_node, Ja13_node = get_contravariant_vector(1, contravariant_vectors,
-                                                               i, j, k, element)
+    Ja1_node = get_contravariant_vector(1, contravariant_vectors,
+                                        i, j, k, element)
 
-    Ja21_node, Ja22_node, Ja23_node = get_contravariant_vector(2, contravariant_vectors,
-                                                               i, j, k, element)
+    Ja2_node = get_contravariant_vector(2, contravariant_vectors,
+                                        i, j, k, element)
 
-    Ja31_node, Ja32_node, Ja33_node = get_contravariant_vector(3, contravariant_vectors,
-                                                               i, j, k, element)
+    Ja3_node = get_contravariant_vector(3, contravariant_vectors,
+                                        i, j, k, element)
 
     # All diagonal entries of `derivative_split` are zero. Thus, we can skip
     # the computation of the diagonal terms. In addition, we use the symmetry
@@ -222,14 +222,12 @@ end
     for ii in (i+1):nnodes(dg)
       u_node_ii = get_node_vars(u, equations, dg, ii, j, k, element)
       # pull the contravariant vectors and compute the average
-      Ja11_node_ii, Ja12_node_ii, Ja13_node_ii = get_contravariant_vector(1, contravariant_vectors,
-                                                                          ii, j, k, element)
-      Ja11_avg = 0.5 * (Ja11_node + Ja11_node_ii)
-      Ja12_avg = 0.5 * (Ja12_node + Ja12_node_ii)
-      Ja13_avg = 0.5 * (Ja13_node + Ja13_node_ii)
+      Ja1_node_ii = get_contravariant_vector(1, contravariant_vectors,
+                                             ii, j, k, element)
+      Ja1_avg = 0.5 * (Ja1_node + Ja1_node_ii)
       # compute the contravariant sharp flux in the direction of the
       # averaged contravariant vector
-      fluxtilde1 = volume_flux(u_node, u_node_ii, SVector(Ja11_avg, Ja12_avg, Ja13_avg), equations)
+      fluxtilde1 = volume_flux(u_node, u_node_ii, Ja1_avg, equations)
       multiply_add_to_node_vars!(du, alpha * derivative_split[i, ii], fluxtilde1, equations, dg, i,  j, k, element)
       multiply_add_to_node_vars!(du, alpha * derivative_split[ii, i], fluxtilde1, equations, dg, ii, j, k, element)
     end
@@ -238,14 +236,12 @@ end
     for jj in (j+1):nnodes(dg)
       u_node_jj = get_node_vars(u, equations, dg, i, jj, k, element)
       # pull the contravariant vectors and compute the average
-      Ja21_node_jj, Ja22_node_jj, Ja23_node_jj = get_contravariant_vector(2, contravariant_vectors,
-                                                                          i, jj, k, element)
-      Ja21_avg = 0.5 * (Ja21_node + Ja21_node_jj)
-      Ja22_avg = 0.5 * (Ja22_node + Ja22_node_jj)
-      Ja23_avg = 0.5 * (Ja23_node + Ja23_node_jj)
+      Ja2_node_jj = get_contravariant_vector(2, contravariant_vectors,
+                                             i, jj, k, element)
+      Ja2_avg = 0.5 * (Ja2_node + Ja2_node_jj)
       # compute the contravariant sharp flux in the direction of the
       # averaged contravariant vector
-      fluxtilde2 = volume_flux(u_node, u_node_jj, SVector(Ja21_avg, Ja22_avg, Ja23_avg), equations)
+      fluxtilde2 = volume_flux(u_node, u_node_jj, Ja2_avg, equations)
       multiply_add_to_node_vars!(du, alpha * derivative_split[j, jj], fluxtilde2, equations, dg, i, j,  k, element)
       multiply_add_to_node_vars!(du, alpha * derivative_split[jj, j], fluxtilde2, equations, dg, i, jj, k, element)
     end
@@ -254,14 +250,12 @@ end
     for kk in (k+1):nnodes(dg)
       u_node_kk = get_node_vars(u, equations, dg, i, j, kk, element)
       # pull the contravariant vectors and compute the average
-      Ja31_node_kk, Ja32_node_kk, Ja33_node_kk = get_contravariant_vector(3, contravariant_vectors,
-                                                                          i, j, kk, element)
-      Ja31_avg = 0.5 * (Ja31_node + Ja31_node_kk)
-      Ja32_avg = 0.5 * (Ja32_node + Ja32_node_kk)
-      Ja33_avg = 0.5 * (Ja33_node + Ja33_node_kk)
+      Ja3_node_kk = get_contravariant_vector(3, contravariant_vectors,
+                                             i, j, kk, element)
+      Ja3_avg = 0.5 * (Ja3_node + Ja3_node_kk)
       # compute the contravariant sharp flux in the direction of the
       # averaged contravariant vector
-      fluxtilde3 = volume_flux(u_node, u_node_kk, SVector(Ja31_avg, Ja32_avg, Ja33_avg), equations)
+      fluxtilde3 = volume_flux(u_node, u_node_kk, Ja3_avg, equations)
       multiply_add_to_node_vars!(du, alpha * derivative_split[k, kk], fluxtilde3, equations, dg, i, j, k,  element)
       multiply_add_to_node_vars!(du, alpha * derivative_split[kk, k], fluxtilde3, equations, dg, i, j, kk, element)
     end

--- a/src/solvers/dgsem_unstructured/dg_2d.jl
+++ b/src/solvers/dgsem_unstructured/dg_2d.jl
@@ -172,14 +172,13 @@ end
     # x direction
     for ii in (i+1):nnodes(dg)
       u_node_ii = get_node_vars(u, equations, dg, ii, j, element)
-      flux1 = volume_flux(u_node, u_node_ii, 1, equations)
-      flux2 = volume_flux(u_node, u_node_ii, 2, equations)
       # pull the contravariant vectors and compute the average
       Ja11_node_ii, Ja12_node_ii = get_contravariant_vector(1, contravariant_vectors, ii, j, element)
       Ja11_avg = 0.5 * (Ja11_node + Ja11_node_ii)
       Ja12_avg = 0.5 * (Ja12_node + Ja12_node_ii)
-      # compute the contravariant sharp flux
-      fluxtilde1 = Ja11_avg * flux1 + Ja12_avg * flux2
+      # compute the contravariant sharp flux in the direction of the
+      # averaged contravariant vector
+      fluxtilde1 = volume_flux(u_node, u_node_ii, SVector(Ja11_avg, Ja12_avg), equations)
       multiply_add_to_node_vars!(du, alpha * derivative_split[i, ii], fluxtilde1, equations, dg, i,  j, element)
       multiply_add_to_node_vars!(du, alpha * derivative_split[ii, i], fluxtilde1, equations, dg, ii, j, element)
     end
@@ -187,14 +186,13 @@ end
     # y direction
     for jj in (j+1):nnodes(dg)
       u_node_jj = get_node_vars(u, equations, dg, i, jj, element)
-      flux1 = volume_flux(u_node, u_node_jj, 1, equations)
-      flux2 = volume_flux(u_node, u_node_jj, 2, equations)
       # pull the contravariant vectors and compute the average
       Ja21_node_jj, Ja22_node_jj = get_contravariant_vector(2, contravariant_vectors, i, jj, element)
       Ja21_avg = 0.5 * (Ja21_node + Ja21_node_jj)
       Ja22_avg = 0.5 * (Ja22_node + Ja22_node_jj)
-      # compute the contravariant sharp flux
-      fluxtilde2 = Ja21_avg * flux1 + Ja22_avg * flux2
+      # compute the contravariant sharp flux in the direction of the
+      # averaged contravariant vector
+      fluxtilde2 = volume_flux(u_node, u_node_jj, SVector(Ja21_avg, Ja22_avg), equations)
       multiply_add_to_node_vars!(du, alpha * derivative_split[j, jj], fluxtilde2, equations, dg, i, j,  element)
       multiply_add_to_node_vars!(du, alpha * derivative_split[jj, j], fluxtilde2, equations, dg, i, jj, element)
     end

--- a/src/solvers/dgsem_unstructured/dg_2d.jl
+++ b/src/solvers/dgsem_unstructured/dg_2d.jl
@@ -161,8 +161,8 @@ end
     u_node = get_node_vars(u, equations, dg, i, j, element)
 
     # pull the contravariant vectors in each coordinate direction
-    Ja11_node, Ja12_node = get_contravariant_vector(1, contravariant_vectors, i, j, element)
-    Ja21_node, Ja22_node = get_contravariant_vector(2, contravariant_vectors, i, j, element)
+    Ja1_node = get_contravariant_vector(1, contravariant_vectors, i, j, element)
+    Ja2_node = get_contravariant_vector(2, contravariant_vectors, i, j, element)
 
     # All diagonal entries of `derivative_split` are zero. Thus, we can skip
     # the computation of the diagonal terms. In addition, we use the symmetry
@@ -173,12 +173,11 @@ end
     for ii in (i+1):nnodes(dg)
       u_node_ii = get_node_vars(u, equations, dg, ii, j, element)
       # pull the contravariant vectors and compute the average
-      Ja11_node_ii, Ja12_node_ii = get_contravariant_vector(1, contravariant_vectors, ii, j, element)
-      Ja11_avg = 0.5 * (Ja11_node + Ja11_node_ii)
-      Ja12_avg = 0.5 * (Ja12_node + Ja12_node_ii)
+      Ja1_node_ii = get_contravariant_vector(1, contravariant_vectors, ii, j, element)
+      Ja1_avg = 0.5 * (Ja1_node + Ja1_node_ii)
       # compute the contravariant sharp flux in the direction of the
       # averaged contravariant vector
-      fluxtilde1 = volume_flux(u_node, u_node_ii, SVector(Ja11_avg, Ja12_avg), equations)
+      fluxtilde1 = volume_flux(u_node, u_node_ii, Ja1_avg, equations)
       multiply_add_to_node_vars!(du, alpha * derivative_split[i, ii], fluxtilde1, equations, dg, i,  j, element)
       multiply_add_to_node_vars!(du, alpha * derivative_split[ii, i], fluxtilde1, equations, dg, ii, j, element)
     end
@@ -187,12 +186,11 @@ end
     for jj in (j+1):nnodes(dg)
       u_node_jj = get_node_vars(u, equations, dg, i, jj, element)
       # pull the contravariant vectors and compute the average
-      Ja21_node_jj, Ja22_node_jj = get_contravariant_vector(2, contravariant_vectors, i, jj, element)
-      Ja21_avg = 0.5 * (Ja21_node + Ja21_node_jj)
-      Ja22_avg = 0.5 * (Ja22_node + Ja22_node_jj)
+      Ja2_node_jj = get_contravariant_vector(2, contravariant_vectors, i, jj, element)
+      Ja2_avg = 0.5 * (Ja2_node + Ja2_node_jj)
       # compute the contravariant sharp flux in the direction of the
       # averaged contravariant vector
-      fluxtilde2 = volume_flux(u_node, u_node_jj, SVector(Ja21_avg, Ja22_avg), equations)
+      fluxtilde2 = volume_flux(u_node, u_node_jj, Ja2_avg, equations)
       multiply_add_to_node_vars!(du, alpha * derivative_split[j, jj], fluxtilde2, equations, dg, i, j,  element)
       multiply_add_to_node_vars!(du, alpha * derivative_split[jj, j], fluxtilde2, equations, dg, i, jj, element)
     end

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -537,7 +537,7 @@ Cassette.@context Ctx
                            SVector(-1.2, 0.3)]
       u_values = [SVector(1.0, 0.5, -0.7, 1.0),
                   SVector(1.5, -0.2, 0.1, 5.0),]
-      fluxes = [flux_central, flux_ranocha]
+      fluxes = [flux_central, flux_ranocha, flux_shima_etal, flux_kennedy_gruber]
 
       for f_std in fluxes
         f_rot = FluxRotated(f_std)
@@ -556,7 +556,7 @@ Cassette.@context Ctx
                           SVector(-1.2, 0.3, 1.4)]
       u_values = [SVector(1.0, 0.5, -0.7, 0.1, 1.0),
                   SVector(1.5, -0.2, 0.1, 0.2, 5.0),]
-      fluxes = [flux_central, flux_ranocha]
+      fluxes = [flux_central, flux_ranocha, flux_shima_etal, flux_kennedy_gruber]
 
       for f_std in fluxes
         f_rot = FluxRotated(f_std)


### PR DESCRIPTION
Flux differencing on curved meshes sucked since the resulting EC methods were only 25% faster than Fluxo :wink: To the rescue!

<details>
<summary>

This speeds up the RHS evaluation in `joinpath(examples_dir(), "structured_3d_dgsem", "elixir_euler_ec.jl")` by 1/3 for `flux_ranocha` and 1/4 for `flux_shima_etal`. Thus, our EC methods should be roughly twice as fast as Fluxo on curved meshes.

</summary>

Teaser: Using `julia --check-bounds=no --threads=1`, I get
```julia
julia> using BenchmarkTools, Trixi

julia> begin # RHS
           redirect_stdout(devnull) do
               trixi_include(joinpath(examples_dir(), "structured_3d_dgsem", "elixir_euler_ec.jl"))
           end
           u_ode = copy(sol.u[end])
           du_ode = similar(u_ode)
           @benchmark Trixi.rhs!($du_ode, $u_ode, $semi, $0.0)
       end
BechmarkTools.Trial: 1456 samples with 1 evaluations.
 Range (min … max):  3.321 ms …   4.301 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.359 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.431 ms ± 178.005 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █ ▆▄▄▄▃▂▃▂▁                                                  
  ███████████████▇▇▇▄█▇▇▆▆▇▇▇▆█▇▇▆▄▇▄▅▁▁▁▄▄▄▄▄▆▅▄▄▄▄▆▄▅▆▁▅▆▆▅ █
  3.32 ms      Histogram: log(frequency) by time      4.16 ms <

 Memory estimate: 416 bytes, allocs estimate: 6.

julia> begin # RHS
           redirect_stdout(devnull) do
               trixi_include(joinpath(examples_dir(), "structured_3d_dgsem", "elixir_euler_ec.jl"),
                             volume_flux=flux_shima_etal)
           end
           u_ode = copy(sol.u[end])
           du_ode = similar(u_ode)
           @benchmark Trixi.rhs!($du_ode, $u_ode, $semi, $0.0)
       end
BechmarkTools.Trial: 3334 samples with 1 evaluations.
 Range (min … max):  1.460 ms …  1.930 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.487 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.497 ms ± 38.342 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▄    ▃█     ▂▄                                              
  █▄▁▁▁███▆█▇▆██▇▆██▇██▆▆▅▄▄█▆▅▅▅▅▄▇▁▃▁▃▃▁▅▃▃▃▁▃▃▁▁▁▃▁▄▁▅▄▅▆ █
  1.46 ms      Histogram: log(frequency) by time     1.71 ms <

 Memory estimate: 416 bytes, allocs estimate: 6.

julia> begin # RHS
           redirect_stdout(devnull) do
               trixi_include(joinpath(examples_dir(), "structured_3d_dgsem", "elixir_euler_ec.jl"),
                             volume_flux=flux_shima_etal, surface_flux=FluxRotated(flux_shima_etal)) # no direct version available, needs `FluxRotated`
           end
           u_ode = copy(sol.u[end])
           du_ode = similar(u_ode)
           @benchmark Trixi.rhs!($du_ode, $u_ode, $semi, $0.0)
       end
BechmarkTools.Trial: 2999 samples with 1 evaluations.
 Range (min … max):  1.617 ms …  2.334 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.653 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.665 ms ± 54.161 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▆      █▇    ▁▄▃ ▁▁ ▂▁▁                                    ▁
  █▄▄▄▃▃▆████████████████▇▇▇█▇▇▆▆▁▃▃▄▆▆▄▄▃▃▃▃▃▁▅▁▁▁▃▃▁▃▃▁▁▃▄ █
  1.62 ms      Histogram: log(frequency) by time     1.88 ms <

 Memory estimate: 416 bytes, allocs estimate: 6.
```
on `main` and
```julia
julia> using BenchmarkTools, Trixi

julia> begin # RHS
           redirect_stdout(devnull) do
               trixi_include(joinpath(examples_dir(), "structured_3d_dgsem", "elixir_euler_ec.jl"))
           end
           u_ode = copy(sol.u[end])
           du_ode = similar(u_ode)
           @benchmark Trixi.rhs!($du_ode, $u_ode, $semi, $0.0)
       end
BechmarkTools.Trial: 2368 samples with 1 evaluations.
 Range (min … max):  2.088 ms …  2.514 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.097 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.109 ms ± 32.061 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▄▃▆█▄        ▁▂▅     ▁    ▁▁                                
  █████▅▁▃▄▅▅▅▆███▇▆▆▆███▇▇███▆▅▅▄▆▅▄▄▅▇▇▆▃▃▄▁▅▄▃▁▁▆▇▅▃▁▁▃▁▅ █
  290 ms       Histogram: log(frequency) by time     2.23 ms <

 Memory estimate: 416 bytes, allocs estimate: 6.

julia> begin # RHS
           redirect_stdout(devnull) do
               trixi_include(joinpath(examples_dir(), "structured_3d_dgsem", "elixir_euler_ec.jl"),
                             volume_flux=flux_shima_etal)
           end
           u_ode = copy(sol.u[end])
           du_ode = similar(u_ode)
           @benchmark Trixi.rhs!($du_ode, $u_ode, $semi, $0.0)
       end
BechmarkTools.Trial: 3903 samples with 1 evaluations.
 Range (min … max):  1.244 ms …  2.337 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.268 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.279 ms ± 49.904 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▄     ▄█▁      ▂▃       ▁                                  ▁
  ██▄▄▄▃████▇▇▇▇▇██▇▇▅▇█▇███▇▅▅▇▆▅▆█▆▆▆▄▄▅▄▄▆▃▄▄▅▁▁▃▄▄▁▄▃▁▃▄ █
  1.24 ms      Histogram: log(frequency) by time     1.44 ms <

 Memory estimate: 416 bytes, allocs estimate: 6.

julia> begin # RHS
           redirect_stdout(devnull) do
               trixi_include(joinpath(examples_dir(), "structured_3d_dgsem", "elixir_euler_ec.jl"),
                             volume_flux=flux_shima_etal, surface_flux=flux_shima_etal) # No need for `FluxRotated` anymore
           end
           u_ode = copy(sol.u[end])
           du_ode = similar(u_ode)
           @benchmark Trixi.rhs!($du_ode, $u_ode, $semi, $0.0)
       end
BechmarkTools.Trial: 4035 samples with 1 evaluations.
 Range (min … max):  1.187 ms …  2.787 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.211 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.237 ms ± 82.842 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▃  █   ▄▄ ▂▂▂   ▁                                          ▁
  █▃▄███▇███████▇███▇▇▇█▇▆▆▇▇▇▆▆▆▆▆▅▃▆▆▃▅▅▃▅▄▃▄▄▃▄▅▃▁▁▄▁▃▁▄▃ █
  1.19 ms      Histogram: log(frequency) by time     1.57 ms <

 Memory estimate: 416 bytes, allocs estimate: 6.
```
from this PR. 

</details>

Benchmarks on Rocinante are running. I will add them later when they are finished (in a few hours?).