### PR TITLE
Improve entropy projection for DGMulti with GSBP

### DIFF
--- a/src/solvers/dgmulti/flux_differencing.jl
+++ b/src/solvers/dgmulti/flux_differencing.jl
@@ -311,7 +311,7 @@ end
 @inline function entropy2cons!(entropy_projected_u_values  ::StructArray,
                                projected_entropy_var_values::StructArray,
                                equations)
-  @threaded for i in Base.OneTo(length(projected_entropy_var_values))
+  @threaded for i in eachindex(projected_entropy_var_values)
     entropy_projected_u_values[i] = entropy2cons(projected_entropy_var_values[i], equations)
   end
 end

--- a/src/solvers/dgmulti/flux_differencing_compressible_euler.jl
+++ b/src/solvers/dgmulti/flux_differencing_compressible_euler.jl
@@ -25,9 +25,9 @@ function cons2entropy!(entropy_var_values::StructArray,
   rho_values, rho_v1_values, rho_v2_values, rho_e_values = StructArrays.components(u_values)
   w1_values, w2_values, w3_values, w4_values = StructArrays.components(entropy_var_values)
 
-  @turbo thread=true for i in indices(
-      (rho_values, rho_v1_values, rho_v2_values, rho_e_values,
-       w1_values, w2_values, w3_values, w4_values))
+  @turbo thread=true for i in eachindex(
+      rho_values, rho_v1_values, rho_v2_values, rho_e_values,
+      w1_values, w2_values, w3_values, w4_values)
     rho    = rho_values[i]
     rho_v1 = rho_v1_values[i]
     rho_v2 = rho_v2_values[i]
@@ -62,9 +62,9 @@ function entropy2cons!(entropy_projected_u_values  ::StructArray,
   rho_values, rho_v1_values, rho_v2_values, rho_e_values = StructArrays.components(entropy_projected_u_values)
   w1_values, w2_values, w3_values, w4_values = StructArrays.components(projected_entropy_var_values)
 
-  @turbo thread=true for i in indices(
-      (rho_values, rho_v1_values, rho_v2_values, rho_e_values,
-       w1_values, w2_values, w3_values, w4_values))
+  @turbo thread=true for i in eachindex(
+      rho_values, rho_v1_values, rho_v2_values, rho_e_values,
+      w1_values, w2_values, w3_values, w4_values)
 
     # The following is basically the same code as in `entropy2cons`
     # Convert to entropy `-rho * s` used by
@@ -106,9 +106,9 @@ function cons2entropy!(entropy_var_values::StructArray,
   rho_values, rho_v1_values, rho_v2_values, rho_v3_values, rho_e_values = StructArrays.components(u_values)
   w1_values, w2_values, w3_values, w4_values, w5_values = StructArrays.components(entropy_var_values)
 
-  @turbo thread=true for i in indices(
-      (rho_values, rho_v1_values, rho_v2_values, rho_v3_values, rho_e_values,
-       w1_values, w2_values, w3_values, w4_values, w5_values))
+  @turbo thread=true for i in eachindex(
+      rho_values, rho_v1_values, rho_v2_values, rho_v3_values, rho_e_values,
+      w1_values, w2_values, w3_values, w4_values, w5_values)
     rho    = rho_values[i]
     rho_v1 = rho_v1_values[i]
     rho_v2 = rho_v2_values[i]
@@ -146,9 +146,9 @@ function entropy2cons!(entropy_projected_u_values  ::StructArray,
   rho_values, rho_v1_values, rho_v2_values, rho_v3_values, rho_e_values = StructArrays.components(entropy_projected_u_values)
   w1_values, w2_values, w3_values, w4_values, w5_values = StructArrays.components(projected_entropy_var_values)
 
-  @turbo thread=true for i in indices(
-      (rho_values, rho_v1_values, rho_v2_values, rho_v3_values, rho_e_values,
-       w1_values, w2_values, w3_values, w4_values, w5_values))
+  @turbo thread=true for i in eachindex(
+      rho_values, rho_v1_values, rho_v2_values, rho_v3_values, rho_e_values,
+      w1_values, w2_values, w3_values, w4_values, w5_values)
 
     # The following is basically the same code as in `entropy2cons`
     # Convert to entropy `-rho * s` used by

--- a/src/solvers/dgmulti/flux_differencing_compressible_euler.jl
+++ b/src/solvers/dgmulti/flux_differencing_compressible_euler.jl
@@ -11,180 +11,169 @@
 #       loop optimally when passing our custom functions `cons2entropy` and
 #       `entropy2cons`. Thus, we need to insert the physics directly here to
 #       get a significant runtime performance improvement.
-function entropy_projection!(cache, u::StructArray{<:SVector{4, <:Union{Float32, Float64}}},
-                             mesh::VertexMappedMesh, equations::CompressibleEulerEquations2D, dg::DGMultiFluxDiff{<:Polynomial})
-  rd = dg.basis
-  @unpack Vq = rd
-  @unpack VhP, u_values, entropy_var_values = cache
-  @unpack projected_entropy_var_values, entropy_projected_u_values = cache
-
-  apply_to_each_field(mul_by!(Vq), u_values, u)
-
+function cons2entropy!(entropy_var_values::StructArray,
+                       u_values          ::StructArray,
+                       equations::CompressibleEulerEquations2D)
   # The following is semantically equivalent to
-  # @threaded for i in Base.OneTo(length(u_values))
+  # @threaded for i in eachindex(u_values)
   #   entropy_var_values[i] = cons2entropy(u_values[i], equations)
   # end
   # but much more efficient due to explicit optimization via `@turbo` from
   # LoopVectorization.jl.
   @unpack gamma, inv_gamma_minus_one = equations
-  let
-    rho_values, rho_v1_values, rho_v2_values, rho_e_values = StructArrays.components(u_values)
-    w1_values, w2_values, w3_values, w4_values = StructArrays.components(entropy_var_values)
 
-    @turbo thread=true for i in indices(
-        (rho_values, rho_v1_values, rho_v2_values, rho_e_values,
-         w1_values, w2_values, w3_values, w4_values))
-      rho    = rho_values[i]
-      rho_v1 = rho_v1_values[i]
-      rho_v2 = rho_v2_values[i]
-      rho_e  = rho_e_values[i]
+  rho_values, rho_v1_values, rho_v2_values, rho_e_values = StructArrays.components(u_values)
+  w1_values, w2_values, w3_values, w4_values = StructArrays.components(entropy_var_values)
 
-      # The following is basically the same code as in `cons2entropy`
-      v1 = rho_v1 / rho
-      v2 = rho_v2 / rho
-      v_square = v1^2 + v2^2
-      p = (gamma - 1) * (rho_e - 0.5 * rho * v_square)
-      s = log(p) - gamma * log(rho)
-      rho_p = rho / p
+  @turbo thread=true for i in indices(
+      (rho_values, rho_v1_values, rho_v2_values, rho_e_values,
+       w1_values, w2_values, w3_values, w4_values))
+    rho    = rho_values[i]
+    rho_v1 = rho_v1_values[i]
+    rho_v2 = rho_v2_values[i]
+    rho_e  = rho_e_values[i]
 
-      w1_values[i] = (gamma - s) * inv_gamma_minus_one - 0.5 * rho_p * v_square
-      w2_values[i] = rho_p * v1
-      w3_values[i] = rho_p * v2
-      w4_values[i] = -rho_p
-    end
-  end
+    # The following is basically the same code as in `cons2entropy`
+    v1 = rho_v1 / rho
+    v2 = rho_v2 / rho
+    v_square = v1^2 + v2^2
+    p = (gamma - 1) * (rho_e - 0.5 * rho * v_square)
+    s = log(p) - gamma * log(rho)
+    rho_p = rho / p
 
-  # "VhP" fuses the projection "P" with interpolation to volume and face quadrature "Vh"
-  apply_to_each_field(mul_by!(VhP), projected_entropy_var_values, entropy_var_values)
-
-  # The following is semantically equivalent to
-  # @threaded for i in Base.OneTo(length(projected_entropy_var_values)) #eachindex(projected_entropy_var_values)
-  #   entropy_projected_u_values[i] = entropy2cons(projected_entropy_var_values[i], equations)
-  # end
-  # but much more efficient due to explicit optimization via `@turbo` from
-  # LoopVectorization.jl.
-  let
-    rho_values, rho_v1_values, rho_v2_values, rho_e_values = StructArrays.components(entropy_projected_u_values)
-    w1_values, w2_values, w3_values, w4_values = StructArrays.components(projected_entropy_var_values)
-
-    @turbo thread=true for i in indices(
-        (rho_values, rho_v1_values, rho_v2_values, rho_e_values,
-         w1_values, w2_values, w3_values, w4_values))
-
-      # The following is basically the same code as in `entropy2cons`
-      # Convert to entropy `-rho * s` used by
-      # - See Hughes, Franca, Mallet (1986) A new finite element formulation for CFD
-      #   [DOI: 10.1016/0045-7825(86)90127-1](https://doi.org/10.1016/0045-7825(86)90127-1)
-      # instead of `-rho * s / (gamma - 1)`
-      gamma_minus_one = gamma - 1
-      w1 = gamma_minus_one * w1_values[i]
-      w2 = gamma_minus_one * w2_values[i]
-      w3 = gamma_minus_one * w3_values[i]
-      w4 = gamma_minus_one * w4_values[i]
-
-      # s = specific entropy, eq. (53)
-      s = gamma - w1 + (w2^2 + w3^2) / (2 * w4)
-
-      # eq. (52)
-      rho_iota = (gamma_minus_one / (-w4)^gamma)^(inv_gamma_minus_one) * exp(-s * inv_gamma_minus_one)
-
-      # eq. (51)
-      rho_values[i]    = -rho_iota * w4
-      rho_v1_values[i] =  rho_iota * w2
-      rho_v2_values[i] =  rho_iota * w3
-      rho_e_values[i]  =  rho_iota * (1 - (w2^2 + w3^2) / (2 * w4))
-    end
+    w1_values[i] = (gamma - s) * inv_gamma_minus_one - 0.5 * rho_p * v_square
+    w2_values[i] = rho_p * v1
+    w3_values[i] = rho_p * v2
+    w4_values[i] = -rho_p
   end
 end
 
-function entropy_projection!(cache, u::StructArray{<:SVector{5, <:Union{Float32, Float64}}},
-                             mesh::VertexMappedMesh, equations::CompressibleEulerEquations3D, dg::DGMultiFluxDiff{<:Polynomial})
-  rd = dg.basis
-  @unpack Vq = rd
-  @unpack VhP, u_values, entropy_var_values = cache
-  @unpack projected_entropy_var_values, entropy_projected_u_values = cache
-
-  apply_to_each_field(mul_by!(Vq), u_values, u)
-
+function entropy2cons!(entropy_projected_u_values  ::StructArray,
+                       projected_entropy_var_values::StructArray,
+                       equations::CompressibleEulerEquations2D)
   # The following is semantically equivalent to
-  # @threaded for i in Base.OneTo(length(u_values))
+  # @threaded for i in eachindex(projected_entropy_var_values)
+  #   entropy_projected_u_values[i] = entropy2cons(projected_entropy_var_values[i], equations)
+  # end
+  # but much more efficient due to explicit optimization via `@turbo` from
+  # LoopVectorization.jl.
+  @unpack gamma, inv_gamma_minus_one = equations
+
+  rho_values, rho_v1_values, rho_v2_values, rho_e_values = StructArrays.components(entropy_projected_u_values)
+  w1_values, w2_values, w3_values, w4_values = StructArrays.components(projected_entropy_var_values)
+
+  @turbo thread=true for i in indices(
+      (rho_values, rho_v1_values, rho_v2_values, rho_e_values,
+       w1_values, w2_values, w3_values, w4_values))
+
+    # The following is basically the same code as in `entropy2cons`
+    # Convert to entropy `-rho * s` used by
+    # - See Hughes, Franca, Mallet (1986) A new finite element formulation for CFD
+    #   [DOI: 10.1016/0045-7825(86)90127-1](https://doi.org/10.1016/0045-7825(86)90127-1)
+    # instead of `-rho * s / (gamma - 1)`
+    gamma_minus_one = gamma - 1
+    w1 = gamma_minus_one * w1_values[i]
+    w2 = gamma_minus_one * w2_values[i]
+    w3 = gamma_minus_one * w3_values[i]
+    w4 = gamma_minus_one * w4_values[i]
+
+    # s = specific entropy, eq. (53)
+    s = gamma - w1 + (w2^2 + w3^2) / (2 * w4)
+
+    # eq. (52)
+    rho_iota = (gamma_minus_one / (-w4)^gamma)^(inv_gamma_minus_one) * exp(-s * inv_gamma_minus_one)
+
+    # eq. (51)
+    rho_values[i]    = -rho_iota * w4
+    rho_v1_values[i] =  rho_iota * w2
+    rho_v2_values[i] =  rho_iota * w3
+    rho_e_values[i]  =  rho_iota * (1 - (w2^2 + w3^2) / (2 * w4))
+  end
+end
+
+
+function cons2entropy!(entropy_var_values::StructArray,
+                       u_values          ::StructArray,
+                       equations::CompressibleEulerEquations3D)
+  # The following is semantically equivalent to
+  # @threaded for i in eachindex(u_values)
   #   entropy_var_values[i] = cons2entropy(u_values[i], equations)
   # end
   # but much more efficient due to explicit optimization via `@turbo` from
   # LoopVectorization.jl.
   @unpack gamma, inv_gamma_minus_one = equations
-  let
-    rho_values, rho_v1_values, rho_v2_values, rho_v3_values, rho_e_values = StructArrays.components(u_values)
-    w1_values, w2_values, w3_values, w4_values, w5_values = StructArrays.components(entropy_var_values)
 
-    @turbo thread=true for i in indices(
-        (rho_values, rho_v1_values, rho_v2_values, rho_v3_values, rho_e_values,
-         w1_values, w2_values, w3_values, w4_values, w5_values))
-      rho    = rho_values[i]
-      rho_v1 = rho_v1_values[i]
-      rho_v2 = rho_v2_values[i]
-      rho_v3 = rho_v3_values[i]
-      rho_e  = rho_e_values[i]
+  rho_values, rho_v1_values, rho_v2_values, rho_v3_values, rho_e_values = StructArrays.components(u_values)
+  w1_values, w2_values, w3_values, w4_values, w5_values = StructArrays.components(entropy_var_values)
 
-      # The following is basically the same code as in `cons2entropy`
-      v1 = rho_v1 / rho
-      v2 = rho_v2 / rho
-      v3 = rho_v3 / rho
-      v_square = v1^2 + v2^2 + v3^2
-      p = (gamma - 1) * (rho_e - 0.5 * rho * v_square)
-      s = log(p) - gamma * log(rho)
-      rho_p = rho / p
+  @turbo thread=true for i in indices(
+      (rho_values, rho_v1_values, rho_v2_values, rho_v3_values, rho_e_values,
+       w1_values, w2_values, w3_values, w4_values, w5_values))
+    rho    = rho_values[i]
+    rho_v1 = rho_v1_values[i]
+    rho_v2 = rho_v2_values[i]
+    rho_v3 = rho_v3_values[i]
+    rho_e  = rho_e_values[i]
 
-      w1_values[i] = (gamma - s) * inv_gamma_minus_one - 0.5 * rho_p * v_square
-      w2_values[i] = rho_p * v1
-      w3_values[i] = rho_p * v2
-      w4_values[i] = rho_p * v3
-      w5_values[i] = -rho_p
-    end
+    # The following is basically the same code as in `cons2entropy`
+    v1 = rho_v1 / rho
+    v2 = rho_v2 / rho
+    v3 = rho_v3 / rho
+    v_square = v1^2 + v2^2 + v3^2
+    p = (gamma - 1) * (rho_e - 0.5 * rho * v_square)
+    s = log(p) - gamma * log(rho)
+    rho_p = rho / p
+
+    w1_values[i] = (gamma - s) * inv_gamma_minus_one - 0.5 * rho_p * v_square
+    w2_values[i] = rho_p * v1
+    w3_values[i] = rho_p * v2
+    w4_values[i] = rho_p * v3
+    w5_values[i] = -rho_p
   end
+end
 
-  # "VhP" fuses the projection "P" with interpolation to volume and face quadrature "Vh"
-  apply_to_each_field(mul_by!(VhP), projected_entropy_var_values, entropy_var_values)
-
+function entropy2cons!(entropy_projected_u_values  ::StructArray,
+                       projected_entropy_var_values::StructArray,
+                       equations::CompressibleEulerEquations3D)
   # The following is semantically equivalent to
-  # @threaded for i in Base.OneTo(length(projected_entropy_var_values)) #eachindex(projected_entropy_var_values)
+  # @threaded for i in eachindex(projected_entropy_var_values)
   #   entropy_projected_u_values[i] = entropy2cons(projected_entropy_var_values[i], equations)
   # end
   # but much more efficient due to explicit optimization via `@turbo` from
   # LoopVectorization.jl.
-  let
-    rho_values, rho_v1_values, rho_v2_values, rho_v3_values, rho_e_values = StructArrays.components(entropy_projected_u_values)
-    w1_values, w2_values, w3_values, w4_values, w5_values = StructArrays.components(projected_entropy_var_values)
+  @unpack gamma, inv_gamma_minus_one = equations
 
-    @turbo thread=true for i in indices(
-        (rho_values, rho_v1_values, rho_v2_values, rho_v3_values, rho_e_values,
-         w1_values, w2_values, w3_values, w4_values, w5_values))
+  rho_values, rho_v1_values, rho_v2_values, rho_v3_values, rho_e_values = StructArrays.components(entropy_projected_u_values)
+  w1_values, w2_values, w3_values, w4_values, w5_values = StructArrays.components(projected_entropy_var_values)
 
-      # The following is basically the same code as in `entropy2cons`
-      # Convert to entropy `-rho * s` used by
-      # - See Hughes, Franca, Mallet (1986) A new finite element formulation for CFD
-      #   [DOI: 10.1016/0045-7825(86)90127-1](https://doi.org/10.1016/0045-7825(86)90127-1)
-      # instead of `-rho * s / (gamma - 1)`
-      gamma_minus_one = gamma - 1
-      w1 = gamma_minus_one * w1_values[i]
-      w2 = gamma_minus_one * w2_values[i]
-      w3 = gamma_minus_one * w3_values[i]
-      w4 = gamma_minus_one * w4_values[i]
-      w5 = gamma_minus_one * w5_values[i]
+  @turbo thread=true for i in indices(
+      (rho_values, rho_v1_values, rho_v2_values, rho_v3_values, rho_e_values,
+       w1_values, w2_values, w3_values, w4_values, w5_values))
 
-      # s = specific entropy, eq. (53)
-      s = gamma - w1 + (w2^2 + w3^2 + w4^2) / (2 * w5)
+    # The following is basically the same code as in `entropy2cons`
+    # Convert to entropy `-rho * s` used by
+    # - See Hughes, Franca, Mallet (1986) A new finite element formulation for CFD
+    #   [DOI: 10.1016/0045-7825(86)90127-1](https://doi.org/10.1016/0045-7825(86)90127-1)
+    # instead of `-rho * s / (gamma - 1)`
+    gamma_minus_one = gamma - 1
+    w1 = gamma_minus_one * w1_values[i]
+    w2 = gamma_minus_one * w2_values[i]
+    w3 = gamma_minus_one * w3_values[i]
+    w4 = gamma_minus_one * w4_values[i]
+    w5 = gamma_minus_one * w5_values[i]
 
-      # eq. (52)
-      rho_iota = (gamma_minus_one / (-w5)^gamma)^(inv_gamma_minus_one) * exp(-s * inv_gamma_minus_one)
+    # s = specific entropy, eq. (53)
+    s = gamma - w1 + (w2^2 + w3^2 + w4^2) / (2 * w5)
 
-      # eq. (51)
-      rho_values[i]    = -rho_iota * w5
-      rho_v1_values[i] =  rho_iota * w2
-      rho_v2_values[i] =  rho_iota * w3
-      rho_v3_values[i] =  rho_iota * w4
-      rho_e_values[i]  =  rho_iota * (1 - (w2^2 + w3^2 + w4^2) / (2 * w5))
-    end
+    # eq. (52)
+    rho_iota = (gamma_minus_one / (-w5)^gamma)^(inv_gamma_minus_one) * exp(-s * inv_gamma_minus_one)
+
+    # eq. (51)
+    rho_values[i]    = -rho_iota * w5
+    rho_v1_values[i] =  rho_iota * w2
+    rho_v2_values[i] =  rho_iota * w3
+    rho_v3_values[i] =  rho_iota * w4
+    rho_e_values[i]  =  rho_iota * (1 - (w2^2 + w3^2 + w4^2) / (2 * w5))
   end
 end
 

--- a/src/solvers/dgmulti/flux_differencing_gsbp.jl
+++ b/src/solvers/dgmulti/flux_differencing_gsbp.jl
@@ -104,9 +104,7 @@ function entropy_projection!(cache, u, mesh::VertexMappedMesh, equations, dg::DG
   end
 
   # transform quadrature values to entropy variables
-  @threaded for i in eachindex(u_values)
-    entropy_var_values[i] = cons2entropy(u_values[i], equations)
-  end
+  cons2entropy!(entropy_var_values, u_values, equations)
 
   volume_indices = Base.OneTo(rd.Nq)
   face_indices = (rd.Nq + 1):(rd.Nq + rd.Nfq)
@@ -125,9 +123,9 @@ function entropy_projection!(cache, u, mesh::VertexMappedMesh, equations, dg::DG
 
   # transform entropy to conservative variables on face values
   entropy_projected_face_values = view(entropy_projected_u_values, face_indices, :)
-  @threaded for i in eachindex(entropy_var_face_values)
-    entropy_projected_face_values[i] = entropy2cons(entropy_var_face_values[i], equations)
-  end
+  entropy2cons!(entropy_projected_face_values, entropy_var_face_values, equations)
+
+  return nothing
 end
 
 function calc_volume_integral!(du, u, volume_integral, mesh::VertexMappedMesh,


### PR DESCRIPTION
With this PR, `Polynomial()` and `GSBP()` share the same optimized code using LoopVectorization.jl for the transformations.

`main` with `julia --check-bounds=no --threads=1`, after compilation:
```julia
julia> trixi_include(joinpath(examples_dir(), "dgmulti_2d", "elixir_euler_kelvin_helmholtz_instability.jl"), tspan=(0.0, 0.25), approximation_type=Polynomial(), polydeg=3, cells_per_dimension=(32, 32))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             1.37s / 97.3%           2.57MiB / 60.1%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       406    1.32s  99.3%  3.25ms    526KiB  33.3%  1.30KiB
   volume integral          406    936ms  70.4%  2.30ms     0.00B  0.00%    0.00B
   entropy_projection!      406    189ms  14.2%   466μs     0.00B  0.00%    0.00B
   interface flux           406    163ms  12.2%   401μs     0.00B  0.00%    0.00B
   surface integral         406   16.6ms  1.25%  40.8μs     0.00B  0.00%    0.00B
   invert jacobian          406   7.82ms  0.59%  19.2μs     0.00B  0.00%    0.00B
   Reset du/dt              406   4.40ms  0.33%  10.8μs     0.00B  0.00%    0.00B
   ~rhs!~                   406   2.82ms  0.21%  6.94μs    526KiB  33.3%  1.30KiB
   boundary flux            406   9.64μs  0.00%  23.7ns     0.00B  0.00%    0.00B
   calc sources             406   9.08μs  0.00%  22.4ns     0.00B  0.00%    0.00B
 analyze solution             2   9.77ms  0.74%  4.88ms   1.03MiB  66.7%   528KiB
 ────────────────────────────────────────────────────────────────────────────────

julia> trixi_include(joinpath(examples_dir(), "dgmulti_2d", "elixir_euler_kelvin_helmholtz_instability.jl"), tspan=(0.0, 0.25), approximation_type=GSBP(), polydeg=3, cells_per_dimension=(32, 32))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             2.49s / 98.4%           2.60MiB / 60.6%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       406    2.44s  99.4%  6.00ms    558KiB  34.5%  1.37KiB
   entropy_projection!      406    1.29s  52.6%  3.18ms     0.00B  0.00%    0.00B
   volume integral          406    948ms  38.6%  2.34ms     0.00B  0.00%    0.00B
   interface flux           406    165ms  6.72%   406μs     0.00B  0.00%    0.00B
   surface integral         406   16.6ms  0.68%  40.8μs     0.00B  0.00%    0.00B
   invert jacobian          406   8.25ms  0.34%  20.3μs     0.00B  0.00%    0.00B
   Reset du/dt              406   5.26ms  0.21%  12.9μs     0.00B  0.00%    0.00B
   ~rhs!~                   406   3.15ms  0.13%  7.76μs    558KiB  34.5%  1.37KiB
   boundary flux            406   10.7μs  0.00%  26.3ns     0.00B  0.00%    0.00B
   calc sources             406   10.0μs  0.00%  24.7ns     0.00B  0.00%    0.00B
 analyze solution             2   15.8ms  0.65%  7.92ms   1.03MiB  65.5%   529KiB
 ────────────────────────────────────────────────────────────────────────────────

julia> trixi_include(joinpath(examples_dir(), "dgmulti_2d", "elixir_euler_kelvin_helmholtz_instability.jl"), tspan=(0.0, 0.25), approximation_type=Polynomial(), polydeg=7, cells_per_dimension=(16, 16))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             3.46s / 98.2%           3.50MiB / 70.3%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       726    3.38s  99.4%  4.66ms    936KiB  37.2%  1.29KiB
   volume integral          726    2.72s  79.9%  3.74ms     0.00B  0.00%    0.00B
   entropy_projection!      726    438ms  12.9%   603μs     0.00B  0.00%    0.00B
   interface flux           726    146ms  4.30%   201μs     0.00B  0.00%    0.00B
   surface integral         726   50.7ms  1.49%  69.8μs     0.00B  0.00%    0.00B
   invert jacobian          726   14.6ms  0.43%  20.1μs     0.00B  0.00%    0.00B
   Reset du/dt              726   9.42ms  0.28%  13.0μs     0.00B  0.00%    0.00B
   ~rhs!~                   726   5.09ms  0.15%  7.01μs    936KiB  37.2%  1.29KiB
   boundary flux            726   24.7μs  0.00%  34.0ns     0.00B  0.00%    0.00B
   calc sources             726   12.4μs  0.00%  17.1ns     0.00B  0.00%    0.00B
 analyze solution             3   19.5ms  0.57%  6.51ms   1.54MiB  62.8%   527KiB
 ────────────────────────────────────────────────────────────────────────────────

julia> trixi_include(joinpath(examples_dir(), "dgmulti_2d", "elixir_euler_kelvin_helmholtz_instability.jl"), tspan=(0.0, 0.25), approximation_type=GSBP(), polydeg=7, cells_per_dimension=(16, 16))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             4.05s / 98.5%           3.55MiB / 70.8%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       726    3.97s  99.4%  5.46ms   0.97MiB  38.5%  1.37KiB
   volume integral          726    2.47s  61.9%  3.40ms     0.00B  0.00%    0.00B
   entropy_projection!      726    1.28s  32.0%  1.76ms     0.00B  0.00%    0.00B
   interface flux           726    146ms  3.65%   201μs     0.00B  0.00%    0.00B
   surface integral         726   49.3ms  1.24%  67.9μs     0.00B  0.00%    0.00B
   invert jacobian          726   13.7ms  0.34%  18.9μs     0.00B  0.00%    0.00B
   Reset du/dt              726   7.51ms  0.19%  10.3μs     0.00B  0.00%    0.00B
   ~rhs!~                   726   5.07ms  0.13%  6.98μs   0.97MiB  38.5%  1.37KiB
   calc sources             726   15.7μs  0.00%  21.6ns     0.00B  0.00%    0.00B
   boundary flux            726   12.9μs  0.00%  17.8ns     0.00B  0.00%    0.00B
 analyze solution             3   22.4ms  0.56%  7.46ms   1.55MiB  61.5%   528KiB
 ────────────────────────────────────────────────────────────────────────────────

julia> trixi_include(joinpath(examples_dir(), "dgmulti_3d", "elixir_euler_taylor_green_vortex.jl"), tspan=(0.0, 0.25), approximation_type=Polynomial(), polydeg=3, cells_per_dimension=(8, 8, 8))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             2.95s / 95.7%           9.41MiB / 30.8%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       210    2.79s  98.6%  13.3ms    370KiB  12.5%  1.76KiB
   volume integral          210    1.85s  65.3%  8.79ms     0.00B  0.00%    0.00B
   entropy_projection!      210    483ms  17.1%  2.30ms     0.00B  0.00%    0.00B
   interface flux           210    304ms  10.8%  1.45ms     0.00B  0.00%    0.00B
   surface integral         210    126ms  4.47%   602μs     0.00B  0.00%    0.00B
   invert jacobian          210   12.0ms  0.42%  56.9μs     0.00B  0.00%    0.00B
   Reset du/dt              210   11.6ms  0.41%  55.3μs     0.00B  0.00%    0.00B
   ~rhs!~                   210   2.91ms  0.10%  13.9μs    370KiB  12.5%  1.76KiB
   boundary flux            210   21.7μs  0.00%   103ns     0.00B  0.00%    0.00B
   calc sources             210   21.3μs  0.00%   101ns     0.00B  0.00%    0.00B
 analyze solution             2   38.8ms  1.38%  19.4ms   2.54MiB  87.5%  1.27MiB
 ────────────────────────────────────────────────────────────────────────────────

julia> trixi_include(joinpath(examples_dir(), "dgmulti_3d", "elixir_euler_taylor_green_vortex.jl"), tspan=(0.0, 0.25), approximation_type=GSBP(), polydeg=3, cells_per_dimension=(8, 8, 8))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             4.53s / 97.2%           9.41MiB / 30.8%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       210    4.35s  98.8%  20.7ms    370KiB  12.5%  1.76KiB
   entropy_projection!      210    2.24s  50.9%  10.7ms     0.00B  0.00%    0.00B
   volume integral          210    1.65s  37.4%  7.85ms     0.00B  0.00%    0.00B
   interface flux           210    308ms  7.00%  1.47ms     0.00B  0.00%    0.00B
   surface integral         210    123ms  2.80%   587μs     0.00B  0.00%    0.00B
   Reset du/dt              210   13.1ms  0.30%  62.3μs     0.00B  0.00%    0.00B
   invert jacobian          210   12.2ms  0.28%  57.9μs     0.00B  0.00%    0.00B
   ~rhs!~                   210   2.91ms  0.07%  13.9μs    370KiB  12.5%  1.76KiB
   calc sources             210   21.5μs  0.00%   102ns     0.00B  0.00%    0.00B
   boundary flux            210   8.47μs  0.00%  40.4ns     0.00B  0.00%    0.00B
 analyze solution             2   54.2ms  1.23%  27.1ms   2.53MiB  87.5%  1.27MiB
 ────────────────────────────────────────────────────────────────────────────────

julia> trixi_include(joinpath(examples_dir(), "dgmulti_3d", "elixir_euler_taylor_green_vortex.jl"), tspan=(0.0, 0.25), approximation_type=Polynomial(), polydeg=7, cells_per_dimension=(4, 4, 4))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             16.4s / 98.8%           9.60MiB / 32.1%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       318    16.1s  99.2%  50.6ms    557KiB  17.7%  1.75KiB
   volume integral          318    12.2s  75.2%  38.3ms     0.00B  0.00%    0.00B
   entropy_projection!      318    2.87s  17.7%  9.03ms     0.00B  0.00%    0.00B
   surface integral         318    753ms  4.64%  2.37ms     0.00B  0.00%    0.00B
   interface flux           318    225ms  1.39%   708μs     0.00B  0.00%    0.00B
   invert jacobian          318   17.7ms  0.11%  55.7μs     0.00B  0.00%    0.00B
   Reset du/dt              318   17.0ms  0.10%  53.4μs     0.00B  0.00%    0.00B
   ~rhs!~                   318   8.85ms  0.05%  27.8μs    557KiB  17.7%  1.75KiB
   boundary flux            318   34.0μs  0.00%   107ns     0.00B  0.00%    0.00B
   calc sources             318   25.8μs  0.00%  81.1ns     0.00B  0.00%    0.00B
 analyze solution             2    135ms  0.83%  67.3ms   2.53MiB  82.3%  1.27MiB
 ────────────────────────────────────────────────────────────────────────────────

julia> trixi_include(joinpath(examples_dir(), "dgmulti_3d", "elixir_euler_taylor_green_vortex.jl"), tspan=(0.0, 0.25), approximation_type=GSBP(), polydeg=7, cells_per_dimension=(4, 4, 4))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             10.7s / 98.2%           9.60MiB / 32.1%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       318    10.4s  99.1%  32.7ms    557KiB  17.7%  1.75KiB
   volume integral          318    6.90s  65.9%  21.7ms     0.00B  0.00%    0.00B
   entropy_projection!      318    2.47s  23.6%  7.78ms     0.00B  0.00%    0.00B
   surface integral         318    739ms  7.05%  2.32ms     0.00B  0.00%    0.00B
   interface flux           318    227ms  2.16%   713μs     0.00B  0.00%    0.00B
   Reset du/dt              318   20.3ms  0.19%  63.8μs     0.00B  0.00%    0.00B
   invert jacobian          318   18.4ms  0.18%  57.8μs     0.00B  0.00%    0.00B
   ~rhs!~                   318   5.92ms  0.06%  18.6μs    557KiB  17.7%  1.75KiB
   boundary flux            318   31.6μs  0.00%  99.3ns     0.00B  0.00%    0.00B
   calc sources             318   13.7μs  0.00%  43.1ns     0.00B  0.00%    0.00B
 analyze solution             2   93.0ms  0.89%  46.5ms   2.54MiB  82.3%  1.27MiB
 ────────────────────────────────────────────────────────────────────────────────
```

This PR:
```julia
julia> trixi_include(joinpath(examples_dir(), "dgmulti_2d", "elixir_euler_kelvin_helmholtz_instability.jl"), tspan=(0.0, 0.25), approximation_type=Polynomial(), polydeg=3, cells_per_dimension=(32, 32))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             1.37s / 97.2%           2.57MiB / 60.0%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       406    1.32s  99.3%  3.25ms    526KiB  33.3%  1.30KiB
   volume integral          406    924ms  69.5%  2.28ms     0.00B  0.00%    0.00B
   entropy_projection!      406    196ms  14.7%   483μs     0.00B  0.00%    0.00B
   interface flux           406    164ms  12.3%   404μs     0.00B  0.00%    0.00B
   surface integral         406   17.1ms  1.28%  42.0μs     0.00B  0.00%    0.00B
   invert jacobian          406   8.53ms  0.64%  21.0μs     0.00B  0.00%    0.00B
   Reset du/dt              406   6.28ms  0.47%  15.5μs     0.00B  0.00%    0.00B
   ~rhs!~                   406   2.93ms  0.22%  7.22μs    526KiB  33.3%  1.30KiB
   calc sources             406   8.07μs  0.00%  19.9ns     0.00B  0.00%    0.00B
   boundary flux            406   6.81μs  0.00%  16.8ns     0.00B  0.00%    0.00B
 analyze solution             2   9.85ms  0.74%  4.93ms   1.03MiB  66.7%   527KiB
 ────────────────────────────────────────────────────────────────────────────────

julia> trixi_include(joinpath(examples_dir(), "dgmulti_2d", "elixir_euler_kelvin_helmholtz_instability.jl"), tspan=(0.0, 0.25), approximation_type=GSBP(), polydeg=3, cells_per_dimension=(32, 32))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             1.51s / 97.1%           2.60MiB / 60.5%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       406    1.46s  99.2%  3.58ms    558KiB  34.6%  1.37KiB
   volume integral          406    1.02s  69.8%  2.52ms     0.00B  0.00%    0.00B
   entropy_projection!      406    213ms  14.5%   524μs     0.00B  0.00%    0.00B
   interface flux           406    181ms  12.3%   445μs     0.00B  0.00%    0.00B
   surface integral         406   20.6ms  1.40%  50.7μs     0.00B  0.00%    0.00B
   invert jacobian          406   9.27ms  0.63%  22.8μs     0.00B  0.00%    0.00B
   Reset du/dt              406   4.81ms  0.33%  11.8μs     0.00B  0.00%    0.00B
   ~rhs!~                   406   4.09ms  0.28%  10.1μs    558KiB  34.6%  1.37KiB
   calc sources             406   18.8μs  0.00%  46.3ns     0.00B  0.00%    0.00B
   boundary flux            406   15.7μs  0.00%  38.7ns     0.00B  0.00%    0.00B
 analyze solution             2   11.5ms  0.79%  5.77ms   1.03MiB  65.4%   527KiB
 ────────────────────────────────────────────────────────────────────────────────

julia> trixi_include(joinpath(examples_dir(), "dgmulti_2d", "elixir_euler_kelvin_helmholtz_instability.jl"), tspan=(0.0, 0.25), approximation_type=Polynomial(), polydeg=7, cells_per_dimension=(16, 16))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             3.39s / 98.2%           3.50MiB / 70.3%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       726    3.31s  99.4%  4.56ms    936KiB  37.2%  1.29KiB
   volume integral          726    2.65s  79.7%  3.65ms     0.00B  0.00%    0.00B
   entropy_projection!      726    433ms  13.0%   597μs     0.00B  0.00%    0.00B
   interface flux           726    145ms  4.35%   200μs     0.00B  0.00%    0.00B
   surface integral         726   50.0ms  1.50%  68.8μs     0.00B  0.00%    0.00B
   invert jacobian          726   14.2ms  0.43%  19.6μs     0.00B  0.00%    0.00B
   Reset du/dt              726   9.08ms  0.27%  12.5μs     0.00B  0.00%    0.00B
   ~rhs!~                   726   5.67ms  0.17%  7.81μs    936KiB  37.2%  1.29KiB
   boundary flux            726   17.4μs  0.00%  23.9ns     0.00B  0.00%    0.00B
   calc sources             726   14.7μs  0.00%  20.3ns     0.00B  0.00%    0.00B
 analyze solution             3   19.4ms  0.58%  6.46ms   1.55MiB  62.8%   528KiB
 ────────────────────────────────────────────────────────────────────────────────

julia> trixi_include(joinpath(examples_dir(), "dgmulti_2d", "elixir_euler_kelvin_helmholtz_instability.jl"), tspan=(0.0, 0.25), approximation_type=GSBP(), polydeg=7, cells_per_dimension=(16, 16))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             3.11s / 97.9%           3.56MiB / 70.8%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       726    3.03s  99.4%  4.17ms   0.97MiB  38.5%  1.37KiB
   volume integral          726    2.53s  83.2%  3.49ms     0.00B  0.00%    0.00B
   entropy_projection!      726    261ms  8.56%   359μs     0.00B  0.00%    0.00B
   interface flux           726    151ms  4.97%   209μs     0.00B  0.00%    0.00B
   surface integral         726   51.7ms  1.70%  71.2μs     0.00B  0.00%    0.00B
   invert jacobian          726   14.6ms  0.48%  20.1μs     0.00B  0.00%    0.00B
   Reset du/dt              726   8.23ms  0.27%  11.3μs     0.00B  0.00%    0.00B
   ~rhs!~                   726   5.64ms  0.19%  7.76μs   0.97MiB  38.5%  1.37KiB
   boundary flux            726   19.4μs  0.00%  26.7ns     0.00B  0.00%    0.00B
   calc sources             726   18.0μs  0.00%  24.8ns     0.00B  0.00%    0.00B
 analyze solution             3   18.5ms  0.61%  6.17ms   1.55MiB  61.5%   529KiB
 ────────────────────────────────────────────────────────────────────────────────

julia> trixi_include(joinpath(examples_dir(), "dgmulti_3d", "elixir_euler_taylor_green_vortex.jl"), tspan=(0.0, 0.25), approximation_type=Polynomial(), polydeg=3, cells_per_dimension=(8, 8, 8))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             2.91s / 95.6%           9.41MiB / 30.8%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       210    2.74s  98.6%  13.1ms    370KiB  12.5%  1.76KiB
   volume integral          210    1.82s  65.4%  8.66ms     0.00B  0.00%    0.00B
   entropy_projection!      210    477ms  17.2%  2.27ms     0.00B  0.00%    0.00B
   interface flux           210    301ms  10.8%  1.43ms     0.00B  0.00%    0.00B
   surface integral         210    120ms  4.32%   571μs     0.00B  0.00%    0.00B
   Reset du/dt              210   11.1ms  0.40%  53.0μs     0.00B  0.00%    0.00B
   invert jacobian          210   11.0ms  0.40%  52.3μs     0.00B  0.00%    0.00B
   ~rhs!~                   210   2.69ms  0.10%  12.8μs    370KiB  12.5%  1.76KiB
   boundary flux            210   19.2μs  0.00%  91.3ns     0.00B  0.00%    0.00B
   calc sources             210   18.0μs  0.00%  85.6ns     0.00B  0.00%    0.00B
 analyze solution             2   38.0ms  1.37%  19.0ms   2.54MiB  87.5%  1.27MiB
 ────────────────────────────────────────────────────────────────────────────────

julia> trixi_include(joinpath(examples_dir(), "dgmulti_3d", "elixir_euler_taylor_green_vortex.jl"), tspan=(0.0, 0.25), approximation_type=GSBP(), polydeg=3, cells_per_dimension=(8, 8, 8))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             2.62s / 95.5%           9.41MiB / 30.8%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       210    2.47s  98.6%  11.8ms    370KiB  12.5%  1.76KiB
   volume integral          210    1.67s  66.6%  7.95ms     0.00B  0.00%    0.00B
   entropy_projection!      210    343ms  13.7%  1.64ms     0.00B  0.00%    0.00B
   interface flux           210    306ms  12.2%  1.46ms     0.00B  0.00%    0.00B
   surface integral         210    125ms  5.01%   597μs     0.00B  0.00%    0.00B
   invert jacobian          210   11.3ms  0.45%  54.0μs     0.00B  0.00%    0.00B
   Reset du/dt              210   11.1ms  0.44%  52.7μs     0.00B  0.00%    0.00B
   ~rhs!~                   210   2.81ms  0.11%  13.4μs    370KiB  12.5%  1.76KiB
   boundary flux            210   10.8μs  0.00%  51.4ns     0.00B  0.00%    0.00B
   calc sources             210   3.68μs  0.00%  17.5ns     0.00B  0.00%    0.00B
 analyze solution             2   35.1ms  1.40%  17.5ms   2.54MiB  87.5%  1.27MiB
 ────────────────────────────────────────────────────────────────────────────────

julia> trixi_include(joinpath(examples_dir(), "dgmulti_3d", "elixir_euler_taylor_green_vortex.jl"), tspan=(0.0, 0.25), approximation_type=Polynomial(), polydeg=7, cells_per_dimension=(4, 4, 4))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             16.3s / 98.7%           9.60MiB / 32.1%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       318    15.9s  99.2%  50.1ms    557KiB  17.7%  1.75KiB
   volume integral          318    12.1s  75.1%  38.0ms     0.00B  0.00%    0.00B
   entropy_projection!      318    2.87s  17.9%  9.03ms     0.00B  0.00%    0.00B
   surface integral         318    737ms  4.58%  2.32ms     0.00B  0.00%    0.00B
   interface flux           318    225ms  1.40%   706μs     0.00B  0.00%    0.00B
   invert jacobian          318   17.8ms  0.11%  56.1μs     0.00B  0.00%    0.00B
   Reset du/dt              318   17.4ms  0.11%  54.8μs     0.00B  0.00%    0.00B
   ~rhs!~                   318   7.91ms  0.05%  24.9μs    557KiB  17.7%  1.75KiB
   boundary flux            318   25.0μs  0.00%  78.5ns     0.00B  0.00%    0.00B
   calc sources             318   24.7μs  0.00%  77.6ns     0.00B  0.00%    0.00B
 analyze solution             2    128ms  0.79%  63.8ms   2.53MiB  82.3%  1.27MiB
 ────────────────────────────────────────────────────────────────────────────────

julia> trixi_include(joinpath(examples_dir(), "dgmulti_3d", "elixir_euler_taylor_green_vortex.jl"), tspan=(0.0, 0.25), approximation_type=GSBP(), polydeg=7, cells_per_dimension=(4, 4, 4))
[...]
 ────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                    Time                   Allocations
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             8.52s / 97.7%           9.60MiB / 32.1%

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 rhs!                       318    8.24s  99.0%  25.9ms    557KiB  17.7%  1.75KiB
   volume integral          318    6.28s  75.5%  19.7ms     0.00B  0.00%    0.00B
   entropy_projection!      318    973ms  11.7%  3.06ms     0.00B  0.00%    0.00B
   surface integral         318    719ms  8.64%  2.26ms     0.00B  0.00%    0.00B
   interface flux           318    225ms  2.71%   708μs     0.00B  0.00%    0.00B
   invert jacobian          318   17.9ms  0.21%  56.2μs     0.00B  0.00%    0.00B
   Reset du/dt              318   16.8ms  0.20%  52.8μs     0.00B  0.00%    0.00B
   ~rhs!~                   318   6.43ms  0.08%  20.2μs    557KiB  17.7%  1.75KiB
   calc sources             318   26.2μs  0.00%  82.5ns     0.00B  0.00%    0.00B
   boundary flux            318   6.08μs  0.00%  19.1ns     0.00B  0.00%    0.00B
 analyze solution             2   81.6ms  0.98%  40.8ms   2.54MiB  82.3%  1.27MiB
 ────────────────────────────────────────────────────────────────────────────────
```