### PR TITLE
Adding Rayleigh-Taylor instability elixir

### DIFF
--- a/examples/dgmulti_2d/elixir_euler_kelvin_helmholtz_instability.jl
+++ b/examples/dgmulti_2d/elixir_euler_kelvin_helmholtz_instability.jl
@@ -5,7 +5,30 @@ dg = DGMulti(polydeg = 3, element_type = Quad(), approximation_type = SBP(),
              volume_integral = VolumeIntegralFluxDifferencing(flux_ranocha))
 
 equations = CompressibleEulerEquations2D(1.4)
-initial_condition = initial_condition_khi
+
+"""
+    initial_condition_kelvin_helmholtz_instability(x, t, equations::CompressibleEulerEquations2D)
+
+A version of the classical Kelvin-Helmholtz instability based on
+- Andrés M. Rueda-Ramírez, Gregor J. Gassner (2021)
+  A Subcell Finite Volume Positivity-Preserving Limiter for DGSEM Discretizations
+  of the Euler Equations
+  [arXiv: 2102.06017](https://arxiv.org/abs/2102.06017)
+"""
+function initial_condition_kelvin_helmholtz_instability(x, t, equations::CompressibleEulerEquations2D)
+  # change discontinuity to tanh
+  # typical resolution 128^2, 256^2
+  # domain size is [-1,+1]^2
+  slope = 15
+  amplitude = 0.02
+  B = tanh(slope * x[2] + 7.5) - tanh(slope * x[2] - 7.5)
+  rho = 0.5 + 0.75 * B
+  v1 = 0.5 * (B - 1)
+  v2 = 0.1 * sin(2 * pi * x[1])
+  p = 1.0
+  return prim2cons(SVector(rho, v1, v2, p), equations)
+end
+initial_condition = initial_condition_kelvin_helmholtz_instability
 
 vertex_coordinates, EToV = StartUpDG.uniform_mesh(dg.basis.elementType, 32)
 mesh = VertexMappedMesh(vertex_coordinates, EToV, dg, is_periodic=(true, true))

--- a/examples/structured_2d_dgsem/elixir_euler_rayleigh_taylor_instability.jl
+++ b/examples/structured_2d_dgsem/elixir_euler_rayleigh_taylor_instability.jl
@@ -1,0 +1,73 @@
+
+using OrdinaryDiffEq
+using Trixi
+
+###############################################################################
+# semidiscretization of the compressible Euler equations
+gamma = 1.4
+equations = CompressibleEulerEquations2D(gamma)
+
+initial_condition = initial_condition_rti
+source_terms = source_terms_rti
+
+surface_flux = flux_hll
+volume_flux  = flux_ranocha
+polydeg = 3
+basis = LobattoLegendreBasis(polydeg)
+volume_integral = VolumeIntegralFluxDifferencing(volume_flux)
+solver = DGSEM(basis, surface_flux, volume_integral)
+
+# The domain is [0, .25] x [0, 1]
+mapping(xi, eta) = SVector(.25 * .5 * (1 + xi), .5 * (1 + eta))
+
+num_elements_per_dimension = 32
+cells_per_dimension = (num_elements_per_dimension, num_elements_per_dimension * 4)
+mesh = StructuredMesh(cells_per_dimension, mapping)
+
+boundary_condition_wall = BoundaryConditionWall(boundary_state_slip_wall)
+boundary_conditions = (
+                       x_neg=boundary_condition_wall,
+                       x_pos=boundary_condition_wall,
+                       y_neg=boundary_condition_wall,
+                       y_pos=boundary_condition_wall,
+                      )
+
+## Alternative setup: left/right periodic BCs and Dirichlet BCs on the top/bottom.
+# boundary_conditions = (
+#                        x_neg=boundary_condition_periodic,
+#                        x_pos=boundary_condition_periodic,
+#                        y_neg=BoundaryConditionDirichlet(initial_condition),
+#                        y_pos=BoundaryConditionDirichlet(initial_condition),
+#                       )
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver;
+                                    source_terms = source_terms,
+                                    boundary_conditions = boundary_conditions)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 1.5)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+stepsize_callback = StepsizeCallback(cfl=1.3)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback,
+                        alive_callback,
+                        stepsize_callback)
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, RDPK3SpFSAL49(), abstol=1.0e-6, reltol=1.0e-6,
+            save_everystep=false, callback=callbacks);
+
+summary_callback() # print the timer summary

