### PR TITLE
WIP Enable Makie plots from PlotData2D objects

### DIFF
--- a/src/visualization/recipes_makie.jl
+++ b/src/visualization/recipes_makie.jl
@@ -23,10 +23,14 @@ Inputs:
     This is an experimental feature and may change in future releases.
 """
 function iplot(pd::PlotData2DTriangulated;
-               solution_variables=nothing, variable_to_plot_in=1,
+               solution_variables=nothing, nvisnodes=nothing, variable_to_plot_in=1,
                colormap = default_Makie_colormap())
 
   @unpack variable_names = pd
+
+  if nvisnodes == nothing
+    nvisnodes = 2*sqrt(size(pd.x, 1))
+  end
 
   # Initialize a Makie figure that we'll add the solution and toggle switches to.
   fig = Makie.Figure()
@@ -61,7 +65,7 @@ function iplot(pd::PlotData2DTriangulated;
   solution_z = Makie.@lift(getindex.($plotting_mesh.position, 3))
 
   # Plot the actual solution.
-  Makie.mesh!(ax, plotting_mesh; color=solution_z, 2*sqrt(size(pd.x,1)), colormap)
+  Makie.mesh!(ax, plotting_mesh; color=solution_z, nvisnodes, colormap)
 
   # Create a mesh overlay by plotting a mesh both on top of and below the solution contours.
   wire_points = Makie.@lift(mesh_plotting_wireframe(getindex(pd, variable_names[$(menu.selection)])))
@@ -105,7 +109,7 @@ function iplot(u, mesh, equations, solver, cache;
                colormap = default_Makie_colormap())
 
   @assert ndims(mesh) == 2
-  pd = PlotData2D(u, mesh, equations, solver, cache;
+  pd = PlotData2DTriangulated(u, mesh, equations, solver, cache;
                   solution_variables=solution_variables, nvisnodes=nvisnodes)
 
   iplot(pd; solution_variables, variable_to_plot_in, colormap)

--- a/src/visualization/recipes_makie.jl
+++ b/src/visualization/recipes_makie.jl
@@ -22,16 +22,11 @@ Inputs:
 !!! warning "Experimental implementation"
     This is an experimental feature and may change in future releases.
 """
