### PR TITLE
Do not run doc preview cleanup from forks

### DIFF
--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   doc-preview-cleanup:
+    # Do not run on forks to avoid authorization errors
+    # Source: https://github.community/t/have-github-action-only-run-on-master-repo-and-not-on-forks/140840/18
+    if: github.repository_owner == 'trixi-framework'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch


### PR DESCRIPTION
As discussed on Slack.

In addition, I checked the contents of https://github.com/trixi-framework/Trixi.jl/tree/gh-pages/previews and it seems like the following previews can be removed:
* https://github.com/trixi-framework/Trixi.jl/pull/467
* https://github.com/trixi-framework/Trixi.jl/pull/470
* https://github.com/trixi-framework/Trixi.jl/pull/472
* https://github.com/trixi-framework/Trixi.jl/pull/475
* https://github.com/trixi-framework/Trixi.jl/pull/480
* https://github.com/trixi-framework/Trixi.jl/pull/488
* https://github.com/trixi-framework/Trixi.jl/pull/539
* https://github.com/trixi-framework/Trixi.jl/pull/575
* https://github.com/trixi-framework/Trixi.jl/pull/586
* https://github.com/trixi-framework/Trixi.jl/pull/629
* https://github.com/trixi-framework/Trixi.jl/pull/669
* https://github.com/trixi-framework/Trixi.jl/pull/684

However, I have to admit that I don't understand why we would have to delete the latter ones, since they are from roughly a week ago where `DocPreviewCleanup` should have already kicked in.