### PR TITLE
add feature matrix

### DIFF
--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -52,6 +52,7 @@ different features on different mesh types.
 | Spatial dimension                                            |     1D, 2D, 3D     |        1D, 2D, 3D        |              2D              |          2D, 3D          |
 | Coordinates                                                  |      Cartesian     |        curvilinear       |          curvilinear         |        curvilinear       |
 | Connectivity                                                 |  *h*-nonconforming |        conforming        |          conforming          |     *h*-nonconforming    |
+| Element type                                                 |      hypercube     |         hypercube        |           hypercube          |         hypercube        |
 | Adaptive mesh refinement ([`AMRCallback`](@ref))             | :heavy_check_mark: | :heavy_multiplication_x: |   :heavy_multiplication_x:   |    :heavy_check_mark:    |
 | Domain                                                       |      hypercube     |     mapped hypercube     |           arbitrary          |         arbitrary        |
 | Weak form ([`VolumeIntegralWeakForm`](@ref))                 | :heavy_check_mark: |    :heavy_check_mark:    |      :heavy_check_mark:      |    :heavy_check_mark:    |

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -10,7 +10,7 @@ folder.
 
 Trixi uses the method of lines, i.e., the full space-time discretization is separated into two steps;
 the spatial semidiscretization is performed at first and the resulting ODE system is solved numerically
-using a suitable time integration method. 
+using a suitable time integration method.
 Thus, the main ingredients of an elixir designed
 to solve a PDE numerically are the spatial semidiscretization and the time
 integration scheme.
@@ -22,6 +22,8 @@ Semidiscretizations are high-level descriptions of spatial discretizations
 specialized for certain PDEs. Trixi's main focus is on hyperbolic conservation
 laws represented in a [`SemidiscretizationHyperbolic`](@ref).
 Such semidiscretizations are usually named `semi` in Trixi.
