### PR TITLE
more robust tests

### DIFF
--- a/examples/p4est_3d_dgsem/elixir_euler_ec.jl
+++ b/examples/p4est_3d_dgsem/elixir_euler_ec.jl
@@ -1,4 +1,5 @@
 
+using Downloads: download
 using OrdinaryDiffEq
 using Trixi
 

--- a/examples/p4est_3d_dgsem/elixir_euler_free_stream.jl
+++ b/examples/p4est_3d_dgsem/elixir_euler_free_stream.jl
@@ -1,4 +1,5 @@
 
+using Downloads: download
 using OrdinaryDiffEq
 using Trixi
 

--- a/examples/p4est_3d_dgsem/elixir_euler_free_stream_extruded.jl
+++ b/examples/p4est_3d_dgsem/elixir_euler_free_stream_extruded.jl
@@ -1,4 +1,5 @@
 
+using Downloads: download
 using OrdinaryDiffEq
 using Trixi
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ const TRIXI_NTHREADS   = clamp(Sys.CPU_THREADS, 2, 3)
     # Hence, the additional flag `--compiled-modules=no` is required for Julia
     # versions older than v1.6.
     mpiexec() do cmd
-      run(`$cmd -n $TRIXI_MPI_NPROCS $(Base.julia_cmd()) --threads=1 --check-bounds=yes test_examples_2d_parallel.jl`)
+      run(`$cmd -n $TRIXI_MPI_NPROCS $(Base.julia_cmd()) --threads=1 --check-bounds=yes $(abspath("test_examples_2d_parallel.jl"))`)
     end
   end
 
@@ -31,7 +31,7 @@ const TRIXI_NTHREADS   = clamp(Sys.CPU_THREADS, 2, 3)
     # cf. https://github.com/JuliaParallel/MPI.jl/pull/391
     @test true
 
-    run(`$(Base.julia_cmd()) --threads=$TRIXI_NTHREADS --check-bounds=yes --code-coverage=none test_examples_2d_parallel.jl`)
+    run(`$(Base.julia_cmd()) --threads=$TRIXI_NTHREADS --check-bounds=yes --code-coverage=none $(abspath("test_examples_2d_parallel.jl"))`)
   end
 
   @time if TRIXI_TEST == "all" || TRIXI_TEST == "1d"


### PR DESCRIPTION
This increases the robustness of running tests locally and improves the output when using MPI.

Pinging @efaulhaber to let him know that elixirs should use `Downloads.download` instead of the deprecated `Base.download`.