### PR TITLE
Adding Makie colorbars

### DIFF
--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -415,5 +415,5 @@ Both `plot` and `iplot` use `colormap = :inferno` by default.
 by providing an appropriate keyword argument. For example, `plot(sol, colormap=:blues)` and
 `iplot(sol, colormap=:blues)` produce the following figures:
 
-![makie-plot-example](https://user-images.githubusercontent.com/1156048/131539853-2ab51c33-5fd3-4d3b-a49b-3b1de8f63a98.png)
+![makie-plot-example](https://user-images.githubusercontent.com/1156048/132954265-e7d395a8-f894-4056-841b-87711b7ba012.png)
 ![makie-iplot-example](https://user-images.githubusercontent.com/1156048/131613266-8a86a074-62fb-49d6-bf6b-8df94d2a9b65.png)

--- a/src/visualization/recipes_makie.jl
+++ b/src/visualization/recipes_makie.jl
@@ -126,7 +126,7 @@ function Makie.plot!(myplot::TrixiHeatmap)
   pd = pds.plot_data
   solution_z = vec(StructArrays.component(pd.data, variable_id))
   Makie.mesh!(myplot, plotting_mesh, color=solution_z, shading=false, colormap=myplot[:colormap])
-  myplot.colorrange=extrema(solution_z)
+  myplot.colorrange = extrema(solution_z)
 
   # Makie hides keyword arguments within `myplot`; see also
   # https://github.com/JuliaPlots/Makie.jl/issues/837#issuecomment-845985070

--- a/src/visualization/recipes_makie.jl
+++ b/src/visualization/recipes_makie.jl
@@ -149,7 +149,7 @@ Makie.plottype(::Trixi.PlotDataSeries{<:Trixi.UnstructuredPlotData2D}) = TrixiHe
 
 # Makie does not yet support layouts in its plot recipes, so we overload `Makie.plot` directly.
 function Makie.plot(sol::TrixiODESolution;
-                    plot_mesh=true, solution_variables=nothing, colormap=default_Makie_colormap())
+                    plot_mesh=false, solution_variables=nothing, colormap=default_Makie_colormap())
   return Makie.plot(PlotData2D(sol; solution_variables); plot_mesh, colormap)
 end
 
@@ -175,14 +175,14 @@ function Base.iterate(fa::FigureAndAxes, state=1)
 end
 
 function Makie.plot(pd::UnstructuredPlotData2D, fig=Makie.Figure();
-                    plot_mesh=true, colormap=default_Makie_colormap())
+                    plot_mesh=false, colormap=default_Makie_colormap())
   figAxes = Makie.plot!(fig, pd; plot_mesh, colormap)
   display(figAxes.fig)
   return figAxes
 end
 
 function Makie.plot!(fig, pd::UnstructuredPlotData2D;
-                     plot_mesh=true, colormap=default_Makie_colormap())
+                     plot_mesh=false, colormap=default_Makie_colormap())
   # Create layout that is as square as possible, when there are more than 3 subplots.
   # This is done with a preference for more columns than rows if not.
   if length(pd) <= 3
@@ -194,10 +194,16 @@ function Makie.plot!(fig, pd::UnstructuredPlotData2D;
   end
 
   axes = [Makie.Axis(fig[i,j], xlabel="x", ylabel="y") for j in 1:rows, i in 1:cols]
+  row_list, col_list = [i for j in 1:rows, i in 1:cols], [j for j in 1:rows, i in 1:cols]
 
   for (variable_to_plot, (variable_name, pds)) in enumerate(pd)
     ax = axes[variable_to_plot]
-    trixiheatmap!(ax, pds; plot_mesh, colormap)
+    plt = trixiheatmap!(ax, pds; plot_mesh, colormap)
+
+    row = row_list[variable_to_plot]
+    col = col_list[variable_to_plot]
+    Makie.Colorbar(fig[row, col][1,2], plt)
+
     ax.aspect = Makie.DataAspect() # equal aspect ratio
     ax.title  = variable_name
     Makie.xlims!(ax, extrema(pd.x))

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -279,7 +279,7 @@ isdir(outdir) && rm(outdir, recursive=true)
   @timed_testset "Makie visualization tests for UnstructuredMesh2D" begin
     @test_nowarn_debug trixi_include(@__MODULE__, joinpath(examples_dir(), "unstructured_2d_dgsem", "elixir_euler_wall_bc.jl"))
     @test_nowarn_debug Trixi.iplot(sol) # test interactive surface plot
-    @test_nowarn_debug Makie.plot(sol) # test heatmap plot
+    @test_nowarn_debug Makie.plot(sol, plot_mesh=true) # test heatmap plot
 
     fa = Makie.plot(sol) # test heatmap plot
     fig, axes = fa # test unpacking/iteration for FigureAndAxes


### PR DESCRIPTION
Should address the first point on https://github.com/trixi-framework/Trixi.jl/issues/818. 

I also made it so Makie recipes don't plot the mesh by default (for consistency with Plots recipes).