### PR TITLE
Fix the transformation from the parallelogram to the square in `elixir_advection_parallelogram.jl`

### DIFF
--- a/examples/structured_2d_dgsem/elixir_advection_parallelogram.jl
+++ b/examples/structured_2d_dgsem/elixir_advection_parallelogram.jl
@@ -6,9 +6,9 @@ using Trixi
 # initial_condition_convergence_test transformed to the parallelogram
 function initial_condition_parallelogram(x, t, equation::LinearScalarAdvectionEquation2D)
   # Transform back to unit square
-  x_transformed = SVector(x[1] + x[2], x[2])
+  x_transformed = SVector(x[1] - x[2], x[2])
   a = equation.advectionvelocity
-  a_transformed = SVector(a[1] + a[2], a[2])
+  a_transformed = SVector(a[1] - a[2], a[2])
 
   # Store translated coordinate for easy use of exact solution
   x_translated = x_transformed - a_transformed * t

--- a/test/test_examples_2d_structured.jl
+++ b/test/test_examples_2d_structured.jl
@@ -56,8 +56,8 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "struct
 
   @trixi_testset "elixir_advection_parallelogram.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_parallelogram.jl"),
-      l2   = [0.0005165995033861579],
-      linf = [0.002506176163321605])
+      l2   = [9.14468177884088e-6],
+      linf = [6.437440532947036e-5])
   end
 
   @trixi_testset "elixir_advection_waving_flag.jl" begin


### PR DESCRIPTION
The example `examples/structured_2d/elixir_advection_paralellogram.jl` is supposed to be exactly the same as `elixir_advection_basic.jl`, but with the domain, initial condition, and advection velocity transformed to the parallelogram. 
In practice, the nodal values of both the initial condition and the exact solution are supposed to be exactly identical to `elixir_advection_basic.jl`, just the node coordinates and thus the metric terms should be different to test the method on a non-rectangular mesh.

I fixed the transformation, so now this example works with the same errors as the basic one.