### PR TITLE
Fix notebook links for nbviewer and download

### DIFF
--- a/docs/literate/make.jl
+++ b/docs/literate/make.jl
@@ -15,8 +15,8 @@ function create_files(title, file, repo_src, pages_dir, notebooks_dir; folder=""
 
     notebook_path = "tutorials/notebooks/$notebook_filename"
     binder_url   = "https://mybinder.org/v2/gh/trixi-framework/Trixi.jl/tutorial_notebooks?filepath=$notebook_path"
-    nbviewer_url = "https://nbviewer.jupyter.org/github/trixi-framework/Trixi.jl/blob/gh-pages/$notebook_path"
-    download_url = "https://raw.githubusercontent.com/trixi-framework/Trixi.jl/gh-pages/$notebook_path"
+    nbviewer_url = "https://nbviewer.jupyter.org/github/trixi-framework/Trixi.jl/blob/tutorial_notebooks/$notebook_path"
+    download_url = "https://raw.githubusercontent.com/trixi-framework/Trixi.jl/tutorial_notebooks/$notebook_path"
 
     binder_badge   = "# [![]($binder_logo)]($binder_url)"
     nbviewer_badge = "# [![]($nbviewer_logo)]($nbviewer_url)"
@@ -24,9 +24,8 @@ function create_files(title, file, repo_src, pages_dir, notebooks_dir; folder=""
     
     # Generate notebook file
     function preprocess_notebook(content)
-        warning = "# **Note:** To improve responsiveness via caching, the notebooks on `Binder` are updated only once a week. They are only
-        # available for the latest stable release of Trixi at the time of caching. The notebooks in `nbviewer` and the downloaded versions
-        # are always up-to-date with the latest stable release of Trixi.\n\n"
+        warning = "# **Note:** To improve responsiveness via caching, the notebooks are updated only once a week. They are only
+        # available for the latest stable release of Trixi at the time of caching.\n\n"
         return string("# # $title\n\n", warning, content)
     end
     Literate.notebook(joinpath(repo_src, folder, file), joinpath(notebooks_dir, folder); execute=false, preprocess=preprocess_notebook, credit=false)

--- a/docs/literate/src/files/index.jl
+++ b/docs/literate/src/files/index.jl
@@ -4,14 +4,12 @@
 # interactive step-by-step explanations via [Binder](https://mybinder.org).
 
 # Right now, you are using the classic documentation. The corresponding interactive notebooks can
-# be opened in [Binder](https://mybinder.org/) via ![](https://mybinder.org/badge_logo.svg) in the respective tutorial.
-# **Note:** To improve responsiveness via caching, the notebooks on `Binder` are updated only once a week. They are only
+# be opened in [Binder](https://mybinder.org/) and viewed in [nbviewer](https://nbviewer.jupyter.org/)
+# via the icons ![](https://mybinder.org/badge_logo.svg) and ![](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)
+# in the respective tutorial.
+# You can download the raw notebooks from GitHub via ![](https://camo.githubusercontent.com/aea75103f6d9f690a19cb0e17c06f984ab0f472d9e6fe4eadaa0cc438ba88ada/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f646f776e6c6f61642d6e6f7465626f6f6b2d627269676874677265656e).
+# **Note:** To improve responsiveness via caching, the notebooks are updated only once a week. They are only
 # available for the latest stable release of Trixi at the time of caching.
-
-# The notebooks for the latest stable version of Trixi can always be viewed in [nbviewer](https://nbviewer.jupyter.org/)
-# and downloaded from GitHub via the icons ![](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)
-# and ![](https://camo.githubusercontent.com/aea75103f6d9f690a19cb0e17c06f984ab0f472d9e6fe4eadaa0cc438ba88ada/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f646f776e6c6f61642d6e6f7465626f6f6b2d627269676874677265656e).
-
 # There are tutorials for the following topics:
 
 # ### 1 Adding a new equation


### PR DESCRIPTION
This PR fixes the notebook links for nbviewer and download by changing them to the branch `tutorial_notebooks` like it's already used for binder. The notes/warnings in the notebooks and introduction are updated.