### PR TITLE
Implement a fast multithreaded way to reset du

### DIFF
--- a/src/solvers/dgsem_structured/dg_1d.jl
+++ b/src/solvers/dgsem_structured/dg_1d.jl
@@ -10,7 +10,7 @@ function rhs!(du, u, t,
               initial_condition, boundary_conditions, source_terms,
               dg::DG, cache)
   # Reset du
-  @trixi_timeit timer() "reset ∂u/∂t" du .= zero(eltype(du))
+  @trixi_timeit timer() "reset ∂u/∂t" reset_du!(du, dg, cache)
 
   # Calculate volume integral
   @trixi_timeit timer() "volume integral" calc_volume_integral!(

--- a/src/solvers/dgsem_structured/dg_2d.jl
+++ b/src/solvers/dgsem_structured/dg_2d.jl
@@ -10,7 +10,7 @@ function rhs!(du, u, t,
               initial_condition, boundary_conditions, source_terms,
               dg::DG, cache)
   # Reset du
-  @trixi_timeit timer() "reset ∂u/∂t" du .= zero(eltype(du))
+  @trixi_timeit timer() "reset ∂u/∂t" reset_du!(du, dg, cache)
 
   # Calculate volume integral
   @trixi_timeit timer() "volume integral" calc_volume_integral!(

--- a/src/solvers/dgsem_structured/dg_3d.jl
+++ b/src/solvers/dgsem_structured/dg_3d.jl
@@ -10,7 +10,7 @@ function rhs!(du, u, t,
               initial_condition, boundary_conditions, source_terms,
               dg::DG, cache)
   # Reset du
-  @trixi_timeit timer() "reset ∂u/∂t" du .= zero(eltype(du))
+  @trixi_timeit timer() "reset ∂u/∂t" reset_du!(du, dg, cache)
 
   # Calculate volume integral
   @trixi_timeit timer() "volume integral" calc_volume_integral!(

--- a/src/solvers/dgsem_tree/dg.jl
+++ b/src/solvers/dgsem_tree/dg.jl
@@ -5,6 +5,17 @@
 @muladd begin
 
 
+# du .= zero(eltype(du)) doesn't scale when using multiple threads.
+# See https://github.com/trixi-framework/Trixi.jl/pull/924 for a performance comparison.
+function reset_du!(du, dg, cache)
+  @threaded for element in eachelement(dg, cache)
+      du[.., element] .= zero(eltype(du))
+  end
+
+  return du
+end
+
+
 #     pure_and_blended_element_ids!(element_ids_dg, element_ids_dgfv, alpha, dg, cache)
 #
 # Given blending factors `alpha` and the solver `dg`, fill

--- a/src/solvers/dgsem_tree/dg_1d.jl
+++ b/src/solvers/dgsem_tree/dg_1d.jl
@@ -80,7 +80,7 @@ function rhs!(du, u, t,
               initial_condition, boundary_conditions, source_terms,
               dg::DG, cache)
   # Reset du
-  @trixi_timeit timer() "reset ∂u/∂t" du .= zero(eltype(du))
+  @trixi_timeit timer() "reset ∂u/∂t" reset_du!(du, dg, cache)
 
   # Calculate volume integral
   @trixi_timeit timer() "volume integral" calc_volume_integral!(
@@ -248,7 +248,7 @@ function calc_volume_integral!(du, u,
                        volume_flux_dg, dg, cache, 1 - alpha_element)
 
     # Calculate FV volume integral contribution
-    fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv, 
+    fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv,
                dg, cache, element, alpha_element)
   end
 
@@ -265,7 +265,7 @@ function calc_volume_integral!(du, u,
 
   # Calculate LGL FV volume integral
   @threaded for element in eachelement(dg, cache)
-    fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv, 
+    fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv,
                dg, cache, element, true)
   end
 
@@ -283,7 +283,7 @@ end
 
   # Calculate FV two-point fluxes
   fstar1 = fstar1_threaded[Threads.threadid()]
-  calcflux_fv!(fstar1, u, mesh, nonconservative_terms, equations, volume_flux_fv, 
+  calcflux_fv!(fstar1, u, mesh, nonconservative_terms, equations, volume_flux_fv,
                dg, element, cache)
 
   # Calculate FV volume integral contribution
@@ -298,9 +298,9 @@ end
   return nothing
 end
 
-@inline function calcflux_fv!(fstar1, u::AbstractArray{<:Any,3}, 
+@inline function calcflux_fv!(fstar1, u::AbstractArray{<:Any,3},
                               mesh::Union{TreeMesh{1}, StructuredMesh{1}},
-                              nonconservative_terms::Val{false}, 
+                              nonconservative_terms::Val{false},
                               equations, volume_flux_fv, dg::DGSEM, element, cache)
 
   fstar1[:, 1,           ] .= zero(eltype(fstar1))

--- a/src/solvers/dgsem_tree/dg_2d.jl
+++ b/src/solvers/dgsem_tree/dg_2d.jl
@@ -80,7 +80,7 @@ end
 
 # The methods below are specialized on the mortar type
 # and called from the basic `create_cache` method at the top.
-function create_cache(mesh::Union{TreeMesh{2}, StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}}, 
+function create_cache(mesh::Union{TreeMesh{2}, StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
                       equations, mortar_l2::LobattoLegendreMortarL2, uEltype)
   # TODO: Taal performance using different types
   MA2d = MArray{Tuple{nvariables(equations), nnodes(mortar_l2)}, uEltype, 2, nvariables(equations) * nnodes(mortar_l2)}
@@ -102,7 +102,7 @@ function rhs!(du, u, t,
               initial_condition, boundary_conditions, source_terms,
               dg::DG, cache)
   # Reset du
-  @trixi_timeit timer() "reset ∂u/∂t" du .= zero(eltype(du))
+  @trixi_timeit timer() "reset ∂u/∂t" reset_du!(du, dg, cache)
 
   # Calculate volume integral
   @trixi_timeit timer() "volume integral" calc_volume_integral!(
@@ -231,7 +231,7 @@ end
   end
 end
 
-@inline function split_form_kernel!(du::AbstractArray{<:Any,4}, u, element, 
+@inline function split_form_kernel!(du::AbstractArray{<:Any,4}, u, element,
                                     mesh::Union{TreeMesh{2}, StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
                                     nonconservative_terms::Val{true}, equations,
                                     volume_flux, dg::DGSEM, cache, alpha=true)
@@ -305,7 +305,7 @@ function calc_volume_integral!(du, u,
                        volume_flux_dg, dg, cache, 1 - alpha_element)
 
     # Calculate FV volume integral contribution
-    fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv, 
+    fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv,
                dg, cache, element, alpha_element)
   end
 
@@ -322,7 +322,7 @@ function calc_volume_integral!(du, u,
 
   # Calculate LGL FV volume integral
   @threaded for element in eachelement(dg, cache)
-    fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv, 
+    fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv,
                dg, cache, element, true)
   end
 
@@ -342,7 +342,7 @@ end
   fstar2_L = fstar2_L_threaded[Threads.threadid()]
   fstar1_R = fstar1_R_threaded[Threads.threadid()]
   fstar2_R = fstar2_R_threaded[Threads.threadid()]
-  calcflux_fv!(fstar1_L, fstar1_R, fstar2_L, fstar2_R, u, mesh, 
+  calcflux_fv!(fstar1_L, fstar1_R, fstar2_L, fstar2_R, u, mesh,
                nonconservative_terms, equations, volume_flux_fv, dg, element, cache)
 
   # Calculate FV volume integral contribution

--- a/src/solvers/dgsem_tree/dg_2d_parallel.jl
+++ b/src/solvers/dgsem_tree/dg_2d_parallel.jl
@@ -282,7 +282,7 @@ function rhs!(du, u, t,
     cache.mpi_cache, mesh, equations, dg, cache)
 
   # Reset du
-  @trixi_timeit timer() "reset ∂u/∂t" du .= zero(eltype(du))
+  @trixi_timeit timer() "reset ∂u/∂t" reset_du!(du, dg, cache)
 
   # Calculate volume integral
   @trixi_timeit timer() "volume integral" calc_volume_integral!(

--- a/src/solvers/dgsem_tree/dg_3d.jl
+++ b/src/solvers/dgsem_tree/dg_3d.jl
@@ -125,7 +125,7 @@ function rhs!(du, u, t,
               initial_condition, boundary_conditions, source_terms,
               dg::DG, cache)
   # Reset du
-  @trixi_timeit timer() "reset ∂u/∂t" du .= zero(eltype(du))
+  @trixi_timeit timer() "reset ∂u/∂t" reset_du!(du, dg, cache)
 
   # Calculate volume integral
   @trixi_timeit timer() "volume integral" calc_volume_integral!(

--- a/src/solvers/dgsem_unstructured/dg_2d.jl
+++ b/src/solvers/dgsem_unstructured/dg_2d.jl
@@ -37,7 +37,7 @@ function rhs!(du, u, t,
               initial_condition, boundary_conditions, source_terms,
               dg::DG, cache)
   # Reset du
-  @trixi_timeit timer() "reset ∂u/∂t" du .= zero(eltype(du))
+  @trixi_timeit timer() "reset ∂u/∂t" reset_du!(du, dg, cache)
 
   # Calculate volume integral
   @trixi_timeit timer() "volume integral" calc_volume_integral!(


### PR DESCRIPTION
Currently, we are resetting the `du` array like this:
```julia
du .= zero(eltype(du))
```
Unfortunately, this implementation doesn't scale when using multiple threads. On one thread, there is not much time spent in this line compared to `calc_volume_integral!`. However, on multiple threads, the latter is sped up, while the former still retains the same speed. Running a large(ish) atmospheric simulation on an AMD Ryzen Threadripper 3990X using 24 threads in Julia (which is the sweet spot for this machine and simulation. More threads don't speed it up further), `reset ∂u/∂t` becomes the second most expensive part of `rhs!` (after `calc_volume_integral!`), although it should arguably be one of the least expensive parts.

I benchmarked several alternative implementations (thanks @ranocha for the last function):
```julia
using Trixi, BenchmarkTools, Polyester, LoopVectorization

function reset_plain!(du)
  du .= zero(eltype(du))

  return du
end

function reset_loop!(du)
  @batch for i in eachindex(du)
      du[i] = zero(eltype(du))
  end

  return du
end

function reset_ellipsis!(du)
  @batch for i in Base.OneTo(size(du, 5))
      du[.., i] .= zero(eltype(du))
  end

  return du
end

function reset_turbo!(du)
  @turbo thread=true for i in eachindex(du)
      du[i] = zero(eltype(du))
  end

  return du
end

du_ode = randn(5 * 6 * 6 * 6 * 1536); du = Trixi.PtrArray(pointer(du_ode), 
    (Trixi.StaticInt(5), Trixi.StaticInt(6), Trixi.StaticInt(6), Trixi.StaticInt(6), 1536));

@benchmark reset_plain!($du)
@benchmark reset_loop!($du)
@benchmark reset_ellipsis!($du)
@benchmark reset_turbo!($du)
```

Here are the results on two machines:
| | `reset_plain!` | `reset_loop!` | `reset_ellipsis!` | `reset_turbo!` |
| --- | --- | --- | --- | --- |
| AMD Ryzen Threadripper 3990X, 1 thread, check bounds | **`300.627 μs`** | `499.781 μs` | `315.237 μs` | `307.916 μs` |
| AMD Ryzen Threadripper 3990X, 1 thread, no check bounds | `292.056 μs` | **`290.506 μs`** | `312.956 μs` | `307.746 μs` |
| AMD Ryzen Threadripper 3990X, 24 threads, check bounds | `284.797 μs` | **`6.960 μs`** | `7.108 μs` | `10.591 μs` |
| AMD Ryzen Threadripper 3990X, 24 threads, no check bounds | `295.066 μs` | **`7.190 μs`** | `7.270 μs` | `11.000 μs` |
| Intel i5 8250U, 1 thread, check bounds | `749.168 μs` | `805.413 μs` | **`578.246 μs`** | `741.193 μs` |
| Intel i5 8250U, 1 thread, no check bounds | `745.897 μs` | `737.328 μs` | **`558.226 μs`** | `739.141 μs` |
| Intel i5 8250U, 4 threads, check bounds | `756.759 μs` | `614.203 μs` | **`410.489 μs`** | `611.506 μs` |
| Intel i5 8250U, 4 threads, no check bounds | `746.440 μs` | `618.554 μs` | **`409.176 μs`** | `618.131 μs` |

I implemented `reset_ellipsis!` in this PR. On the Threadripper, it's close to the fastest implementation for every configuration, while having significantly better single-thread, check bounds performance than the otherwise fastest `reset_loop!`. On my laptop, `reset_ellipsis!` is always the fastest.