### PR TITLE
Fix broken example links

### DIFF
--- a/docs/src/callbacks.md
+++ b/docs/src/callbacks.md
@@ -15,7 +15,7 @@ control, adaptive mesh refinement, I/O, and more.
 
 ### CFL-based time step control
 Time step control can be performed with a [`StepsizeCallback`](@ref). An example making use
-of this can be found at [examples/2d/elixir\_advection\_basic.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/2d/elixir_advection_basic.jl)
+of this can be found at [examples/tree_2d_dgsem/elixir\_advection\_basic.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_advection_basic.jl)
 
 ### Adaptive mesh refinement
 Trixi uses a hierarchical Cartesian mesh which can be locally refined in a solution-adaptive way.
@@ -24,27 +24,27 @@ passing an [`AMRCallback`](@ref) to the ODE solver. The `AMRCallback` requires a
 [`ControllerThreeLevel`](@ref) or [`ControllerThreeLevelCombined`](@ref) to tell the AMR
 algorithm which cells to refine/coarsen.
 
-An example elixir using AMR can be found at [examples/2d/elixir\_advection\_amr.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/2d/elixir_advection_amr.jl).
+An example elixir using AMR can be found at [examples/tree_2d_dgsem/elixir\_advection\_amr.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_advection_amr.jl).
 
 ### Analyzing the numerical solution
 The [`AnalysisCallback`](@ref) can be used to analyze the numerical solution, e.g. calculate
 errors or user-specified integrals, and print the results to the screen. The results can also be
-saved in a file. An example can be found at [examples/2d/elixir\_euler\_vortex.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/2d/elixir_euler_vortex.jl).
+saved in a file. An example can be found at [examples/tree_2d_dgsem/elixir\_euler\_vortex.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_euler_vortex.jl).
 
 ### I/O
 
 #### Solution and restart files
 To save the solution in regular intervals you can use a [`SaveSolutionCallback`](@ref). It is also
 possible to create restart files using the [`SaveRestartCallback`](@ref). An example making use
-of these can be found at [examples/2d/elixir\_advection\_extended.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/2d/elixir_advection_extended.jl).
+of these can be found at [examples/tree_2d_dgsem/elixir\_advection\_extended.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_advection_extended.jl).
 An example showing how to restart a simulation from a restart file can be found at
-[examples/2d/elixir\_advection\_restart.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/2d/elixir_advection_restart.jl).
+[examples/tree_2d_dgsem/elixir\_advection\_restart.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_advection_restart.jl).
 
 #### Time series
 Sometimes it is useful to record the evoluation of state variables over time at
 a given set of points. This can be achieved by the [`TimeSeriesCallback`](@ref), which is used,
 e.g., in
-[examples/2d/elixir\_ape\_gaussian\_source.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/2d/elixir_ape_gaussian_source.jl).
+[examples/tree_2d_dgsem/elixir\_ape\_gaussian\_source.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_ape_gaussian_source.jl).
 The `TimeSeriesCallback` constructor expects a semidiscretization and a list of points at
 which the solution should be recorded in regular time step intervals. After the
 last time step, the entire record is stored in an HDF5 file.
