### PR TITLE
make all using statements explicit

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -24,26 +24,26 @@ using Printf: @printf, @sprintf, println
 # import @reexport now to make it available for further imports/exports
 using Reexport: @reexport
 
-import DiffEqBase: @muladd, CallbackSet, DiscreteCallback,
-                   ODEProblem, ODESolution, ODEFunction,
-                   get_du, get_tmp_cache, u_modified!,
-                   get_proposed_dt, set_proposed_dt!, terminate!, remake
+using DiffEqBase: @muladd, CallbackSet, DiscreteCallback,
+                  ODEProblem, ODESolution, ODEFunction,
+                  get_du, get_tmp_cache, u_modified!,
+                  get_proposed_dt, set_proposed_dt!, terminate!, remake
 using CodeTracking: code_string
 @reexport using EllipsisNotation # ..
-import ForwardDiff
+using ForwardDiff: ForwardDiff
 using HDF5: h5open, attributes
 using LinearMaps: LinearMap
 using LoopVectorization: LoopVectorization, @turbo, indices
 using LoopVectorization.ArrayInterface: static_length
-import MPI
+using MPI: MPI
 using GeometryBasics: GeometryBasics
 using Octavian: matmul!
 using Polyester: @batch # You know, the cheapest threads you can find...
 using OffsetArrays: OffsetArray, OffsetVector
 using P4est
-using RecipesBase
-using Requires
-using SparseArrays: sparse, droptol!, rowvals, nzrange, AbstractSparseMatrix
+using RecipesBase: RecipesBase
+using Requires: @require
+using SparseArrays: AbstractSparseMatrix, sparse, droptol!, rowvals, nzrange
 @reexport using StaticArrays: SVector
 using StaticArrays: MVector, MArray, SMatrix
 using StrideArrays: PtrArray, StrideArray, StaticInt

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -42,7 +42,7 @@ using Octavian: matmul!
 using Polyester: @batch # You know, the cheapest threads you can find...
 using OffsetArrays: OffsetArray, OffsetVector
 using P4est
-using RecipesBase: RecipesBase, @series
+using RecipesBase: RecipesBase, @recipe, @series
 using Requires: @require
 using SparseArrays: AbstractSparseMatrix, sparse, droptol!, rowvals, nzrange
 @reexport using StaticArrays: SVector

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -42,7 +42,7 @@ using Octavian: matmul!
 using Polyester: @batch # You know, the cheapest threads you can find...
 using OffsetArrays: OffsetArray, OffsetVector
 using P4est
-using RecipesBase: RecipesBase
+using RecipesBase: RecipesBase, @series
 using Requires: @require
 using SparseArrays: AbstractSparseMatrix, sparse, droptol!, rowvals, nzrange
 @reexport using StaticArrays: SVector

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -25,9 +25,10 @@ using Printf: @printf, @sprintf, println
 using Reexport: @reexport
 
 using DiffEqBase: @muladd, CallbackSet, DiscreteCallback,
-                  ODEProblem, ODESolution, ODEFunction,
-                  get_du, get_tmp_cache, u_modified!,
-                  get_proposed_dt, set_proposed_dt!, terminate!, remake
+                  ODEProblem, ODESolution, ODEFunction
+import DiffEqBase: get_du, get_tmp_cache, u_modified!,
+                   get_proposed_dt, set_proposed_dt!, 
+                   terminate!, remake
 using CodeTracking: code_string
 @reexport using EllipsisNotation # ..
 using ForwardDiff: ForwardDiff

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -27,7 +27,7 @@ using Reexport: @reexport
 using DiffEqBase: @muladd, CallbackSet, DiscreteCallback,
                   ODEProblem, ODESolution, ODEFunction
 import DiffEqBase: get_du, get_tmp_cache, u_modified!,
-                   get_proposed_dt, set_proposed_dt!, 
+                   get_proposed_dt, set_proposed_dt!,
                    terminate!, remake
 using CodeTracking: code_string
 @reexport using EllipsisNotation # ..
@@ -42,7 +42,7 @@ using Octavian: matmul!
 using Polyester: @batch # You know, the cheapest threads you can find...
 using OffsetArrays: OffsetArray, OffsetVector
 using P4est
-using RecipesBase: RecipesBase, @recipe, @series
+using RecipesBase: RecipesBase
 using Requires: @require
 using SparseArrays: AbstractSparseMatrix, sparse, droptol!, rowvals, nzrange
 @reexport using StaticArrays: SVector

--- a/src/visualization/recipes_plots.jl
+++ b/src/visualization/recipes_plots.jl
@@ -128,7 +128,7 @@ RecipesBase.@recipe function f(pd::AbstractPlotData)
 
   # Plot all existing variables
   for (i, (variable_name, series)) in enumerate(pd)
-    @series begin
+    RecipesBase.@series begin
       subplot := i
       series
     end
@@ -136,7 +136,7 @@ RecipesBase.@recipe function f(pd::AbstractPlotData)
 
   # Fill remaining subplots with empty plot
   for i in (length(pd)+1):(rows*cols)
-    @series begin
+    RecipesBase.@series begin
       subplot := i
       axis := false
       ticks := false
@@ -243,7 +243,7 @@ RecipesBase.@recipe function f(pds::PlotDataSeries{<:UnstructuredPlotData2D})
 end
 
 # Visualize a 2D mesh given an `UnstructuredPlotData2D` object
-@recipe function f(pm::PlotMesh{<:UnstructuredPlotData2D})
+RecipesBase.@recipe function f(pm::PlotMesh{<:UnstructuredPlotData2D})
   pd = pm.plot_data
   @unpack x_face, y_face = pd
 


### PR DESCRIPTION
This PR makes all `using` statements explicit. Additionally, it serves as a test of the new Coveralls integration.