### PR TITLE
introduce a weak form kernel

### DIFF
--- a/src/solvers/dgsem_structured/dg_2d.jl
+++ b/src/solvers/dgsem_structured/dg_2d.jl
@@ -44,36 +44,35 @@ function rhs!(du, u, t,
 end
 
 
-function calc_volume_integral!(du, u,
-                               mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
-                               nonconservative_terms::Val{false}, equations,
-                               volume_integral::VolumeIntegralWeakForm,
-                               dg::DGSEM, cache)
+@inline function weak_form_kernel!(du, u,
+                                   element, mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
+                                   nonconservative_terms::Val{false}, equations,
+                                   dg::DGSEM, cache, alpha=true)
+  # true * [some floating point value] == [exactly the same floating point value]
+  # This can (hopefully) be optimized away due to constant propagation.
   @unpack derivative_dhat = dg.basis
   @unpack contravariant_vectors = cache.elements
 
-  @threaded for element in eachelement(dg, cache)
-    for j in eachnode(dg), i in eachnode(dg)
-      u_node = get_node_vars(u, equations, dg, i, j, element)
+  for j in eachnode(dg), i in eachnode(dg)
+    u_node = get_node_vars(u, equations, dg, i, j, element)
 
-      flux1 = flux(u_node, 1, equations)
-      flux2 = flux(u_node, 2, equations)
+    flux1 = flux(u_node, 1, equations)
+    flux2 = flux(u_node, 2, equations)
 
-      # Compute the contravariant flux by taking the scalar product of the
-      # first contravariant vector Ja^1 and the flux vector
-      Ja11, Ja12 = get_contravariant_vector(1, contravariant_vectors, i, j, element)
-      contravariant_flux1 = Ja11 * flux1 + Ja12 * flux2
-      for ii in eachnode(dg)
-        multiply_add_to_node_vars!(du, derivative_dhat[ii, i], contravariant_flux1, equations, dg, ii, j, element)
-      end
+    # Compute the contravariant flux by taking the scalar product of the
+    # first contravariant vector Ja^1 and the flux vector
+    Ja11, Ja12 = get_contravariant_vector(1, contravariant_vectors, i, j, element)
+    contravariant_flux1 = Ja11 * flux1 + Ja12 * flux2
+    for ii in eachnode(dg)
+      multiply_add_to_node_vars!(du, alpha * derivative_dhat[ii, i], contravariant_flux1, equations, dg, ii, j, element)
+    end
 
-      # Compute the contravariant flux by taking the scalar product of the
-      # second contravariant vector Ja^2 and the flux vector
-      Ja21, Ja22 = get_contravariant_vector(2, contravariant_vectors, i, j, element)
-      contravariant_flux2 = Ja21 * flux1 + Ja22 * flux2
-      for jj in eachnode(dg)
-        multiply_add_to_node_vars!(du, derivative_dhat[jj, j], contravariant_flux2, equations, dg, i, jj, element)
-      end
+    # Compute the contravariant flux by taking the scalar product of the
+    # second contravariant vector Ja^2 and the flux vector
+    Ja21, Ja22 = get_contravariant_vector(2, contravariant_vectors, i, j, element)
+    contravariant_flux2 = Ja21 * flux1 + Ja22 * flux2
+    for jj in eachnode(dg)
+      multiply_add_to_node_vars!(du, alpha * derivative_dhat[jj, j], contravariant_flux2, equations, dg, i, jj, element)
     end
   end
 

--- a/src/solvers/dgsem_structured/dg_3d.jl
+++ b/src/solvers/dgsem_structured/dg_3d.jl
@@ -44,45 +44,44 @@ function rhs!(du, u, t,
 end
 
 
-function calc_volume_integral!(du, u,
-                               mesh::Union{StructuredMesh{3}, P4estMesh{3}},
-                               nonconservative_terms::Val{false}, equations,
-                               volume_integral::VolumeIntegralWeakForm,
-                               dg::DGSEM, cache)
+@inline function weak_form_kernel!(du, u,
+                                   element, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
+                                   nonconservative_terms::Val{false}, equations,
+                                   dg::DGSEM, cache, alpha=true)
+  # true * [some floating point value] == [exactly the same floating point value]
+  # This can (hopefully) be optimized away due to constant propagation.
   @unpack derivative_dhat = dg.basis
   @unpack contravariant_vectors = cache.elements
 
-  @threaded for element in eachelement(dg, cache)
-    for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-      u_node = get_node_vars(u, equations, dg, i, j, k, element)
+  for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
+    u_node = get_node_vars(u, equations, dg, i, j, k, element)
 
-      flux1 = flux(u_node, 1, equations)
-      flux2 = flux(u_node, 2, equations)
-      flux3 = flux(u_node, 3, equations)
+    flux1 = flux(u_node, 1, equations)
+    flux2 = flux(u_node, 2, equations)
+    flux3 = flux(u_node, 3, equations)
 
-      # Compute the contravariant flux by taking the scalar product of the
-      # first contravariant vector Ja^1 and the flux vector
-      Ja11, Ja12, Ja13 = get_contravariant_vector(1, contravariant_vectors, i, j, k, element)
-      contravariant_flux1 = Ja11 * flux1 + Ja12 * flux2 + Ja13 * flux3
-      for ii in eachnode(dg)
-        multiply_add_to_node_vars!(du, derivative_dhat[ii, i], contravariant_flux1, equations, dg, ii, j, k, element)
-      end
+    # Compute the contravariant flux by taking the scalar product of the
+    # first contravariant vector Ja^1 and the flux vector
+    Ja11, Ja12, Ja13 = get_contravariant_vector(1, contravariant_vectors, i, j, k, element)
+    contravariant_flux1 = Ja11 * flux1 + Ja12 * flux2 + Ja13 * flux3
+    for ii in eachnode(dg)
+      multiply_add_to_node_vars!(du, alpha * derivative_dhat[ii, i], contravariant_flux1, equations, dg, ii, j, k, element)
+    end
 
-      # Compute the contravariant flux by taking the scalar product of the
-      # second contravariant vector Ja^2 and the flux vector
-      Ja21, Ja22, Ja23 = get_contravariant_vector(2, contravariant_vectors, i, j, k, element)
-      contravariant_flux2 = Ja21 * flux1 + Ja22 * flux2 + Ja23 * flux3
-      for jj in eachnode(dg)
-        multiply_add_to_node_vars!(du, derivative_dhat[jj, j], contravariant_flux2, equations, dg, i, jj, k, element)
-      end
+    # Compute the contravariant flux by taking the scalar product of the
+    # second contravariant vector Ja^2 and the flux vector
+    Ja21, Ja22, Ja23 = get_contravariant_vector(2, contravariant_vectors, i, j, k, element)
+    contravariant_flux2 = Ja21 * flux1 + Ja22 * flux2 + Ja23 * flux3
+    for jj in eachnode(dg)
+      multiply_add_to_node_vars!(du, alpha * derivative_dhat[jj, j], contravariant_flux2, equations, dg, i, jj, k, element)
+    end
 
-      # Compute the contravariant flux by taking the scalar product of the
-      # third contravariant vector Ja^3 and the flux vector
-      Ja31, Ja32, Ja33 = get_contravariant_vector(3, contravariant_vectors, i, j, k, element)
-      contravariant_flux3 = Ja31 * flux1 + Ja32 * flux2 + Ja33 * flux3
-      for kk in eachnode(dg)
-        multiply_add_to_node_vars!(du, derivative_dhat[kk, k], contravariant_flux3, equations, dg, i, j, kk, element)
-      end
+    # Compute the contravariant flux by taking the scalar product of the
+    # third contravariant vector Ja^3 and the flux vector
+    Ja31, Ja32, Ja33 = get_contravariant_vector(3, contravariant_vectors, i, j, k, element)
+    contravariant_flux3 = Ja31 * flux1 + Ja32 * flux2 + Ja33 * flux3
+    for kk in eachnode(dg)
+      multiply_add_to_node_vars!(du, alpha * derivative_dhat[kk, k], contravariant_flux3, equations, dg, i, j, kk, element)
     end
   end
 

--- a/src/solvers/dgsem_tree/dg_1d.jl
+++ b/src/solvers/dgsem_tree/dg_1d.jl
@@ -124,19 +124,33 @@ end
 
 function calc_volume_integral!(du, u,
                                mesh::Union{TreeMesh{1}, StructuredMesh{1}},
-                               nonconservative_terms::Val{false}, equations,
+                               nonconservative_terms, equations,
                                volume_integral::VolumeIntegralWeakForm,
                                dg::DGSEM, cache)
-  @unpack derivative_dhat = dg.basis
 
   @threaded for element in eachelement(dg, cache)
-    for i in eachnode(dg)
-      u_node = get_node_vars(u, equations, dg, i, element)
+    weak_form_kernel!(du, u, element, mesh,
+                      nonconservative_terms, equations,
+                      dg, cache)
+  end
 
-      flux1 = flux(u_node, 1, equations)
-      for ii in eachnode(dg)
-        multiply_add_to_node_vars!(du, derivative_dhat[ii, i], flux1, equations, dg, ii, element)
-      end
+  return nothing
+end
+
+@inline function weak_form_kernel!(du, u,
+                                   element, mesh::Union{TreeMesh{1}, StructuredMesh{1}},
+                                   nonconservative_terms::Val{false}, equations,
+                                   dg::DGSEM, cache, alpha=true)
+  # true * [some floating point value] == [exactly the same floating point value]
+  # This can (hopefully) be optimized away due to constant propagation.
+  @unpack derivative_dhat = dg.basis
+
+  for i in eachnode(dg)
+    u_node = get_node_vars(u, equations, dg, i, element)
+
+    flux1 = flux(u_node, 1, equations)
+    for ii in eachnode(dg)
+      multiply_add_to_node_vars!(du, alpha * derivative_dhat[ii, i], flux1, equations, dg, ii, element)
     end
   end
 

--- a/src/solvers/dgsem_tree/dg_2d.jl
+++ b/src/solvers/dgsem_tree/dg_2d.jl
@@ -155,25 +155,40 @@ end
 
 
 function calc_volume_integral!(du, u,
-                               mesh::TreeMesh{2},
-                               nonconservative_terms::Val{false}, equations,
+                               mesh::Union{TreeMesh{2}, StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
+                               nonconservative_terms, equations,
                                volume_integral::VolumeIntegralWeakForm,
                                dg::DGSEM, cache)
-  @unpack derivative_dhat = dg.basis
 
   @threaded for element in eachelement(dg, cache)
-    for j in eachnode(dg), i in eachnode(dg)
-      u_node = get_node_vars(u, equations, dg, i, j, element)
+    weak_form_kernel!(du, u, element, mesh,
+                      nonconservative_terms, equations,
+                      dg, cache)
+  end
 
-      flux1 = flux(u_node, 1, equations)
-      for ii in eachnode(dg)
-        multiply_add_to_node_vars!(du, derivative_dhat[ii, i], flux1, equations, dg, ii, j, element)
-      end
+  return nothing
+end
 
-      flux2 = flux(u_node, 2, equations)
-      for jj in eachnode(dg)
-        multiply_add_to_node_vars!(du, derivative_dhat[jj, j], flux2, equations, dg, i, jj, element)
-      end
+@inline function weak_form_kernel!(du, u,
+                                   element, mesh::TreeMesh{2},
+                                   nonconservative_terms::Val{false}, equations,
+                                   dg::DGSEM, cache, alpha=true)
+  # true * [some floating point value] == [exactly the same floating point value]
+  # This can (hopefully) be optimized away due to constant propagation.
+  @unpack derivative_dhat = dg.basis
+
+  # Calculate volume terms in one element
+  for j in eachnode(dg), i in eachnode(dg)
+    u_node = get_node_vars(u, equations, dg, i, j, element)
+
+    flux1 = flux(u_node, 1, equations)
+    for ii in eachnode(dg)
+      multiply_add_to_node_vars!(du, alpha * derivative_dhat[ii, i], flux1, equations, dg, ii, j, element)
+    end
+
+    flux2 = flux(u_node, 2, equations)
+    for jj in eachnode(dg)
+      multiply_add_to_node_vars!(du, alpha * derivative_dhat[jj, j], flux2, equations, dg, i, jj, element)
     end
   end
 


### PR DESCRIPTION
I implemented a `weak_form_kernel!` mimicking the approach we use for the `split_form_kernel!`. This allows us to use use and benchmark it alone, e.g. when experimenting with overintegration etc.

@andrewwinters5000 It would be great if you could review this.