### PR TITLE
Implement shallow water equations on TreeMesh2D

### DIFF
--- a/examples/tree_2d_dgsem/elixir_shallowwater_ec.jl
+++ b/examples/tree_2d_dgsem/elixir_shallowwater_ec.jl
@@ -1,0 +1,116 @@
+
+using Downloads: download
+using OrdinaryDiffEq
+using Trixi
+
+###############################################################################
+# semidiscretization of the shallow water equations with a discontinuous
+# bottom topography function
+
+equations = ShallowWaterEquations2D(gravity_constant=9.81)
+
+# Note, this initial condition is used to compute errors in the analysis callback but the initialization is
+# overwritten by `initial_condition_ec_discontinuous_bottom` below.
+initial_condition = initial_condition_weak_blast_wave
+
+###############################################################################
+# Get the DG approximation space
+
+volume_flux = (flux_wintermeyer_etal, flux_nonconservative_wintermeyer_etal)
+solver = DGSEM(polydeg=4, surface_flux=(flux_fjordholm_etal, flux_nonconservative_fjordholm_etal),
+               volume_integral=VolumeIntegralFluxDifferencing(volume_flux))
+
+###############################################################################
+# Get the TreeMesh and setup a periodic mesh
+
+coordinates_min = (-1.0, -1.0)
+coordinates_max = ( 1.0,  1.0)
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level=2,
+                n_cells_max=10_000)
+
+# Create the semi discretization object
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+
+###############################################################################
+# ODE solver
+
+tspan = (0.0, 2.0)
+ode = semidiscretize(semi, tspan)
+
+###############################################################################
+# Workaround to set a discontinuous bottom topography and initial condition for debugging and testing.
+
+# alternative version of the initial conditinon used to setup a truly discontinuous
+# bottom topography function and initial condtion for this academic testcase of entropy conservation.
+# The errors from the analysis callback are not important but `∑∂S/∂U ⋅ Uₜ` should be around machine roundoff
+# In contrast to the usual signature of initial conditions, this one get passed the
+# `element_id` explicitly. In particular, this initial conditions works as intended
+# only for the TreeMesh2D with initial_refinement_level=2.
+function initial_condition_ec_discontinuous_bottom(x, t, element_id, equations::ShallowWaterEquations2D)
+  # Set up polar coordinates
+  inicenter = SVector(0.7, 0.7)
+  x_norm = x[1] - inicenter[1]
+  y_norm = x[2] - inicenter[2]
+  r = sqrt(x_norm^2 + y_norm^2)
+  phi = atan(y_norm, x_norm)
+  sin_phi, cos_phi = sincos(phi)
+
+  # Set the background values
+  H = 4.25
+  v1 = 0.0
+  v2 = 0.0
+  b = 0.0
+
+  # setup the discontinuous water height and velocities
+  if element_id == 10
+    H = 5.0
+    v1 = 0.1882 * cos_phi
+    v2 = 0.1882 * sin_phi
+  end
+
+  # Setup a discontinuous bottom topography using the element id number
+  if element_id == 7
+    b = 2.0 + 0.5 * sin(2.0 * pi * x[1]) + 0.5 * cos(2.0 * pi * x[2])
+  end
+
+  return prim2cons(SVector(H, v1, v2, b), equations)
+end
+
+# point to the data we want to augment
+u = Trixi.wrap_array(ode.u0, semi)
+# reset the initial condition
+for element in eachelement(semi.solver, semi.cache)
+  for j in eachnode(semi.solver), i in eachnode(semi.solver)
+    x_node = Trixi.get_node_coords(semi.cache.elements.node_coordinates, equations, semi.solver, i, j, element)
+    u_node = initial_condition_ec_discontinuous_bottom(x_node, first(tspan), element, equations)
+    Trixi.set_node_vars!(u, u_node, equations, semi.solver, i, j, element)
+  end
+end
+
+###############################################################################
+# Callbacks
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_solution = SaveSolutionCallback(interval=100,
+                                     save_initial_solution=true,
+                                     save_final_solution=true)
+
+stepsize_callback = StepsizeCallback(cfl=3.0)
+
+callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback, save_solution,
+                        stepsize_callback)
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_shallowwater_source_terms.jl
+++ b/examples/tree_2d_dgsem/elixir_shallowwater_source_terms.jl
@@ -25,7 +25,8 @@ coordinates_min = (0.0, 0.0)
 coordinates_max = (sqrt(2.0), sqrt(2.0))
 mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level=3,