-function iplot(u, mesh::UnstructuredMesh2D, equations, solver, cache;
-               solution_variables=nothing, nvisnodes=2*nnodes(solver), variable_to_plot_in=1,
+function iplot(pd::PlotData2DTriangulated;
+               solution_variables=nothing, variable_to_plot_in=1,
                colormap = default_Makie_colormap())
 
-  pd = PlotData2D(u, mesh, equations, solver, cache;
-                  solution_variables=solution_variables, nvisnodes=nvisnodes)
-
   @unpack variable_names = pd
-
-  @assert ndims(mesh) == 2
 
   # Initialize a Makie figure that we'll add the solution and toggle switches to.
   fig = Makie.Figure()
@@ -66,7 +61,7 @@ function iplot(u, mesh::UnstructuredMesh2D, equations, solver, cache;
   solution_z = Makie.@lift(getindex.($plotting_mesh.position, 3))
 
   # Plot the actual solution.
-  Makie.mesh!(ax, plotting_mesh; color=solution_z, nvisnodes, colormap)
+  Makie.mesh!(ax, plotting_mesh; color=solution_z, 2*sqrt(size(pd.x,1)), colormap)
 
   # Create a mesh overlay by plotting a mesh both on top of and below the solution contours.
   wire_points = Makie.@lift(mesh_plotting_wireframe(getindex(pd, variable_names[$(menu.selection)])))
@@ -105,6 +100,21 @@ end
 # redirect `iplot(sol)` to dispatchable `iplot` signature.
 iplot(sol::TrixiODESolution; kwargs...) = iplot(sol.u[end], sol.prob.p; kwargs...)
 iplot(u, semi; kwargs...) = iplot(wrap_array_native(u, semi), mesh_equations_solver_cache(semi)...; kwargs...)
+function iplot(u, mesh, equations, solver, cache;
+               solution_variables=nothing, nvisnodes=2*nnodes(solver), variable_to_plot_in=1,
+               colormap = default_Makie_colormap())
+
+  @assert ndims(mesh) == 2
+  pd = PlotData2D(u, mesh, equations, solver, cache;
+                  solution_variables=solution_variables, nvisnodes=nvisnodes)
+
+  iplot(pd; solution_variables, variable_to_plot_in, colormap)
+end
+
+
+
+
+
 
 
 # ================== new Makie plot recipes ====================

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -231,7 +231,12 @@ PlotData2D(u_ode, semi; kwargs...) = PlotData2D(wrap_array_native(u_ode, semi),
                                                 mesh_equations_solver_cache(semi)...;
                                                 kwargs...)
 
-function PlotData2D(u, mesh::TreeMesh, equations, solver, cache;
+PlotData2DTriangulated(u_ode, semi; kwargs...) = PlotData2DTriangulated(wrap_array_native(u_ode, semi),
+                                                                        mesh_equations_solver_cache(semi)...;
+                                                                        kwargs...)
+
+
+function PlotData2DCartesian(u, mesh::TreeMesh, equations, solver, cache;
                     solution_variables=nothing,
                     grid_lines=true, max_supported_level=11, nvisnodes=nothing,
                     slice=:xy, point=(0.0, 0.0, 0.0))
@@ -272,6 +277,15 @@ returns a `DiffEqBase.ODESolution`) or Trixi's own `solve!` (which returns a
     This is an experimental feature and may change in future releases.
 """
 PlotData2D(sol::TrixiODESolution; kwargs...) = PlotData2D(sol.u[end], sol.prob.p; kwargs...)
+PlotData2DTriangulated(sol::TrixiODESolution; kwargs...) = PlotData2DTriangulated(sol.u[end], sol.prob.p; kwargs...)
+
+function PlotData2D(u, mesh, equations, solver, cache, kwargs...)
+  if get_name(mesh) == "TreeMesh"
+    return PlotData2DCartesian(u, mesh, equations, solver, cache, kwargs...)
+  else
+    return PlotData2DTriangulated(u, mesh, equations, solver, cache, kwargs...)
+  end
+end
 
 
 # If `u` is an `Array{<:SVectors}` and not a `StructArray`, convert it to a `StructArray` first.
@@ -332,7 +346,7 @@ end
 
 # specializes the PlotData2D constructor to return an PlotData2DTriangulated if the mesh is
 # a non-TreeMesh type.
-function PlotData2D(u, mesh::Union{StructuredMesh, UnstructuredMesh2D, P4estMesh}, equations, dg, cache;
+function PlotData2DTriangulated(u, mesh, equations, dg, cache;
                     solution_variables=nothing, nvisnodes=2*polydeg(dg))
   @assert ndims(mesh) == 2
 

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -235,6 +235,7 @@ PlotData2DTriangulated(u_ode, semi; kwargs...) = PlotData2DTriangulated(wrap_arr
                                                                         mesh_equations_solver_cache(semi)...;
                                                                         kwargs...)
 
+PlotData2D(u, mesh::TreeMesh, equations, solver, cache; kwargs...) = PlotData2DCartesian(u, mesh::TreeMesh, equations, solver, cache; kwargs...)
 
 function PlotData2DCartesian(u, mesh::TreeMesh, equations, solver, cache;
                     solution_variables=nothing,

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -280,6 +280,7 @@ returns a `DiffEqBase.ODESolution`) or Trixi's own `solve!` (which returns a
 PlotData2D(sol::TrixiODESolution; kwargs...) = PlotData2D(sol.u[end], sol.prob.p; kwargs...)
 PlotData2DTriangulated(sol::TrixiODESolution; kwargs...) = PlotData2DTriangulated(sol.u[end], sol.prob.p; kwargs...)
 
+# Create a PlotData2DCartesian if the mesh is a TreeMesh; else create a PlotData2DTriangulated.
 function PlotData2D(u, mesh, equations, solver, cache; kwargs...)
   if get_name(mesh) == "TreeMesh"
     return PlotData2DCartesian(u, mesh, equations, solver, cache; kwargs...)

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -280,11 +280,11 @@ returns a `DiffEqBase.ODESolution`) or Trixi's own `solve!` (which returns a
 PlotData2D(sol::TrixiODESolution; kwargs...) = PlotData2D(sol.u[end], sol.prob.p; kwargs...)
 PlotData2DTriangulated(sol::TrixiODESolution; kwargs...) = PlotData2DTriangulated(sol.u[end], sol.prob.p; kwargs...)
 
-function PlotData2D(u, mesh, equations, solver, cache, kwargs...)
+function PlotData2D(u, mesh, equations, solver, cache; kwargs...)
   if get_name(mesh) == "TreeMesh"
-    return PlotData2DCartesian(u, mesh, equations, solver, cache, kwargs...)
+    return PlotData2DCartesian(u, mesh, equations, solver, cache; kwargs...)
   else
-    return PlotData2DTriangulated(u, mesh, equations, solver, cache, kwargs...)
+    return PlotData2DTriangulated(u, mesh, equations, solver, cache; kwargs...)
   end
 end
 


### PR DESCRIPTION
This PR makes it possible to create an interactive Makie plot (compare #613 and #755) from a PlotData2DTriangulated object., which also allows mesh types other then UnstructruedMesh2D.

For example:
1. "p4est_2d_dgsem/elixir_advection_amr_unstructured_flag.jl":
![image](https://user-images.githubusercontent.com/72009492/133638416-f83fb614-7cca-480f-906e-31d4e42d4bbd.png)

2. "tree_2d_dgsem/elixir_euler_blast_wave.jl":
![image](https://user-images.githubusercontent.com/72009492/133652519-9a4f67cc-90ec-4968-876e-15dd74702fa0.png)