### PR TITLE
improve performance of MHD (quite a bit) and Euler (a little bit)

### DIFF
--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -258,8 +258,8 @@ end
 # Calculate 1D flux for a single point
 @inline function flux(u, orientation::Integer, equations::CompressibleEulerEquations1D)
   rho, rho_v1, rho_e = u
-  v1 = rho_v1/rho
-  p = (equations.gamma - 1) * (rho_e - 1/2 * rho * v1^2)
+  v1 = rho_v1 / rho
+  p = (equations.gamma - 1) * (rho_e - 0.5 * rho_v1 * v1)
   # Ignore orientation since it is always "1" in 1D
   f1 = rho_v1
   f2 = rho_v1 * v1 + p

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -350,7 +350,7 @@ end
 
 A version of the classical Kelvin-Helmholtz instability based on
 - Andrés M. Rueda-Ramírez, Gregor J. Gassner (2021)
-  A Subcell Finite Volume Positivity-Preserving Limiter for DGSEM Discretizations 
+  A Subcell Finite Volume Positivity-Preserving Limiter for DGSEM Discretizations
   of the Euler Equations
   [arXiv: 2102.06017](https://arxiv.org/abs/2102.06017)
 """
@@ -606,9 +606,9 @@ end
 # Calculate 1D flux for a single point
 @inline function flux(u, orientation::Integer, equations::CompressibleEulerEquations2D)
   rho, rho_v1, rho_v2, rho_e = u
-  v1 = rho_v1/rho
-  v2 = rho_v2/rho
-  p = (equations.gamma - 1) * (rho_e - 1/2 * rho * (v1^2 + v2^2))
+  v1 = rho_v1 / rho
+  v2 = rho_v2 / rho
+  p = (equations.gamma - 1) * (rho_e - 0.5 * (rho_v1 * v1 + rho_v2 * v2))
   if orientation == 1
     f1 = rho_v1
     f2 = rho_v1 * v1 + p

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -461,7 +461,7 @@ end
   v1 = rho_v1 / rho
   v2 = rho_v2 / rho
   v3 = rho_v3 / rho
-  p = (equations.gamma - 1) * (rho_e - 1/2 * rho * (v1^2 + v2^2 + v3^2))
+  p = (equations.gamma - 1) * (rho_e - 0.5 * (rho_v1 * v1 + rho_v2 * v2 + rho_v3 * v3))
   if orientation == 1
     f1 = rho_v1
     f2 = rho_v1 * v1 + p

--- a/src/equations/ideal_glm_mhd_1d.jl
+++ b/src/equations/ideal_glm_mhd_1d.jl
@@ -200,19 +200,20 @@ end
 # Calculate 1D flux in for a single point
 @inline function flux(u, orientation::Integer, equations::IdealGlmMhdEquations1D)
   rho, rho_v1, rho_v2, rho_v3, rho_e, B1, B2, B3 = u
-  v1 = rho_v1/rho
-  v2 = rho_v2/rho
-  v3 = rho_v3/rho
-  kin_en = 0.5 * rho * (v1^2 + v2^2 + v3^2)
-  mag_en = 0.5 * (B1^2 + B2^2 + B3^2)
-  p = (equations.gamma - 1) * (rho_e - kin_en - mag_en)
+  v1 = rho_v1 / rho
+  v2 = rho_v2 / rho
+  v3 = rho_v3 / rho
+  kin_en = 0.5 * (rho_v1 * v1 + rho_v2 * v2 + rho_v3 * v3)
+  mag_en = 0.5 * (B1 * B1 + B2 * B2 + B3 * B3)
+  p_over_gamma_minus_one = (rho_e - kin_en - mag_en)
+  p = (equations.gamma - 1) * p_over_gamma_minus_one
 
   # Ignore orientation since it is always "1" in 1D
   f1 = rho_v1
   f2 = rho_v1*v1 + p + mag_en - B1^2
   f3 = rho_v1*v2 - B1*B2
   f4 = rho_v1*v3 - B1*B3
-  f5 = (kin_en + equations.gamma*p/(equations.gamma - 1) + 2*mag_en)*v1 - B1*(v1*B1 + v2*B2 + v3*B3)
+  f5 = (kin_en + equations.gamma * p_over_gamma_minus_one + 2*mag_en)*v1 - B1*(v1*B1 + v2*B2 + v3*B3)
   f6 = 0.0
   f7 = v1*B2 - v2*B1
   f8 = v1*B3 - v3*B1

--- a/src/equations/ideal_glm_mhd_2d.jl
+++ b/src/equations/ideal_glm_mhd_2d.jl
@@ -210,25 +210,26 @@ end
   v1 = rho_v1 / rho
   v2 = rho_v2 / rho
   v3 = rho_v3 / rho
-  kin_en = 0.5 * rho * (v1^2 + v2^2 + v3^2)
-  mag_en = 0.5*(B1^2 + B2^2 + B3^2)
-  p = (equations.gamma - 1) * (rho_e - kin_en - mag_en - 0.5*psi^2)
+  kin_en = 0.5 * (rho_v1 * v1 + rho_v2 * v2 + rho_v3 * v3)
+  mag_en = 0.5 * (B1 * B1 + B2 * B2 + B3 * B3)
+  p_over_gamma_minus_one = (rho_e - kin_en - mag_en - 0.5 * psi^2)
+  p = (equations.gamma - 1) * p_over_gamma_minus_one
   if orientation == 1
     f1 = rho_v1
     f2 = rho_v1*v1 + p + mag_en - B1^2
     f3 = rho_v1*v2 - B1*B2
     f4 = rho_v1*v3 - B1*B3
-    f5 = (kin_en + equations.gamma*p * equations.inv_gamma_minus_one + 2*mag_en)*v1 - B1*(v1*B1 + v2*B2 + v3*B3) + equations.c_h*psi*B1
+    f5 = (kin_en + equations.gamma * p_over_gamma_minus_one + 2*mag_en)*v1 - B1*(v1*B1 + v2*B2 + v3*B3) + equations.c_h*psi*B1
     f6 = equations.c_h*psi
     f7 = v1*B2 - v2*B1
     f8 = v1*B3 - v3*B1
     f9 = equations.c_h*B1
-  else # orientation == 2
+  else #if orientation == 2
     f1 = rho_v2
-    f2 = rho_v2*v1 - B1*B2
+    f2 = rho_v2*v1 - B2*B1
     f3 = rho_v2*v2 + p + mag_en - B2^2
     f4 = rho_v2*v3 - B2*B3
-    f5 = (kin_en + equations.gamma*p * equations.inv_gamma_minus_one + 2*mag_en)*v2 - B2*(v1*B1 + v2*B2 + v3*B3) + equations.c_h*psi*B2
+    f5 = (kin_en + equations.gamma * p_over_gamma_minus_one + 2*mag_en)*v2 - B2*(v1*B1 + v2*B2 + v3*B3) + equations.c_h*psi*B2
     f6 = v2*B1 - v1*B2
     f7 = equations.c_h*psi
     f8 = v2*B3 - v3*B2
@@ -241,9 +242,14 @@ end
 # Calculate 1D flux for a single point in the normal direction
 # Note, this directional vector is not normalized
 @inline function flux(u, normal_direction::AbstractVector, equations::IdealGlmMhdEquations2D)
-  rho, v1, v2, v3, p, B1, B2, B3, psi = cons2prim(u, equations)
-  kin_en = 0.5 * rho * (v1^2 + v2^2 + v3^2)
-  mag_en = 0.5 * (B1^2 + B2^2 + B3^2)
+  rho, rho_v1, rho_v2, rho_v3, rho_e, B1, B2, B3, psi = u
+  v1 = rho_v1 / rho
+  v2 = rho_v2 / rho
+  v3 = rho_v3 / rho
+  kin_en = 0.5 * (rho_v1 * v1 + rho_v2 * v2 + rho_v3 * v3)
+  mag_en = 0.5 * (B1 * B1 + B2 * B2 + B3 * B3)
+  p_over_gamma_minus_one = (rho_e - kin_en - mag_en - 0.5 * psi^2)
+  p = (equations.gamma - 1) * p_over_gamma_minus_one
 
   v_normal = v1 * normal_direction[1] + v2 * normal_direction[2]
   B_normal = B1 * normal_direction[1] + B2 * normal_direction[2]
@@ -253,7 +259,7 @@ end
   f2 = rho_v_normal * v1 - B1 * B_normal + (p + mag_en) * normal_direction[1]
   f3 = rho_v_normal * v2 - B2 * B_normal + (p + mag_en) * normal_direction[2]
   f4 = rho_v_normal * v3 - B3 * B_normal
-  f5 = ( (kin_en + equations.gamma*p * equations.inv_gamma_minus_one + 2*mag_en) * v_normal
+  f5 = ( (kin_en + equations.gamma * p_over_gamma_minus_one + 2*mag_en) * v_normal
         - B_normal * (v1*B1 + v2*B2 + v3*B3) + equations.c_h * psi * B_normal )
   f6 = equations.c_h * psi * normal_direction[1] + (v2 * B1 - v1 * B2) * normal_direction[2]
   f7 = equations.c_h * psi * normal_direction[2] + (v1 * B2 - v2 * B1) * normal_direction[1]

--- a/src/equations/ideal_glm_mhd_2d.jl
+++ b/src/equations/ideal_glm_mhd_2d.jl
@@ -700,16 +700,28 @@ end
   return max(v_mag_ll, v_mag_rr) + max(cf_ll, cf_rr)
 end
 
-
 @inline function max_abs_speed_naive(u_ll, u_rr, normal_direction::AbstractVector, equations::IdealGlmMhdEquations2D)
+  rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, _ = u_ll
+  rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, _ = u_rr
 
-  norm_ = norm(normal_direction)
-  # Normalize the vector without using `normalize` since we need to multiply by the `norm_` later
-  normal_vector = normal_direction / norm_
-  u_ll_rotated = rotate_to_x(u_ll, normal_vector, equations)
-  u_rr_rotated = rotate_to_x(u_rr, normal_vector, equations)
+  norm_squared = (normal_direction[1] * normal_direction[1] +
+                  normal_direction[2] * normal_direction[2])
 
-  return max_abs_speed_naive(u_ll_rotated, u_rr_rotated, 1, equations) * norm_
+  # Calculate velocities and fast magnetoacoustic wave speeds
+  # left
+  v1_ll = rho_v1_ll / rho_ll
+  v2_ll = rho_v2_ll / rho_ll
+  v3_ll = rho_v3_ll / rho_ll
+  v_mag_ll = sqrt((v1_ll^2 + v2_ll^2 + v3_ll^2) * norm_squared)
+  cf_ll = calc_fast_wavespeed(u_ll, normal_direction, equations)
+  # right
+  v1_rr = rho_v1_rr / rho_rr
+  v2_rr = rho_v2_rr / rho_rr
+  v3_rr = rho_v3_rr / rho_rr
+  v_mag_rr = sqrt((v1_rr^2 + v2_rr^2 + v3_rr^2) * norm_squared)
+  cf_rr = calc_fast_wavespeed(u_rr, normal_direction, equations)
+
+  return max(v_mag_ll, v_mag_rr) + max(cf_ll, cf_rr)
 end
 
 
@@ -750,40 +762,30 @@ Calculate minimum and maximum wave speeds for HLL-type fluxes as in
   return λ_min, λ_max
 end
 
-
-# Very naive way to approximate the edges of the Riemann fan in the normal direction
 @inline function min_max_speed_naive(u_ll, u_rr, normal_direction::AbstractVector,
                                      equations::IdealGlmMhdEquations2D)
   rho_ll, rho_v1_ll, rho_v2_ll, _ = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, _ = u_rr
 
   # Calculate primitive velocity variables
-  v1_ll = rho_v1_ll/rho_ll
-  v2_ll = rho_v2_ll/rho_ll
+  v1_ll = rho_v1_ll / rho_ll
+  v2_ll = rho_v2_ll / rho_ll
 
-  v1_rr = rho_v1_rr/rho_rr
-  v2_rr = rho_v2_rr/rho_rr
+  v1_rr = rho_v1_rr / rho_rr
+  v2_rr = rho_v2_rr / rho_rr
 
-  # Compute wave speed estimates in each direction. Requires rotation because
-  # the fast magnetoacoustic wave speed has a nonlinear dependence on the direction
-  norm_ = norm(normal_direction)
-  # Normalize the vector without using `normalize` since we need to multiply by the `norm_` later
-  normal_vector = normal_direction / norm_
+  v_normal_ll = (v1_ll * normal_direction[1] +
+                 v2_ll * normal_direction[2])
+  v_normal_rr = (v1_rr * normal_direction[1] +
+                 v2_rr * normal_direction[2])
 
-  # Rotate the velocities
-  v_normal_ll = v1_ll * normal_vector[1] + v2_ll * normal_vector[2]
-  v_normal_rr = v1_rr * normal_vector[1] + v2_rr * normal_vector[2]
-
-  u_ll_rotated = rotate_to_x(u_ll, normal_vector, equations)
-  u_rr_rotated = rotate_to_x(u_rr, normal_vector, equations)
-
-  c_f_ll_rotated = calc_fast_wavespeed(u_ll_rotated, 1, equations)
-  c_f_rr_rotated = calc_fast_wavespeed(u_rr_rotated, 1, equations)
-  v_roe_rotated, c_f_roe_rotated = calc_fast_wavespeed_roe(u_ll_rotated, u_rr_rotated, 1, equations)
+  c_f_ll = calc_fast_wavespeed(u_ll, normal_direction, equations)
+  c_f_rr = calc_fast_wavespeed(u_rr, normal_direction, equations)
+  v_roe, c_f_roe = calc_fast_wavespeed_roe(u_ll, u_rr, normal_direction, equations)
 
   # Estimate the min/max eigenvalues in the normal direction
-  λ_min = min(v_normal_ll - c_f_ll_rotated, v_roe_rotated - c_f_roe_rotated) * norm_
-  λ_max = max(v_normal_rr + c_f_rr_rotated, v_roe_rotated + c_f_roe_rotated) * norm_
+  λ_min = min(v_normal_ll - c_f_ll, v_roe - c_f_roe)
+  λ_max = max(v_normal_rr + c_f_rr, v_roe + c_f_roe)
 
   return λ_min, λ_max
 end
@@ -1081,8 +1083,34 @@ end
   return c_f
 end
 
+@inline function calc_fast_wavespeed(cons, normal_direction::AbstractVector, equations::IdealGlmMhdEquations2D)
+  rho, rho_v1, rho_v2, rho_v3, rho_e, B1, B2, B3, psi = cons
+  v1 = rho_v1 / rho
+  v2 = rho_v2 / rho
+  v3 = rho_v3 / rho
+  kin_en = 0.5 * (rho_v1 * v1 + rho_v2 * v2 + rho_v3 * v3)
+  mag_en = 0.5 * (B1 * B1 + B2 * B2 + B3 * B3)
+  p = (equations.gamma - 1) * (rho_e - kin_en - mag_en - 0.5 * psi^2)
+  a_square = equations.gamma * p / rho
+  sqrt_rho = sqrt(rho)
+  b1 = B1 / sqrt_rho
+  b2 = B2 / sqrt_rho
+  b3 = B3 / sqrt_rho
+  b_square = b1^2 + b2^2 + b3^2
+  norm_squared = (normal_direction[1] * normal_direction[1] +
+                  normal_direction[2] * normal_direction[2])
+  b_dot_n_squared = (b1 * normal_direction[1] +
+                     b2 * normal_direction[2])^2 / norm_squared
+
+  c_f = sqrt(
+    (0.5 * (a_square + b_square) +
+     0.5 * sqrt((a_square + b_square)^2 - 4 * a_square * b_dot_n_squared)) * norm_squared)
+  return c_f
+end
+
+
 """
-    calc_fast_wavespeed_roe(u_ll, u_rr, direction, equations::IdealGlmMhdEquations2D)
+    calc_fast_wavespeed_roe(u_ll, u_rr, orientation_or_normal_direction, equations::IdealGlmMhdEquations2D)
 
 Compute the fast magnetoacoustic wave speed using Roe averages
 as given by
@@ -1091,28 +1119,28 @@ as given by
   of Roe Matrices for Systems of Conservation Laws
   [DOI: 10.1006/jcph.1997.5773](https://doi.org/10.1006/jcph.1997.5773)
 """
-@inline function calc_fast_wavespeed_roe(u_ll, u_rr, direction, equations::IdealGlmMhdEquations2D)
+@inline function calc_fast_wavespeed_roe(u_ll, u_rr, orientation::Integer, equations::IdealGlmMhdEquations2D)
   rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll, psi_ll = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr, psi_rr = u_rr
 
   # Calculate primitive variables
-  v1_ll = rho_v1_ll/rho_ll
-  v2_ll = rho_v2_ll/rho_ll
-  v3_ll = rho_v3_ll/rho_ll
-  vel_norm_ll = v1_ll^2 + v2_ll^2 + v3_ll^2
-  mag_norm_ll = B1_ll^2 + B2_ll^2 + B3_ll^2
-  p_ll = (equations.gamma - 1)*(rho_e_ll - 0.5*rho_ll*vel_norm_ll - 0.5*mag_norm_ll - 0.5*psi_ll^2)
+  v1_ll = rho_v1_ll / rho_ll
+  v2_ll = rho_v2_ll / rho_ll
+  v3_ll = rho_v3_ll / rho_ll
+  kin_en_ll = 0.5 * (rho_v1_ll * v1_ll + rho_v2_ll * v2_ll + rho_v3_ll * v3_ll)
+  mag_norm_ll = B1_ll * B1_ll + B2_ll * B2_ll + B3_ll * B3_ll
+  p_ll = (equations.gamma - 1)*(rho_e_ll - kin_en_ll - 0.5*mag_norm_ll - 0.5*psi_ll^2)
 
-  v1_rr = rho_v1_rr/rho_rr
-  v2_rr = rho_v2_rr/rho_rr
-  v3_rr = rho_v3_rr/rho_rr
-  vel_norm_rr = v1_rr^2 + v2_rr^2 + v3_rr^2
-  mag_norm_rr = B1_rr^2 + B2_rr^2 + B3_rr^2
-  p_rr = (equations.gamma - 1)*(rho_e_rr - 0.5*rho_rr*vel_norm_rr - 0.5*mag_norm_rr - 0.5*psi_rr^2)
+  v1_rr = rho_v1_rr / rho_rr
+  v2_rr = rho_v2_rr / rho_rr
+  v3_rr = rho_v3_rr / rho_rr
+  kin_en_rr = 0.5 * (rho_v1_rr * v1_rr + rho_v2_rr * v2_rr + rho_v3_rr * v3_rr)
+  mag_norm_rr = B1_rr * B1_rr + B2_rr * B2_rr + B3_rr * B3_rr
+  p_rr = (equations.gamma - 1)*(rho_e_rr - kin_en_rr - 0.5*mag_norm_rr - 0.5*psi_rr^2)
 
   # compute total pressure which is thermal + magnetic pressures
-  p_total_ll = p_ll + 0.5*mag_norm_ll
-  p_total_rr = p_rr + 0.5*mag_norm_rr
+  p_total_ll = p_ll + 0.5 * mag_norm_ll
+  p_total_rr = p_rr + 0.5 * mag_norm_rr
 
   # compute the Roe density averages
   sqrt_rho_ll = sqrt(rho_ll)
@@ -1133,7 +1161,7 @@ as given by
   H_ll  = (rho_e_ll + p_total_ll) / rho_ll
   H_rr  = (rho_e_rr + p_total_rr) / rho_rr
   H_roe = H_ll * rho_ll_roe + H_rr * rho_rr_roe
-  # temporary vairable see equations (4.12) in Cargo and Gallice
+  # temporary variable see equation (4.12) in Cargo and Gallice
   X = 0.5 * ( (B1_ll - B1_rr)^2 + (B2_ll - B2_rr)^2 + (B3_ll - B3_rr)^2 ) * inv_sqrt_rho_add^2
   # averaged components needed to compute c_f, the fast magnetoacoustic wave speed
   b_square_roe = (B1_roe^2 + B2_roe^2 + B3_roe^2) * inv_sqrt_rho_prod # scaled magnectic sum
@@ -1141,7 +1169,7 @@ as given by
                  (equations.gamma -1.0) * (H_roe - 0.5*(v1_roe^2 + v2_roe^2 + v3_roe^2) -
                                           b_square_roe)) # acoustic speed
   # finally compute the average wave speed and set the output velocity (depends on orientation)
-  if direction == 1 # x-direction
+  if orientation == 1 # x-direction
     c_a_roe = B1_roe^2 * inv_sqrt_rho_prod # (squared) Alfvén wave speed
     a_star_roe = sqrt( (a_square_roe + b_square_roe)^2 - 4.0 * a_square_roe * c_a_roe )
     c_f_roe = sqrt( 0.5 * (a_square_roe + b_square_roe + a_star_roe) )
@@ -1155,6 +1183,72 @@ as given by
 
   return vel_out_roe, c_f_roe
 end
+
+@inline function calc_fast_wavespeed_roe(u_ll, u_rr, normal_direction::AbstractVector, equations::IdealGlmMhdEquations2D)
+  rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll, psi_ll = u_ll
+  rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr, psi_rr = u_rr
+
+  # Calculate primitive variables
+  v1_ll = rho_v1_ll / rho_ll
+  v2_ll = rho_v2_ll / rho_ll
+  v3_ll = rho_v3_ll / rho_ll
+  kin_en_ll = 0.5 * (rho_v1_ll * v1_ll + rho_v2_ll * v2_ll + rho_v3_ll * v3_ll)
+  mag_norm_ll = B1_ll * B1_ll + B2_ll * B2_ll + B3_ll * B3_ll
+  p_ll = (equations.gamma - 1)*(rho_e_ll - kin_en_ll - 0.5*mag_norm_ll - 0.5*psi_ll^2)
+
+  v1_rr = rho_v1_rr / rho_rr
+  v2_rr = rho_v2_rr / rho_rr
+  v3_rr = rho_v3_rr / rho_rr
+  kin_en_rr = 0.5 * (rho_v1_rr * v1_rr + rho_v2_rr * v2_rr + rho_v3_rr * v3_rr)
+  mag_norm_rr = B1_rr * B1_rr + B2_rr * B2_rr + B3_rr * B3_rr
+  p_rr = (equations.gamma - 1)*(rho_e_rr - kin_en_rr - 0.5*mag_norm_rr - 0.5*psi_rr^2)
+
+  # compute total pressure which is thermal + magnetic pressures
+  p_total_ll = p_ll + 0.5 * mag_norm_ll
+  p_total_rr = p_rr + 0.5 * mag_norm_rr
+
+  # compute the Roe density averages
+  sqrt_rho_ll = sqrt(rho_ll)
+  sqrt_rho_rr = sqrt(rho_rr)
+  inv_sqrt_rho_add  = 1.0 / (sqrt_rho_ll + sqrt_rho_rr)
+  inv_sqrt_rho_prod = 1.0 / (sqrt_rho_ll * sqrt_rho_rr)
+  rho_ll_roe =  sqrt_rho_ll * inv_sqrt_rho_add
+  rho_rr_roe =  sqrt_rho_rr * inv_sqrt_rho_add
+  # Roe averages
+  # velocities and magnetic fields
+  v1_roe = v1_ll * rho_ll_roe + v1_rr * rho_rr_roe
+  v2_roe = v2_ll * rho_ll_roe + v2_rr * rho_rr_roe
+  v3_roe = v3_ll * rho_ll_roe + v3_rr * rho_rr_roe
+  B1_roe = B1_ll * rho_ll_roe + B1_rr * rho_rr_roe
+  B2_roe = B2_ll * rho_ll_roe + B2_rr * rho_rr_roe
+  B3_roe = B3_ll * rho_ll_roe + B3_rr * rho_rr_roe
+  # enthalpy
+  H_ll  = (rho_e_ll + p_total_ll) / rho_ll
+  H_rr  = (rho_e_rr + p_total_rr) / rho_rr
+  H_roe = H_ll * rho_ll_roe + H_rr * rho_rr_roe
+  # temporary variable see equation (4.12) in Cargo and Gallice
+  X = 0.5 * ( (B1_ll - B1_rr)^2 + (B2_ll - B2_rr)^2 + (B3_ll - B3_rr)^2 ) * inv_sqrt_rho_add^2
+  # averaged components needed to compute c_f, the fast magnetoacoustic wave speed
+  b_square_roe = (B1_roe^2 + B2_roe^2 + B3_roe^2) * inv_sqrt_rho_prod # scaled magnectic sum
+  a_square_roe = ((2.0 - equations.gamma) * X +
+                 (equations.gamma -1.0) * (H_roe - 0.5*(v1_roe^2 + v2_roe^2 + v3_roe^2) -
+                                          b_square_roe)) # acoustic speed
+
+  # finally compute the average wave speed and set the output velocity (depends on orientation)
+  norm_squared = (normal_direction[1] * normal_direction[1] +
+                  normal_direction[2] * normal_direction[2])
+  B_roe_dot_n_squared = (B1_roe * normal_direction[1] +
+                         B2_roe * normal_direction[2])^2 / norm_squared
+
+  c_a_roe = B_roe_dot_n_squared * inv_sqrt_rho_prod # (squared) Alfvén wave speed
+  a_star_roe = sqrt((a_square_roe + b_square_roe)^2 - 4 * a_square_roe * c_a_roe)
+  c_f_roe = sqrt(0.5 * (a_square_roe + b_square_roe + a_star_roe) * norm_squared)
+  vel_out_roe = (v1_roe * normal_direction[1] +
+                 v2_roe * normal_direction[2])
+
+  return vel_out_roe, c_f_roe
+end
+
 
 # Calculate thermodynamic entropy for a conservative state `cons`
 @inline function entropy_thermodynamic(cons, equations::IdealGlmMhdEquations2D)

--- a/src/equations/ideal_glm_mhd_3d.jl
+++ b/src/equations/ideal_glm_mhd_3d.jl
@@ -706,13 +706,13 @@ end
   v1_ll = rho_v1_ll / rho_ll
   v2_ll = rho_v2_ll / rho_ll
   v3_ll = rho_v3_ll / rho_ll
-  v_mag_ll = sqrt(v1_ll^2 + v2_ll^2 + v3_ll^2)
+  v_mag_ll = sqrt(v1_ll * v1_ll + v2_ll * v2_ll + v3_ll * v3_ll)
   cf_ll = calc_fast_wavespeed(u_ll, orientation, equations)
   # right
   v1_rr = rho_v1_rr / rho_rr
   v2_rr = rho_v2_rr / rho_rr
   v3_rr = rho_v3_rr / rho_rr
-  v_mag_rr = sqrt(v1_rr^2 + v2_rr^2 + v3_rr^2)
+  v_mag_rr = sqrt(v1_rr * v1_rr + v2_rr * v2_rr + v3_rr * v3_rr)
   cf_rr = calc_fast_wavespeed(u_rr, orientation, equations)
 
   return max(v_mag_ll, v_mag_rr) + max(cf_ll, cf_rr)
@@ -732,13 +732,13 @@ end
   v1_ll = rho_v1_ll / rho_ll
   v2_ll = rho_v2_ll / rho_ll
   v3_ll = rho_v3_ll / rho_ll
-  v_mag_ll = sqrt((v1_ll^2 + v2_ll^2 + v3_ll^2) * norm_squared)
+  v_mag_ll = sqrt((v1_ll * v1_ll + v2_ll * v2_ll + v3_ll * v3_ll) * norm_squared)
   cf_ll = calc_fast_wavespeed(u_ll, normal_direction, equations)
   # right
   v1_rr = rho_v1_rr / rho_rr
   v2_rr = rho_v2_rr / rho_rr
   v3_rr = rho_v3_rr / rho_rr
-  v_mag_rr = sqrt((v1_rr^2 + v2_rr^2 + v3_rr^2) * norm_squared)
+  v_mag_rr = sqrt((v1_rr * v1_rr + v2_rr * v2_rr + v3_rr * v3_rr) * norm_squared)
   cf_rr = calc_fast_wavespeed(u_rr, normal_direction, equations)
 
   return max(v_mag_ll, v_mag_rr) + max(cf_ll, cf_rr)
@@ -1056,7 +1056,7 @@ end
   b1 = B1 / sqrt_rho
   b2 = B2 / sqrt_rho
   b3 = B3 / sqrt_rho
-  b_square = b1^2 + b2^2 + b3^2
+  b_square = b1 * b1 + b2 * b2 + b3 * b3
   if orientation == 1 # x-direction
     c_f = sqrt(0.5*(a_square + b_square) + 0.5*sqrt((a_square + b_square)^2 - 4.0*a_square*b1^2))
   elseif orientation == 2 # y-direction
@@ -1080,7 +1080,7 @@ end
   b1 = B1 / sqrt_rho
   b2 = B2 / sqrt_rho
   b3 = B3 / sqrt_rho
-  b_square = b1^2 + b2^2 + b3^2
+  b_square = b1 * b1 + b2 * b2 + b3 * b3
   norm_squared = (normal_direction[1] * normal_direction[1] +
                   normal_direction[2] * normal_direction[2] +
                   normal_direction[3] * normal_direction[3])

--- a/src/equations/ideal_glm_mhd_3d.jl
+++ b/src/equations/ideal_glm_mhd_3d.jl
@@ -741,7 +741,7 @@ end
 
 
 """
-    min_max_speed_naive(u_ll, u_rr, orientation, equations::IdealGlmMhdEquations3D)
+    min_max_speed_naive(u_ll, u_rr, orientation_or_normal_direction, equations::IdealGlmMhdEquations3D)
 
 Calculate minimum and maximum wave speeds for HLL-type fluxes as in
 - Li (2005)
@@ -785,8 +785,6 @@ Calculate minimum and maximum wave speeds for HLL-type fluxes as in
   return λ_min, λ_max
 end
 
-
-# Very naive way to approximate the edges of the Riemann fan in the normal direction
 @inline function min_max_speed_naive(u_ll, u_rr, normal_direction::AbstractVector,
                                      equations::IdealGlmMhdEquations3D)
   rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, _ = u_ll
@@ -801,34 +799,20 @@ end
   v2_rr = rho_v2_rr / rho_rr
   v3_rr = rho_v3_rr / rho_rr
 
-  # Compute wave speed estimates in each direction. Requires rotation because
-  # the fast magnetoacoustic wave speed has a nonlinear dependence on the direction
-  norm_ = norm(normal_direction)
-  # Normalize the vector without using `normalize` since we need to multiply by the `norm_` later
-  normal_vector = normal_direction / norm_
-  # Some vector that can't be identical to normal_vector (unless normal_vector == 0)
-  tangent1 = SVector(normal_direction[2], normal_direction[3], -normal_direction[1])
-  # Orthogonal projection
-  tangent1 -= dot(normal_vector, tangent1) * normal_vector
-  tangent1 = normalize(tangent1)
+  v_normal_ll = (v1_ll * normal_direction[1] +
+                 v2_ll * normal_direction[2] +
+                 v3_ll * normal_direction[3])
+  v_normal_rr = (v1_rr * normal_direction[1] +
+                 v2_rr * normal_direction[2] +
+                 v3_rr * normal_direction[3])
 
-  # Third orthogonal vector
-  tangent2 = normalize(cross(normal_direction, tangent1))
-
-  # Compute the rotated velocities and wave speeds
-  v_normal_ll = v1_ll*normal_vector[1] + v2_ll*normal_vector[2] + v3_ll*normal_vector[3]
-  v_normal_rr = v1_rr*normal_vector[1] + v2_rr*normal_vector[2] + v3_rr*normal_vector[3]
-
-  u_ll_rotated = rotate_to_x(u_ll, normal_vector, tangent1, tangent2, equations)
-  u_rr_rotated = rotate_to_x(u_rr, normal_vector, tangent1, tangent2, equations)
-
-  c_f_ll_rotated = calc_fast_wavespeed(u_ll_rotated, 1, equations)
-  c_f_rr_rotated = calc_fast_wavespeed(u_rr_rotated, 1, equations)
-  v_roe_rotated, c_f_roe_rotated = calc_fast_wavespeed_roe(u_ll_rotated, u_rr_rotated, 1, equations)
+  c_f_ll = calc_fast_wavespeed(u_ll, normal_direction, equations)
+  c_f_rr = calc_fast_wavespeed(u_rr, normal_direction, equations)
+  v_roe, c_f_roe = calc_fast_wavespeed_roe(u_ll, u_rr, normal_direction, equations)
 
   # Estimate the min/max eigenvalues in the normal direction
-  λ_min = min(v_normal_ll - c_f_ll_rotated, v_roe_rotated - c_f_roe_rotated) * norm_
-  λ_max = max(v_normal_rr + c_f_rr_rotated, v_roe_rotated + c_f_roe_rotated) * norm_
+  λ_min = min(v_normal_ll - c_f_ll, v_roe - c_f_roe)
+  λ_max = max(v_normal_rr + c_f_rr, v_roe + c_f_roe)
 
   return λ_min, λ_max
 end
@@ -1054,21 +1038,23 @@ end
 
 
 # Compute the fastest wave speed for ideal MHD equations: c_f, the fast magnetoacoustic eigenvalue
-@inline function calc_fast_wavespeed(cons, direction, equations::IdealGlmMhdEquations3D)
+@inline function calc_fast_wavespeed(cons, orientation::Integer, equations::IdealGlmMhdEquations3D)
   rho, rho_v1, rho_v2, rho_v3, rho_e, B1, B2, B3, psi = cons
-  v1 = rho_v1/rho
-  v2 = rho_v2/rho
-  v3 = rho_v3/rho
-  v_mag = sqrt(v1^2 + v2^2 + v3^2)
-  p = (equations.gamma - 1)*(rho_e - 0.5*rho*v_mag^2 - 0.5*(B1^2 + B2^2 + B3^2) - 0.5*psi^2)
+  v1 = rho_v1 / rho
+  v2 = rho_v2 / rho
+  v3 = rho_v3 / rho
+  kin_en = 0.5 * (rho_v1 * v1 + rho_v2 * v2 + rho_v3 * v3)
+  mag_en = 0.5 * (B1 * B1 + B2 * B2 + B3 * B3)
+  p = (equations.gamma - 1) * (rho_e - kin_en - mag_en - 0.5 * psi^2)
   a_square = equations.gamma * p / rho
-  b1 = B1/sqrt(rho)
-  b2 = B2/sqrt(rho)
-  b3 = B3/sqrt(rho)
+  sqrt_rho = sqrt(rho)
+  b1 = B1 / sqrt_rho
+  b2 = B2 / sqrt_rho
+  b3 = B3 / sqrt_rho
   b_square = b1^2 + b2^2 + b3^2
-  if direction == 1 # x-direction
+  if orientation == 1 # x-direction
     c_f = sqrt(0.5*(a_square + b_square) + 0.5*sqrt((a_square + b_square)^2 - 4.0*a_square*b1^2))
-  elseif direction == 2 # y-direction
+  elseif orientation == 2 # y-direction
     c_f = sqrt(0.5*(a_square + b_square) + 0.5*sqrt((a_square + b_square)^2 - 4.0*a_square*b2^2))
   else # z-direction
     c_f = sqrt(0.5*(a_square + b_square) + 0.5*sqrt((a_square + b_square)^2 - 4.0*a_square*b3^2))
@@ -1076,9 +1062,36 @@ end
   return c_f
 end
 
+@inline function calc_fast_wavespeed(cons, normal_direction::AbstractVector, equations::IdealGlmMhdEquations3D)
+  rho, rho_v1, rho_v2, rho_v3, rho_e, B1, B2, B3, psi = cons
+  v1 = rho_v1 / rho
+  v2 = rho_v2 / rho
+  v3 = rho_v3 / rho
+  kin_en = 0.5 * (rho_v1 * v1 + rho_v2 * v2 + rho_v3 * v3)
+  mag_en = 0.5 * (B1 * B1 + B2 * B2 + B3 * B3)
+  p = (equations.gamma - 1) * (rho_e - kin_en - mag_en - 0.5 * psi^2)
+  a_square = equations.gamma * p / rho
+  sqrt_rho = sqrt(rho)
+  b1 = B1 / sqrt_rho
+  b2 = B2 / sqrt_rho
+  b3 = B3 / sqrt_rho
+  b_square = b1^2 + b2^2 + b3^2
+  norm_squared = (normal_direction[1] * normal_direction[1] +
+                  normal_direction[2] * normal_direction[2] +
+                  normal_direction[3] * normal_direction[3])
+  b_dot_n_squared = (b1 * normal_direction[1] +
+                     b2 * normal_direction[2] +
+                     b3 * normal_direction[3])^2 / norm_squared
+
+  c_f = sqrt(
+    (0.5 * (a_square + b_square) +
+     0.5 * sqrt((a_square + b_square)^2 - 4 * a_square * b_dot_n_squared)) * norm_squared)
+  return c_f
+end
+
 
 """
-    calc_fast_wavespeed_roe(u_ll, u_rr, direction, equations::IdealGlmMhdEquations3D)
+    calc_fast_wavespeed_roe(u_ll, u_rr, orientation_or_normal_direction, equations::IdealGlmMhdEquations3D)
 
 Compute the fast magnetoacoustic wave speed using Roe averages as given by
 - Cargo and Gallice (1997)
@@ -1086,28 +1099,28 @@ Compute the fast magnetoacoustic wave speed using Roe averages as given by
   of Roe Matrices for Systems of Conservation Laws
   [DOI: 10.1006/jcph.1997.5773](https://doi.org/10.1006/jcph.1997.5773)
 """
-@inline function calc_fast_wavespeed_roe(u_ll, u_rr, direction, equations::IdealGlmMhdEquations3D)
+@inline function calc_fast_wavespeed_roe(u_ll, u_rr, orientation::Integer, equations::IdealGlmMhdEquations3D)
   rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll, psi_ll = u_ll
   rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr, psi_rr = u_rr
 
   # Calculate primitive variables
-  v1_ll = rho_v1_ll/rho_ll
-  v2_ll = rho_v2_ll/rho_ll
-  v3_ll = rho_v3_ll/rho_ll
-  vel_norm_ll = v1_ll^2 + v2_ll^2 + v3_ll^2
-  mag_norm_ll = B1_ll^2 + B2_ll^2 + B3_ll^2
-  p_ll = (equations.gamma - 1)*(rho_e_ll - 0.5*rho_ll*vel_norm_ll - 0.5*mag_norm_ll - 0.5*psi_ll^2)
+  v1_ll = rho_v1_ll / rho_ll
+  v2_ll = rho_v2_ll / rho_ll
+  v3_ll = rho_v3_ll / rho_ll
+  kin_en_ll = 0.5 * (rho_v1_ll * v1_ll + rho_v2_ll * v2_ll + rho_v3_ll * v3_ll)
+  mag_norm_ll = B1_ll * B1_ll + B2_ll * B2_ll + B3_ll * B3_ll
+  p_ll = (equations.gamma - 1)*(rho_e_ll - kin_en_ll - 0.5*mag_norm_ll - 0.5*psi_ll^2)
 
-  v1_rr = rho_v1_rr/rho_rr
-  v2_rr = rho_v2_rr/rho_rr
-  v3_rr = rho_v3_rr/rho_rr
-  vel_norm_rr = v1_rr^2 + v2_rr^2 + v3_rr^2
-  mag_norm_rr = B1_rr^2 + B2_rr^2 + B3_rr^2
-  p_rr = (equations.gamma - 1)*(rho_e_rr - 0.5*rho_rr*vel_norm_rr - 0.5*mag_norm_rr - 0.5*psi_rr^2)
+  v1_rr = rho_v1_rr / rho_rr
+  v2_rr = rho_v2_rr / rho_rr
+  v3_rr = rho_v3_rr / rho_rr
+  kin_en_rr = 0.5 * (rho_v1_rr * v1_rr + rho_v2_rr * v2_rr + rho_v3_rr * v3_rr)
+  mag_norm_rr = B1_rr * B1_rr + B2_rr * B2_rr + B3_rr * B3_rr
+  p_rr = (equations.gamma - 1)*(rho_e_rr - kin_en_rr - 0.5*mag_norm_rr - 0.5*psi_rr^2)
 
   # compute total pressure which is thermal + magnetic pressures
-  p_total_ll = p_ll + 0.5*mag_norm_ll
-  p_total_rr = p_rr + 0.5*mag_norm_rr
+  p_total_ll = p_ll + 0.5 * mag_norm_ll
+  p_total_rr = p_rr + 0.5 * mag_norm_rr
 
   # compute the Roe density averages
   sqrt_rho_ll = sqrt(rho_ll)
@@ -1128,7 +1141,7 @@ Compute the fast magnetoacoustic wave speed using Roe averages as given by
   H_ll  = (rho_e_ll + p_total_ll) / rho_ll
   H_rr  = (rho_e_rr + p_total_rr) / rho_rr
   H_roe = H_ll * rho_ll_roe + H_rr * rho_rr_roe
-  # temporary vairable see equation (4.12) in Cargo and Gallice
+  # temporary variable see equation (4.12) in Cargo and Gallice
   X = 0.5 * ( (B1_ll - B1_rr)^2 + (B2_ll - B2_rr)^2 + (B3_ll - B3_rr)^2 ) * inv_sqrt_rho_add^2
   # averaged components needed to compute c_f, the fast magnetoacoustic wave speed
   b_square_roe = (B1_roe^2 + B2_roe^2 + B3_roe^2) * inv_sqrt_rho_prod # scaled magnectic sum
@@ -1136,12 +1149,12 @@ Compute the fast magnetoacoustic wave speed using Roe averages as given by
                  (equations.gamma -1.0) * (H_roe - 0.5*(v1_roe^2 + v2_roe^2 + v3_roe^2) -
                                           b_square_roe)) # acoustic speed
   # finally compute the average wave speed and set the output velocity (depends on orientation)
-  if direction == 1 # x-direction
+  if orientation == 1 # x-direction
     c_a_roe = B1_roe^2 * inv_sqrt_rho_prod # (squared) Alfvén wave speed
     a_star_roe = sqrt( (a_square_roe + b_square_roe)^2 - 4.0 * a_square_roe * c_a_roe )
     c_f_roe = sqrt( 0.5 * (a_square_roe + b_square_roe + a_star_roe) )
     vel_out_roe = v1_roe
-  elseif direction == 2 # y-direction
+  elseif orientation == 2 # y-direction
     c_a_roe = B2_roe^2 * inv_sqrt_rho_prod # (squared) Alfvén wave speed
     a_star_roe = sqrt( (a_square_roe + b_square_roe)^2 - 4.0 * a_square_roe * c_a_roe )
     c_f_roe = sqrt( 0.5 * (a_square_roe + b_square_roe + a_star_roe) )
@@ -1152,6 +1165,74 @@ Compute the fast magnetoacoustic wave speed using Roe averages as given by
     c_f_roe = sqrt( 0.5 * (a_square_roe + b_square_roe + a_star_roe) )
     vel_out_roe = v3_roe
   end
+
+  return vel_out_roe, c_f_roe
+end
+
+@inline function calc_fast_wavespeed_roe(u_ll, u_rr, normal_direction::AbstractVector, equations::IdealGlmMhdEquations3D)
+  rho_ll, rho_v1_ll, rho_v2_ll, rho_v3_ll, rho_e_ll, B1_ll, B2_ll, B3_ll, psi_ll = u_ll
+  rho_rr, rho_v1_rr, rho_v2_rr, rho_v3_rr, rho_e_rr, B1_rr, B2_rr, B3_rr, psi_rr = u_rr
+
+  # Calculate primitive variables
+  v1_ll = rho_v1_ll / rho_ll
+  v2_ll = rho_v2_ll / rho_ll
+  v3_ll = rho_v3_ll / rho_ll
+  kin_en_ll = 0.5 * (rho_v1_ll * v1_ll + rho_v2_ll * v2_ll + rho_v3_ll * v3_ll)
+  mag_norm_ll = B1_ll * B1_ll + B2_ll * B2_ll + B3_ll * B3_ll
+  p_ll = (equations.gamma - 1)*(rho_e_ll - kin_en_ll - 0.5*mag_norm_ll - 0.5*psi_ll^2)
+
+  v1_rr = rho_v1_rr / rho_rr
+  v2_rr = rho_v2_rr / rho_rr
+  v3_rr = rho_v3_rr / rho_rr
+  kin_en_rr = 0.5 * (rho_v1_rr * v1_rr + rho_v2_rr * v2_rr + rho_v3_rr * v3_rr)
+  mag_norm_rr = B1_rr * B1_rr + B2_rr * B2_rr + B3_rr * B3_rr
+  p_rr = (equations.gamma - 1)*(rho_e_rr - kin_en_rr - 0.5*mag_norm_rr - 0.5*psi_rr^2)
+
+  # compute total pressure which is thermal + magnetic pressures
+  p_total_ll = p_ll + 0.5 * mag_norm_ll
+  p_total_rr = p_rr + 0.5 * mag_norm_rr
+
+  # compute the Roe density averages
+  sqrt_rho_ll = sqrt(rho_ll)
+  sqrt_rho_rr = sqrt(rho_rr)
+  inv_sqrt_rho_add  = 1.0 / (sqrt_rho_ll + sqrt_rho_rr)
+  inv_sqrt_rho_prod = 1.0 / (sqrt_rho_ll * sqrt_rho_rr)
+  rho_ll_roe =  sqrt_rho_ll * inv_sqrt_rho_add
+  rho_rr_roe =  sqrt_rho_rr * inv_sqrt_rho_add
+  # Roe averages
+  # velocities and magnetic fields
+  v1_roe = v1_ll * rho_ll_roe + v1_rr * rho_rr_roe
+  v2_roe = v2_ll * rho_ll_roe + v2_rr * rho_rr_roe
+  v3_roe = v3_ll * rho_ll_roe + v3_rr * rho_rr_roe
+  B1_roe = B1_ll * rho_ll_roe + B1_rr * rho_rr_roe
+  B2_roe = B2_ll * rho_ll_roe + B2_rr * rho_rr_roe
+  B3_roe = B3_ll * rho_ll_roe + B3_rr * rho_rr_roe
+  # enthalpy
+  H_ll  = (rho_e_ll + p_total_ll) / rho_ll
+  H_rr  = (rho_e_rr + p_total_rr) / rho_rr
+  H_roe = H_ll * rho_ll_roe + H_rr * rho_rr_roe
+  # temporary variable see equation (4.12) in Cargo and Gallice
+  X = 0.5 * ( (B1_ll - B1_rr)^2 + (B2_ll - B2_rr)^2 + (B3_ll - B3_rr)^2 ) * inv_sqrt_rho_add^2
+  # averaged components needed to compute c_f, the fast magnetoacoustic wave speed
+  b_square_roe = (B1_roe^2 + B2_roe^2 + B3_roe^2) * inv_sqrt_rho_prod # scaled magnectic sum
+  a_square_roe = ((2.0 - equations.gamma) * X +
+                 (equations.gamma -1.0) * (H_roe - 0.5*(v1_roe^2 + v2_roe^2 + v3_roe^2) -
+                                          b_square_roe)) # acoustic speed
+
+  # finally compute the average wave speed and set the output velocity (depends on orientation)
+  norm_squared = (normal_direction[1] * normal_direction[1] +
+                  normal_direction[2] * normal_direction[2] +
+                  normal_direction[3] * normal_direction[3])
+  B_roe_dot_n_squared = (B1_roe * normal_direction[1] +
+                         B2_roe * normal_direction[2] +
+                         B3_roe * normal_direction[3])^2 / norm_squared
+
+  c_a_roe = B_roe_dot_n_squared * inv_sqrt_rho_prod # (squared) Alfvén wave speed
+  a_star_roe = sqrt((a_square_roe + b_square_roe)^2 - 4 * a_square_roe * c_a_roe)
+  c_f_roe = sqrt(0.5 * (a_square_roe + b_square_roe + a_star_roe) * norm_squared)
+  vel_out_roe = (v1_roe * normal_direction[1] +
+                 v2_roe * normal_direction[2] +
+                 v3_roe * normal_direction[3])
 
   return vel_out_roe, c_f_roe
 end

--- a/test/test_examples_1d_euler.jl
+++ b/test/test_examples_1d_euler.jl
@@ -24,7 +24,7 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1
   @trixi_testset "elixir_euler_density_wave.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_density_wave.jl"),
       l2   = [0.0011482554820185795, 0.00011482554830363504, 5.741277417754598e-6],
