### PR TITLE
make some `P4estMesh3D` tests less expensive

### DIFF
--- a/test/test_p4est_2d.jl
+++ b/test/test_p4est_2d.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "p4est_2d_dgsem")
+EXAMPLES_DIR = joinpath(examples_dir(), "p4est_2d_dgsem")
 
 # Start with a clean environment: remove Trixi output directory if it exists
 outdir = "out"
@@ -16,26 +15,26 @@ isdir(outdir) && rm(outdir, recursive=true)
   @trixi_testset "elixir_advection_basic.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_basic.jl"),
       # Expected errors are exactly the same as with TreeMesh!
-      l2   = [8.311947673061856e-6], 
+      l2   = [8.311947673061856e-6],
       linf = [6.627000273229378e-5])
   end
 
   @trixi_testset "elixir_advection_nonconforming_flag.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_nonconforming_flag.jl"),
-      l2   = [3.198940059144588e-5], 
+      l2   = [3.198940059144588e-5],
       linf = [0.00030636069494005547])
   end
 
   @trixi_testset "elixir_advection_unstructured_flag.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_unstructured_flag.jl"),
-      l2   = [0.0005379687442422346], 
+      l2   = [0.0005379687442422346],
       linf = [0.007438525029884735])
   end
 
   @trixi_testset "elixir_advection_amr_solution_independent.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr_solution_independent.jl"),
       # Expected errors are exactly the same as with StructuredMesh!
-      l2   = [4.949660644033807e-5], 
+      l2   = [4.949660644033807e-5],
       linf = [0.0004867846262313763])
   end
 
@@ -47,13 +46,13 @@ isdir(outdir) && rm(outdir, recursive=true)
 
   @trixi_testset "elixir_advection_restart.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_restart.jl"),
-      l2   = [4.507575525876275e-6], 
+      l2   = [4.507575525876275e-6],
       linf = [6.21489667023134e-5])
   end
 
   @trixi_testset "elixir_euler_source_terms_nonconforming_unstructured_flag.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms_nonconforming_unstructured_flag.jl"),
-    l2   = [0.0034516244508588046, 0.0023420334036925493, 0.0024261923964557187, 0.004731710454271893], 
+    l2   = [0.0034516244508588046, 0.0023420334036925493, 0.0024261923964557187, 0.004731710454271893],
     linf = [0.04155789011775046, 0.024772109862748914, 0.03759938693042297, 0.08039824959535657])
   end
 

--- a/test/test_p4est_3d.jl
+++ b/test/test_p4est_3d.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "p4est_3d_dgsem")
+EXAMPLES_DIR = joinpath(examples_dir(), "p4est_3d_dgsem")
 
 # Start with a clean environment: remove Trixi output directory if it exists
 outdir = "out"
@@ -16,19 +15,19 @@ isdir(outdir) && rm(outdir, recursive=true)
   @trixi_testset "elixir_advection_basic.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_basic.jl"),
       # Expected errors are exactly the same as with TreeMesh!
-      l2   = [0.00016263963870641478], 
+      l2   = [0.00016263963870641478],
       linf = [0.0014537194925779984])
   end
 
   @trixi_testset "elixir_advection_unstructured_curved.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_unstructured_curved.jl"),
-      l2   = [0.0004750004258546538], 
+      l2   = [0.0004750004258546538],
       linf = [0.026527551737137167])
   end
 
   @trixi_testset "elixir_advection_nonconforming.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_nonconforming.jl"),
-      l2   = [0.00253595715323843], 
+      l2   = [0.00253595715323843],
       linf = [0.016486952252155795])
   end
 
@@ -41,51 +40,56 @@ isdir(outdir) && rm(outdir, recursive=true)
 
   @trixi_testset "elixir_advection_amr_unstructured_curved.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr_unstructured_curved.jl"),
-      l2   = [3.28458370046859e-5],
-      linf = [0.003607158327703943])
+      l2   = [1.6236411810065552e-5],
+      linf = [0.0010554006923731395],
+      tspan = (0.0, 1.0))
   end
 
   @trixi_testset "elixir_advection_cubed_sphere.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_cubed_sphere.jl"),
-      l2   = [0.002006918015656413], 
+      l2   = [0.002006918015656413],
       linf = [0.027655117058380085])
   end
 
   @trixi_testset "elixir_advection_restart.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_restart.jl"),
