### PR TITLE
improve performance of DGMulti methods using entropy-projections (for 2D Euler)

### DIFF
--- a/src/solvers/dgmulti.jl
+++ b/src/solvers/dgmulti.jl
@@ -2,3 +2,6 @@
 include("dgmulti/types.jl")
 include("dgmulti/dg.jl")
 include("dgmulti/flux_differencing.jl")
+
+# specialization of DGMulti to specific equations
+include("dgmulti/flux_differencing_compressible_euler.jl")

--- a/src/solvers/dgmulti/dg.jl
+++ b/src/solvers/dgmulti/dg.jl
@@ -21,7 +21,7 @@ mul_by!(A::UniformScaling) = MulByUniformScaling()
 mul_by_accum!(A::UniformScaling) = MulByAccumUniformScaling()
 
 # StructArray fallback
-@inline apply_to_each_field(f, args...) = StructArrays.foreachfield(f, args...)
+@inline apply_to_each_field(f::F, args::Vararg{Any, N}) where {F, N} = StructArrays.foreachfield(f, args...)
 
 # specialize for UniformScaling types: works for either StructArray{SVector} or Matrix{SVector}
 # solution storage formats.
@@ -173,7 +173,7 @@ function calc_volume_integral!(du, u, volume_integral::VolumeIntegralWeakForm,
 end
 
 function calc_interface_flux!(cache, surface_integral::SurfaceIntegralWeakForm,
-                mesh::VertexMappedMesh, equations, dg::DGMulti{NDIMS}) where {NDIMS}
+                              mesh::VertexMappedMesh, equations, dg::DGMulti{NDIMS}) where {NDIMS}
 
   @unpack surface_flux = surface_integral
   md = mesh.md
@@ -198,8 +198,8 @@ end
 # assumes cache.flux_face_values is computed and filled with
 # for polyomial discretizations, use dense LIFT matrix for surface contributions.
 function calc_surface_integral!(du, u, surface_integral::SurfaceIntegralWeakForm,
-                mesh::VertexMappedMesh, equations,
-                dg::DGMulti, cache)
+                                mesh::VertexMappedMesh, equations,
+                                dg::DGMulti, cache)
   rd = dg.basis
   apply_to_each_field(mul_by_accum!(rd.LIFT), du, cache.flux_face_values)
 end