@@ -84,7 +84,7 @@ example, executing
 ```julia
 julia> using Trixi, Plots
 
-julia> trixi_include("examples/2d/elixir_ape_gaussian_source.jl")
+julia> trixi_include(joinpath(examples_dir(), "tree_2d_dgsem", "elixir_ape_gaussian_source.jl"))
 
 julia> pd1 = PlotData1D(time_series, 1)
 
@@ -111,12 +111,12 @@ will yield the following plot:
 Some callbacks provided by Trixi implement specific features for certain equations:
 * The [`LBMCollisionCallback`](@ref) implements the Lattice-Boltzmann method (LBM) collision
   operator and should only be used when solving the Lattice-Boltzmann equations. See e.g.
-  [examples/2d/elixir\_lbm\_constant.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/2d/elixir_lbm_constant.jl)
+  [examples/tree_2d_dgsem/elixir\_lbm\_constant.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_lbm_constant.jl)
 * The [`SteadyStateCallback`](@ref) terminates the time integration when the residual steady state
   falls below a certain threshold. This checks the convergence of the potential ``\phi`` for
-  hyperbolic diffusion. See e.g. [examples/2d/elixir\_hypdiff\_nonperiodic.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/2d/elixir_hypdiff_nonperiodic.jl).
+  hyperbolic diffusion. See e.g. [examples/tree_2d_dgsem/elixir\_hypdiff\_nonperiodic.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_hypdiff_nonperiodic.jl).
 * The [`GlmSpeedCallback`](@ref) updates the divergence cleaning wave speed `c_h` for the ideal
-  GLM-MHD equations. See e.g. [examples/2d/elixir\_mhd\_alfven\_wave.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/2d/elixir_mhd_alfven_wave.jl).
+  GLM-MHD equations. See e.g. [examples/tree_2d_dgsem/elixir\_mhd\_alfven\_wave.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_mhd_alfven_wave.jl).
 
 ## Usage of step callbacks
 Step callbacks are passed to the `solve` method from the ODE solver via the keyword argument
@@ -150,7 +150,7 @@ more callbacks, you need to turn them into a `CallbackSet` first by calling
 ## Stage callbacks
 [`PositivityPreservingLimiterZhangShu`](@ref) is a positivity-preserving limiter, used to enforce
 physical constraints. An example elixir using this feature can be found at
-[examples/2d/elixir\_euler\_positivity.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/2d/elixir_euler_positivity.jl).
+[examples/tree_2d_dgsem/elixir\_euler\_positivity.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_euler_positivity.jl).
 
 ## Implementing new callbacks
 Since Trixi is compatible with [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl),
@@ -160,4 +160,4 @@ Step callbacks are just called [callbacks](https://diffeq.sciml.ai/latest/featur
 Stage callbacks are called [`stage_limiter!`](https://diffeq.sciml.ai/latest/solvers/ode_solve/#Explicit-Strong-Stability-Preserving-Runge-Kutta-Methods-for-Hyperbolic-PDEs-(Conservation-Laws)).
 
 An example elixir showing how to implement a new simple stage callback and a new simple step
-callback can be found at [examples/2d/elixir\_advection\_callbacks.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_advection_callbacks.jl).
+callback can be found at [examples/tree_2d_dgsem/elixir\_advection\_callbacks.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_advection_callbacks.jl).

--- a/docs/src/meshes/unstructured_quad_mesh.md
+++ b/docs/src/meshes/unstructured_quad_mesh.md
@@ -20,7 +20,7 @@ We use the following unstructured mesh with three elements for this discussion:
 ![example-mesh](https://user-images.githubusercontent.com/25242486/117508011-2e2c4b80-af88-11eb-8b15-949fc2d43253.png)
 
 Further, a simulation using Trixi on this example unstructured mesh is provided in
-[`examples/2d/elixir_euler_unstructured_quad_basic.jl`](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/2d/elixir_euler_unstructured_quad_basic.jl).
+[`examples/unstructured_2d_dgsem/elixir_euler_basic.jl`](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/unstructured_2d_dgsem/elixir_euler_basic.jl).
 
 
 ## Mesh file header

--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -264,7 +264,7 @@ During the simulation, the visualization callback creates and displays
 visualizations of the current solution in regular intervals. This can be useful
 to, e.g., monitor the validity of a long-running simulation or for illustrative
 purposes. An example for how to create a `VisualizationCallback` can be found in
-[examples/2d/elixir\_advection\_amr\_visualization.jl](https://trixi-framework.github.com/Trixi.jl/examples/2d/elixir_advection_amr_visualization.jl):
+[examples/tree_2d_dgsem/elixir\_advection\_amr\_visualization.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_advection_amr_visualization.jl):
 ```julia
 [...]
 


### PR DESCRIPTION
Some of the links in the documentation are broken due to the restructuring of the `examples` folder. This PR fixes them.