--- a/examples/structured_2d_dgsem/elixir_euler_rayleigh_taylor_instability.jl
+++ b/examples/structured_2d_dgsem/elixir_euler_rayleigh_taylor_instability.jl
@@ -106,12 +106,9 @@ analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
 
 alive_callback = AliveCallback(analysis_interval=analysis_interval)
 
-stepsize_callback = StepsizeCallback(cfl=1.3)
-
 callbacks = CallbackSet(summary_callback,
                         analysis_callback,
-                        alive_callback,
-                        stepsize_callback)
+                        alive_callback)
 
 ###############################################################################
 # run the simulation

--- a/examples/structured_2d_dgsem/elixir_euler_rayleigh_taylor_instability.jl
+++ b/examples/structured_2d_dgsem/elixir_euler_rayleigh_taylor_instability.jl
@@ -7,15 +7,9 @@ using Trixi
 gamma = 1.4
 equations = CompressibleEulerEquations2D(gamma)
 
-initial_condition = initial_condition_rti
-source_terms = source_terms_rti
-
-surface_flux = flux_hll
 volume_flux  = flux_ranocha
-polydeg = 3
-basis = LobattoLegendreBasis(polydeg)
-volume_integral = VolumeIntegralFluxDifferencing(volume_flux)
-solver = DGSEM(basis, surface_flux, volume_integral)
+solver = DGSEM(polydeg=3, surface_flux=flux_hll,
+               volume_integral=VolumeIntegralFluxDifferencing(volume_flux))
 
 # The domain is [0, .25] x [0, 1]
 mapping(xi, eta) = SVector(.25 * .5 * (1 + xi), .5 * (1 + eta))
@@ -40,9 +34,10 @@ boundary_conditions = (
 #                        y_pos=BoundaryConditionDirichlet(initial_condition),
 #                       )
 
+initial_condition = initial_condition_rayleigh_taylor_instability
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver;
-                                    source_terms = source_terms,
-                                    boundary_conditions = boundary_conditions)
+                                    source_terms=source_terms_rayleigh_taylor_instability,
+                                    boundary_conditions=boundary_conditions)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/structured_2d_dgsem/elixir_euler_rayleigh_taylor_instability.jl
+++ b/examples/structured_2d_dgsem/elixir_euler_rayleigh_taylor_instability.jl
@@ -96,7 +96,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver;
 ###############################################################################
 # ODE solvers, callbacks etc.
 
-tspan = (0.0, 1.5)
+tspan = (0.0, 1.65)
 ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()

--- a/examples/structured_2d_dgsem/elixir_euler_rayleigh_taylor_instability.jl
+++ b/examples/structured_2d_dgsem/elixir_euler_rayleigh_taylor_instability.jl
@@ -59,9 +59,8 @@ end
   return SVector(0.0, 0.0, g*rho, g*rho_v2)
 end
 
-surface_flux = flux_hll
 volume_flux  = flux_ranocha
