### PR TITLE
Simplify `source_terms_convergence_test` of Euler manufactured solution

### DIFF
--- a/examples/structured_2d_dgsem/elixir_euler_source_terms_rotated.jl
+++ b/examples/structured_2d_dgsem/elixir_euler_source_terms_rotated.jl
@@ -34,17 +34,7 @@ function (initial_condition::InitialConditionSourceTermsRotated)(x, t, equations
   x1 =  cos_ * x[1] + sin_ * x[2] + 1
   x2 = -sin_ * x[1] + cos_ * x[2] + 1
 
-  c = 2
-  A = 0.1
-  L = 2
-  f = 1/L
-  ω = 2 * pi * f
-  ini = c + A * sin(ω * (x1 + x2 - t))
-
-  rho = ini
-  rho_v1 = ini
-  rho_v2 = ini
-  rho_e = ini^2
+  rho, rho_v1, rho_v2, rho_e = initial_condition_convergence_test(SVector(x1, x2), t, equations)
 
   # Rotate velocity vector counterclockwise
   # Multiply with [ cos(α)  -sin(α);
@@ -68,35 +58,7 @@ end
   x1 =  cos_ * x[1] + sin_ * x[2] + 1
   x2 = -sin_ * x[1] + cos_ * x[2] + 1
 
-  # Same settings as in `initial_condition`
-  c = 2
-  A = 0.1
-  L = 2
-  f = 1/L
-  ω = 2 * pi * f
-  γ = equations.gamma
-
-  si, co = sincos((x1 + x2 - t)*ω)
-  tmp1 = co * A * ω
-  tmp2 = si * A
-  tmp3 = γ - 1
-  tmp4 = (2*c - 1)*tmp3
-  tmp5 = (2*tmp2*γ - 2*tmp2 + tmp4 + 1)*tmp1
-  tmp6 = tmp2 + c
-
-  du1 = tmp1
-  du2 = tmp5
-  du3 = tmp5
-  du4 = 2*((tmp6 - 1)*tmp3 + tmp6*γ)*tmp1
-
-  # Original terms (without performanc enhancements)
-  # du1 = cos((x1 + x2 - t)*ω)*A*ω
-  # du2 = (2*sin((x1 + x2 - t)*ω)*A*γ - 2*sin((x1 + x2 - t)*ω)*A +
-  #                             2*c*γ - 2*c - γ + 2)*cos((x1 + x2 - t)*ω)*A*ω
-  # du3 = (2*sin((x1 + x2 - t)*ω)*A*γ - 2*sin((x1 + x2 - t)*ω)*A +
-  #                             2*c*γ - 2*c - γ + 2)*cos((x1 + x2 - t)*ω)*A*ω
-  # du3 = 2*((c - 1 + sin((x1 + x2 - t)*ω)*A)*(γ - 1) +
-  #                             (sin((x1 + x2 - t)*ω)*A + c)*γ)*cos((x1 + x2 - t)*ω)*A*ω
+  du1, du2, du3, du4 = source_terms_convergence_test(u, SVector(x1, x2), t, equations)
 
   # Rotate velocity vector counterclockwise
   # Multiply with [ cos(α)  -sin(α);

--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -79,19 +79,16 @@ Source terms used for convergence tests in combination with
 
   x1, = x
 
-  si, co = sincos((t - x1)*ω)
-  tmp = (-((4 * si * A - 4c) + 1) * (γ - 1) * co * A * ω) / 2
+  si, co = sincos(ω * (x1 - t))
+  rho = c + A * si
+  rho_x = ω * A * co
 
+  # Note that d/dt rho = -d/dx rho.
+  # This yields du2 = du3 = d/dx p (derivative of pressure).
+  # Other terms vanish because of v = 1.
   du1 = zero(eltype(u))
-  du2 = tmp
-  du3 = tmp
-
-  # Original terms (without performanc enhancements)
-  # du1 = 0
-  # du2 = (-(((4 * sin((t - x1) * ω) * A - 4c) + 1)) *
-  #                          (γ - 1) * cos((t - x1) * ω) * A * ω) / 2
-  # du3 = (-(((4 * sin((t - x1) * ω) * A - 4c) + 1)) *
-  #                          (γ - 1) * cos((t - x1) * ω) * A * ω) / 2
+  du2 = rho_x * (2 * rho - 0.5) * (γ - 1)
+  du3 = du2
 
   return SVector(du1, du2, du3)
 end

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -81,27 +81,17 @@ Source terms used for convergence tests in combination with
   γ = equations.gamma
 
   x1, x2 = x
-  si, co = sincos((x1 + x2 - t)*ω)
-  tmp1 = co * A * ω
-  tmp2 = si * A
-  tmp3 = γ - 1
-  tmp4 = (2*c - 1)*tmp3
-  tmp5 = (2*tmp2*γ - 2*tmp2 + tmp4 + 1)*tmp1
-  tmp6 = tmp2 + c
+  si, co = sincos(ω * (x1 + x2 - t))
+  rho = c + A * si
+  rho_x = ω * A * co
+  # Note that d/dt rho = -d/dx rho = -d/dy rho.
 
-  du1 = tmp1
-  du2 = tmp5
-  du3 = tmp5
-  du4 = 2*((tmp6 - 1)*tmp3 + tmp6*γ)*tmp1
+  tmp = (2 * rho - 1) * (γ - 1)
 
-  # Original terms (without performanc enhancements)
-  # du1 = cos((x1 + x2 - t)*ω)*A*ω
-  # du2 = (2*sin((x1 + x2 - t)*ω)*A*γ - 2*sin((x1 + x2 - t)*ω)*A +
-  #                             2*c*γ - 2*c - γ + 2)*cos((x1 + x2 - t)*ω)*A*ω
-  # du3 = (2*sin((x1 + x2 - t)*ω)*A*γ - 2*sin((x1 + x2 - t)*ω)*A +
-  #                             2*c*γ - 2*c - γ + 2)*cos((x1 + x2 - t)*ω)*A*ω
-  # du3 = 2*((c - 1 + sin((x1 + x2 - t)*ω)*A)*(γ - 1) +
-  #                             (sin((x1 + x2 - t)*ω)*A + c)*γ)*cos((x1 + x2 - t)*ω)*A*ω
+  du1 = rho_x
+  du2 = rho_x * (1 + tmp)
+  du3 = du2
+  du4 = 2 * rho_x * (rho + tmp)
 
   return SVector(du1, du2, du3, du4)
 end

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -81,24 +81,18 @@ Source terms used for convergence tests in combination with
   γ = equations.gamma
 
   x1, x2, x3 = x
-  si, co = sincos(((x1 + x2 + x3) - t) * ω)
-  tmp1 = si * A
-  tmp2 = co * A * ω
-  tmp3 = ((((((4 * tmp1 * γ - 4 * tmp1) + 4 * c * γ) - 4c) - 3γ) + 7) * tmp2) / 2
+  si, co = sincos(ω * (x1 + x2 + x3 - t))
+  rho = c + A * si
+  rho_x = ω * A * co
+  # Note that d/dt rho = -d/dx rho = -d/dy rho = - d/dz rho.
 
-  du1 = 2 * tmp2
-  du2 = tmp3
-  du3 = tmp3
-  du4 = tmp3
-  du5 = ((((((12 * tmp1 * γ - 4 * tmp1) + 12 * c * γ) - 4c) - 9γ) + 9) * tmp2) / 2
+  tmp = (2 * rho - 1.5) * (γ - 1)
 
-  # Original terms (without performance enhancements)
-  # tmp2 = ((((((4 * sin(((x1 + x2 + x3) - t) * ω) * A * γ - 4 * sin(((x1 + x2 + x3) - t) * ω) * A) + 4 * c * γ) - 4c) - 3γ) + 7) * cos(((x1 + x2 + x3) - t) * ω) * A * ω) / 2
-  # du1 = 2 * cos(((x1 + x2 + x3) - t) * ω) * A * ω
-  # du2 = tmp2
-  # du3 = tmp2
-  # du4 = tmp2
-  # du5 = ((((((12 * sin(((x1 + x2 + x3) - t) * ω) * A * γ - 4 * sin(((x1 + x2 + x3) - t) * ω) * A) + 12 * c * γ) - 4c) - 9γ) + 9) * cos(((x1 + x2 + x3) - t) * ω) * A * ω) / 2
+  du1 = 2 * rho_x
+  du2 = rho_x * (2 + tmp)
+  du3 = du2
+  du4 = du2
+  du5 = rho_x * (4 * rho + 3 * tmp)
 
   return SVector(du1, du2, du3, du4, du5)
 end


### PR DESCRIPTION
While copying the initial condition and source terms of the manufactured solution `elixir_euler_source_terms` to my thesis, I tried to simplify the source terms a bit, and after calculating them again by hand, I noticed how simple this manufactured solution actually is.

IMHO, the current implementation of the source terms looks incredibly complicated, and even the “original terms without performance enhancements” are more complicated than they could be.

There's also no reason to duplicate the source terms and IC in the rotated example instead of just calling the functions.

My new (IMO much easier to read) implementations are actually slightly faster than the previous ones:
```
1D before:
julia> @benchmark source_terms_convergence_test($u, $x, $t, $equations)
BechmarkTools.Trial: 10000 samples with 998 evaluations.
 Range (min … max):  15.263 ns … 84.434 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     15.378 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   17.220 ns ±  5.714 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▂▁▃▄   ▃▃                                                  ▁
  ██████▆▇███▆▅▇▆▇▃▅▃▃▄▅▄▅▅▇██▇▇▅▆▆▆█▇▇▆▅▆▇▅▆▅▅▆▆▅▆▅▅▄▅▅▅▄▃▁▅ █
  15.3 ns      Histogram: log(frequency) by time        47 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

1D after:
julia> @benchmark source_terms_convergence_test($u, $x, $t, $equations)
BechmarkTools.Trial: 10000 samples with 998 evaluations.
 Range (min … max):  14.168 ns … 147.304 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     14.204 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   15.799 ns ±   5.700 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▂▂▁     ▂                                                   ▁
  █████▄▆▆▄██▅▅▅▇▅▆▄▄▆▅▅▆▄▄▃▄▄▆▇▇▅▅▄▅▆▄▆▇▇▆▅▅▄▆▆▅▅▅▅▄▅▅▄▅▄▄▄▃▄ █
  14.2 ns       Histogram: log(frequency) by time      43.1 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

2D before:
julia> @benchmark source_terms_convergence_test($u, $x, $t, $equations)
BechmarkTools.Trial: 10000 samples with 999 evaluations.
 Range (min … max):  11.935 ns … 61.952 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     12.176 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.470 ns ±  3.903 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▄▁  ▆▄   ▁▁                                                ▁
  ███▆███▇▅▆██▇▄▆▆▇▅▅▅▅▅▅▅▅▅▅▅▅▅▃▅▆▃▄▁▃▁▃▇▇▆▇▆▅▆▆▆▆▅▅▆▇▆▆▅▅▅▆ █
  11.9 ns      Histogram: log(frequency) by time      33.2 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

2D after:
julia> @benchmark source_terms_convergence_test($u, $x, $t, $equations)
BechmarkTools.Trial: 10000 samples with 999 evaluations.
 Range (min … max):  10.759 ns … 66.640 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     10.895 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   12.244 ns ±  4.523 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▁▃ ▄    ▃                                                  ▁
  ███▇██▇█▇██▄▇▆▅▆▇▆▅▅▅▅▅▄▃▄▄▃▄▁▅▁▄▄▅▅▇██▆▇▄▆▅▆▆▆▅▇█▇▆▆▆▆▆▆▆▅ █
  10.8 ns      Histogram: log(frequency) by time      33.3 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

3D before:
julia> @benchmark source_terms_convergence_test($u, $x, $t, $equations)
BechmarkTools.Trial: 10000 samples with 997 evaluations.
 Range (min … max):  19.368 ns … 105.811 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     24.513 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   28.482 ns ±  11.231 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▅▆▆▇▆▇▅▄▄▄▄▃▃▁▁▁▁▁▁▂▃▃▁▂▂▃▂▃▂▂▂▁▁▂▁▁▁                       ▂
  ████████████████████████████████████████▇▇▇▇▇▇▇▇▇▆▇▇▇▇▆▆▆▅▆▆ █
  19.4 ns       Histogram: log(frequency) by time      69.7 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

3D after:
julia> @benchmark source_terms_convergence_test($u, $x, $t, $equations)
BechmarkTools.Trial: 10000 samples with 998 evaluations.
 Range (min … max):  16.031 ns … 89.385 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     16.420 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   19.098 ns ±  6.578 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▂▃▃▄▃▁ ▁▃▁▁                                                ▁
  ████████████▆▆▇▇▆▆▆▆▅▆▆▅▆█▇▇▆▇▇▇▆█▇▇▆▆▆▆▆▆▆▆▅▄▅▅▅▄▅▆▅▅▅▅▅▄▅ █
  16 ns        Histogram: log(frequency) by time      49.2 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```