-      linf = [0.004090978306814375, 0.00040909783135059663, 2.045489171820236e-5])
+      linf = [0.004090978306814375, 0.00040909783135059663, 2.045489209479001e-5])
   end
 
   @trixi_testset "elixir_euler_density_wave.jl with initial_condition_density_pulse" begin

--- a/test/test_examples_2d_p4est.jl
+++ b/test/test_examples_2d_p4est.jl
@@ -61,7 +61,7 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "p4est_
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_free_stream.jl"),
       l2   = [2.063350241405049e-15, 1.8571016296925367e-14, 3.1769447886391905e-14, 1.4104095258528071e-14],
       linf = [1.9539925233402755e-14, 2e-12, 4.8e-12, 4e-12],
-      atol = 1.5e-12, # required to make CI tests pass on macOS
+      atol = 2.0e-12, # required to make CI tests pass on macOS
     )
   end
 

--- a/test/test_examples_3d_structured.jl
+++ b/test/test_examples_3d_structured.jl
@@ -96,7 +96,7 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "struct
       linf = [0.027618475633440998, 0.027093787212065318, 0.012584560784257667, 0.039456640084648914,
               0.020759073985165077, 0.031771018340953416, 0.02059036404759229, 0.03456102393654076,
               0.019663511833857894],
