### PR TITLE
filter warning in doctest using Measurements

### DIFF
--- a/docs/src/differentiable_programming.md
+++ b/docs/src/differentiable_programming.md
@@ -335,6 +335,11 @@ As an example, let's create a system representing the linear advection equation
 in 1D with an uncertain velocity. Then, we create a semidiscretization using a
 sine wave as initial condition, solve the ODE, and plot the resulting uncertainties
 in the primitive variables.
+
+```@meta
+DocTestFilters = r"[┌│└].*"
+```
+
 ```jldoctest;  output = false
 using Trixi, OrdinaryDiffEq, Measurements, Plots, LaTeXStrings
 
@@ -356,6 +361,10 @@ plot(sol)
 # output
 
 Plot{Plots.GRBackend() n=1}
+```
+
+```@meta
+DocTestFilters = nothing
 ```
 
 You should see a plot like the following, where small error bars are shown around

--- a/docs/src/differentiable_programming.md
+++ b/docs/src/differentiable_programming.md
@@ -336,11 +336,7 @@ in 1D with an uncertain velocity. Then, we create a semidiscretization using a
 sine wave as initial condition, solve the ODE, and plot the resulting uncertainties
 in the primitive variables.
 
-```@meta
-DocTestFilters = r"[┌│└].*"
-```
-
-```jldoctest;  output = false
+```jldoctest; output = false, filter = r"[┌│└].*"
 using Trixi, OrdinaryDiffEq, Measurements, Plots, LaTeXStrings
 
 equations = LinearScalarAdvectionEquation1D(1.0 ± 0.1);
@@ -361,10 +357,6 @@ plot(sol)
 # output
 
 Plot{Plots.GRBackend() n=1}
-```
-
-```@meta
-DocTestFilters = nothing
 ```
 
 You should see a plot like the following, where small error bars are shown around


### PR DESCRIPTION
This will be necessary for newer versions of LoopVectorization.jl, see #832 (which will not be merged because of problems with Polyester v0.4 - #832 is effectively superseded by #853)