### PR TITLE
Make Coveralls great again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,26 +125,66 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
-      # Coveralls is disabled since it is just annoying for parallel builds, see, e.g.,
+      # The standard setup of Coveralls is just annoying for parallel builds, see, e.g.,
       # https://github.com/trixi-framework/Trixi.jl/issues/691
       # https://github.com/coverallsapp/github-action/issues/47
       # https://github.com/coverallsapp/github-action/issues/67
-      # - uses: coverallsapp/github-action@master
+      # This standard setup is reproduced below for completeness.
       #   with:
       #     github-token: ${{ secrets.GITHUB_TOKEN }}
       #     flag-name: run-${{ matrix.trixi_test }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-${{ github.run_id }}
       #     parallel: true
       #     path-to-lcov: ./lcov.info
+      # Instead, we use a more tedious approach:
+      # - Store all inidvidual coverage files as artifacts (directly below)
+      # - Download and merge individual coverage reports in another step
+      # - Upload only the merged coverage report to Coveralls
+      - shell: bash
+        run: |
+          cp ./lcov.info ./lcov-${{ matrix.trixi_test }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}.info
+      - uses: actions/upload-artifact@v2
+        with:
+          name: lcov-${{ matrix.trixi_test }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}
+          path: ./lcov-${{ matrix.trixi_test }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}.info
 
   finish:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      # Coveralls is disabled since it is just annoying for parallel builds,
-      # see https://github.com/trixi-framework/Trixi.jl/issues/691
+      # The standard setup of Coveralls is just annoying for parallel builds, see, e.g.,
+      # https://github.com/trixi-framework/Trixi.jl/issues/691
+      # https://github.com/coverallsapp/github-action/issues/47
+      # https://github.com/coverallsapp/github-action/issues/67
+      # This standard setup is reproduced below for completeness.
       # - name: Coveralls Finished
       #   uses: coverallsapp/github-action@master
       #   with:
       #     github-token: ${{ secrets.GITHUB_TOKEN }}
       #     parallel-finished: true
+      # Instead, we use the more tedious approach described above.
+      # At first, we download th source files and all artifacts 
+      # (and list files for debugging).
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+      - run: ls -R
+      # Next, we merge the individual converage files and upload 
+      # the combined results to Coveralls.
+      - name: Merge lcov files using Coverage.jl
+        shell: julia --color=yes --project=. {0}
+        run: |
+          using Pkg
+          Pkg.add("Coverage")
+          using Coverage
+          coverage = LCOV.readfolder(".")
+          for cov in coverage
+            cov.filename = replace(cov.filename, "\\" => "/")
+          end
+          coverage = merge_coverage_counts(coverage)
+          @show covered_lines, total_lines = get_summary(coverage)
+          LCOV.writefile("./lcov.info", coverage)
+      - uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./lcov.info
+      # That's it
       - run: echo "Finished testing Trixi"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       #     parallel: true
       #     path-to-lcov: ./lcov.info
       # Instead, we use a more tedious approach:
-      # - Store all inidvidual coverage files as artifacts (directly below)
+      # - Store all individual coverage files as artifacts (directly below)
       # - Download and merge individual coverage reports in another step
       # - Upload only the merged coverage report to Coveralls
       - shell: bash
@@ -162,12 +162,12 @@ jobs:
       #     github-token: ${{ secrets.GITHUB_TOKEN }}
       #     parallel-finished: true
       # Instead, we use the more tedious approach described above.
-      # At first, we download th source files and all artifacts 
+      # At first, we check out the repository and download all artifacts
       # (and list files for debugging).
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
       - run: ls -R
-      # Next, we merge the individual converage files and upload 
+      # Next, we merge the individual coverage files and upload
       # the combined results to Coveralls.
       - name: Merge lcov files using Coverage.jl
         shell: julia --color=yes --project=. {0}

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 [![Slack](https://img.shields.io/badge/chat-slack-e01e5a)](https://join.slack.com/t/trixi-framework/shared_invite/zt-sgkc6ppw-6OXJqZAD5SPjBYqLd8MU~g)
 [![Build Status](https://github.com/trixi-framework/Trixi.jl/workflows/CI/badge.svg)](https://github.com/trixi-framework/Trixi.jl/actions?query=workflow%3ACI)
 [![Codecov](https://codecov.io/gh/trixi-framework/Trixi.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/trixi-framework/Trixi.jl)
+[![Coveralls](https://coveralls.io/repos/github/trixi-framework/Trixi.jl/badge.svg?branch=main)](https://coveralls.io/github/trixi-framework/Trixi.jl?branch=main)
 [![License: MIT](https://img.shields.io/badge/License-MIT-success.svg)](https://opensource.org/licenses/MIT)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3996439.svg)](https://doi.org/10.5281/zenodo.3996439)
 <!-- [![GitHub commits since tagged version](https://img.shields.io/github/commits-since/trixi-framework/Trixi.jl/v0.3.43.svg?style=social&logo=github)](https://github.com/trixi-framework/Trixi.jl) -->
 <!-- [![PkgEval](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/T/Trixi.svg)](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/report.html) -->
-<!-- [![Coveralls](https://coveralls.io/repos/github/trixi-framework/Trixi.jl/badge.svg?branch=main)](https://coveralls.io/github/trixi-framework/Trixi.jl?branch=main) -->
 
 <p align="center">
   <img width="300px" src="docs/src/assets/logo.png">


### PR DESCRIPTION
This makes Coveralls with parallel builds not annoying anymore.

TODO:
- [x] Update required CI checks
- [x] Add Coveralls badge to README.md