-      l2   = [0.002590388934758452], 
+      l2   = [0.002590388934758452],
       linf = [0.01840757696885409])
   end
 
   @trixi_testset "elixir_euler_source_terms_nonconforming_unstructured_curved.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms_nonconforming_unstructured_curved.jl"),
-      l2   = [0.0002509450739533392, 0.00023785492442943794, 0.0002846031670226135, 0.0002932332754336982, 0.0006288429844253074], 
-      linf = [0.011596300191441644, 0.009930481243511924, 0.013095959848100192, 0.02014760183990494, 0.03885749726552046])
+      l2   = [4.070355207909268e-5, 4.4993257426833716e-5, 5.10588457841744e-5, 5.102840924036687e-5, 0.00019986264001630542],
+      linf = [0.0016987332417202072, 0.003622956808262634, 0.002029576258317789, 0.0024206977281964193, 0.008526972236273522],
+      tspan = (0.0, 0.01))
   end
 
   @trixi_testset "elixir_euler_source_terms_nonperiodic.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms_nonperiodic.jl"),
-      l2   = [0.0015695663270391823, 0.0015490919943862824, 0.0015490919943864445, 0.0015490919943865404, 0.0030142321185958622], 
-      linf = [0.011169568009149922, 0.012122645263175524, 0.012122645263178411, 0.012122645263167309, 0.022766806484090463])
+      l2   = [0.0015106060984283647, 0.0014733349038567685, 0.00147333490385685, 0.001473334903856929, 0.0028149479453087093],
+      linf = [0.008070806335238156, 0.009007245083113125, 0.009007245083121784, 0.009007245083102688, 0.01562861968368434],
+      tspan = (0.0, 1.0))
   end
 
   @trixi_testset "elixir_euler_free_stream.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_free_stream.jl"),
-      l2   = [7.853107070208087e-15, 4.3176689497299765e-14, 4.605888682511052e-14, 5.468131071212009e-14, 9.42558567776032e-14],
-      linf = [1.0187406473960436e-12, 4.899927685819705e-12, 6.2305716141963785e-12, 7.49544870615182e-12, 1.149125239408022e-11],
-      tspan = (0.0, 0.1))
+      l2   = [5.162664597942288e-15, 1.941857343642486e-14, 2.0232366394187278e-14, 2.3381518645408552e-14, 7.083114561232324e-14],
+      linf = [7.269740365245525e-13, 3.289868377720495e-12, 4.440087186807773e-12, 3.8686831516088205e-12, 9.412914891981927e-12],
+      tspan = (0.0, 0.03))
   end
 
   @trixi_testset "elixir_euler_free_stream_extruded.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_free_stream_extruded.jl"),
-      l2   = [1.6667578354338437e-14, 8.351207753024527e-15, 1.805859250264852e-14, 1.90966219766217e-14, 1.90966219766217e-14],
-      linf = [1.0413891970983968e-13, 4.988787161153141e-13, 2.0694557179012918e-13, 6.221689829999377e-13, 1.0587086762825493e-12])
+      l2   = [8.444868392439035e-16, 4.889826056731442e-15, 2.2921260987087585e-15, 4.268460455702414e-15, 1.1356712092620279e-14],
+      linf = [7.749356711883593e-14, 2.8792246364872653e-13, 1.1121659149182506e-13, 3.3228975127030935e-13, 9.592326932761353e-13],
+      tspan=(0.0, 0.1))
   end
 
   @trixi_testset "elixir_euler_ec.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_ec.jl"),
-      l2   = [0.00921799151005215, 0.007057841476498664, 0.0074046565631184, 0.007421119519873141, 0.023272322544764468],
-      linf = [0.18671575807969953, 0.2550156016690984, 0.2577539185993992, 0.26308798001518957, 0.443547750485219])
+      l2   = [0.010380390326164493, 0.006192950051354618, 0.005970674274073704, 0.005965831290564327, 0.02628875593094754],
+      linf = [0.3326911600075694, 0.2824952141320467, 0.41401037398065543, 0.45574161423218573, 0.8099577682187109],
+      tspan = (0.0, 0.2))
   end
 
   @trixi_testset "elixir_euler_sedov.jl" begin


### PR DESCRIPTION
I reduced the final time for some `P4estMesh3D` tests since CI took more than two hours.