-solver = DGSEM(polydeg=3, surface_flux=surface_flux,
+solver = DGSEM(polydeg=3, surface_flux=flux_hll,
                volume_integral=VolumeIntegralFluxDifferencing(volume_flux))
 
 # The domain is [0, 0.25] x [0, 1]

--- a/examples/structured_2d_dgsem/elixir_euler_rayleigh_taylor_instability.jl
+++ b/examples/structured_2d_dgsem/elixir_euler_rayleigh_taylor_instability.jl
@@ -14,7 +14,6 @@ Setup used for the Rayleigh-Taylor instability. Initial condition adapted from
 - Shi, Jing, Yong-Tao Zhang, and Chi-Wang Shu (2003).
   Resolution of high order WENO schemes for complicated flow structures.
   [DOI](https://doi.org/10.1016/S0021-9991(03)00094-9).
-
 - Remacle, Jean-François, Joseph E. Flaherty, and Mark S. Shephard (2003).
   An adaptive discontinuous Galerkin technique with an orthogonal basis applied to compressible
   flow problems.
@@ -33,7 +32,7 @@ defined below.
                                                                slope=1000)
   tol = 1e2*eps()
 
-  if x[2] < .5
+  if x[2] < 0.5
     p = 2*x[2] + 1
   else
     p = x[2] + 3/2

--- a/examples/structured_2d_dgsem/elixir_euler_rayleigh_taylor_instability.jl
+++ b/examples/structured_2d_dgsem/elixir_euler_rayleigh_taylor_instability.jl
@@ -11,8 +11,8 @@ volume_flux  = flux_ranocha
 solver = DGSEM(polydeg=3, surface_flux=flux_hll,
                volume_integral=VolumeIntegralFluxDifferencing(volume_flux))
 
-# The domain is [0, .25] x [0, 1]
-mapping(xi, eta) = SVector(.25 * .5 * (1 + xi), .5 * (1 + eta))
+# The domain is [0, 0.25] x [0, 1]
+mapping(xi, eta) = SVector(0.25 * 0.5 * (1 + xi), 0.5 * (1 + eta))
 
 num_elements_per_dimension = 32
 cells_per_dimension = (num_elements_per_dimension, num_elements_per_dimension * 4)

--- a/examples/tree_2d_dgsem/elixir_euler_kelvin_helmholtz_instability.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_kelvin_helmholtz_instability.jl
@@ -7,7 +7,29 @@ using Trixi
 gamma = 1.4
 equations = CompressibleEulerEquations2D(gamma)
 
-initial_condition = initial_condition_khi
+"""
+    initial_condition_kelvin_helmholtz_instability(x, t, equations::CompressibleEulerEquations2D)
+
+A version of the classical Kelvin-Helmholtz instability based on
+- Andrés M. Rueda-Ramírez, Gregor J. Gassner (2021)
+  A Subcell Finite Volume Positivity-Preserving Limiter for DGSEM Discretizations
+  of the Euler Equations
+  [arXiv: 2102.06017](https://arxiv.org/abs/2102.06017)
+"""
+function initial_condition_kelvin_helmholtz_instability(x, t, equations::CompressibleEulerEquations2D)
+  # change discontinuity to tanh
+  # typical resolution 128^2, 256^2
+  # domain size is [-1,+1]^2
+  slope = 15
+  amplitude = 0.02
+  B = tanh(slope * x[2] + 7.5) - tanh(slope * x[2] - 7.5)
+  rho = 0.5 + 0.75 * B
+  v1 = 0.5 * (B - 1)
+  v2 = 0.1 * sin(2 * pi * x[1])
+  p = 1.0
+  return prim2cons(SVector(rho, v1, v2, p), equations)
+end
+initial_condition = initial_condition_kelvin_helmholtz_instability
 
 surface_flux = flux_lax_friedrichs
 volume_flux  = flux_ranocha

--- a/examples/tree_2d_dgsem/elixir_euler_kelvin_helmholtz_instability_amr.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_kelvin_helmholtz_instability_amr.jl
@@ -7,7 +7,29 @@ using Trixi
 gamma = 1.4
 equations = CompressibleEulerEquations2D(gamma)
 
-initial_condition = initial_condition_khi
+"""
+    initial_condition_kelvin_helmholtz_instability(x, t, equations::CompressibleEulerEquations2D)
+
+A version of the classical Kelvin-Helmholtz instability based on
+- Andrés M. Rueda-Ramírez, Gregor J. Gassner (2021)
+  A Subcell Finite Volume Positivity-Preserving Limiter for DGSEM Discretizations
+  of the Euler Equations
+  [arXiv: 2102.06017](https://arxiv.org/abs/2102.06017)
+"""
+function initial_condition_kelvin_helmholtz_instability(x, t, equations::CompressibleEulerEquations2D)
+  # change discontinuity to tanh
+  # typical resolution 128^2, 256^2
+  # domain size is [-1,+1]^2
+  slope = 15
+  amplitude = 0.02
+  B = tanh(slope * x[2] + 7.5) - tanh(slope * x[2] - 7.5)
+  rho = 0.5 + 0.75 * B
+  v1 = 0.5 * (B - 1)
+  v2 = 0.1 * sin(2 * pi * x[1])
+  p = 1.0
+  return prim2cons(SVector(rho, v1, v2, p), equations)
+end
+initial_condition = initial_condition_kelvin_helmholtz_instability
 
 surface_flux = flux_lax_friedrichs
 volume_flux  = flux_ranocha

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -130,7 +130,6 @@ export initial_condition_constant,
        initial_condition_gauss,
        initial_condition_density_wave, initial_condition_density_pulse,
        initial_condition_isentropic_vortex,
-       initial_condition_khi,
        initial_condition_weak_blast_wave, initial_condition_blast_wave,
        initial_condition_sedov_blast_wave, initial_condition_medium_sedov_blast_wave,
        initial_condition_two_interacting_blast_waves, boundary_condition_two_interacting_blast_waves,
@@ -160,7 +159,6 @@ export initial_condition_lid_driven_cavity, boundary_condition_lid_driven_cavity
 export initial_condition_couette_steady, initial_condition_couette_unsteady, boundary_condition_couette
 export initial_condition_gauss_wall
 export initial_condition_monopole, boundary_condition_monopole
-export initial_condition_rti, source_terms_rti
 
 export cons2cons, cons2prim, prim2cons, cons2macroscopic, cons2state, cons2mean,
        cons2entropy, entropy2cons

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -160,6 +160,7 @@ export initial_condition_lid_driven_cavity, boundary_condition_lid_driven_cavity
 export initial_condition_couette_steady, initial_condition_couette_unsteady, boundary_condition_couette
 export initial_condition_gauss_wall
 export initial_condition_monopole, boundary_condition_monopole
+export initial_condition_rti, source_terms_rti
 
 export cons2cons, cons2prim, prim2cons, cons2macroscopic, cons2state, cons2mean,
        cons2entropy, entropy2cons

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -462,7 +462,8 @@ The domain is [0, .25] x [0, 1]. Boundary conditions can be
 
 or reflective wall boundary conditions on all boundaries.
 """
-@inline function initial_condition_rti(coordinates, t, equations::CompressibleEulerEquations2D)
+@inline function initial_condition_rti(coordinates, t, equations::CompressibleEulerEquations2D,
+                                       slope=500)
   tol = 1e2*eps()
   x, y = coordinates
   if y < .5
@@ -472,7 +473,6 @@ or reflective wall boundary conditions on all boundaries.
   end
 
   # smooth the discontinuity to avoid ambiguity at element interfaces
-  slope = 500
   smoothed_heaviside(x, left, right) = left + .5*(1 + tanh(slope * x)) * (right-left)
   rho = smoothed_heaviside(y - .5, 2.0, 1.0)
 

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -495,7 +495,8 @@ in combination with [`initial_condition_eoc_test_coupled_euler_gravity`](@ref).
 """
 @inline function source_terms_rti(u, coordinates, t, equations::CompressibleEulerEquations2D)
   g = 1.0
-  rho, rho_v1, rho_v2, E = u
+  rho, rho_v1, rho_v2, rho_e = u
+  
   return SVector(0.0, 0.0, g*rho, g*rho_v2)
 end
 

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -473,15 +473,16 @@ or reflective wall boundary conditions on all boundaries.
   end
 
   # smooth the discontinuity to avoid ambiguity at element interfaces
-  smoothed_heaviside(x, left, right) = left + .5*(1 + tanh(slope * x)) * (right-left)
-  rho = smoothed_heaviside(y - .5, 2.0, 1.0)
+  smoothed_heaviside(x, left, right) = left + 0.5*(1 + tanh(slope * x)) * (right-left)
+  rho = smoothed_heaviside(y - 0.5, 2.0, 1.0)
 
   c = sqrt(equations.gamma * p / rho)
   # the velocity is multiplied by sin(pi*y)^6 as in Remacle et al. 2003 to ensure that the
   # initial condition satisfies reflective boundary conditions at the top/bottom boundaries.
   v = -0.025 * c * cos(8*pi*x) * sin(pi*y)^6
   u = 0.0
-  return prim2cons(SVector{4}(rho, u, v, p), equations)
+  
+  return prim2cons(SVector(rho, u, v, p), equations)
 end
 
 """

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -441,6 +441,62 @@ function initial_condition_eoc_test_coupled_euler_gravity(x, t, equations::Compr
 end
 
 """
+    initial_condition_rti(coordinates, t, equations::CompressibleEulerEquations2D)
+
+Setup used for the Rayleigh-Taylor instability. Initial condition adapted from
+- Shi, Jing, Yong-Tao Zhang, and Chi-Wang Shu (2003).
+  Resolution of high order WENO schemes for complicated flow structures.
+  [DOI](https://doi.org/10.1016/S0021-9991(03)00094-9).
+
+  and
+
+- Remacle, Jean-François, Joseph E. Flaherty, and Mark S. Shephard (2003).
+  An adaptive discontinuous Galerkin technique with an orthogonal basis applied to compressible flow problems.
+  [DOI](https://doi.org/10.1137/S00361445023830)
+
+  Should be used together with [`source_terms_rti`](@ref).
+
+The domain is [0, .25] x [0, 1]. Boundary conditions can be
+- periodic boundary conditions on the leftd/right boundaries
+- Dirichlet boundary conditions on the top/bottom boundaries
+
+or reflective wall boundary conditions on all boundaries.
+"""
+function initial_condition_rti(coordinates, t, equations::CompressibleEulerEquations2D)
+  tol = 1e2*eps()
+  x, y = coordinates
+  if y < .5
+    rho = 2.0
+    p = 2*y + 1
+  else
+    rho = 1.0
+    p = y + 3/2
+  end
+  c = sqrt(equations.gamma * p / rho)
+  # the velocity is multiplied by sin(pi*y)^6 as in Remacle et al. 2003 to ensure that the
+  # initial condition satisfies reflective boundary conditions at the top/bottom boundaries.
+  v = -0.025 * c * cos(8*pi*x) * sin(pi*y)^6
+  u = 0.0
+  return prim2cons(SVector{4}(rho, u, v, p), equations)
+end
+
+"""
+    source_terms_eoc_test_coupled_euler_gravity(u, x, t, equations::CompressibleEulerEquations2D)
+
+Setup used for convergence tests of the Euler equations with self-gravity used in
+- Michael Schlottke-Lakemper, Andrew R. Winters, Hendrik Ranocha, Gregor J. Gassner (2020)
+  A purely hyperbolic discontinuous Galerkin approach for self-gravitating gas dynamics
+  [arXiv: 2008.10593](https://arxiv.org/abs/2008.10593)
+in combination with [`initial_condition_eoc_test_coupled_euler_gravity`](@ref).
+"""
+function source_terms_rti(u, coordinates, t, equations::CompressibleEulerEquations2D)
+  g = 1.0
+  rho, rho_v1, rho_v2, E = u
+  return SVector(0.0, 0.0, g*rho, g*rho_v2)
+end
+
+
+"""
     source_terms_eoc_test_coupled_euler_gravity(u, x, t, equations::CompressibleEulerEquations2D)
 
 Setup used for convergence tests of the Euler equations with self-gravity used in
@@ -497,7 +553,6 @@ in combination with [`initial_condition_eoc_test_coupled_euler_gravity`](@ref).
 
   return SVector(du1, du2, du3, du4)
 end
-
 
 """
     initial_condition_sedov_self_gravity(x, t, equations::CompressibleEulerEquations2D)

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -485,7 +485,7 @@ or reflective wall boundary conditions on all boundaries.
 end
 
 """
-    source_terms_eoc_test_coupled_euler_gravity(u, x, t, equations::CompressibleEulerEquations2D)
+    source_terms_rayleigh_taylor_instability(u, x, t, equations::CompressibleEulerEquations2D)
 
 Setup used for convergence tests of the Euler equations with self-gravity used in
 - Michael Schlottke-Lakemper, Andrew R. Winters, Hendrik Ranocha, Gregor J. Gassner (2020)

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -346,29 +346,6 @@ end
 
 
 """
-    initial_condition_khi(x, t, equations::CompressibleEulerEquations2D)
-
-A version of the classical Kelvin-Helmholtz instability based on
-- Andrés M. Rueda-Ramírez, Gregor J. Gassner (2021)
-  A Subcell Finite Volume Positivity-Preserving Limiter for DGSEM Discretizations
-  of the Euler Equations
-  [arXiv: 2102.06017](https://arxiv.org/abs/2102.06017)
-"""
-function initial_condition_khi(x, t, equations::CompressibleEulerEquations2D)
-  # change discontinuity to tanh
-  # typical resolution 128^2, 256^2
-  # domain size is [-1,+1]^2
-  slope = 15
-  amplitude = 0.02
-  B = tanh(slope * x[2] + 7.5) - tanh(slope * x[2] - 7.5)
-  rho = 0.5 + 0.75 * B
-  v1 = 0.5 * (B - 1)
-  v2 = 0.1 * sin(2 * pi * x[1])
-  p = 1.0
-  return prim2cons(SVector(rho, v1, v2, p), equations)
-end
-
-"""
     initial_condition_blob(x, t, equations::CompressibleEulerEquations2D)
 
 The blob test case taken from

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -176,6 +176,22 @@ struct BoundaryConditionWall{B}
   boundary_value_function::B
 end
 
+@inline function (boundary_condition::BoundaryConditionWall)(u_inner, orientation_or_normal,
+                                                             direction,
+                                                             x, t,
+                                                             surface_flux_function, equations)
+
+  u_boundary = boundary_condition.boundary_value_function(u_inner, orientation_or_normal, equations)
+
+  # Calculate boundary flux
+  if direction in (2, 4, 6) # u_inner is "left" of boundary, u_boundary is "right" of boundary
+    flux = surface_flux_function(u_inner, u_boundary, orientation_or_normal, equations)
+  else # u_boundary is "left" of boundary, u_inner is "right" of boundary
+    flux = surface_flux_function(u_boundary, u_inner, orientation_or_normal, equations)
+  end
+
+  return flux
+end
 @inline function (boundary_condition::BoundaryConditionWall)(u_inner,
                                                              normal_direction::AbstractVector,
                                                              x, t,

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -176,6 +176,7 @@ struct BoundaryConditionWall{B}
   boundary_value_function::B
 end
 
+# Wall boundary condition for use with TreeMesh or StructuredMesh
 @inline function (boundary_condition::BoundaryConditionWall)(u_inner, orientation_or_normal,
                                                              direction,
                                                              x, t,
@@ -192,6 +193,9 @@ end
 
   return flux
 end
+
+# Wall boundary condition for use with UnstructuredMesh2D
+# Note: For unstructured we lose the concept of an "absolute direction"
 @inline function (boundary_condition::BoundaryConditionWall)(u_inner,
                                                              normal_direction::AbstractVector,
                                                              x, t,

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -185,7 +185,7 @@ end
   u_boundary = boundary_condition.boundary_value_function(u_inner, orientation_or_normal, equations)
 
   # Calculate boundary flux
-  if direction in (2, 4, 6) # u_inner is "left" of boundary, u_boundary is "right" of boundary
+  if iseven(direction) # u_inner is "left" of boundary, u_boundary is "right" of boundary
     flux = surface_flux_function(u_inner, u_boundary, orientation_or_normal, equations)
   else # u_boundary is "left" of boundary, u_inner is "right" of boundary
     flux = surface_flux_function(u_boundary, u_inner, orientation_or_normal, equations)

--- a/src/visualization/recipes_plots.jl
+++ b/src/visualization/recipes_plots.jl
@@ -207,13 +207,16 @@ RecipesBase.@recipe function f(u, semi::AbstractSemidiscretization;
   end
 end
 
-# need to define this function because some keywords from the more general plot recipe
+# need to define these functions because some keywords from the more general plot recipe
 # are not supported (e.g., `max_supported_level`).
 RecipesBase.@recipe function f(u, semi::DGMultiSemidiscretizationHyperbolic;
-                               solution_variables=cons2cons, grid_lines=true)
-  return PlotData2D(u, semi)
+                               solution_variables=nothing)
+  return PlotData2D(u, semi; solution_variables=solution_variables)
 end
-
+RecipesBase.@recipe function f(u, semi::SemidiscretizationHyperbolic{<:Union{StructuredMesh, UnstructuredMesh2D}};
+                               solution_variables=nothing)
+  return PlotData2D(u, semi; solution_variables=solution_variables)
+end
 
 # Series recipe for UnstructuredPlotData2D
 RecipesBase.@recipe function f(pds::PlotDataSeries{<:UnstructuredPlotData2D})

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -267,36 +267,6 @@ function PlotData2D(u, mesh::TreeMesh, equations, solver, cache;
 end
 
 
-function PlotData2D(u, mesh::Union{StructuredMesh,UnstructuredMesh2D}, equations, solver, cache;
-                    solution_variables=nothing, grid_lines=true, kwargs...)
-  @unpack node_coordinates = cache.elements
-
-  @assert ndims(mesh) == 2 "unsupported number of dimensions $ndims (must be 2)"
-  solution_variables_ = digest_solution_variables(equations, solution_variables)
-
-  unstructured_data = get_unstructured_data(u, solution_variables_, mesh, equations, solver, cache)
-
-  x = vec(view(node_coordinates, 1, ..))
-  y = vec(view(node_coordinates, 2, ..))
-
-  data = [vec(unstructured_data[.., v]) for v in eachvariable(equations)]
-
-  if grid_lines
-    mesh_vertices_x, mesh_vertices_y = calc_vertices(node_coordinates, mesh)
-  else
-    mesh_vertices_x = Matrix{Float64}(undef, 0, 0)
-    mesh_vertices_y = Matrix{Float64}(undef, 0, 0)
-  end
-
-  variable_names = SVector(varnames(solution_variables_, equations))
-
-  orientation_x, orientation_y = _get_orientations(mesh, nothing)
-
-  return PlotData2D(x, y, data, variable_names, mesh_vertices_x, mesh_vertices_y,
-                    orientation_x, orientation_y)
-end
-
-
 """
     PlotData2D(sol; kwargs...)
 
@@ -368,7 +338,7 @@ end
 
 # specializes the PlotData2D constructor to return an UnstructuredPlotData2D if the mesh is
 # an UnstructuredMesh2D type.
-function PlotData2D(u, mesh::UnstructuredMesh2D, equations, dg::DGSEM, cache;
+function PlotData2D(u, mesh::Union{StructuredMesh, UnstructuredMesh2D}, equations, dg, cache;
                     solution_variables=nothing, nvisnodes=2*polydeg(dg))
   @assert ndims(mesh) == 2
 

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -349,6 +349,9 @@ function PlotData2D(u, mesh::Union{StructuredMesh, UnstructuredMesh2D}, equation
   r, s = reference_node_coordinates_2d(dg)
 
   # reference plotting nodes
+  if nvisnodes == 0 || nvisnodes === nothing
+    nvisnodes = polydeg(dg) + 1
+  end
   plotting_interp_matrix = plotting_interpolation_matrix(dg; nvisnodes=nvisnodes)
 
   # create triangulation for plotting nodes

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -337,7 +337,7 @@ function PlotData2D(u::StructArray, mesh, equations, dg::DGMulti, cache;
 end
 
 # specializes the PlotData2D constructor to return an UnstructuredPlotData2D if the mesh is
-# an UnstructuredMesh2D type.
+# a non-TreeMesh type.
 function PlotData2D(u, mesh::Union{StructuredMesh, UnstructuredMesh2D}, equations, dg, cache;
                     solution_variables=nothing, nvisnodes=2*polydeg(dg))
   @assert ndims(mesh) == 2

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -34,12 +34,12 @@ isdir(outdir) && rm(outdir, recursive=true)
                                      tspan=(0,0.1))
 
     # Constructor tests
-    if mesh == "DGMulti"
-      @test PlotData2D(sol) isa Trixi.UnstructuredPlotData2D
-      @test PlotData2D(sol; nvisnodes=0, solution_variables=cons2cons) isa Trixi.UnstructuredPlotData2D
-    else
+    if mesh == "TreeMesh"
       @test PlotData2D(sol) isa PlotData2D
       @test PlotData2D(sol; nvisnodes=0, grid_lines=false, solution_variables=cons2cons) isa PlotData2D
+    else
+      @test PlotData2D(sol) isa Trixi.UnstructuredPlotData2D
+      @test PlotData2D(sol; nvisnodes=0, solution_variables=cons2cons) isa Trixi.UnstructuredPlotData2D
     end
     pd = PlotData2D(sol)
 


### PR DESCRIPTION
This PR does three things: 
1. Extends BoundaryConditionWall and addresses #805
2. Replaces the `scatter` plot default for `StructuredMesh` and `UnstructuredMesh` with the new Plots.jl recipe using `UnstructuredPlotData2D` 
3. Adds initial conditions and an elixir for the Rayleigh Taylor instability. 
4. Renames the Kelvin-Helmholtz instability from `*_khi` to `*_kelvin_helmholtz_instability` and moves the initial condition definition into the elixir.

Example of the solution for `polydeg=3` and a 32 x 128 mesh:
![khi_p3_32cells](https://user-images.githubusercontent.com/1156048/130336433-f8622a79-de18-4f35-af0e-992500ef24f8.png)
