### PR TITLE
reexport StructArrays

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -47,7 +47,7 @@ using SparseArrays: sparse, droptol!, rowvals, nzrange, AbstractSparseMatrix
 @reexport using StaticArrays: SVector
 using StaticArrays: MVector, MArray, SMatrix
 using StrideArrays: PtrArray, StrideArray, StaticInt
-using StructArrays: StructArrays, StructArray
+@reexport using StructArrays: StructArrays, StructArray
 using TimerOutputs: TimerOutputs, @notimeit, TimerOutput, print_timer, reset_timer!
 using Triangulate: Triangulate, TriangulateIO, triangulate
 using TriplotBase: TriplotBase


### PR DESCRIPTION
Exports `StructArrays` and `StructArray`, which is useful for manipulating and examining solutions after running a `DGMulti` elixir. 