-                n_cells_max=10_000)
+                n_cells_max=10_000,
+                periodicity=true)
 
 # create the semi discretization object
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,

--- a/examples/tree_2d_dgsem/elixir_shallowwater_source_terms.jl
+++ b/examples/tree_2d_dgsem/elixir_shallowwater_source_terms.jl
@@ -1,0 +1,59 @@
+
+using Downloads: download
+using OrdinaryDiffEq
+using Trixi
+
+###############################################################################
+# semidiscretization of the compressible Euler equations
+
+equations = ShallowWaterEquations2D(gravity_constant=9.81)
+
+initial_condition = initial_condition_convergence_test # MMS EOC test
+
+
+###############################################################################
+# Get the DG approximation space
+
+volume_flux = (flux_wintermeyer_etal, flux_nonconservative_wintermeyer_etal)
+solver = DGSEM(polydeg=3, surface_flux=(flux_lax_friedrichs, flux_nonconservative_fjordholm_etal),
+               volume_integral=VolumeIntegralFluxDifferencing(volume_flux))
+
+###############################################################################
+# Get the TreeMesh and setup a periodic mesh
+
+coordinates_min = (0.0, 0.0)
+coordinates_max = (sqrt(2.0), sqrt(2.0))
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level=3,
+                n_cells_max=10_000)
+
+# create the semi discretization object
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                    source_terms=source_terms_convergence_test)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 500
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_solution = SaveSolutionCallback(interval=200,
+                                     save_initial_solution=true,
+                                     save_final_solution=true)
+
+callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback, save_solution)
+
+###############################################################################
+# run the simulation
+
+# use a Runge-Kutta method with automatic (error based) time step size control
+sol = solve(ode, RDPK3SpFSAL49(), abstol=1.0e-8, reltol=1.0e-8,
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_shallowwater_well_balanced.jl
+++ b/examples/tree_2d_dgsem/elixir_shallowwater_well_balanced.jl
@@ -1,0 +1,116 @@
+
+using Downloads: download
+using OrdinaryDiffEq
+using Trixi
+
+###############################################################################
+# semidiscretization of the shallow water equations with a discontinuous
+# bottom topography function
+
+equations = ShallowWaterEquations2D(gravity_constant=9.81, H0=3.25)
+
+# An initial condition with constant total water height and zero velocities to test well-balancedness.
+# Note, this routine is used to compute errors in the analysis callback but the initialization is
+# overwritten by `initial_condition_discontinuous_well_balancedness` below.
+function initial_condition_well_balancedness(x, t, equations::ShallowWaterEquations2D)
+  # Set the background values
+  H = equations.H0
+  v1 = 0.0
+  v2 = 0.0
+  # bottom topography taken from Pond.control in [HOHQMesh](https://github.com/trixi-framework/HOHQMesh)
+  x1, x2 = x
+  b = (  1.5 / exp( 0.5 * ((x1 - 1.0)^2 + (x2 - 1.0)^2) )
+       + 0.75 / exp( 0.5 * ((x1 + 1.0)^2 + (x2 + 1.0)^2) ) )
+  return prim2cons(SVector(H, v1, v2, b), equations)
+end
+
+initial_condition = initial_condition_well_balancedness
+
+###############################################################################
+# Get the DG approximation space
+
+volume_flux = (flux_wintermeyer_etal, flux_nonconservative_wintermeyer_etal)
+solver = DGSEM(polydeg=4, surface_flux=(flux_fjordholm_etal, flux_nonconservative_fjordholm_etal),
+               volume_integral=VolumeIntegralFluxDifferencing(volume_flux))
+
+###############################################################################
+# Get the TreeMesh and setup a periodic mesh
+
+coordinates_min = (-1.0, -1.0)
+coordinates_max = ( 1.0,  1.0)
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level=2,
+                n_cells_max=10_000)
+
+# Create the semi discretization object
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+
+###############################################################################
+# ODE solver
+
+tspan = (0.0, 100.0)
+ode = semidiscretize(semi, tspan)
+
+###############################################################################
+# Workaround to set a discontinuous bottom topography and initial condition for debugging and testing.
+
+# alternative version of the initial conditinon used to setup a truly discontinuous
+# bottom topography function for this academic testcase of well-balancedness.
+# The errors from the analysis callback are not important but the error for this lake at rest test case
+# `∑|H0-(h+b)|` should be around machine roundoff
+# In contrast to the usual signature of initial conditions, this one get passed the
+# `element_id` explicitly. In particular, this initial conditions works as intended
+# only for the TreeMesh2D with initial_refinement_level=2.
+function initial_condition_discontinuous_well_balancedness(x, t, element_id, equations::ShallowWaterEquations2D)
+  # Set the background values
+  H = equations.H0
+  v1 = 0.0
+  v2 = 0.0
+  b = 0.0
+
+  # Setup a discontinuous bottom topography using the element id number
+  if element_id == 7
+    b = 2.0 + 0.5 * sin(2.0 * pi * x[1]) + 0.5 * cos(2.0 * pi * x[2])
+  end
+
+  return prim2cons(SVector(H, v1, v2, b), equations)
+end
+
+# point to the data we want to augment
+u = Trixi.wrap_array(ode.u0, semi)
+# reset the initial condition
+for element in eachelement(semi.solver, semi.cache)
+  for j in eachnode(semi.solver), i in eachnode(semi.solver)
+    x_node = Trixi.get_node_coords(semi.cache.elements.node_coordinates, equations, semi.solver, i, j, element)
+    u_node = initial_condition_discontinuous_well_balancedness(x_node, first(tspan), element, equations)
+    Trixi.set_node_vars!(u, u_node, equations, semi.solver, i, j, element)
+  end
+end
+
+###############################################################################
+# Callbacks
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 1000
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval,
+                                     extra_analysis_integrals=(lake_at_rest_error,))
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_solution = SaveSolutionCallback(interval=1000,
+                                     save_initial_solution=true,
+                                     save_final_solution=true)
+
+stepsize_callback = StepsizeCallback(cfl=3.0)
+
+callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback, save_solution,
+                        stepsize_callback)
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/src/equations/shallow_water_2d.jl
+++ b/src/equations/shallow_water_2d.jl
@@ -198,6 +198,26 @@ function boundary_condition_slip_wall(u_inner, normal_direction::AbstractVector,
 end
 
 
+# Calculate 1D flux for a single point
+# Note, the bottom topography has no flux
+@inline function flux(u, orientation::Integer, equations::ShallowWaterEquations2D)
+  h, h_v1, h_v2, _ = u
+  v1, v2 = velocity(u, equations)
+
+  p = 0.5 * equations.gravity * h^2
+  if orientation == 1
+    f1 = h_v1
+    f2 = h_v1 * v1 + p
+    f3 = h_v1 * v2
+  else
+    f1 = h_v2
+    f2 = h_v2 * v1
+    f3 = h_v2 * v2 + p
+  end
+  return SVector(f1, f2, f3, zero(eltype(u)))
+end
+
+
 # Calculate 1D flux for a single point in the normal direction
 # Note, this directional vector is not normalized and the bottom topography has no flux
 @inline function flux(u, normal_direction::AbstractVector, equations::ShallowWaterEquations2D)
@@ -216,6 +236,8 @@ end
 
 
 """
+    flux_nonconservative_wintermeyer_etal(u_ll, u_rr, orientation::Integer,
+                                          equations::ShallowWaterEquations2D)
     flux_nonconservative_wintermeyer_etal(u_ll, u_rr,
                                           normal_direction_ll     ::AbstractVector,
                                           normal_direction_average::AbstractVector,
@@ -235,6 +257,22 @@ Further details are available in the paper:
   shallow water equations on unstructured curvilinear meshes with discontinuous bathymetry
   [DOI: 10.1016/j.jcp.2017.03.036](https://doi.org/10.1016/j.jcp.2017.03.036)
 """
+@inline function flux_nonconservative_wintermeyer_etal(u_ll, u_rr, orientation::Integer,
+                                                       equations::ShallowWaterEquations2D)
+  # Pull the necessary left and right state information
+  h_ll = waterheight(u_ll, equations)
+  b_rr = u_rr[4]
+
+  z = zero(eltype(u_ll))
+  # Bottom gradient nonconservative term: (0, g h b_x, g h b_y, 0)
+  if orientation == 1
+    f = SVector(z, equations.gravity * h_ll * b_rr, z, z)
+  else # orientation == 2
+    f = SVector(z, z, equations.gravity * h_ll * b_rr, z)
+  end
+  return f
+end
+
 @inline function flux_nonconservative_wintermeyer_etal(u_ll, u_rr,
                                                        normal_direction_ll::AbstractVector,
                                                        normal_direction_average::AbstractVector,
@@ -252,6 +290,8 @@ end
 
 
 """
+    flux_nonconservative_fjordholm_etal(u_ll, u_rr, orientation::Integer,
+                                        equations::ShallowWaterEquations2D)
     flux_nonconservative_fjordholm_etal(u_ll, u_rr,
                                         normal_direction_ll     ::AbstractVector,
                                         normal_direction_average::AbstractVector,
@@ -281,6 +321,34 @@ and for curvilinear 2D case in the paper:
   shallow water equations on unstructured curvilinear meshes with discontinuous bathymetry
   [DOI: 10.1016/j.jcp.2017.03.036](https://doi.org/10.1016/j.jcp.2017.03.036)
 """
+@inline function flux_nonconservative_fjordholm_etal(u_ll, u_rr, orientation::Integer,
+                                                     equations::ShallowWaterEquations2D)
+  # Pull the necessary left and right state information
+  h_ll, _, _, b_ll = u_ll
+  h_rr, _, _, b_rr = u_rr
+
+  h_average = 0.5 * (h_ll + h_rr)
+  b_jump = b_rr - b_ll
+
+  # Includes two parts:
+  #   (i)  Diagonal (consistent) term from the volume flux that uses `b_ll` to avoid
+  #        cross-averaging across a discontinuous bottom topography
+  #   (ii) True surface part that uses `normal_direction_ll`, `h_average` and `b_jump`
+  #        to handle discontinuous bathymetry
+  z = zero(eltype(u_ll))
+  if orientation == 1
+    f = SVector(z,
+                equations.gravity * h_ll * b_ll + equations.gravity * h_average * b_jump,
+                z, z)
+  else # orientation == 2
+    f = SVector(z, z,
+                equations.gravity * h_ll * b_ll + equations.gravity * h_average * b_jump,
+                z)
+  end
+
+  return f
+end
+
 @inline function flux_nonconservative_fjordholm_etal(u_ll, u_rr,
                                                      normal_direction_ll::AbstractVector,
                                                      normal_direction_average::AbstractVector,
@@ -323,6 +391,33 @@ Details are available in Eq. (4.1) in the paper:
   Well-balanced and energy stable schemes for the shallow water equations with discontinuous topography
   [DOI: 10.1016/j.jcp.2011.03.042](https://doi.org/10.1016/j.jcp.2011.03.042)
 """
+@inline function flux_fjordholm_etal(u_ll, u_rr, orientation::Integer, equations::ShallowWaterEquations2D)
+  # Unpack left and right state
+  h_ll = waterheight(u_ll, equations)
+  v1_ll, v2_ll = velocity(u_ll, equations)
+  h_rr = waterheight(u_rr, equations)
+  v1_rr, v2_rr = velocity(u_rr, equations)
+
+  # Average each factor of products in flux
+  h_avg  = 0.5 * (h_ll   + h_rr  )
+  v1_avg = 0.5 * (v1_ll  + v1_rr )
+  v2_avg = 0.5 * (v2_ll  + v2_rr )
+  p_avg  = 0.25 * equations.gravity * (h_ll^2 + h_rr^2)
+
+  # Calculate fluxes depending on orientation
+  if orientation == 1
+    f1 = h_avg * v1_avg
+    f2 = h_avg * v1_avg * v1_avg + p_avg
+    f3 = h_avg * v1_avg * v2_avg
+  else
+    f1 = h_avg * v2_avg
+    f2 = h_avg * v2_avg * v1_avg
+    f3 = h_avg * v2_avg * v2_avg + p_avg
+  end
+
+  return SVector(f1, f2, f3, zero(eltype(u_ll)))
+end
+
 @inline function flux_fjordholm_etal(u_ll, u_rr, normal_direction::AbstractVector, equations::ShallowWaterEquations2D)
   # Unpack left and right state
   h_ll = waterheight(u_ll, equations)
@@ -364,6 +459,34 @@ Further details are available in Theorem 1 of the paper:
   shallow water equations on unstructured curvilinear meshes with discontinuous bathymetry
   [DOI: 10.1016/j.jcp.2017.03.036](https://doi.org/10.1016/j.jcp.2017.03.036)
 """
+@inline function flux_wintermeyer_etal(u_ll, u_rr, orientation::Integer, equations::ShallowWaterEquations2D)
+  # Unpack left and right state
+  h_ll, h_v1_ll, h_v2_ll, _ = u_ll
+  h_rr, h_v1_rr, h_v2_rr, _ = u_rr
+
+  # Get the velocities on either side
+  v1_ll, v2_ll = velocity(u_ll, equations)
+  v1_rr, v2_rr = velocity(u_rr, equations)
+
+  # Average each factor of products in flux
+  v1_avg = 0.5 * (v1_ll + v1_rr)
+  v2_avg = 0.5 * (v2_ll + v2_rr)
+  p_avg  = 0.5 * equations.gravity * h_ll * h_rr
+
+  # Calculate fluxes depending on orientation
+  if orientation == 1
+    f1 = 0.5 * (h_v1_ll + h_v1_rr)
+    f2 = f1 * v1_avg + p_avg
+    f3 = f1 * v2_avg
+  else
+    f1 = 0.5 * (h_v2_ll + h_v2_rr)
+    f2 = f1 * v1_avg
+    f3 = f1 * v2_avg + p_avg
+  end
+
+  return SVector(f1, f2, f3, zero(eltype(u_ll)))
+end
+
 @inline function flux_wintermeyer_etal(u_ll, u_rr, normal_direction::AbstractVector, equations::ShallowWaterEquations2D)
   # Unpack left and right state
   h_ll, h_v1_ll, h_v2_ll, _ = u_ll
@@ -391,6 +514,25 @@ end
 
 # Calculate maximum wave speed for local Lax-Friedrichs-type dissipation as the
 # maximum velocity magnitude plus the maximum speed of sound
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation::Integer, equations::ShallowWaterEquations2D)
+  # Get the velocity quantities in the appropriate direction
+  if orientation == 1
+    v_ll, _ = velocity(u_ll, equations)
+    v_rr, _ = velocity(u_rr, equations)
+  else
+    _, v_ll = velocity(u_ll, equations)
+    _, v_rr = velocity(u_rr, equations)
+  end
+
+  # Calculate the wave celerity on the left and right
+  h_ll = waterheight(u_ll, equations)
+  h_rr = waterheight(u_rr, equations)
+  c_ll = sqrt(equations.gravity * h_ll)
+  c_rr = sqrt(equations.gravity * h_rr)
+
+  λ_max = max(abs(v_ll), abs(v_rr)) + max(c_ll, c_rr)
+end
+
 @inline function max_abs_speed_naive(u_ll, u_rr, normal_direction::AbstractVector, equations::ShallowWaterEquations2D)
   # Extract and compute the velocities in the normal direction
   v1_ll, v2_ll = velocity(u_ll, equations)
@@ -439,6 +581,25 @@ end
   end
 end
 
+
+# Calculate minimum and maximum wave speeds for HLL-type fluxes
+@inline function min_max_speed_naive(u_ll, u_rr, orientation::Integer,
+                                     equations::ShallowWaterEquations2D)
+  h_ll = waterheight(u_ll, equations)
+  v1_ll, v2_ll = velocity(u_ll, equations)
+  h_rr = waterheight(u_rr, equations)
+  v1_rr, v2_rr = velocity(u_rr, equations)
+
+  if orientation == 1 # x-direction
+    λ_min = v1_ll - sqrt(equations.gravity * h_ll)
+    λ_max = v1_rr + sqrt(equations.gravity * h_rr)
+  else # y-direction
+    λ_min = v2_ll - sqrt(equations.gravity * h_ll)
+    λ_max = v2_rr + sqrt(equations.gravity * h_rr)
+  end
+
+  return λ_min, λ_max
+end
 
 @inline function min_max_speed_naive(u_ll, u_rr, normal_direction::AbstractVector,
                                      equations::ShallowWaterEquations2D)

--- a/src/equations/shallow_water_2d.jl
+++ b/src/equations/shallow_water_2d.jl
@@ -378,7 +378,7 @@ end
 
 
 """
-    flux_fjordholm_etal(u_ll, u_rr, normal_direction,
+    flux_fjordholm_etal(u_ll, u_rr, orientation_or_normal_direction,
                         equations::ShallowWaterEquations2D)
 
 Total energy conservative (mathematical entropy for shallow water equations). When the bottom topography
@@ -445,7 +445,7 @@ end
 
 
 """
-    flux_wintermeyer_etal(u_ll, u_rr, normal_direction,
+    flux_wintermeyer_etal(u_ll, u_rr, orientation_or_normal_direction,
                           equations::ShallowWaterEquations2D)
 
 Total energy conservative (mathematical entropy for shallow water equations) split form.

--- a/src/equations/shallow_water_2d.jl
+++ b/src/equations/shallow_water_2d.jl
@@ -333,8 +333,7 @@ and for curvilinear 2D case in the paper:
   # Includes two parts:
   #   (i)  Diagonal (consistent) term from the volume flux that uses `b_ll` to avoid
   #        cross-averaging across a discontinuous bottom topography
-  #   (ii) True surface part that uses `normal_direction_ll`, `h_average` and `b_jump`
-  #        to handle discontinuous bathymetry
+  #   (ii) True surface part that uses `h_average` and `b_jump` to handle discontinuous bathymetry
   z = zero(eltype(u_ll))
   if orientation == 1
     f = SVector(z,
@@ -407,12 +406,12 @@ Details are available in Eq. (4.1) in the paper:
   # Calculate fluxes depending on orientation
   if orientation == 1
     f1 = h_avg * v1_avg
-    f2 = h_avg * v1_avg * v1_avg + p_avg
-    f3 = h_avg * v1_avg * v2_avg
+    f2 = f1 * v1_avg + p_avg
+    f3 = f1 * v2_avg
   else
     f1 = h_avg * v2_avg
-    f2 = h_avg * v2_avg * v1_avg
-    f3 = h_avg * v2_avg * v2_avg + p_avg
+    f2 = f1 * v1_avg
+    f3 = f1 * v2_avg + p_avg
   end
 
   return SVector(f1, f2, f3, zero(eltype(u_ll)))

--- a/src/solvers/dgsem_structured/dg_2d.jl
+++ b/src/solvers/dgsem_structured/dg_2d.jl
@@ -99,7 +99,7 @@ end
 
     # All diagonal entries of `derivative_split` are zero. Thus, we can skip
     # the computation of the diagonal terms. In addition, we use the symmetry
-    # of the `volume_flux` to save half of the possible two-poitn flux
+    # of the `volume_flux` to save half of the possible two-point flux
     # computations.
 
     # x direction

--- a/src/solvers/dgsem_structured/dg_3d.jl
+++ b/src/solvers/dgsem_structured/dg_3d.jl
@@ -114,7 +114,7 @@ end
 
     # All diagonal entries of `derivative_split` are zero. Thus, we can skip
     # the computation of the diagonal terms. In addition, we use the symmetry
-    # of the `volume_flux` to save half of the possible two-poitn flux
+    # of the `volume_flux` to save half of the possible two-point flux
     # computations.
 
     # x direction

--- a/test/test_tree_2d_part3.jl
+++ b/test/test_tree_2d_part3.jl
@@ -22,6 +22,9 @@ isdir(outdir) && rm(outdir, recursive=true)
   # Lattice-Boltzmann
   include("test_tree_2d_lbm.jl")
 
+  # Shallow water
+  include("test_tree_2d_shallowwater.jl")
+
   # FDSBP methods on the TreeMesh
   include("test_tree_2d_fdsbp.jl")
 end

--- a/test/test_tree_2d_shallowwater.jl
+++ b/test/test_tree_2d_shallowwater.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = joinpath(examples_dir(), "tree_2d_dgsem")
 
 @testset "Shallow Water" begin
   @trixi_testset "elixir_shallowwater_ec.jl" begin

--- a/test/test_tree_2d_shallowwater.jl
+++ b/test/test_tree_2d_shallowwater.jl
@@ -1,0 +1,41 @@
+module TestExamples2DShallowWater
+
+using Test
+using Trixi
+
+include("test_trixi.jl")
+
+# pathof(Trixi) returns /path/to/Trixi/src/Trixi.jl, dirname gives the parent directory
+EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+
+@testset "Shallow Water" begin
+  @trixi_testset "elixir_shallowwater_ec.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_shallowwater_ec.jl"),
+      l2   = [0.9911807999456177, 0.7340358820001013, 0.7446688375175905, 0.5875351036989047],
+      linf = [2.0118414065026426, 2.9946841579032526, 2.6555844309739545, 3.0],
+      tspan = (0.0, 0.25))
+  end
+
+  @trixi_testset "elixir_shallowwater_well_balanced.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_shallowwater_well_balanced.jl"),
+      l2   = [0.9130579602987144, 1.0602847041965408e-14, 1.082225645390032e-14, 0.9130579602987147],
+      linf = [2.113062037615659, 4.6613606802974e-14, 5.4225772771633196e-14, 2.1130620376156584],
+      tspan = (0.0, 0.25))
+  end
+
+  @trixi_testset "elixir_shallowwater_source_terms.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_shallowwater_source_terms.jl"),
+      l2   = [0.001868474306068482, 0.01731687445878443, 0.017649083171490863, 6.274146767717023e-5],
+      linf = [0.016962486402209986, 0.08768628853889782, 0.09038488750767648, 0.0001819675955490041],
+      tspan = (0.0, 0.025))
+  end
+
+  @trixi_testset "elixir_shallowwater_source_terms.jl with flux_hll" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_shallowwater_source_terms.jl"),
+      l2   = [0.0018957692481057034, 0.016943229710439864, 0.01755623297390675, 6.274146767717414e-5],
+      linf = [0.015156105797771602, 0.07964811135780492, 0.0839787097210376, 0.0001819675955490041],
+      tspan = (0.0, 0.025), surface_flux=(flux_hll, flux_nonconservative_fjordholm_etal))
+  end
+end
+
+end # module


### PR DESCRIPTION
Addresses one item on the checklist #879. This implements and tests the shallow water equations (e.g. discontinuous bottom + entropy conservation) on `TreeMesh2D`. 