### PR TITLE
update feature matrix

### DIFF
--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -47,19 +47,19 @@ new features. This allows rapid prototyping of new ideas and is one of the main
 design goals behind Trixi. Below is a brief overview of the availability of
 different features on different mesh types.
 
-| Feature                                                      | [`TreeMesh`](@ref) | [`StructuredMesh`](@ref) | [`UnstructuredMesh2D`](@ref) | [`P4estMesh`](@ref) | [`VertexMappedMesh`](@ref) |
-|--------------------------------------------------------------|:------------------:|:------------------------:|:----------------------------:|:-------------------:|:--------------------------:|
+| Feature                                                      | [`TreeMesh`](@ref) | [`StructuredMesh`](@ref) | [`UnstructuredMesh2D`](@ref) | [`P4estMesh`](@ref) | [`VertexMappedMesh`](@ref) | Further reading
+|:-------------------------------------------------------------|:------------------:|:------------------------:|:----------------------------:|:-------------------:|:--------------------------:|:-----------------------------------------
 | Spatial dimension                                            |     1D, 2D, 3D     |        1D, 2D, 3D        |              2D              |        2D, 3D       |          1D, 2D, 3D        |
 | Coordinates                                                  |      Cartesian     |        curvilinear       |          curvilinear         |     curvilinear     |            affine          |
 | Connectivity                                                 |  *h*-nonconforming |        conforming        |          conforming          |  *h*-nonconforming  |          conforming        |
 | Element type                                                 | line, square, cube |     line, quadᵃ, hexᵃ    |             quadᵃ            |     quadᵃ, hexᵃ     |    simplex, quadᵃ, hexᵃ    |
-| Adaptive mesh refinement ([`AMRCallback`](@ref))             |          ✅         |             ❌            |               ❌              |          ✅          |               ❌            |
-| Solver/discretization type                                   |   [`DGSEM`](@ref)  |      [`DGSEM`](@ref)     |        [`DGSEM`](@ref)       |   [`DGSEM`](@ref)   |       [`DGMulti`](@ref)    |
+| Adaptive mesh refinement                                     |          ✅         |             ❌            |               ❌              |          ✅          |               ❌            | [`AMRCallback`](@ref)
+| Solver type                                                  |   [`DGSEM`](@ref)  |      [`DGSEM`](@ref)     |        [`DGSEM`](@ref)       |   [`DGSEM`](@ref)   |       [`DGMulti`](@ref)    |
 | Domain                                                       |      hypercube     |     mapped hypercube     |           arbitrary          |      arbitrary      |       arbitrary (affine)   |
-| Weak form ([`VolumeIntegralWeakForm`](@ref))                 |          ✅         |             ✅            |               ✅              |          ✅          |               ✅            |
-| Flux differencing ([`VolumeIntegralFluxDifferencing`](@ref)) |          ✅         |             ✅            |               ✅              |          ✅          |               ✅            |
-| Shock capturing ([`VolumeIntegralShockCapturingHG`](@ref))   |          ✅         |         partially        |            partially         |          ❌          |               ❌            |
-| Nonconservative equations (e.g., GLM MHD)                    |          ✅         |         partially        |            partially         |          ❌          |               ✅            |
+| Weak form                                                    |          ✅         |             ✅            |               ✅              |          ✅          |               ✅            | [`VolumeIntegralWeakForm`](@ref)
+| Flux differencing                                            |          ✅         |             ✅            |               ✅              |          ✅          |               ✅            | [`VolumeIntegralFluxDifferencing`](@ref)
+| Shock capturing                                              |          ✅         |             ✅            |               ✅              |          ❌          |               ❌            | [`VolumeIntegralShockCapturingHG`](@ref)
+| Nonconservative equations                                    |          ✅         |             ✅            |               ✅              |          ❌          |               ✅            | e.g., GLM MHD or shallow water equations
 
 ᵃ: quad = quadrilateral, hex = hexahedron
 


### PR DESCRIPTION
I updated the feature matrix to include the new shock capturing capabilities on curved meshes implemented by @andrewwinters5000 in #900. Moreover, I added some "further reading" stuff to the right end of the table so that we can at least view more of it by default.

Current `dev` docs:
![image](https://user-images.githubusercontent.com/12693098/136752726-2bb53b75-bf59-4d6a-ac32-dbd871a7178c.png)

This PR:
![image](https://user-images.githubusercontent.com/12693098/136752794-756f7be2-4eae-4d30-a5fa-e43e57da90d3.png)
