### PR TITLE
p4est surface performance 3D

### DIFF
--- a/examples/p4est_3d_dgsem/elixir_advection_cubed_sphere.jl
+++ b/examples/p4est_3d_dgsem/elixir_advection_cubed_sphere.jl
@@ -29,7 +29,8 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver, 
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/p4est_3d_dgsem/elixir_advection_nonconforming.jl
+++ b/examples/p4est_3d_dgsem/elixir_advection_nonconforming.jl
@@ -44,7 +44,8 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/tree_3d_dgsem/elixir_advection_extended.jl
+++ b/examples/tree_3d_dgsem/elixir_advection_extended.jl
@@ -21,8 +21,8 @@ boundary_conditions = boundary_condition_periodic
 # Create DG solver with polynomial degree = 3 and (local) Lax-Friedrichs/Rusanov flux as surface flux
 solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs)
 
-coordinates_min = (-1, -1, -1) # minimum coordinates (min(x), min(y), min(z))
-coordinates_max = ( 1,  1,  1) # maximum coordinates (max(x), max(y), max(z))
+coordinates_min = (-1.0, -1.0, -1.0) # minimum coordinates (min(x), min(y), min(z))
+coordinates_max = ( 1.0,  1.0,  1.0) # maximum coordinates (max(x), max(y), max(z))
 
 # Create a uniformly refined mesh with periodic boundaries
 mesh = TreeMesh(coordinates_min, coordinates_max,

--- a/src/solvers/dgsem_p4est/dg.jl
+++ b/src/solvers/dgsem_p4est/dg.jl
@@ -27,23 +27,6 @@ function create_cache(mesh::P4estMesh, equations::AbstractEquations, dg::DG, ::A
 end
 
 
-# TODO: p4est interface performance, remove
-# Extract outward-pointing normal vector (contravariant vector ±Ja^i, i = index) as SVector
-# Note that this vector is not normalized
-@inline function get_normal_vector(direction, cache, indices...)
-  @unpack contravariant_vectors = cache.elements
-
-  orientation = div(direction + 1, 2)
-  normal = get_contravariant_vector(orientation, contravariant_vectors, indices...)
-
-  # Contravariant vectors at interfaces in negative coordinate direction are pointing inwards
-  if direction in (1, 3, 5)
-    normal *= -1
-  end
-
-  return normal
-end
-
 # Extract outward-pointing normal direction
 # (contravariant vector ±Ja^i, i = index)
 # Note that this vector is not normalized

--- a/src/solvers/dgsem_p4est/dg_2d.jl
+++ b/src/solvers/dgsem_p4est/dg_2d.jl
@@ -20,10 +20,11 @@ function create_cache(mesh::P4estMesh{2}, equations, mortar_l2::LobattoLegendreM
 end
 
 
-# TODO: p4est interface performance, move and generalize this function for 3D
+# TODO: p4est interface performance, generalize (2D, 3D) and document
 @inline function index_to_start_step(index::Symbol, index_range)
   index_begin = first(index_range)
   index_end   = last(index_range)
+
   if index === :one
     return index_begin, 0
   elseif index === :end
@@ -42,8 +43,8 @@ function prolong2interfaces!(cache, u,
   index_range = eachnode(dg)
 
   @threaded for interface in eachinterface(dg, cache)
-    # Copy solution data from the primary element on a case-by-case basis to get
-    # the correct face and orientation.
+    # Copy solution data from the primary element on a case-by-case basis
+    # to get the correct face and orientation.
     # Note that in the current implementation, the interface will be
     # "aligned at the primary element", i.e., the index of the primary side
     # will always run forwards.
@@ -63,8 +64,8 @@ function prolong2interfaces!(cache, u,
       j_primary += j_primary_step
     end
 
-    # Copy solution data from the secondary element on a case-by-case basis to get
-    # the correct face and orientation.
+    # Copy solution data from the secondary element on a case-by-case basis
+    # to get the correct face and orientation.
     secondary_element = interfaces.element_ids[2, interface]
     secondary_indices = interfaces.node_indices[2, interface]
 

--- a/src/solvers/dgsem_p4est/dg_2d.jl
+++ b/src/solvers/dgsem_p4est/dg_2d.jl
@@ -241,8 +241,8 @@ function prolong2mortars!(cache, u,
   index_range = eachnode(dg)
 
   @threaded for mortar in eachmortar(dg, cache)
-    # Copy solution data from the small elements on a case-by-case basis to get
-    # the correct face and orientation.
+    # Copy solution data from the small elements on a case-by-case basis
+    # to get the correct face and orientation.
     small_indices = node_indices[1, mortar]
 
     i_small_start, i_small_step = index_to_start_step(small_indices[1], index_range)
@@ -266,7 +266,8 @@ function prolong2mortars!(cache, u,
     # before interpolating
     u_buffer = cache.u_threaded[Threads.threadid()]
 
-    # Copy solution of large element face to buffer in the correct orientation
+    # Copy solution of large element face to buffer in the
+    # correct orientation
     large_indices = node_indices[2, mortar]
 
     i_large_start, i_large_step = index_to_start_step(large_indices[1], index_range)

--- a/src/solvers/dgsem_p4est/dg_2d.jl
+++ b/src/solvers/dgsem_p4est/dg_2d.jl
@@ -343,8 +343,8 @@ function calc_mortar_flux!(surface_flux_values,
       end
     end
 
-    # Buffer to interpolate flux values of the large element to before copying
-    # in the correct orientation
+    # Buffer to interpolate flux values of the large element to before
+    # copying in the correct orientation
     u_buffer = cache.u_threaded[Threads.threadid()]
 
     mortar_fluxes_to_elements!(surface_flux_values,
@@ -362,9 +362,6 @@ end
                                             dg::DGSEM, cache, mortar, fstar, u_buffer)
   @unpack element_ids, node_indices = cache.mortars
 
-  large_indices  = node_indices[2, mortar]
-  large_direction = indices2direction(large_indices)
-
   # Copy solution small to small
   small_indices   = node_indices[1, mortar]
   small_direction = indices2direction(small_indices)
@@ -378,8 +375,6 @@ end
     end
   end
 
-  large_element = element_ids[3, mortar]
-
   # Project small fluxes to large element.
   multiply_dimensionwise!(u_buffer,
                           mortar_l2.reverse_upper, fstar[2],
@@ -388,10 +383,10 @@ end
   # The flux is calculated in the outward direction of the small elements,
   # so the sign must be switched to get the flux in outward direction
   # of the large element.
-  # The contravariant vectors of the large element (and therefore the normal vectors
-  # of the large element as well) are twice as large as the contravariant vectors
-  # of the small elements. Therefore, the flux need to be scaled by a factor of 2
-  # to obtain the flux of the large element.
+  # The contravariant vectors of the large element (and therefore the normal
+  # vectors of the large element as well) are twice as large as the
+  # contravariant vectors of the small elements. Therefore, the flux needs
+  # to be scaled by a factor of 2 to obtain the flux of the large element.
   u_buffer .*= -2
 
   # Copy interpolated flux values from buffer to large element face in the
@@ -400,6 +395,10 @@ end
   # the index of the large side might need to run backwards for flipped sides.
   # TODO: p4est interface performance; see whether this can be made simpler and
   #       more general when working on the 3D version
+  large_element  = element_ids[3, mortar]
+  large_indices  = node_indices[2, mortar]
+  large_direction = indices2direction(large_indices)
+
   if :i_backwards in large_indices
     for i in eachnode(dg)
       for v in eachvariable(equations)

--- a/src/solvers/dgsem_p4est/dg_2d.jl
+++ b/src/solvers/dgsem_p4est/dg_2d.jl
@@ -23,16 +23,23 @@ end
 #     index_to_start_step_2d(index::Symbol, index_range)
 #
 # Given a symbolic `index` and an `indexrange` (usually `eachnode(dg)`),
-# return an index value to begin a loop and an index step to update during a
-# loop. The resulting indices translate surface indices to volume indices.
+# return `index_start, index_step`, i.e., a tuple containing
+# - `index_start`, an index value to begin a loop
+# - `index_step`,  an index step to update during a loop
+# The resulting indices translate surface indices to volume indices.
 #
 # !!! warning
 #     This assumes that loops using the return values are written as
 #
-#     my_i, my_j = # begin values
-#     for i in ...
-#       # do stuff with i and (my_i, my_j)
-#       my_[ij] += my_[ij]_step
+#     i_volume_start, i_volume_step = index_to_start_step_2d(symbolic_index_i, index_range)
+#     j_volume_start, j_volume_step = index_to_start_step_2d(symbolic_index_j, index_range)
+#
+#     i_volume, j_volume = i_volume_start, j_volume_start
+#     for i_surface in index_range
+#       # do stuff with `i_surface` and `(i_volume, j_volume)`
+#
+#       i_volume += i_volume_step
+#       j_volume += j_volume_step
 #     end
 @inline function index_to_start_step_2d(index::Symbol, index_range)
   index_begin = first(index_range)

--- a/src/solvers/dgsem_p4est/dg_3d.jl
+++ b/src/solvers/dgsem_p4est/dg_3d.jl
@@ -24,19 +24,31 @@ end
 #     index_to_start_step_3d(index::Symbol, index_range)
 #
 # Given a symbolic `index` and an `indexrange` (usually `eachnode(dg)`),
-# return an index value to begin a loop and index steps to update during a
-# loop. The resulting indices translate surface indices to volume indices.
+# return `index_start, index_step_i, index_step_j`, i.e., a tuple containing
+# - `index_start`,   an index value to begin a loop
+# - `index_step_i`,  an index step to update during an `i` loop
+# - `index_step_j`,  an index step to update during a `j` loop
+# The resulting indices translate surface indices to volume indices.
 #
 # !!! warning
-#     This assumes that loops using the return values are ordered as
+#     This assumes that loops using the return values are written as
 #
-#     my_i, my_j, my_k = # begin values
-#     for j in ...
-#       for i in ...
-#         # do stuff with (i, j) and (my_i, my_j, my_k)
-#         my_[ijk] += my_[ijk]_step_i
+#     i_volume_start, i_volume_step_i, i_volume_step_j = index_to_start_step_3d(symbolic_index_i, index_range)
+#     j_volume_start, j_volume_step_i, j_volume_step_j = index_to_start_step_3d(symbolic_index_j, index_range)
+#     k_volume_start, k_volume_step_i, k_volume_step_j = index_to_start_step_3d(symbolic_index_k, index_range)
+#
+#     i_volume, j_volume, k_volume = i_volume_start, j_volume_start, k_volume_start
+#     for j_surface in index_range
+#       for i_surface in index_range
+#         # do stuff with `(i_surface, j_surface)` and `(i_volume, j_volume, k_volume)`
+#
+#         i_volume += i_volume_step_i
+#         j_volume += j_volume_step_i
+#         k_volume += k_volume_step_i
 #       end
-#       my_[ijk] += my_[ijk]_step_j
+#       i_volume += i_volume_step_j
+#       j_volume += j_volume_step_j
+#       k_volume += k_volume_step_j
 #     end
 @inline function index_to_start_step_3d(index::Symbol, index_range)
   index_begin = first(index_range)
@@ -57,6 +69,8 @@ end
   end
 end
 
+# Extract the two varying indices from a symbolic index tuple.
+# For example, `surface_indices((:i, :end, :j)) == (:i, :j)`.
 @inline function surface_indices(indices::NTuple{3, Symbol})
   i1, i2, i3 = indices
   index = i1

--- a/src/solvers/dgsem_p4est/dg_3d.jl
+++ b/src/solvers/dgsem_p4est/dg_3d.jl
@@ -21,7 +21,12 @@ function create_cache(mesh::P4estMesh{3}, equations, mortar_l2::LobattoLegendreM
 end
 
 
-# TODO: p4est interface performance, generalize (2D, 3D) and document
+#     index_to_start_step_3d(index::Symbol, index_range)
+#
+# Given a symbolic `index` and an `indexrange` (usually `eachnode(dg)`),
+# return an index value to begin a loop and index steps to update during a
+# loop. The resulting indices translate surface indices to volume indices.
+#
 # !!! warning
 #     This assumes that loops using the return values are ordered as
 #
@@ -191,8 +196,6 @@ function calc_interface_flux!(surface_flux_values,
 
     # Note that the indices of the primary side will always run forward but
     # the secondary indices might need to run backwards for flipped sides.
-    # TODO: p4est interface performance; see whether this can be made simpler and
-    #       more general
     i_secondary = i_secondary_start
     j_secondary = j_secondary_start
     for j in eachnode(dg)
@@ -527,8 +530,6 @@ end
   # correct orientation.
   # Note that the index of the small sides will always run forward but
   # the index of the large side might need to run backwards for flipped sides.
-  # TODO: p4est interface performance; see whether this can be made simpler and
-  #       more general when working on the 3D version
   large_element = element_ids[5, mortar]
   large_indices  = node_indices[2, mortar]
   large_direction = indices2direction(large_indices)
@@ -539,8 +540,6 @@ end
 
   # Note that the indices of the small sides will always run forward but
   # the large indices might need to run backwards for flipped sides.
-  # TODO: p4est interface performance; see whether this can be made simpler and
-  #       more general
   i_large = i_large_start
   j_large = j_large_start
   for j in eachnode(dg)


### PR DESCRIPTION
I ported the 2D surface performance improvements for the `P4estMesh` of #767 to 3D.

Current `main` (after compilation, using `julia --check-bounds=no --num-threads-1`):
```julia
julia> trixi_include("examples/p4est_3d_dgsem/elixir_advection_unstructured_curved.jl",
                     save_solution=TrivialCallback(), save_restart=TrivialCallback())
[...]
 ───────────────────────────────────────────────────────────────────────────────
            Trixi.jl                    Time                   Allocations
                                ──────────────────────   ───────────────────────
        Tot / % measured:            2.43s / 95.8%           7.42MiB / 71.2%

 Section                ncalls     time   %tot     avg     alloc   %tot      avg
 ───────────────────────────────────────────────────────────────────────────────
 rhs!                      206    2.19s  94.4%  10.7ms   84.9KiB  1.57%     422B
   interface flux          206    1.05s  45.3%  5.11ms     0.00B  0.00%    0.00B
   volume integral         206    435ms  18.7%  2.11ms     0.00B  0.00%    0.00B
   prolong2interfaces      206    430ms  18.5%  2.09ms     0.00B  0.00%    0.00B
   surface integral        206    103ms  4.45%   502μs     0.00B  0.00%    0.00B
   Jacobian                206   71.0ms  3.06%   345μs     0.00B  0.00%    0.00B
   boundary flux           206   66.0ms  2.84%   320μs     0.00B  0.00%    0.00B
   reset ∂u/∂t             206   14.0ms  0.60%  68.1μs     0.00B  0.00%    0.00B
   prolong2boundaries      206   12.7ms  0.55%  61.8μs     0.00B  0.00%    0.00B
   ~rhs!~                  206   9.21ms  0.40%  44.7μs   84.9KiB  1.57%     422B
   prolong2mortars         206   82.8μs  0.00%   402ns     0.00B  0.00%    0.00B
   mortar flux             206   47.1μs  0.00%   229ns     0.00B  0.00%    0.00B
   source terms            206   14.4μs  0.00%  70.0ns     0.00B  0.00%    0.00B
 analyze solution            2   72.5ms  3.12%  36.2ms   5.20MiB  98.4%  2.60MiB
 calculate dt               42   57.3ms  2.46%  1.36ms     0.00B  0.00%    0.00B
 ───────────────────────────────────────────────────────────────────────────────

julia> trixi_include("examples/p4est_3d_dgsem/elixir_advection_cubed_sphere.jl",
                     save_solution=TrivialCallback(), save_restart=TrivialCallback())
[...]
 ───────────────────────────────────────────────────────────────────────────────
            Trixi.jl                    Time                   Allocations
                                ──────────────────────   ───────────────────────
        Tot / % measured:           67.7ms / 97.4%            318KiB / 80.7%

 Section                ncalls     time   %tot     avg     alloc   %tot      avg
 ───────────────────────────────────────────────────────────────────────────────
 rhs!                      261   62.3ms  94.4%   239μs    105KiB  40.8%     410B
   interface flux          261   17.5ms  26.6%  67.1μs     0.00B  0.00%    0.00B
   boundary flux           261   12.4ms  18.8%  47.6μs     0.00B  0.00%    0.00B
   prolong2interfaces      261   11.7ms  17.7%  44.8μs     0.00B  0.00%    0.00B
   volume integral         261   11.1ms  16.9%  42.7μs     0.00B  0.00%    0.00B
   ~rhs!~                  261   4.01ms  6.08%  15.4μs    105KiB  40.8%     410B
   surface integral        261   2.15ms  3.26%  8.24μs     0.00B  0.00%    0.00B
   Jacobian                261   1.77ms  2.69%  6.80μs     0.00B  0.00%    0.00B
   prolong2boundaries      261   1.34ms  2.03%  5.14μs     0.00B  0.00%    0.00B
   reset ∂u/∂t             261    211μs  0.32%   808ns     0.00B  0.00%    0.00B
   prolong2mortars         261   14.1μs  0.02%  54.0ns     0.00B  0.00%    0.00B
   mortar flux             261   8.88μs  0.01%  34.0ns     0.00B  0.00%    0.00B
   source terms            261   4.82μs  0.01%  18.5ns     0.00B  0.00%    0.00B
 analyze solution            2   2.69ms  4.08%  1.35ms    152KiB  59.2%  76.0KiB
 calculate dt               53   1.01ms  1.54%  19.1μs     0.00B  0.00%    0.00B
 ───────────────────────────────────────────────────────────────────────────────

julia> trixi_include("examples/p4est_3d_dgsem/elixir_advection_nonconforming.jl",
                     save_solution=TrivialCallback(), save_restart=TrivialCallback())
[...]
 ───────────────────────────────────────────────────────────────────────────────
            Trixi.jl                    Time                   Allocations
                                ──────────────────────   ───────────────────────
        Tot / % measured:           33.7ms / 97.0%            216KiB / 80.1%

 Section                ncalls     time   %tot     avg     alloc   %tot      avg
 ───────────────────────────────────────────────────────────────────────────────
 rhs!                      156   30.1ms  92.0%   193μs   66.9KiB  38.7%     439B
   interface flux          156   10.3ms  31.5%  66.0μs     0.00B  0.00%    0.00B
   prolong2interfaces      156   6.70ms  20.5%  42.9μs     0.00B  0.00%    0.00B
   volume integral         156   5.26ms  16.1%  33.7μs     0.00B  0.00%    0.00B
   ~rhs!~                  156   3.03ms  9.27%  19.4μs   66.9KiB  38.7%     439B
   mortar flux             156   1.73ms  5.30%  11.1μs     0.00B  0.00%    0.00B
   surface integral        156   1.03ms  3.15%  6.59μs     0.00B  0.00%    0.00B
   prolong2mortars         156    988μs  3.02%  6.33μs     0.00B  0.00%    0.00B
   Jacobian                156    928μs  2.84%  5.95μs     0.00B  0.00%    0.00B
   reset ∂u/∂t             156   93.3μs  0.29%   598ns     0.00B  0.00%    0.00B
   prolong2boundaries      156   8.26μs  0.03%  52.9ns     0.00B  0.00%    0.00B
   boundary flux           156   4.67μs  0.01%  29.9ns     0.00B  0.00%    0.00B
   source terms            156   3.03μs  0.01%  19.4ns     0.00B  0.00%    0.00B
 analyze solution            2   2.12ms  6.49%  1.06ms    106KiB  61.3%  53.0KiB
 calculate dt               32    481μs  1.47%  15.0μs     0.00B  0.00%    0.00B
 ───────────────────────────────────────────────────────────────────────────────
```

This PR:
```julia
julia> trixi_include("examples/p4est_3d_dgsem/elixir_advection_unstructured_curved.jl",
                     save_solution=TrivialCallback(), save_restart=TrivialCallback())
[...]
 ───────────────────────────────────────────────────────────────────────────────
            Trixi.jl                    Time                   Allocations
                                ──────────────────────   ───────────────────────
        Tot / % measured:            1.51s / 93.3%           7.42MiB / 71.2%

 Section                ncalls     time   %tot     avg     alloc   %tot      avg
 ───────────────────────────────────────────────────────────────────────────────
 rhs!                      206    1.29s  91.5%  6.24ms   84.9KiB  1.57%     422B
   interface flux          206    526ms  37.4%  2.56ms     0.00B  0.00%    0.00B
   volume integral         206    433ms  30.8%  2.10ms     0.00B  0.00%    0.00B
   surface integral        206   89.3ms  6.36%   434μs     0.00B  0.00%    0.00B
   prolong2interfaces      206   88.2ms  6.27%   428μs     0.00B  0.00%    0.00B
   Jacobian                206   71.6ms  5.09%   347μs     0.00B  0.00%    0.00B
   boundary flux           206   47.0ms  3.35%   228μs     0.00B  0.00%    0.00B
   reset ∂u/∂t             206   14.0ms  0.99%  67.9μs     0.00B  0.00%    0.00B
   ~rhs!~                  206   8.96ms  0.64%  43.5μs   84.9KiB  1.57%     422B
   prolong2boundaries      206   7.55ms  0.54%  36.6μs     0.00B  0.00%    0.00B
   prolong2mortars         206   93.1μs  0.01%   452ns     0.00B  0.00%    0.00B
   mortar flux             206   29.5μs  0.00%   143ns     0.00B  0.00%    0.00B
   source terms            206   3.83μs  0.00%  18.6ns     0.00B  0.00%    0.00B
 analyze solution            2   63.4ms  4.51%  31.7ms   5.20MiB  98.4%  2.60MiB
 calculate dt               42   56.7ms  4.03%  1.35ms     0.00B  0.00%    0.00B
 ───────────────────────────────────────────────────────────────────────────────

julia> trixi_include("examples/p4est_3d_dgsem/elixir_advection_cubed_sphere.jl",
                     save_solution=TrivialCallback(), save_restart=TrivialCallback())
[...]
 ───────────────────────────────────────────────────────────────────────────────
            Trixi.jl                    Time                   Allocations
                                ──────────────────────   ───────────────────────
        Tot / % measured:           39.8ms / 95.4%            317KiB / 80.6%

 Section                ncalls     time   %tot     avg     alloc   %tot      avg
 ───────────────────────────────────────────────────────────────────────────────
 rhs!                      261   34.6ms  91.2%   133μs    105KiB  40.9%     410B
   volume integral         261   11.2ms  29.5%  42.9μs     0.00B  0.00%    0.00B
   boundary flux           261   7.33ms  19.3%  28.1μs     0.00B  0.00%    0.00B
   interface flux          261   5.58ms  14.7%  21.4μs     0.00B  0.00%    0.00B
   ~rhs!~                  261   3.96ms  10.4%  15.2μs    105KiB  40.9%     410B
   surface integral        261   2.16ms  5.68%  8.27μs     0.00B  0.00%    0.00B
   prolong2interfaces      261   1.91ms  5.02%  7.30μs     0.00B  0.00%    0.00B
   Jacobian                261   1.80ms  4.73%  6.88μs     0.00B  0.00%    0.00B
   prolong2boundaries      261    417μs  1.10%  1.60μs     0.00B  0.00%    0.00B
   reset ∂u/∂t             261    227μs  0.60%   868ns     0.00B  0.00%    0.00B
   prolong2mortars         261   13.9μs  0.04%  53.1ns     0.00B  0.00%    0.00B
   mortar flux             261   8.61μs  0.02%  33.0ns     0.00B  0.00%    0.00B
   source terms            261   5.74μs  0.02%  22.0ns     0.00B  0.00%    0.00B
 analyze solution            2   2.33ms  6.15%  1.17ms    151KiB  59.1%  75.5KiB
 calculate dt               53   1.01ms  2.66%  19.1μs     0.00B  0.00%    0.00B
 ───────────────────────────────────────────────────────────────────────────────

julia> trixi_include("examples/p4est_3d_dgsem/elixir_advection_nonconforming.jl",
                     save_solution=TrivialCallback(), save_restart=TrivialCallback())
[...]
 ───────────────────────────────────────────────────────────────────────────────
            Trixi.jl                    Time                   Allocations
                                ──────────────────────   ───────────────────────
        Tot / % measured:           15.5ms / 94.4%            217KiB / 80.2%

 Section                ncalls     time   %tot     avg     alloc   %tot      avg
 ───────────────────────────────────────────────────────────────────────────────
 rhs!                      156   12.5ms  85.3%  80.2μs   66.9KiB  38.5%     439B
   volume integral         156   4.45ms  30.3%  28.5μs     0.00B  0.00%    0.00B
   interface flux          156   2.50ms  17.0%  16.0μs     0.00B  0.00%    0.00B
   ~rhs!~                  156   2.18ms  14.9%  14.0μs   66.9KiB  38.5%     439B
   surface integral        156    860μs  5.87%  5.51μs     0.00B  0.00%    0.00B
   prolong2interfaces      156    814μs  5.56%  5.22μs     0.00B  0.00%    0.00B
   Jacobian                156    698μs  4.76%  4.47μs     0.00B  0.00%    0.00B
   mortar flux             156    554μs  3.78%  3.55μs     0.00B  0.00%    0.00B
   prolong2mortars         156    358μs  2.44%  2.30μs     0.00B  0.00%    0.00B
   reset ∂u/∂t             156   83.4μs  0.57%   535ns     0.00B  0.00%    0.00B
   prolong2boundaries      156   7.74μs  0.05%  49.6ns     0.00B  0.00%    0.00B
   boundary flux           156   4.12μs  0.03%  26.4ns     0.00B  0.00%    0.00B
   source terms            156   2.90μs  0.02%  18.6ns     0.00B  0.00%    0.00B
 analyze solution            2   1.75ms  11.9%   873μs    107KiB  61.5%  53.5KiB
 calculate dt               32    404μs  2.76%  12.6μs     0.00B  0.00%    0.00B
 ───────────────────────────────────────────────────────────────────────────────
```

CC @efaulhaber 

Closes #642