### PR TITLE
fix reference to trixi2vtk-dev in the docs

### DIFF
--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -271,7 +271,7 @@ arbitrary stuff to the Trixi website, including malicious code).
 
 
 
-## Developing Trixi2Vtk (@id trixi2vtk-dev)
+## [Developing Trixi2Vtk](@id trixi2vtk-dev)
 
 Trixi2Vtk has Trixi as dependency and uses Trixi's implementation to, e.g., load mesh files.
 When developing Trixi2Vtk, one may want to change functions in Trixi to allow them to be reused

--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -349,7 +349,7 @@ solution time. A comprehensive list of all possible arguments for
 `trixi2vtk` can be found in the [Trixi2Vtk.jl API](@ref).
 
 Further information regarding the development of Trixi2Vtk can be found in the
-[development section](@id trixi2vtk-dev).
+[development section](@ref trixi2vtk-dev).
 
 
 ## Trixi2Img


### PR DESCRIPTION
The preview of the docs will appear at https://trixi-framework.github.io/Trixi.jl/previews/PR716