### PR TITLE
fix type instability introduced in #707

### DIFF
--- a/src/visualization/convert.jl
+++ b/src/visualization/convert.jl
@@ -72,8 +72,8 @@ function get_data_2d(center_level_0, length_level_0, leaf_cells, coordinates, le
   if grid_lines
     mesh_vertices_x, mesh_vertices_y = calc_vertices(coordinates, levels, length_level_0)
   else
-    mesh_vertices_x = Matrix{Float64}(undef, 0, 0)
-    mesh_vertices_y = Matrix{Float64}(undef, 0, 0)
+    mesh_vertices_x = Vector{Float64}(undef, 0)
+    mesh_vertices_y = Vector{Float64}(undef, 0)
   end
 
   return xs, ys, node_centered_data, mesh_vertices_x, mesh_vertices_y


### PR DESCRIPTION
Before:
```julia
julia> using Revise, Trixi

julia> trixi_include("examples/tree_2d_dgsem/elixir_advection_amr.jl")

julia> @code_warntype PlotData2D(sol.u[end], mesh, equations, solver, semi.cache)
Variables
  #self#::Type{PlotData2D}
  u::Vector{Float64}
  mesh::TreeMesh{2, Trixi.SerialTree{2}}
  equations::LinearScalarAdvectionEquation2D{Float64}
  solver::DGSEM{LobattoLegendreBasis{Float64, 4, SVector{4, Float64}, Matrix{Float64}, Matrix{Float64}, Matrix{Float64}}, Trixi.LobattoLegendreMortarL2{Float64, 4, Matrix{Float64}, Matrix{Float64}}, SurfaceIntegralWeakForm{FluxLaxFriedrichs{typeof(max_abs_speed_naive)}}, VolumeIntegralWeakForm}                                            
  cache::NamedTuple{(:elements, :interfaces, :boundaries, :mortars, :fstar_upper_threaded, :fstar_lower_threaded), Tuple{Trixi.ElementContainer2D{Float64, Float64}, Trixi.InterfaceContainer2D{Float64}, Trixi.BoundaryContainer2D{Float64, Float64}, Trixi.L2MortarContainer2D{Float64}, Vector{StaticArrays.MMatrix{1, 4, Float64, 4}}, Vector{StaticArrays.MMatrix{1, 4, Float64, 4}}}}                                                                         

Body::Union{PlotData2D{Vector{Float64}, Vector{Matrix{Float64}}, SVector{1, String}, Vector{Float64}}, PlotData2D{Vector{Float64}, Vector{Matrix{Float64}}, SVector{1, String}, Matrix{Float64}}}
1 ─ %1 = Core.tuple(0.0, 0.0, 0.0)::Core.Const((0.0, 0.0, 0.0))
│   %2 = Trixi.:(var"#PlotData2D#711")(Trixi.nothing, true, 11, Trixi.nothing, :xy, %1, #self#, u, mesh, equations, solver, cache)::Union{PlotData2D{Vector{Float64}, Vector{Matrix{Float64}}, SVector{1, String}, Vector{Float64}}, PlotData2D{Vector{Float64}, Vector{Matrix{Float64}}, SVector{1, String}, Matrix{Float64}}}
└──      return %2
```
After:
```julia
julia> @code_warntype PlotData2D(sol.u[end], mesh, equations, solver, semi.cache)
Variables
  #self#::Type{PlotData2D}
  u::Vector{Float64}
  mesh::TreeMesh{2, Trixi.SerialTree{2}}
  equations::LinearScalarAdvectionEquation2D{Float64}
  solver::DGSEM{LobattoLegendreBasis{Float64, 4, SVector{4, Float64}, Matrix{Float64}, Matrix{Float64}, Matrix{Float64}}, Trixi.LobattoLegendreMortarL2{Float64, 4, Matrix{Float64}, Matrix{Float64}}, SurfaceIntegralWeakForm{FluxLaxFriedrichs{typeof(max_abs_speed_naive)}}, VolumeIntegralWeakForm}
  cache::NamedTuple{(:elements, :interfaces, :boundaries, :mortars, :fstar_upper_threaded, :fstar_lower_threaded), Tuple{Trixi.ElementContainer2D{Float64, Float64}, Trixi.InterfaceContainer2D{Float64}, Trixi.BoundaryContainer2D{Float64, Float64}, Trixi.L2MortarContainer2D{Float64}, Vector{StaticArrays.MMatrix{1, 4, Float64, 4}}, Vector{StaticArrays.MMatrix{1, 4, Float64, 4}}}}

Body::PlotData2D{Vector{Float64}, Vector{Matrix{Float64}}, SVector{1, String}, Vector{Float64}}
1 ─ %1 = Core.tuple(0.0, 0.0, 0.0)::Core.Const((0.0, 0.0, 0.0))
│   %2 = Trixi.:(var"#PlotData2D#759")(Trixi.nothing, true, 11, Trixi.nothing, :xy, %1, #self#, u, mesh, equations, solver, cache)::Core.PartialStruct(PlotData2D{Vector{Float64}, Vector{Matrix{Float64}}, SVector{1, String}, Vector{Float64}}, Any[Vector{Float64}, Vector{Float64}, Vector{Matrix{Float64}}, Core.Const(["scalar"]), Vector{Float64}, Vector{Float64}, Core.Const(1), Core.Const(2)])
└──      return %2
```