### PR TITLE
faster `min` and `max`

### DIFF
--- a/src/auxiliary/math.jl
+++ b/src/auxiliary/math.jl
@@ -162,6 +162,10 @@ end
 Return the maximum of the arguments. See also the `maximum` function to take
 the maximum element from a collection.
 
+This version in Trixi.jl is semantically equivalent to `Base.max` but may
+be implemented differently. In particular, it may avoid potentially expensive
+checks necessary in the presence of `NaN`s (or signed zeros).
+
 # Examples
 
 julia> max(2, 5, 1)
@@ -174,6 +178,10 @@ julia> max(2, 5, 1)
 
 Return the minimum of the arguments. See also the `minimum` function to take
 the minimum element from a collection.
+
+This version in Trixi.jl is semantically equivalent to `Base.min` but may
+be implemented differently. In particular, it may avoid potentially expensive
+checks necessary in the presence of `NaN`s (or signed zeros).
 
 # Examples
 


### PR DESCRIPTION
I recognized this opportunity for increased performance while working on #767. Some numbers generated using `julia --check-bounds=no --threads=1` on `main`:
```julia
julia> using Trixi

julia> trixi_include(joinpath(examples_dir(), "tree_2d_dgsem", "elixir_euler_vortex.jl"),
           save_restart=TrivialCallback(), save_solution=TrivialCallback()) 
[...] # results after the second run
 ───────────────────────────────────────────────────────────────────────────────
            Trixi.jl                    Time                   Allocations      
                                ──────────────────────   ───────────────────────
        Tot / % measured:            332ms / 88.5%           1.39MiB / 84.0%    

 Section                ncalls     time   %tot     avg     alloc   %tot      avg
 ───────────────────────────────────────────────────────────────────────────────
 rhs!                    2.78k    271ms  92.1%  97.3μs   0.99MiB  84.7%     372B
   interface flux        2.78k    111ms  37.7%  39.8μs     0.00B  0.00%    0.00B
   volume integral       2.78k   70.1ms  23.9%  25.2μs     0.00B  0.00%    0.00B
   ~rhs!~                2.78k   39.3ms  13.4%  14.1μs   0.99MiB  84.7%     372B
   surface integral      2.78k   22.4ms  7.64%  8.07μs     0.00B  0.00%    0.00B
   prolong2interfaces    2.78k   15.6ms  5.31%  5.61μs     0.00B  0.00%    0.00B
   reset ∂u/∂t           2.78k   6.59ms  2.24%  2.37μs     0.00B  0.00%    0.00B
   Jacobian              2.78k   5.19ms  1.77%  1.87μs     0.00B  0.00%    0.00B
   prolong2boundaries    2.78k    140μs  0.05%  50.3ns     0.00B  0.00%    0.00B
   prolong2mortars       2.78k    127μs  0.04%  45.6ns     0.00B  0.00%    0.00B
   mortar flux           2.78k   85.7μs  0.03%  30.8ns     0.00B  0.00%    0.00B
   boundary flux         2.78k   74.8μs  0.03%  26.9ns     0.00B  0.00%    0.00B
   source terms          2.78k   43.7μs  0.01%  15.7ns     0.00B  0.00%    0.00B
 calculate dt              557   14.4ms  4.91%  25.9μs     0.00B  0.00%    0.00B
 analyze solution            7   8.85ms  3.01%  1.26ms    182KiB  15.3%  26.0KiB
 ───────────────────────────────────────────────────────────────────────────────
```

In this PR
```julia
julia> using Trixi

julia> trixi_include(joinpath(examples_dir(), "tree_2d_dgsem", "elixir_euler_vortex.jl"),
           save_restart=TrivialCallback(), save_solution=TrivialCallback()) 
[...] # results after the second run
 ───────────────────────────────────────────────────────────────────────────────
            Trixi.jl                    Time                   Allocations      
                                ──────────────────────   ───────────────────────
        Tot / % measured:            318ms / 87.5%           1.39MiB / 84.0%    

 Section                ncalls     time   %tot     avg     alloc   %tot      avg
 ───────────────────────────────────────────────────────────────────────────────
 rhs!                    2.78k    260ms  93.7%  93.7μs   0.99MiB  84.7%     372B
   interface flux        2.78k   98.8ms  35.5%  35.5μs     0.00B  0.00%    0.00B
   volume integral       2.78k   71.8ms  25.8%  25.8μs     0.00B  0.00%    0.00B
   ~rhs!~                2.78k   38.9ms  14.0%  14.0μs   0.99MiB  84.7%     372B
   surface integral      2.78k   22.6ms  8.14%  8.13μs     0.00B  0.00%    0.00B
   prolong2interfaces    2.78k   15.4ms  5.55%  5.54μs     0.00B  0.00%    0.00B
   reset ∂u/∂t           2.78k   6.98ms  2.51%  2.51μs     0.00B  0.00%    0.00B
   Jacobian              2.78k   5.47ms  1.97%  1.97μs     0.00B  0.00%    0.00B
   prolong2boundaries    2.78k    151μs  0.05%  54.2ns     0.00B  0.00%    0.00B
   prolong2mortars       2.78k    115μs  0.04%  41.4ns     0.00B  0.00%    0.00B
   mortar flux           2.78k   80.6μs  0.03%  29.0ns     0.00B  0.00%    0.00B
   boundary flux         2.78k   68.1μs  0.02%  24.5ns     0.00B  0.00%    0.00B
   source terms          2.78k   61.2μs  0.02%  22.0ns     0.00B  0.00%    0.00B
 analyze solution            7   8.90ms  3.20%  1.27ms    182KiB  15.3%  26.0KiB
 calculate dt              557   8.63ms  3.10%  15.5μs     0.00B  0.00%    0.00B
 ───────────────────────────────────────────────────────────────────────────────
```