--- a/src/solvers/dgmulti/flux_differencing.jl
+++ b/src/solvers/dgmulti/flux_differencing.jl
@@ -171,7 +171,7 @@ function create_cache(mesh::VertexMappedMesh, equations, dg::DGMultiFluxDiff{<:P
   # Instead, this step is also performed in `entropy_projection!`. Thus, we set
   # `u_face_values` as a `view` into `entropy_projected_u_values`. We do not do
   # the same for `u_values` since we will use that with LoopVectorization, which
-  # cannot handle such views at the time of writing.
+  # cannot handle such views as of v0.12.66, the latest version at the time of writing.
   u_values = allocate_nested_array(uEltype, nvars, size(md.xq), dg)
   u_face_values = view(entropy_projected_u_values, rd.Nq+1:num_quad_points_total, :)
   flux_face_values = similar(u_face_values)

--- a/src/solvers/dgmulti/flux_differencing.jl
+++ b/src/solvers/dgmulti/flux_differencing.jl
@@ -167,8 +167,12 @@ function create_cache(mesh::VertexMappedMesh, equations, dg::DGMultiFluxDiff{<:P
   entropy_projected_u_values = allocate_nested_array(uEltype, nvars, (num_quad_points_total, md.num_elements), dg)
   projected_entropy_var_values = allocate_nested_array(uEltype, nvars, (num_quad_points_total, md.num_elements), dg)
 
-  # initialize temporary storage as views into entropy_projected_u_values
-  u_values = view(entropy_projected_u_values, 1:rd.Nq, :)
+  # For this specific solver, `prolong2interfaces` will not be used anymore.
+  # Instead, this step is also performed in `entropy_projection!`. Thus, we set
+  # `u_face_values` as a `view` into `entropy_projected_u_values`. We do not do
+  # the same for `u_values` since we will use that with LoopVectorization, which
+  # cannot handle such views at the time of writing.
+  u_values = allocate_nested_array(uEltype, nvars, size(md.xq), dg)
   u_face_values = view(entropy_projected_u_values, rd.Nq+1:num_quad_points_total, :)
   flux_face_values = similar(u_face_values)
 
@@ -192,12 +196,12 @@ function entropy_projection!(cache, u, mesh::VertexMappedMesh, equations, dg::DG
 
   rd = dg.basis
   @unpack Vq = rd
-  @unpack VhP, entropy_var_values, u_values, entropy_var_values = cache
+  @unpack VhP, entropy_var_values, u_values = cache
   @unpack projected_entropy_var_values, entropy_projected_u_values = cache
 
   apply_to_each_field(mul_by!(Vq), u_values, u)
 
-  # TODO: DGMulti. @threaded crashes when using `eachindex(u_values)`.
+  # TODO: DGMulti. `@threaded` crashes when using `eachindex(u_values)`.
   # See https://github.com/JuliaSIMD/Polyester.jl/issues/37 for more details.
   @threaded for i in Base.OneTo(length(u_values))
     entropy_var_values[i] = cons2entropy(u_values[i], equations)
@@ -205,7 +209,10 @@ function entropy_projection!(cache, u, mesh::VertexMappedMesh, equations, dg::DG
 
   # "VhP" fuses the projection "P" with interpolation to volume and face quadrature "Vh"
   apply_to_each_field(mul_by!(VhP), projected_entropy_var_values, entropy_var_values)
-  @threaded for i in Base.OneTo(length(projected_entropy_var_values)) #eachindex(projected_entropy_var_values)
+
+  # TODO: DGMulti. `@threaded` crashes when using `eachindex(projected_entropy_var_values)`.
+  # See https://github.com/JuliaSIMD/Polyester.jl/issues/37 for more details.
+  @threaded for i in Base.OneTo(length(projected_entropy_var_values))
     entropy_projected_u_values[i] = entropy2cons(projected_entropy_var_values[i], equations)
   end
 end

--- a/src/solvers/dgmulti/flux_differencing_compressible_euler.jl
+++ b/src/solvers/dgmulti/flux_differencing_compressible_euler.jl
@@ -12,7 +12,7 @@
 #       `entropy2cons`. Thus, we need to insert the physics directly here to
 #       get a significant runtime performance improvement.
 function entropy_projection!(cache, u::StructArray{<:SVector{4, <:Union{Float32, Float64}}},
-                             mesh::VertexMappedMesh, equations::CompressibleEulerEquations2D, dg::DGMulti)
+                             mesh::VertexMappedMesh, equations::CompressibleEulerEquations2D, dg::DGMultiFluxDiff{<:Polynomial})
   rd = dg.basis
   @unpack Vq = rd
   @unpack VhP, u_values, entropy_var_values = cache

--- a/src/solvers/dgmulti/flux_differencing_compressible_euler.jl
+++ b/src/solvers/dgmulti/flux_differencing_compressible_euler.jl
@@ -1,0 +1,102 @@
+# By default, Julia/LLVM does not use fused multiply-add operations (FMAs).
+# Since these FMAs can increase the performance of many numerical algorithms,
+# we need to opt-in explicitly.
+# See https://ranocha.de/blog/Optimizing_EC_Trixi for further details.
+@muladd begin
+
+
+
+# TODO: Upstream, LoopVectorization
+#       At the time of writing, LoopVectorization.jl cannot handle this kind of
+#       loop optimally when passing our custom functions `cons2entropy` and
+#       `entropy2cons`. Thus, we need to insert the physics directly here to
+#       get a significant runtime performance improvement.
+function entropy_projection!(cache, u::StructArray{<:SVector{4, <:Union{Float32, Float64}}},
+                             mesh::VertexMappedMesh, equations::CompressibleEulerEquations2D, dg::DGMulti)
+  rd = dg.basis
+  @unpack Vq = rd
+  @unpack VhP, u_values, entropy_var_values = cache
+  @unpack projected_entropy_var_values, entropy_projected_u_values = cache
+
+  apply_to_each_field(mul_by!(Vq), u_values, u)
+
+  # The following is semantically equivalent to
+  # @threaded for i in Base.OneTo(length(u_values))
+  #   entropy_var_values[i] = cons2entropy(u_values[i], equations)
+  # end
+  # but much more efficient due to explicit optimization via `@turbo` from
+  # LoopVectorization.jl.
+  @unpack gamma, inv_gamma_minus_one = equations
+  let
+    rho_values, rho_v1_values, rho_v2_values, rho_e_values = StructArrays.components(u_values)
+    w1_values, w2_values, w3_values, w4_values = StructArrays.components(entropy_var_values)
+
+    @turbo thread=true for i in indices(
+        (rho_values, rho_v1_values, rho_v2_values, rho_e_values,
+         w1_values, w2_values, w3_values, w4_values))
+      rho    = rho_values[i]
+      rho_v1 = rho_v1_values[i]
+      rho_v2 = rho_v2_values[i]
+      rho_e  = rho_e_values[i]
+
+      # The following is basically the same code as in `cons2entropy`
+      v1 = rho_v1 / rho
+      v2 = rho_v2 / rho
+      v_square = v1^2 + v2^2
+      p = (gamma - 1) * (rho_e - 0.5 * rho * v_square)
+      s = log(p) - gamma * log(rho)
+      rho_p = rho / p
+
+      w1_values[i] = (gamma - s) * inv_gamma_minus_one - 0.5 * rho_p * v_square
+      w2_values[i] = rho_p * v1
+      w3_values[i] = rho_p * v2
+      w4_values[i] = -rho_p
+    end
+  end
+
+  # "VhP" fuses the projection "P" with interpolation to volume and face quadrature "Vh"
+  apply_to_each_field(mul_by!(VhP), projected_entropy_var_values, entropy_var_values)
+
+  # The following is semantically equivalent to
+  # @threaded for i in Base.OneTo(length(projected_entropy_var_values)) #eachindex(projected_entropy_var_values)
+  #   entropy_projected_u_values[i] = entropy2cons(projected_entropy_var_values[i], equations)
+  # end
+  # but much more efficient due to explicit optimization via `@turbo` from
+  # LoopVectorization.jl.
+  let
+    rho_values, rho_v1_values, rho_v2_values, rho_e_values = StructArrays.components(entropy_projected_u_values)
+    w1_values, w2_values, w3_values, w4_values = StructArrays.components(projected_entropy_var_values)
+
+    @turbo thread=true for i in indices(
+        (rho_values, rho_v1_values, rho_v2_values, rho_e_values,
+         w1_values, w2_values, w3_values, w4_values))
+
+      # The following is basically the same code as in `entropy2cons`
+      # Convert to entropy `-rho * s` used by
+      # - See Hughes, Franca, Mallet (1986) A new finite element formulation for CFD
+      #   [DOI: 10.1016/0045-7825(86)90127-1](https://doi.org/10.1016/0045-7825(86)90127-1)
+      # instead of `-rho * s / (gamma - 1)`
+      gamma_minus_one = gamma - 1
+      w1 = gamma_minus_one * w1_values[i]
+      w2 = gamma_minus_one * w2_values[i]
+      w3 = gamma_minus_one * w3_values[i]
+      w4 = gamma_minus_one * w4_values[i]
+
+      # s = specific entropy, eq. (53)
+      s = gamma - w1 + (w2^2 + w3^2) / (2 * w4)
+
+      # eq. (52)
+      rho_iota = (gamma_minus_one / (-w4)^gamma)^(inv_gamma_minus_one) * exp(-s * inv_gamma_minus_one)
+
+      # eq. (51)
+      rho_values[i]    = -rho_iota * w4
+      rho_v1_values[i] =  rho_iota * w2
+      rho_v2_values[i] =  rho_iota * w3
+      rho_e_values[i]  =  rho_iota * (1 - (w2^2 + w3^2) / (2 * w4))
+    end
+  end
+end
+
+
+
+end # @muladd


### PR DESCRIPTION
@jlchan This should help us to get some real science done faster.

Running `trixi_include("examples/dgmulti_2d/elixir_euler_rayleigh_taylor_instability.jl", tspan=(0.0, 0.5))`
(second time, after compilation) with `julia --check-bounds=no --threads=1` yields the following results.
- Current `main`:
  ```
  ────────────────────────────────────────────────────────────────────────────────────────────────────
  Trixi simulation finished.  Final time: 0.5  Time steps: 254 (accepted), 256 (total)
  ────────────────────────────────────────────────────────────────────────────────────────────────────

  ───────────────────────────────────────────────────────────────────────────────────
                Trixi.jl                      Time                   Allocations
                                      ──────────────────────   ───────────────────────
            Tot / % measured:              37.1s / 91.9%           6.93GiB / 98.9%

  Section                    ncalls     time   %tot     avg     alloc   %tot      avg
  ───────────────────────────────────────────────────────────────────────────────────
  rhs!                        2.31k    33.9s  99.4%  14.7ms   6.83GiB  100%   3.03MiB
    entropy_projection!       2.31k    15.2s  44.6%  6.58ms     0.00B  0.00%    0.00B
    calc_volume_integral!     2.31k    14.3s  42.0%  6.20ms   4.12GiB  60.0%  1.83MiB
    calc_sources!             2.31k    2.69s  7.89%  1.17ms   2.71GiB  39.5%  1.20MiB
    calc_interface_flux!      2.31k    1.24s  3.63%   537μs     0.00B  0.00%    0.00B
    calc_surface_integral!    2.31k    254ms  0.75%   110μs     0.00B  0.00%    0.00B
    invert_jacobian           2.31k   76.8ms  0.23%  33.3μs     0.00B  0.00%    0.00B
    ~rhs!~                    2.31k   66.4ms  0.19%  28.8μs   3.07MiB  0.04%  1.36KiB
    Reset du/dt               2.31k   34.7ms  0.10%  15.0μs     0.00B  0.00%    0.00B
    calc_boundary_flux!       2.31k   15.3ms  0.04%  6.65μs     0.00B  0.00%    0.00B
  analyze solution                4    219ms  0.64%  54.8ms   27.7MiB  0.39%  6.93MiB
  ───────────────────────────────────────────────────────────────────────────────────
  ```
- This PR:
  ```
  ────────────────────────────────────────────────────────────────────────────────────────────────────
  Trixi simulation finished.  Final time: 0.5  Time steps: 254 (accepted), 256 (total)
  ────────────────────────────────────────────────────────────────────────────────────────────────────

  ───────────────────────────────────────────────────────────────────────────────────
                Trixi.jl                      Time                   Allocations
                                      ──────────────────────   ───────────────────────
            Tot / % measured:              20.1s / 89.7%           6.79GiB / 98.9%

  Section                    ncalls     time   %tot     avg     alloc   %tot      avg
  ───────────────────────────────────────────────────────────────────────────────────
  rhs!                        2.31k    17.9s  99.1%  7.76ms   6.69GiB  100%   2.97MiB
    calc_volume_integral!     2.31k    13.1s  72.4%  5.67ms   4.12GiB  61.3%  1.83MiB
    calc_sources!             2.31k    2.14s  11.8%   927μs   2.57GiB  38.3%  1.14MiB
    entropy_projection!       2.31k    1.25s  6.92%   542μs     0.00B  0.00%    0.00B
    calc_interface_flux!      2.31k    1.12s  6.22%   487μs     0.00B  0.00%    0.00B
    calc_surface_integral!    2.31k    169ms  0.93%  73.1μs     0.00B  0.00%    0.00B
    invert_jacobian           2.31k   60.3ms  0.33%  26.1μs     0.00B  0.00%    0.00B
    Reset du/dt               2.31k   33.6ms  0.19%  14.6μs     0.00B  0.00%    0.00B
    ~rhs!~                    2.31k   31.2ms  0.17%  13.5μs   2.75MiB  0.04%  1.22KiB
    calc_boundary_flux!       2.31k   12.5ms  0.07%  5.44μs     0.00B  0.00%    0.00B
  analyze solution                4    171ms  0.95%  42.7ms   27.5MiB  0.40%  6.89MiB
  ───────────────────────────────────────────────────────────────────────────────────
  ```
- This PR with my [performance fixes for StructArrays.jl](https://github.com/JuliaArrays/StructArrays.jl/pull/194):
  ```
  ────────────────────────────────────────────────────────────────────────────────────────────────────
  Trixi simulation finished.  Final time: 0.5  Time steps: 254 (accepted), 256 (total)
  ────────────────────────────────────────────────────────────────────────────────────────────────────

  ───────────────────────────────────────────────────────────────────────────────────
                Trixi.jl                      Time                   Allocations
                                      ──────────────────────   ───────────────────────
            Tot / % measured:              14.0s / 96.0%           11.1MiB / 75.7%

  Section                    ncalls     time   %tot     avg     alloc   %tot      avg
  ───────────────────────────────────────────────────────────────────────────────────
  rhs!                        2.31k    13.3s  99.0%  5.77ms   2.75MiB  32.8%  1.22KiB
    calc_volume_integral!     2.31k    10.3s  76.8%  4.47ms     0.00B  0.00%    0.00B
    entropy_projection!       2.31k    1.24s  9.23%   538μs     0.00B  0.00%    0.00B
    calc_interface_flux!      2.31k    1.15s  8.55%   498μs     0.00B  0.00%    0.00B
    calc_sources!             2.31k    320ms  2.38%   139μs     0.00B  0.00%    0.00B
    calc_surface_integral!    2.31k    149ms  1.11%  64.5μs     0.00B  0.00%    0.00B
    invert_jacobian           2.31k   58.7ms  0.44%  25.5μs     0.00B  0.00%    0.00B
    ~rhs!~                    2.31k   30.1ms  0.22%  13.1μs   2.75MiB  32.8%  1.22KiB
    Reset du/dt               2.31k   28.7ms  0.21%  12.4μs     0.00B  0.00%    0.00B
    calc_boundary_flux!       2.31k   11.7ms  0.09%  5.07μs     0.00B  0.00%    0.00B
  analyze solution                4    129ms  0.96%  32.1ms   5.64MiB  67.2%  1.41MiB
  ───────────────────────────────────────────────────────────────────────────────────
  ```

CC @sloede for approving the general strategy of performance optimizations specific to combinations of the solver/equations.