-      surface_flux = flux_lax_friedrichs)
+      surface_flux = (flux_lax_friedrichs, flux_nonconservative_powell))
   end
 
   # TODO: nonconservative terms, remove


### PR DESCRIPTION
I know, you will hate me that I didn't make these changes earlier, but I was just motivated by the first performance comparisons you showed earlier today... 

I get the following results running `julia --check-bounds=no --threads=1` on `main`.
```julia
julia> using Trixi, BenchmarkTools

julia> begin # performance
           elixirs = [
               joinpath(examples_dir(), "structured_3d_dgsem", "elixir_mhd_alfven_wave.jl"),]
           tspan = (0.0, 1.0e-5)
           
           for elixir in elixirs
               println(basename(elixir))
               redirect_stdout(devnull) do
                   trixi_include(elixir, tspan=tspan)
               end
               u_ode = copy(sol.u[end]); du_ode = similar(u_ode)
               display(@benchmark Trixi.rhs!($du_ode, $u_ode, $semi, $0.0))
               println()
           end
       end
elixir_mhd_alfven_wave.jl
BenchmarkTools.Trial: 1217 samples with 1 evaluation.
 Range (min … max):  4.035 ms …  4.638 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     4.088 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.106 ms ± 71.805 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▅    █▂▁▂ ▅▅ ▁ ▁▃    ▁▁                                     
  █▁▄▄▁████████████▇▇█▇██▇▇▇█▇▆▅▅▇▅▅▅▆▆▅▅▅▆▅▅▅▅▇▇▅▅▅▆▅▆▅▅▅▆▆ █
  440 ms       Histogram: log(frequency) by time     4.35 ms <

 Memory estimate: 480 bytes, allocs estimate: 5.
```
With this PR, I get
```julia
julia> using Trixi, BenchmarkTools

julia> begin # performance
           elixirs = [
               joinpath(examples_dir(), "structured_3d_dgsem", "elixir_mhd_alfven_wave.jl"),]
           tspan = (0.0, 1.0e-5)
           
           for elixir in elixirs
               println(basename(elixir))
               redirect_stdout(devnull) do
                   trixi_include(elixir, tspan=tspan)
               end
               u_ode = copy(sol.u[end]); du_ode = similar(u_ode)
               display(@benchmark Trixi.rhs!($du_ode, $u_ode, $semi, $0.0))
               println()
           end
       end
elixir_mhd_alfven_wave.jl
BenchmarkTools.Trial: 1428 samples with 1 evaluation.
 Range (min … max):  3.416 ms …  4.637 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.474 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.501 ms ± 79.232 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▅    ▁ ▂█▁▁ ▆▁ ▁▂▂                                          
  █▄▆▁▇██████▇██████▆████▇▆▆▆▇▇▇▅▆▆█▆▆▆▄▄▅▄▁▅▄▁▄▄▄▅▄▄▄▄▆▁▄▁▄ █
  3.42 ms      Histogram: log(frequency) by time     3.81 ms <

 Memory estimate: 480 bytes, allocs estimate: 5.
```
That's a speed-up of ca. 15%. We can get an additional speed-up of ca. 3% once https://github.com/JuliaArrays/StaticArrays.jl/pull/949 is merged (but we can ignore this for our performance comparison).