### PR TITLE
GitHub action for caching notebooks

### DIFF
--- a/.github/workflows/CacheNotebooks.yml
+++ b/.github/workflows/CacheNotebooks.yml
@@ -28,6 +28,8 @@ jobs:
             git fetch origin
             git checkout tutorial_notebooks_new
             git checkout origin/main -- docs/Project.toml
+            cp docs/Project.toml Project.toml
+            rmdir docs/
             sed -i '1 a Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"' Project.toml
             git checkout origin/gh-pages -- dev/tutorials/notebooks/
             git add -A && git commit -m "Copy files"

--- a/docs/literate/make.jl
+++ b/docs/literate/make.jl
@@ -24,7 +24,7 @@ function create_files(title, file, repo_src, pages_dir, notebooks_dir; folder=""
     
     # Generate notebook file
     function preprocess_notebook(content)
-        warning = "# **Note:** To improve responsiveness via caching the notebooks on `Binder` are updated only once a week. They are only
+        warning = "# **Note:** To improve responsiveness via caching, the notebooks on `Binder` are updated only once a week. They are only
         # available for the latest stable release of Trixi at the time of caching. The notebooks in `nbviewer` and the downloaded versions
         # are always up-to-date with the latest stable release of Trixi.\n\n"
         return string("# # $title\n\n", warning, content)

--- a/docs/literate/src/files/index.jl
+++ b/docs/literate/src/files/index.jl
@@ -5,7 +5,7 @@
 
 # Right now, you are using the classic documentation. The corresponding interactive notebooks can
 # be opened in [Binder](https://mybinder.org/) via ![](https://mybinder.org/badge_logo.svg) in the respective tutorial.
-# **Note:** To improve responsiveness via caching the notebooks on `Binder` are updated only once a week. They are only
+# **Note:** To improve responsiveness via caching, the notebooks on `Binder` are updated only once a week. They are only
 # available for the latest stable release of Trixi at the time of caching.
 
 # The notebooks for the latest stable version of Trixi can always be viewed in [nbviewer](https://nbviewer.jupyter.org/)


### PR DESCRIPTION
This PR adds a GH action that stores the notebook files and a `Project.toml` in the separate branch `tutorial_notebooks` once a week. A warning regarding "old" tutorials is added to the notebooks.

For the first run of the workflow, the new branch has to be created manually.