### PR TITLE
nonconservative terms in 1D

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -46,7 +46,10 @@ makedocs(
             "Visualization" => "visualization.md",
         ],
         "Tutorials" => [
-            "Adding a new equation" => "adding_a_new_equation.md",
+            "Adding a new equation" => [
+                "Scalar conservation law" => joinpath("adding_new_equations", "cubic_conservation_law.md"),
+                "Nonconservative equation" => joinpath("adding_new_equations", "nonconservative_advection.md")
+            ],
             "Differentiable programming" => "differentiable_programming.md",
         ],
         "Basic building blocks" => [

--- a/docs/src/adding_new_equations/cubic_conservation_law.md
+++ b/docs/src/adding_new_equations/cubic_conservation_law.md
@@ -1,4 +1,4 @@
-# Adding a new equation
+# Adding a new equation: scalar conservation laws
 
 If you want to use Trixi for your own research, you might be interested in
 a new physics model that's not already included in Trixi.jl. In this tutorial,

--- a/docs/src/adding_new_equations/nonconservative_advection.md
+++ b/docs/src/adding_new_equations/nonconservative_advection.md
@@ -1,0 +1,310 @@
+# Adding a new equation: nonconservative linear advection
+
+If you want to use Trixi for your own research, you might be interested in
+a new physics model that's not already included in Trixi.jl. In this tutorial,
+we will implement the nonconservative linear advection equation
+```math
+\partial_t u(t,x) + a(x) \partial_x u(t,x) = 0
+```
+in a periodic domain in one space dimension. In Trixi.jl, such a mathematical model
+is encoded as a subtype of [`Trixi.AbstractEquations`](@ref).
+
+!!! warning "Experimental interface"
+    The support for nonconservative equations in Trixi is in an experimental
+    stage and will likely change in future releases. The interface documented
+    here is not considered to be part of the stable public API at the moment.
+
+
+## Basic setup
+
+Let's start by creating a module (in the REPL, in a file, in a Jupyter notebook, ...).
+That ensures that we can re-create `struct`s defined therein without having to
+restart Julia.
+
+```julia
+# Define new physics
+module NonconservativeLinearAdvection
+
+using Trixi
+using Trixi: AbstractEquations, get_node_vars
+import Trixi: varnames, default_analysis_integrals, flux, max_abs_speed_naive,
+              have_nonconservative_terms, calcflux_twopoint_nonconservative,
+              noncons_interface_flux
+
+# Since there is no native support for variable coefficients, we use two
+# variables: one for the basic unknown `u` and another one for the coefficient `a`
+struct NonconservativeLinearAdvectionEquation <: AbstractEquations{1 #= spatial dimension =#,
+                                                                   2 #= two variables (u,a) =#}
+end
+
+varnames(::typeof(cons2cons), ::NonconservativeLinearAdvectionEquation) = ("scalar", "advectionvelocity")
+
+default_analysis_integrals(::NonconservativeLinearAdvectionEquation) = ()
+
+
+# The conservative part of the flux is zero
+flux(u, orientation, equation::NonconservativeLinearAdvectionEquation) = zero(u)
+
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+function max_abs_speed_naive(u_ll, u_rr, orientation::Integer, ::NonconservativeLinearAdvectionEquation)
+  _, advectionvelocity_ll = u_ll
+  _, advectionvelocity_rr = u_rr
+
+  return max(abs(advectionvelocity_ll), abs(advectionvelocity_rr))
+end
+
+
+# We use nonconservative terms
+have_nonconservative_terms(::NonconservativeLinearAdvectionEquation) = Val(true)
+
+# OBS! This is scaled by 1/2 because it will cancel later with the factor of 2
+# the flux differencing volume integral
+function calcflux_twopoint_nonconservative!(f1, u, element,
+                                                  equations::NonconservativeLinearAdvectionEquation,
+                                                  dg, cache)
+  for i in eachnode(dg)
+    _, advectionvelocity = get_node_vars(u, equations, dg, i, element)
+
+    for l in eachnode(dg)
+      scalar, _ = get_node_vars(u, equations, dg, l, element)
+      f1[1, l, i] += 0.5 * advectionvelocity * scalar
+    end
+  end
+
+  return nothing
+end
+
+function noncons_interface_flux(u_left, u_right, orientation, mode,
+                                      equations::NonconservativeLinearAdvectionEquation)
+  _, advectionvelocity = u_left
+  scalar, _            = u_right
+
+  # assume mode==:weak
+
+  return SVector(0.5 * advectionvelocity * scalar, zero(scalar))
+end
+
+end # module
+```
+
+The implementation of nononservative terms uses `calcflux_twopoint_nonconservative!`
+and `noncons_interface_flux` at the moment. This implementation is not considered
+to be part of the stable API and will likely change in future releases.
+
+
+Now, we can run a simple simulation using a DGSEM discretization. This code is
+written outside of our new `module`.
+```julia
+# Create a simulation setup
+import .NonconservativeLinearAdvection
+using Trixi
+using OrdinaryDiffEq
+
+equation = NonconservativeLinearAdvection.NonconservativeLinearAdvectionEquation()
+
+# You can derive the exact solution for this setup using the method of
+# characteristics
+function initial_condition_sine(x, t, equation::NonconservativeLinearAdvection.NonconservativeLinearAdvectionEquation)
+  x0 = -2 * atan(sqrt(3) * tan(sqrt(3) / 2 * t - atan(tan(x[1] / 2) / sqrt(3))))
+  scalar = sin(x0)
+  advectionvelocity = 2 + cos(x[1])
+  SVector(scalar, advectionvelocity)
+end
+
+# Create a uniform mesh in 1D in the interval [-π, π] with periodic boundaries
+mesh = TreeMesh(-Float64(π), Float64(π), # min/max coordinates
+                initial_refinement_level=4, n_cells_max=10^4)
+
+# Create a DGSEM solver with polynomials of degree `polydeg`
+solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs,
+               volume_integral=VolumeIntegralFluxDifferencing(flux_central))
+
+# Setup the spatial semidiscretization containing all ingredients
+semi = SemidiscretizationHyperbolic(mesh, equation, initial_condition_sine, solver)
+
+# Create an ODE problem with given time span
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan);
+
+# Set up some standard callbacks summarizing the simulation setup and computing
+# errors of the numerical solution
+summary_callback = SummaryCallback()
+analysis_callback = AnalysisCallback(semi, interval=50)
+callbacks = CallbackSet(summary_callback, analysis_callback);
+
+# OrdinaryDiffEq's `solve` method evolves the solution in time and executes
+# the passed callbacks
+sol = solve(ode, Tsit5(), abstol=1.0e-6, reltol=1.0e-6,
+            save_everystep=false, callback=callbacks);
+
+# Print the timer summary
+summary_callback()
+
+# Plot the numerical solution at the final time
+using Plots: plot
+plot(sol)
+```
+
+You should see a plot of the final solution that looks as follows.
+
+![tutorial_nonconservative_advection]()
+
+We can check whether everything fits together by refining the grid and comparing
+the numerical errors. First, we look at the error using the grid resolution
+above.
+```julia
+julia> analysis_callback(sol).l2 |> first
+0.00029610274971929974
+```
+
+Next, we increase the grid resolution by one refinement level and run the
+simulation again.
+```julia
+mesh = TreeMesh(-Float64(π), Float64(π), # min/max coordinates
+                initial_refinement_level=5, n_cells_max=10^4)
+
+solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs,
+               volume_integral=VolumeIntegralFluxDifferencing(flux_central))
+
+semi = SemidiscretizationHyperbolic(mesh, equation, initial_condition_sine, solver)
+
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan);
+
+summary_callback = SummaryCallback()
+analysis_callback = AnalysisCallback(semi, interval=50)
+callbacks = CallbackSet(summary_callback, analysis_callback);
+
+sol = solve(ode, Tsit5(), abstol=1.0e-6, reltol=1.0e-6,
+            save_everystep=false, callback=callbacks);
+summary_callback()
+```
+
+As expected, the new error si roughly reduced by a factor of 16, corresponding
+to an experimental order of convergence of 4 (for polynomials of degree 3).
+```julia
+julia> analysis_callback(sol).l2 |> first
+1.8602959063280523e-5
+
+julia> 0.00029610274971929974 / 1.8602959063280523e-5
+15.916970451424719
+```
+
+
+## Summary of the code
+
+To sum up, here is the complete code that we used (without the callbacks since
+these create a lot of unnecessary output in the doctests of this tutorial).
+
+```jldoctest; output = false
+# Define new physics
+module NonconservativeLinearAdvection
+
+using Trixi
+using Trixi: AbstractEquations, get_node_vars
+import Trixi: varnames, default_analysis_integrals, flux, max_abs_speed_naive,
+              have_nonconservative_terms, calcflux_twopoint_nonconservative!,
+              noncons_interface_flux
+
+# Since there is no native support for variable coefficients, we use two
+# variables: one for the basic unknown `u` and another one for the coefficient `a`
+struct NonconservativeLinearAdvectionEquation <: AbstractEquations{1 #= spatial dimension =#,
+                                                                   2 #= two variables (u,a) =#}
+end
+
+varnames(::typeof(cons2cons), ::NonconservativeLinearAdvectionEquation) = ("scalar", "advectionvelocity")
+
+default_analysis_integrals(::NonconservativeLinearAdvectionEquation) = ()
+
+
+# The conservative part of the flux is zero
+flux(u, orientation, equation::NonconservativeLinearAdvectionEquation) = zero(u)
+
+# Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+function max_abs_speed_naive(u_ll, u_rr, orientation::Integer, ::NonconservativeLinearAdvectionEquation)
+  _, advectionvelocity_ll = u_ll
+  _, advectionvelocity_rr = u_rr
+
+  return max(abs(advectionvelocity_ll), abs(advectionvelocity_rr))
+end
+
+
+# We use nonconservative terms
+have_nonconservative_terms(::NonconservativeLinearAdvectionEquation) = Val(true)
+
+# OBS! This is scaled by 1/2 because it will cancel later with the factor of 2
+# the flux differencing volume integral
+function calcflux_twopoint_nonconservative!(f1, u, element,
+                                                  equations::NonconservativeLinearAdvectionEquation,
+                                                  dg, cache)
+  for i in eachnode(dg)
+    _, advectionvelocity = get_node_vars(u, equations, dg, i, element)
+
+    for l in eachnode(dg)
+      scalar, _ = get_node_vars(u, equations, dg, l, element)
+      f1[1, l, i] += 0.5 * advectionvelocity * scalar
+    end
+  end
+
+  return nothing
+end
+
+function noncons_interface_flux(u_left, u_right, orientation, mode,
+                                      equations::NonconservativeLinearAdvectionEquation)
+  _, advectionvelocity = u_left
+  scalar, _            = u_right
+
+  # assume mode==:weak
+
+  return SVector(0.5 * advectionvelocity * scalar, zero(scalar))
+end
+
+end # module
+
+
+
+# Create a simulation setup
+import .NonconservativeLinearAdvection
+using Trixi
+using OrdinaryDiffEq
+
+equation = NonconservativeLinearAdvection.NonconservativeLinearAdvectionEquation()
+
+# You can derive the exact solution for this setup using the method of
+# characteristics
+function initial_condition_sine(x, t, equation::NonconservativeLinearAdvection.NonconservativeLinearAdvectionEquation)
+  x0 = -2 * atan(sqrt(3) * tan(sqrt(3) / 2 * t - atan(tan(x[1] / 2) / sqrt(3))))
+  scalar = sin(x0)
+  advectionvelocity = 2 + cos(x[1])
+  SVector(scalar, advectionvelocity)
+end
+
+# Create a uniform mesh in 1D in the interval [-π, π] with periodic boundaries
+mesh = TreeMesh(-Float64(π), Float64(π), # min/max coordinates
+                initial_refinement_level=4, n_cells_max=10^4)
+
+# Create a DGSEM solver with polynomials of degree `polydeg`
+solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs,
+               volume_integral=VolumeIntegralFluxDifferencing(flux_central))
+
+# Setup the spatial semidiscretization containing all ingredients
+semi = SemidiscretizationHyperbolic(mesh, equation, initial_condition_sine, solver)
+
+# Create an ODE problem with given time span
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan);
+
+# OrdinaryDiffEq's `solve` method evolves the solution in time and executes
+# the passed callbacks
+sol = solve(ode, Tsit5(), abstol=1.0e-6, reltol=1.0e-6,
+            save_everystep=false);
+
+# Plot the numerical solution at the final time
+using Plots: plot
+plot(sol)
+
+# output
+
+Plot{Plots.GRBackend() n=1}
+
+```

--- a/docs/src/adding_new_equations/nonconservative_advection.md
+++ b/docs/src/adding_new_equations/nonconservative_advection.md
@@ -147,7 +147,7 @@ plot(sol)
 
 You should see a plot of the final solution that looks as follows.
 
-![tutorial_nonconservative_advection]()
+![tutorial_nonconservative_advection](https://user-images.githubusercontent.com/12693098/124343365-1f9a9300-dbcb-11eb-93a5-0f75db2a99f8.png)
 
 We can check whether everything fits together by refining the grid and comparing
 the numerical errors. First, we look at the error using the grid resolution
@@ -180,7 +180,7 @@ sol = solve(ode, Tsit5(), abstol=1.0e-6, reltol=1.0e-6,
 summary_callback()
 ```
 
-As expected, the new error si roughly reduced by a factor of 16, corresponding
+As expected, the new error is roughly reduced by a factor of 16, corresponding
 to an experimental order of convergence of 4 (for polynomials of degree 3).
 ```julia
 julia> analysis_callback(sol).l2 |> first

--- a/docs/src/adding_new_equations/nonconservative_advection.md
+++ b/docs/src/adding_new_equations/nonconservative_advection.md
@@ -1,7 +1,7 @@
 # Adding a new equation: nonconservative linear advection
 
 If you want to use Trixi for your own research, you might be interested in
-a new physics model that's not already included in Trixi.jl. In this tutorial,
+a new physics model that is not present in Trixi.jl. In this tutorial,
 we will implement the nonconservative linear advection equation
 ```math
 \partial_t u(t,x) + a(x) \partial_x u(t,x) = 0
@@ -193,8 +193,8 @@ julia> 0.00029610274971929974 / 1.8602959063280523e-5
 
 ## Summary of the code
 
-To sum up, here is the complete code that we used (without the callbacks since
-these create a lot of unnecessary output in the doctests of this tutorial).
+Here is the complete code that we used (without the callbacks since these
+create a lot of unnecessary output in the doctests of this tutorial).
 
 ```jldoctest; output = false
 # Define new physics
@@ -305,6 +305,6 @@ plot(sol)
 
 # output
 
-Plot{Plots.GRBackend() n=1}
+Plot{Plots.GRBackend() n=2}
 
 ```

--- a/src/solvers/dgsem_tree/dg_1d.jl
+++ b/src/solvers/dgsem_tree/dg_1d.jl
@@ -44,10 +44,15 @@ function create_cache(mesh::TreeMesh{1}, nonconservative_terms::Val{false}, equa
   NamedTuple()
 end
 
-# TODO: MHD in 1D
-# function create_cache(mesh::TreeMesh{1}, nonconservative_terms::Val{true}, equations,
-#                       ::VolumeIntegralFluxDifferencing, dg, uEltype)
-# end
+function create_cache(mesh::TreeMesh{1}, nonconservative_terms::Val{true}, equations,
+                      ::VolumeIntegralFluxDifferencing, dg, uEltype)
+
+  prototype = Array{uEltype, 3}(undef,
+                nvariables(equations), nnodes(dg), nnodes(dg))
+  f1_threaded = [similar(prototype) for _ in 1:Threads.nthreads()]
+
+  return (; f1_threaded)
+end
 
 
 function create_cache(mesh::TreeMesh{1}, equations,
@@ -155,20 +160,65 @@ function calc_volume_integral!(du, u,
 end
 
 
+# Calculate 1D twopoint flux (element version)
+@inline function calcflux_twopoint!(f1, u::AbstractArray{<:Any,3}, element,
+                                    mesh::TreeMesh{1}, equations, volume_flux, dg::DG, cache)
+
+  for i in eachnode(dg)
+    # Pull the solution values at the node i,j
+    u_node = get_node_vars(u, equations, dg, i, element)
+    # diagonal (consistent) part not needed since diagonal of
+    # dg.basis.derivative_split_transpose is zero!
+    set_node_vars!(f1, zero(u_node), equations, dg, i, i)
+
+    # Flux in x-direction
+    for ii in (i+1):nnodes(dg)
+      u_ll = get_node_vars(u, equations, dg, i,  element)
+      u_rr = get_node_vars(u, equations, dg, ii, element)
+      flux = volume_flux(u_ll, u_rr, 1, equations) # 1-> x-direction
+      set_node_vars!(f1, flux, equations, dg, i, ii)
+      set_node_vars!(f1, flux, equations, dg, ii, i)
+    end
+  end
+
+  calcflux_twopoint_nonconservative!(f1, u, element,
+                                     have_nonconservative_terms(equations),
+                                     mesh, equations, dg, cache)
+end
+
+function calcflux_twopoint_nonconservative!(f1, u::AbstractArray{<:Any,3}, element,
+                                            nonconservative_terms::Val{false},
+                                            mesh::TreeMesh{1},
+                                            equations, dg::DG, cache)
+  return nothing
+end
+
+function calcflux_twopoint_nonconservative!(f1, u::AbstractArray{<:Any,3}, element,
+                                            nonconservative_terms::Val{true},
+                                            mesh::TreeMesh{1},
+                                            equations, dg::DG, cache)
+  #TODO: Create a unified interface, e.g. using non-symmetric two-point (extended) volume fluxes
+  #      For now, just dispatch to an existing function for the IdealMhdEquations
+  calcflux_twopoint_nonconservative!(f1, u, element, equations, dg, cache)
+end
+
+
 function calc_volume_integral!(du, u,
                                mesh::TreeMesh{1},
                                nonconservative_terms, equations,
                                volume_integral::VolumeIntegralFluxDifferencing,
                                dg::DGSEM, cache)
   @threaded for element in eachelement(dg, cache)
-    split_form_kernel!(du, u, nonconservative_terms, equations, volume_integral.volume_flux, dg, cache, element)
+    split_form_kernel!(du, u, element, mesh, nonconservative_terms, equations,
+                       volume_integral.volume_flux, dg, cache)
   end
 end
 
 @inline function split_form_kernel!(du::AbstractArray{<:Any,3}, u,
+                                    element, mesh::TreeMesh{1},
                                     nonconservative_terms::Val{false}, equations,
                                     volume_flux, dg::DGSEM, cache,
-                                    element, alpha=true)
+                                    alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
   @unpack derivative_split = dg.basis
@@ -192,6 +242,34 @@ end
   end
 end
 
+@inline function split_form_kernel!(du::AbstractArray{<:Any,3}, u,
+                                    element, mesh::TreeMesh{1},
+                                    nonconservative_terms::Val{true}, equations,
+                                    volume_flux, dg::DGSEM, cache, alpha=true)
+  @unpack derivative_split_transpose = dg.basis
+  @unpack f1_threaded = cache
+
+  # Choose thread-specific pre-allocated container
+  f1 = f1_threaded[Threads.threadid()]
+
+  # Calculate volume fluxes (one more dimension than weak form)
+  calcflux_twopoint!(f1, u, element, mesh, equations, volume_flux, dg, cache)
+
+  # Calculate volume integral in one element
+  for i in eachnode(dg)
+    for v in eachvariable(equations)
+      # Use local accumulator to improve performance
+      acc = zero(eltype(du))
+      for l in eachnode(dg)
+        acc += derivative_split_transpose[l, i] * f1[v, l, i]
+      end
+      du[v, i, element] += alpha * acc
+    end
+  end
+
+  return nothing
+end
+
 
 # TODO: Taal dimension agnostic
 function calc_volume_integral!(du, u,
@@ -211,7 +289,8 @@ function calc_volume_integral!(du, u,
   # Loop over pure DG elements
   @trixi_timeit timer() "pure DG" @threaded for idx_element in eachindex(element_ids_dg)
     element = element_ids_dg[idx_element]
-    split_form_kernel!(du, u, nonconservative_terms, equations, volume_flux_dg, dg, cache, element)
+    split_form_kernel!(du, u, element, mesh, nonconservative_terms, equations,
+                       volume_flux_dg, dg, cache)
   end
 
   # Loop over blended DG-FV elements
@@ -220,7 +299,8 @@ function calc_volume_integral!(du, u,
     alpha_element = alpha[element]
 
     # Calculate DG volume integral contribution
-    split_form_kernel!(du, u, nonconservative_terms, equations, volume_flux_dg, dg, cache, element, 1 - alpha_element)
+    split_form_kernel!(du, u, element, mesh, nonconservative_terms, equations,
+                       volume_flux_dg, dg, cache, 1 - alpha_element)
 
     # Calculate FV volume integral contribution
     fv_kernel!(du, u, equations, volume_flux_fv, dg, cache, element, alpha_element)
@@ -332,11 +412,45 @@ function calc_interface_flux!(surface_flux_values,
   end
 end
 
-# TODO: MHD in 1D
-# function calc_interface_flux!(surface_flux_values, mesh::TreeMesh{1},
-#                               nonconservative_terms::Val{true}, equations,
-#                               dg::DG, cache)
-# end
+function calc_interface_flux!(surface_flux_values,
+                              mesh::TreeMesh{1},
+                              nonconservative_terms::Val{true}, equations,
+                              surface_integral, dg::DG, cache)
+  @unpack surface_flux = surface_integral
+  @unpack u, neighbor_ids, orientations = cache.interfaces
+
+  @threaded for interface in eachinterface(dg, cache)
+    # Get neighboring elements
+    left_neighbor  = neighbor_ids[1, interface]
+    right_neighbor = neighbor_ids[2, interface]
+
+    # Determine interface direction with respect to elements:
+    # orientation = 1: left -> 2, right -> 1
+    left_direction  = 2 * orientations[interface]
+    right_direction = 2 * orientations[interface] - 1
+
+    # Call pointwise Riemann solver
+    u_ll, u_rr = get_surface_node_vars(u, equations, dg, interface)
+    f = surface_flux(u_ll, u_rr, orientations[interface], equations)
+
+    # Compute the nonconservative numerical "flux" along an interface
+    # Done twice because left/right orientation matters så
+    # 1 -> primary element and 2 -> secondary element
+    # See Bohm et al. 2018 for details on the nonconservative diamond "flux"
+
+    # Call pointwise nonconservative term
+    noncons_primary   = noncons_interface_flux(u_ll, u_rr, orientations[interface], :weak, equations)
+    noncons_secondary = noncons_interface_flux(u_rr, u_ll, orientations[interface], :weak, equations)
+
+    # Copy flux to left and right element storage
+    for v in eachvariable(equations)
+      surface_flux_values[v, left_direction,  left_neighbor]  = (f[v] + noncons_primary[v])
+      surface_flux_values[v, right_direction, right_neighbor] = (f[v] + noncons_secondary[v])
+    end
+  end
+
+  return nothing
+end
 
 
 function prolong2boundaries!(cache, u,

--- a/test/test_examples_1d.jl
+++ b/test/test_examples_1d.jl
@@ -196,9 +196,6 @@ end
   # Define new physics
   using Trixi
   using Trixi: AbstractEquations, get_node_vars
-  import Trixi: varnames, default_analysis_integrals, flux, max_abs_speed_naive,
-                have_nonconservative_terms, calcflux_twopoint_nonconservative!,
-                noncons_interface_flux
 
   # Since there is no native support for variable coefficients, we use two
   # variables: one for the basic unknown `u` and another one for the coefficient `a`
@@ -206,16 +203,16 @@ end
                                                                      2 #= two variables (u,a) =#}
   end
 
-  varnames(::typeof(cons2cons), ::NonconservativeLinearAdvectionEquation) = ("scalar", "advectionvelocity")
+  Trixi.varnames(::typeof(cons2cons), ::NonconservativeLinearAdvectionEquation) = ("scalar", "advectionvelocity")
 
-  default_analysis_integrals(::NonconservativeLinearAdvectionEquation) = ()
+  Trixi.default_analysis_integrals(::NonconservativeLinearAdvectionEquation) = ()
 
 
   # The conservative part of the flux is zero
-  flux(u, orientation, equation::NonconservativeLinearAdvectionEquation) = zero(u)
+  Trixi.flux(u, orientation, equation::NonconservativeLinearAdvectionEquation) = zero(u)
 
   # Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
-  function max_abs_speed_naive(u_ll, u_rr, orientation::Integer, ::NonconservativeLinearAdvectionEquation)
+  function Trixi.max_abs_speed_naive(u_ll, u_rr, orientation::Integer, ::NonconservativeLinearAdvectionEquation)
     _, advectionvelocity_ll = u_ll
     _, advectionvelocity_rr = u_rr
 
@@ -224,13 +221,13 @@ end
 
 
   # We use nonconservative terms
-  have_nonconservative_terms(::NonconservativeLinearAdvectionEquation) = Val(true)
+  Trixi.have_nonconservative_terms(::NonconservativeLinearAdvectionEquation) = Val(true)
 
   # OBS! This is scaled by 1/2 because it will cancel later with the factor of 2
   # the flux differencing volume integral
-  function calcflux_twopoint_nonconservative!(f1, u, element,
-                                              equations::NonconservativeLinearAdvectionEquation,
-                                              dg, cache)
+  function Trixi.calcflux_twopoint_nonconservative!(f1, u, element,
+                                                    equations::NonconservativeLinearAdvectionEquation,
+                                                    dg, cache)
     for i in eachnode(dg)
       _, advectionvelocity = get_node_vars(u, equations, dg, i, element)
 
@@ -243,8 +240,8 @@ end
     return nothing
   end
 
-  function noncons_interface_flux(u_left, u_right, orientation, mode,
-                                  equations::NonconservativeLinearAdvectionEquation)
+  function Trixi.noncons_interface_flux(u_left, u_right, orientation, mode,
+                                        equations::NonconservativeLinearAdvectionEquation)
     _, advectionvelocity = u_left
     scalar, _            = u_right
 
@@ -257,15 +254,14 @@ end
 
 
   # Create a simulation setup
-  import .NonconservativeLinearAdvection
   using Trixi
   using OrdinaryDiffEq
 
-  equation = NonconservativeLinearAdvection.NonconservativeLinearAdvectionEquation()
+  equation = NonconservativeLinearAdvectionEquation()
 
   # You can derive the exact solution for this setup using the method of
   # characteristics
-  function initial_condition_sine(x, t, equation::NonconservativeLinearAdvection.NonconservativeLinearAdvectionEquation)
+  function initial_condition_sine(x, t, equation::NonconservativeLinearAdvectionEquation)
     x0 = -2 * atan(sqrt(3) * tan(sqrt(3) / 2 * t - atan(tan(x[1] / 2) / sqrt(3))))
     scalar = sin(x0)
     advectionvelocity = 2 + cos(x[1])

--- a/test/test_examples_1d.jl
+++ b/test/test_examples_1d.jl
@@ -203,7 +203,7 @@ end
   # Since there is no native support for variable coefficients, we use two
   # variables: one for the basic unknown `u` and another one for the coefficient `a`
   struct NonconservativeLinearAdvectionEquation <: AbstractEquations{1 #= spatial dimension =#,
-                                                                    2 #= two variables (u,a) =#}
+                                                                     2 #= two variables (u,a) =#}
   end
 
   varnames(::typeof(cons2cons), ::NonconservativeLinearAdvectionEquation) = ("scalar", "advectionvelocity")

--- a/test/test_examples_1d.jl
+++ b/test/test_examples_1d.jl
@@ -190,6 +190,118 @@ end
   end
 end
 
+@trixi_testset "Nonconservative terms in 1D (linear advection)" begin
+  # Same setup as docs/src/adding_new_equations/nonconservative_advection.md
+
+  # Define new physics
+  module NonconservativeLinearAdvection
+
+  using Trixi
+  using Trixi: AbstractEquations, get_node_vars
+  import Trixi: varnames, default_analysis_integrals, flux, max_abs_speed_naive,
+                have_nonconservative_terms, calcflux_twopoint_nonconservative!,
+                noncons_interface_flux
+
+  # Since there is no native support for variable coefficients, we use two
+  # variables: one for the basic unknown `u` and another one for the coefficient `a`
+  struct NonconservativeLinearAdvectionEquation <: AbstractEquations{1 #= spatial dimension =#,
+                                                                    2 #= two variables (u,a) =#}
+  end
+
+  varnames(::typeof(cons2cons), ::NonconservativeLinearAdvectionEquation) = ("scalar", "advectionvelocity")
+
+  default_analysis_integrals(::NonconservativeLinearAdvectionEquation) = ()
+
+
+  # The conservative part of the flux is zero
+  flux(u, orientation, equation::NonconservativeLinearAdvectionEquation) = zero(u)
+
+  # Calculate maximum wave speed for local Lax-Friedrichs-type dissipation
+  function max_abs_speed_naive(u_ll, u_rr, orientation::Integer, ::NonconservativeLinearAdvectionEquation)
+    _, advectionvelocity_ll = u_ll
+    _, advectionvelocity_rr = u_rr
+
+    return max(abs(advectionvelocity_ll), abs(advectionvelocity_rr))
+  end
+
+
+  # We use nonconservative terms
+  have_nonconservative_terms(::NonconservativeLinearAdvectionEquation) = Val(true)
+
+  # OBS! This is scaled by 1/2 because it will cancel later with the factor of 2
+  # the flux differencing volume integral
+  function calcflux_twopoint_nonconservative!(f1, u, element,
+                                                    equations::NonconservativeLinearAdvectionEquation,
+                                                    dg, cache)
+    for i in eachnode(dg)
+      _, advectionvelocity = get_node_vars(u, equations, dg, i, element)
+
+      for l in eachnode(dg)
+        scalar, _ = get_node_vars(u, equations, dg, l, element)
+        f1[1, l, i] += 0.5 * advectionvelocity * scalar
+      end
+    end
+
+    return nothing
+  end
+
+  function noncons_interface_flux(u_left, u_right, orientation, mode,
+                                        equations::NonconservativeLinearAdvectionEquation)
+    _, advectionvelocity = u_left
+    scalar, _            = u_right
+
+    # assume mode==:weak
+
+    return SVector(0.5 * advectionvelocity * scalar, zero(scalar))
+  end
+
+  end # module
+
+
+
+  # Create a simulation setup
+  import .NonconservativeLinearAdvection
+  using Trixi
+  using OrdinaryDiffEq
+
+  equation = NonconservativeLinearAdvection.NonconservativeLinearAdvectionEquation()
+
+  # You can derive the exact solution for this setup using the method of
+  # characteristics
+  function initial_condition_sine(x, t, equation::NonconservativeLinearAdvection.NonconservativeLinearAdvectionEquation)
+    x0 = -2 * atan(sqrt(3) * tan(sqrt(3) / 2 * t - atan(tan(x[1] / 2) / sqrt(3))))
+    scalar = sin(x0)
+    advectionvelocity = 2 + cos(x[1])
+    SVector(scalar, advectionvelocity)
+  end
+
+  # Create a uniform mesh in 1D in the interval [-π, π] with periodic boundaries
+  mesh = TreeMesh(-Float64(π), Float64(π), # min/max coordinates
+                  initial_refinement_level=4, n_cells_max=10^4)
+
+  # Create a DGSEM solver with polynomials of degree `polydeg`
+  solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs,
+                volume_integral=VolumeIntegralFluxDifferencing(flux_central))
+
+  # Setup the spatial semidiscretization containing all ingredients
+  semi = SemidiscretizationHyperbolic(mesh, equation, initial_condition_sine, solver)
+
+  # Create an ODE problem with given time span
+  tspan = (0.0, 1.0)
+  ode = semidiscretize(semi, tspan);
+
+  summary_callback = SummaryCallback()
+  analysis_callback = AnalysisCallback(semi, interval=50)
+  callbacks = CallbackSet(summary_callback, analysis_callback);
+
+  # OrdinaryDiffEq's `solve` method evolves the solution in time and executes
+  # the passed callbacks
+  sol = solve(ode, Tsit5(), abstol=1.0e-6, reltol=1.0e-6,
+              save_everystep=false, callback=callbacks);
+
+  @test analysis_callback(sol).l2 ≈ [0.00029610274971929974, 5.573684084938363e-6]
+end
+
 
 # Clean up afterwards: delete Trixi output directory
 @test_nowarn rm(outdir, recursive=true)

--- a/test/test_examples_1d.jl
+++ b/test/test_examples_1d.jl
@@ -194,8 +194,6 @@ end
   # Same setup as docs/src/adding_new_equations/nonconservative_advection.md
 
   # Define new physics
-  module NonconservativeLinearAdvection
-
   using Trixi
   using Trixi: AbstractEquations, get_node_vars
   import Trixi: varnames, default_analysis_integrals, flux, max_abs_speed_naive,
@@ -231,8 +229,8 @@ end
   # OBS! This is scaled by 1/2 because it will cancel later with the factor of 2
   # the flux differencing volume integral
   function calcflux_twopoint_nonconservative!(f1, u, element,
-                                                    equations::NonconservativeLinearAdvectionEquation,
-                                                    dg, cache)
+                                              equations::NonconservativeLinearAdvectionEquation,
+                                              dg, cache)
     for i in eachnode(dg)
       _, advectionvelocity = get_node_vars(u, equations, dg, i, element)
 
@@ -246,7 +244,7 @@ end
   end
 
   function noncons_interface_flux(u_left, u_right, orientation, mode,
-                                        equations::NonconservativeLinearAdvectionEquation)
+                                  equations::NonconservativeLinearAdvectionEquation)
     _, advectionvelocity = u_left
     scalar, _            = u_right
 
@@ -255,7 +253,6 @@ end
     return SVector(0.5 * advectionvelocity * scalar, zero(scalar))
   end
 
-  end # module
 
 
 


### PR DESCRIPTION
This enables support for nonconservative terms in 1D on the `TreeMesh`. I also added a tutorial on the nonconservative linear advection equation in 1D. 

Image for the docs:
![nonconservative_linear_advection](https://user-images.githubusercontent.com/12693098/124343365-1f9a9300-dbcb-11eb-93a5-0f75db2a99f8.png)