+
+![semidiscretization_overview](https://user-images.githubusercontent.com/12693098/124783641-83171e80-df45-11eb-8757-daac80cd1599.png)
 
 The basic building blocks of a semidiscretization are
 
@@ -42,7 +44,19 @@ ingredients. For example, a new `mesh` type can be created and implemented at
 first only for a specific solver. Thus, there is no need to consider all
 possible combinations of `mesh`es, `equations`, and `solver`s when implementing
 new features. This allows rapid prototyping of new ideas and is one of the main
-design goals behind Trixi.
+design goals behind Trixi. Below is a brief overview of the availability of
+different features on different mesh types.
+
+| Feature                                                      | [`TreeMesh`](@ref) | [`StructuredMesh`](@ref) | [`UnstructuredMesh2D`](@ref) |    [`P4estMesh`](@ref)   |
+|--------------------------------------------------------------|:------------------:|:------------------------:|:----------------------------:|:------------------------:|
+| Spatial dimension                                            |     1D, 2D, 3D     |        1D, 2D, 3D        |              2D              |          2D, 3D          |
+| Coordinates                                                  |      Cartesian     |        curvilinear       |          curvilinear         |        curvilinear       |
+| Connectivity                                                 |  *h*-nonconforming |        conforming        |          conforming          |     *h*-nonconforming    |
+| Adaptive mesh refinement ([`AMRCallback`](@ref))             | :heavy_check_mark: | :heavy_multiplication_x: |   :heavy_multiplication_x:   |    :heavy_check_mark:    |
+| Domain                                                       |      hypercube     |     mapped hypercube     |           arbitrary          |         arbitrary        |
+| Weak form ([`VolumeIntegralWeakForm`](@ref))                 | :heavy_check_mark: |    :heavy_check_mark:    |      :heavy_check_mark:      |    :heavy_check_mark:    |
+| Flux differencing ([`VolumeIntegralFluxDifferencing`](@ref)) | :heavy_check_mark: |    :heavy_check_mark:    |      :heavy_check_mark:      |    :heavy_check_mark:    |
+| Shock capturing ([`VolumeIntegralShockCapturingHG`](@ref))   | :heavy_check_mark: | :heavy_multiplication_x: |   :heavy_multiplication_x:   | :heavy_multiplication_x: |
 
 
 ## Time integration methods

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -47,17 +47,17 @@ new features. This allows rapid prototyping of new ideas and is one of the main
 design goals behind Trixi. Below is a brief overview of the availability of
 different features on different mesh types.
 
-| Feature                                                      | [`TreeMesh`](@ref) | [`StructuredMesh`](@ref) | [`UnstructuredMesh2D`](@ref) |    [`P4estMesh`](@ref)   |
-|--------------------------------------------------------------|:------------------:|:------------------------:|:----------------------------:|:------------------------:|
-| Spatial dimension                                            |     1D, 2D, 3D     |        1D, 2D, 3D        |              2D              |          2D, 3D          |
-| Coordinates                                                  |      Cartesian     |        curvilinear       |          curvilinear         |        curvilinear       |
-| Connectivity                                                 |  *h*-nonconforming |        conforming        |          conforming          |     *h*-nonconforming    |
-| Element type                                                 |      hypercube     |         hypercube        |           hypercube          |         hypercube        |
-| Adaptive mesh refinement ([`AMRCallback`](@ref))             | :heavy_check_mark: | :heavy_multiplication_x: |   :heavy_multiplication_x:   |    :heavy_check_mark:    |
-| Domain                                                       |      hypercube     |     mapped hypercube     |           arbitrary          |         arbitrary        |
-| Weak form ([`VolumeIntegralWeakForm`](@ref))                 | :heavy_check_mark: |    :heavy_check_mark:    |      :heavy_check_mark:      |    :heavy_check_mark:    |
-| Flux differencing ([`VolumeIntegralFluxDifferencing`](@ref)) | :heavy_check_mark: |    :heavy_check_mark:    |      :heavy_check_mark:      |    :heavy_check_mark:    |
-| Shock capturing ([`VolumeIntegralShockCapturingHG`](@ref))   | :heavy_check_mark: | :heavy_multiplication_x: |   :heavy_multiplication_x:   | :heavy_multiplication_x: |
+| Feature                                                      | [`TreeMesh`](@ref) | [`StructuredMesh`](@ref) | [`UnstructuredMesh2D`](@ref) | [`P4estMesh`](@ref) |
+|--------------------------------------------------------------|:------------------:|:------------------------:|:----------------------------:|:-------------------:|
+| Spatial dimension                                            |     1D, 2D, 3D     |        1D, 2D, 3D        |              2D              |        2D, 3D       |
+| Coordinates                                                  |      Cartesian     |        curvilinear       |          curvilinear         |     curvilinear     |
+| Connectivity                                                 |  *h*-nonconforming |        conforming        |          conforming          |  *h*-nonconforming  |
+| Element type                                                 |      hypercube     |         hypercube        |           hypercube          |      hypercube      |
+| Adaptive mesh refinement ([`AMRCallback`](@ref))             |          ✅         |             ❌            |               ❌              |          ✅          |
+| Domain                                                       |      hypercube     |     mapped hypercube     |           arbitrary          |      arbitrary      |
+| Weak form ([`VolumeIntegralWeakForm`](@ref))                 |          ✅         |             ✅            |               ✅              |          ✅          |
+| Flux differencing ([`VolumeIntegralFluxDifferencing`](@ref)) |          ✅         |             ✅            |               ✅              |          ✅          |
+| Shock capturing ([`VolumeIntegralShockCapturingHG`](@ref))   |          ✅         |             ❌            |               ❌              |          ❌          |
 
 
 ## Time integration methods

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -52,7 +52,7 @@ different features on different mesh types.
 | Spatial dimension                                            |     1D, 2D, 3D     |        1D, 2D, 3D        |              2D              |        2D, 3D       |
 | Coordinates                                                  |      Cartesian     |        curvilinear       |          curvilinear         |     curvilinear     |
 | Connectivity                                                 |  *h*-nonconforming |        conforming        |          conforming          |  *h*-nonconforming  |
-| Element type                                                 |      hypercube     |         hypercube        |           hypercube          |      hypercube      |
+| Element type                                                 | line, square, cube |    line, square, cube    |             square           | line, square, cube  |
 | Adaptive mesh refinement ([`AMRCallback`](@ref))             |          ✅         |             ❌            |               ❌              |          ✅          |
 | Domain                                                       |      hypercube     |     mapped hypercube     |           arbitrary          |      arbitrary      |
 | Weak form ([`VolumeIntegralWeakForm`](@ref))                 |          ✅         |             ✅            |               ✅              |          ✅          |


### PR DESCRIPTION
Closes #611

The preview is available at https://trixi-framework.github.io/Trixi.jl/previews/PR703/overview

Here are two versions of the table. The first one uses unicode names `:heavy_check_mark:` and `:heavy_multiplication_x:`. This version looks better on GitHub (using GH markdown).

| Feature                                                      | [`TreeMesh`](@ref) | [`StructuredMesh`](@ref) | [`UnstructuredMesh2D`](@ref) |    [`P4estMesh`](@ref)   |
|--------------------------------------------------------------|:------------------:|:------------------------:|:----------------------------:|:------------------------:|
| Spatial dimension                                            |     1D, 2D, 3D     |        1D, 2D, 3D        |              2D              |          2D, 3D          |
| Coordinates                                                  |      Cartesian     |        curvilinear       |          curvilinear         |        curvilinear       |
| Connectivity                                                 |  *h*-nonconforming |        conforming        |          conforming          |     *h*-nonconforming    |
| Element type                                                 |      hypercube     |         hypercube        |           hypercube          |         hypercube        |
| Adaptive mesh refinement ([`AMRCallback`](@ref))             | :heavy_check_mark: | :heavy_multiplication_x: |   :heavy_multiplication_x:   |    :heavy_check_mark:    |
| Domain                                                       |      hypercube     |     mapped hypercube     |           arbitrary          |         arbitrary        |
| Weak form ([`VolumeIntegralWeakForm`](@ref))                 | :heavy_check_mark: |    :heavy_check_mark:    |      :heavy_check_mark:      |    :heavy_check_mark:    |
| Flux differencing ([`VolumeIntegralFluxDifferencing`](@ref)) | :heavy_check_mark: |    :heavy_check_mark:    |      :heavy_check_mark:      |    :heavy_check_mark:    |
| Shock capturing ([`VolumeIntegralShockCapturingHG`](@ref))   | :heavy_check_mark: | :heavy_multiplication_x: |   :heavy_multiplication_x:   | :heavy_multiplication_x: |

The second version uses the unicode symbols ✅ (`:white_check_mark:`) and ❌  (`:x:`). This version looks better when processed via Documenter.

| Feature                                                      | [`TreeMesh`](@ref) | [`StructuredMesh`](@ref) | [`UnstructuredMesh2D`](@ref) | [`P4estMesh`](@ref) |
|--------------------------------------------------------------|:------------------:|:------------------------:|:----------------------------:|:-------------------:|
| Spatial dimension                                            |     1D, 2D, 3D     |        1D, 2D, 3D        |              2D              |        2D, 3D       |
| Coordinates                                                  |      Cartesian     |        curvilinear       |          curvilinear         |     curvilinear     |
| Connectivity                                                 |  *h*-nonconforming |        conforming        |          conforming          |  *h*-nonconforming  |
| Element type                                                 |      hypercube     |         hypercube        |           hypercube          |      hypercube      |
| Adaptive mesh refinement ([`AMRCallback`](@ref))             |          ✅         |             ❌            |               ❌              |          ✅          |
| Domain                                                       |      hypercube     |     mapped hypercube     |           arbitrary          |      arbitrary      |
| Weak form ([`VolumeIntegralWeakForm`](@ref))                 |          ✅         |             ✅            |               ✅              |          ✅          |
| Flux differencing ([`VolumeIntegralFluxDifferencing`](@ref)) |          ✅         |             ✅            |               ✅              |          ✅          |
| Shock capturing ([`VolumeIntegralShockCapturingHG`](@ref))   |          ✅         |             ❌            |               ❌              |          ❌          |
