### PR TITLE
insert keyword argument `maxiters` into `solve` and `Trixi.solve` via `trixi_include`

### DIFF
--- a/benchmark/elixir_2d_euler_vortex_p4est.jl
+++ b/benchmark/elixir_2d_euler_vortex_p4est.jl
@@ -80,5 +80,5 @@ callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback)
 # run the simulation
 
 sol = solve(ode, BS3(),
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/benchmark/elixir_2d_euler_vortex_structured.jl
+++ b/benchmark/elixir_2d_euler_vortex_structured.jl
@@ -79,5 +79,5 @@ callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback)
 # run the simulation
 
 sol = solve(ode, BS3(),
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/benchmark/elixir_2d_euler_vortex_tree.jl
+++ b/benchmark/elixir_2d_euler_vortex_tree.jl
@@ -80,5 +80,5 @@ callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback)
 # run the simulation
 
 sol = solve(ode, BS3(),
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/benchmark/elixir_2d_euler_vortex_unstructured.jl
+++ b/benchmark/elixir_2d_euler_vortex_unstructured.jl
@@ -80,5 +80,5 @@ callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback)
 # run the simulation
 
 sol = solve(ode, BS3(),
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/docs/literate/src/files/adding_new_equations/cubic_conservation_law.jl
+++ b/docs/literate/src/files/adding_new_equations/cubic_conservation_law.jl
@@ -67,7 +67,7 @@ callbacks = CallbackSet(summary_callback)
 
 ## OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
 sol = solve(ode, SSPRK43(),
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 
 # That's it, you ran your first simulation using your new equation with Trixi! Now, we can plot
 # the solution at the final time using Plots.jl.

--- a/examples/dgmulti_2d/elixir_mhd_weak_blast_wave_SBP.jl
+++ b/examples/dgmulti_2d/elixir_mhd_weak_blast_wave_SBP.jl
@@ -58,6 +58,6 @@ callbacks = CallbackSet(summary_callback,
 #             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
 #             save_everystep=false, callback=callbacks);
 sol = solve(ode, RDPK3SpFSAL49(), abstol=1.0e-8, reltol=1.0e-8,
-            save_everystep=false, callback=callbacks, maxiters=1e5)
+            save_everystep=false, callback=callbacks)
 
 summary_callback() # print the timer summary

--- a/examples/p4est_2d_dgsem/elixir_advection_extended.jl
+++ b/examples/p4est_2d_dgsem/elixir_advection_extended.jl
@@ -84,7 +84,7 @@ callbacks = CallbackSet(summary_callback,
 # OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 
 # Print the timer summary
 summary_callback()

--- a/examples/structured_2d_dgsem/elixir_advection_extended.jl
+++ b/examples/structured_2d_dgsem/elixir_advection_extended.jl
@@ -80,7 +80,7 @@ callbacks = CallbackSet(summary_callback,
 # OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 
 # Print the timer summary
 summary_callback()

--- a/examples/tree_1d_dgsem/elixir_advection_extended.jl
+++ b/examples/tree_1d_dgsem/elixir_advection_extended.jl
@@ -79,7 +79,7 @@ callbacks = CallbackSet(summary_callback,
 # OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 
 # Print the timer summary
 summary_callback()

--- a/examples/tree_1d_dgsem/elixir_euler_blast_wave.jl
+++ b/examples/tree_1d_dgsem/elixir_euler_blast_wave.jl
@@ -91,5 +91,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_1d_dgsem/elixir_euler_blast_wave_neuralnetwork_perssonperaire.jl
+++ b/examples/tree_1d_dgsem/elixir_euler_blast_wave_neuralnetwork_perssonperaire.jl
@@ -109,5 +109,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_1d_dgsem/elixir_euler_blast_wave_neuralnetwork_rayhesthaven.jl
+++ b/examples/tree_1d_dgsem/elixir_euler_blast_wave_neuralnetwork_rayhesthaven.jl
@@ -109,5 +109,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_1d_dgsem/elixir_euler_ec.jl
+++ b/examples/tree_1d_dgsem/elixir_euler_ec.jl
@@ -53,5 +53,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_1d_dgsem/elixir_eulermulti_two_interacting_blast_waves.jl
+++ b/examples/tree_1d_dgsem/elixir_eulermulti_two_interacting_blast_waves.jl
@@ -111,5 +111,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_1d_dgsem/elixir_mhdmulti_convergence.jl
+++ b/examples/tree_1d_dgsem/elixir_mhdmulti_convergence.jl
@@ -57,5 +57,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_acoustics_monopole.jl
+++ b/examples/tree_2d_dgsem/elixir_acoustics_monopole.jl
@@ -140,7 +140,7 @@ callbacks = CallbackSet(summary_callback, analysis_callback, save_solution, step
 # OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=10^5)
+            save_everystep=false, callback=callbacks)
 
 # Print the timer summary
 summary_callback()

--- a/examples/tree_2d_dgsem/elixir_advection_extended.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_extended.jl
@@ -79,7 +79,7 @@ callbacks = CallbackSet(summary_callback,
 # OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 
 # Print the timer summary
 summary_callback()

--- a/examples/tree_2d_dgsem/elixir_advection_timeintegration.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_timeintegration.jl
@@ -64,5 +64,5 @@ callbacks = CallbackSet(summary_callback,
 ode_algorithm = Trixi.CarpenterKennedy2N54()
 sol = Trixi.solve(ode, ode_algorithm,
                   dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-                  save_everystep=false, callback=callbacks, maxiters=10_000);
+                  save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_euler_blast_wave.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_blast_wave.jl
@@ -89,5 +89,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_euler_blast_wave_neuralnetwork_cnn.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_blast_wave_neuralnetwork_cnn.jl
@@ -106,5 +106,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_euler_blast_wave_neuralnetwork_perssonperaire.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_blast_wave_neuralnetwork_perssonperaire.jl
@@ -106,5 +106,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_euler_blast_wave_neuralnetwork_rayhesthaven.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_blast_wave_neuralnetwork_rayhesthaven.jl
@@ -108,5 +108,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_euler_blast_wave_pure_fv.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_blast_wave_pure_fv.jl
@@ -81,5 +81,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_euler_ec.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_ec.jl
@@ -55,5 +55,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=10^5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_euler_kelvin_helmholtz_instability_amr_neuralnetwork_perssonperaire.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_kelvin_helmholtz_instability_amr_neuralnetwork_perssonperaire.jl
@@ -126,5 +126,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_euler_positivity.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_positivity.jl
@@ -107,5 +107,5 @@ stage_limiter! = PositivityPreservingLimiterZhangShu(thresholds=(5.0e-6, 5.0e-6)
 
 sol = solve(ode, CarpenterKennedy2N54(stage_limiter!, williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_euler_sedov_blast_wave.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_sedov_blast_wave.jl
@@ -103,5 +103,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_euler_sedov_blast_wave_neuralnetwork_perssonperaire.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_sedov_blast_wave_neuralnetwork_perssonperaire.jl
@@ -124,5 +124,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_euler_vortex.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_vortex.jl
@@ -91,5 +91,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_mhd_alfven_wave.jl
+++ b/examples/tree_2d_dgsem/elixir_mhd_alfven_wave.jl
@@ -62,5 +62,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_mhdmulti_convergence.jl
+++ b/examples/tree_2d_dgsem/elixir_mhdmulti_convergence.jl
@@ -60,5 +60,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_2d_fdsbp/elixir_advection_extended.jl
+++ b/examples/tree_2d_fdsbp/elixir_advection_extended.jl
@@ -53,5 +53,5 @@ callbacks = CallbackSet(summary_callback,
 # run the simulation
 
 sol = solve(ode, RDPK3SpFSAL49(), abstol=1.0e-9, reltol=1.0e-9,
-            save_everystep=false, callback=callbacks, maxiters=1e5)
+            save_everystep=false, callback=callbacks)
 summary_callback()

--- a/examples/tree_3d_dgsem/elixir_advection_extended.jl
+++ b/examples/tree_3d_dgsem/elixir_advection_extended.jl
@@ -79,7 +79,7 @@ callbacks = CallbackSet(summary_callback,
 # OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 
 # Print the timer summary
 summary_callback()

--- a/examples/tree_3d_dgsem/elixir_euler_ec.jl
+++ b/examples/tree_3d_dgsem/elixir_euler_ec.jl
@@ -54,5 +54,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=10^5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_3d_dgsem/elixir_euler_sedov_blast_wave.jl
+++ b/examples/tree_3d_dgsem/elixir_euler_sedov_blast_wave.jl
@@ -159,5 +159,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_3d_dgsem/elixir_euler_shockcapturing_amr.jl
+++ b/examples/tree_3d_dgsem/elixir_euler_shockcapturing_amr.jl
@@ -78,6 +78,6 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary
 

--- a/examples/tree_3d_dgsem/elixir_lbm_constant.jl
+++ b/examples/tree_3d_dgsem/elixir_lbm_constant.jl
@@ -58,5 +58,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/examples/tree_3d_dgsem/elixir_lbm_taylor_green_vortex.jl
+++ b/examples/tree_3d_dgsem/elixir_lbm_taylor_green_vortex.jl
@@ -75,6 +75,6 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5,
+            save_everystep=false, callback=callbacks,
             save_start=false, alias_u0=true);
 summary_callback() # print the timer summary

--- a/examples/unstructured_2d_dgsem/elixir_mhd_alfven_wave.jl
+++ b/examples/unstructured_2d_dgsem/elixir_mhd_alfven_wave.jl
@@ -62,5 +62,5 @@ callbacks = CallbackSet(summary_callback,
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
             dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            save_everystep=false, callback=callbacks, maxiters=1e5);
+            save_everystep=false, callback=callbacks);
 summary_callback() # print the timer summary

--- a/src/auxiliary/special_elixirs.jl
+++ b/src/auxiliary/special_elixirs.jl
@@ -18,6 +18,10 @@ It's basic purpose is to make it easier to modify some parameters while running 
 REPL. Additionally, this is used in tests to reduce the computational burden for CI while still
 providing examples with sensible default values for users.
 
+Before replacing assignments in `elixir`, the keyword argument `maxiters` is inserted
+into calls to `solve` with it's default value used in the SciML ecosystem for ODEs, see
+https://diffeq.sciml.ai/stable/basics/common_solver_opts/#Miscellaneous.
+
 # Examples
 
 ```jldoctest
@@ -30,7 +34,7 @@ julia> redirect_stdout(devnull) do
 ```
 """
 function trixi_include(mod::Module, elixir::AbstractString; kwargs...)
-  Base.include(ex -> replace_assignments(ex; kwargs...), mod, elixir)
+  Base.include(ex -> replace_assignments(insert_maxiters(ex); kwargs...), mod, elixir)
 end
 
 trixi_include(elixir::AbstractString; kwargs...) = trixi_include(Main, elixir; kwargs...)
@@ -144,6 +148,31 @@ convergence_test(elixir::AbstractString, iterations; kwargs...) = convergence_te
 # Apply the function `f` to `expr` and all sub-expressions recursively.
 walkexpr(f, expr::Expr) = f(Expr(expr.head, (walkexpr(f, arg) for arg in expr.args)...))
 walkexpr(f, x) = f(x)
+
+# Insert the keyword argument `maxiters` into calls to `solve`
+# with default value `10^5` if it is not already present.
+function insert_maxiters(expr)
+  maxiters_default = 10^5
+
+  expr = walkexpr(expr) do x
+    if x isa Expr
+      if x.head === Symbol("call") && x.args[1] === Symbol("solve")
+        # Do nothing if `maxiters` is already set as keyword argument...
+        for arg in x.args
+          if arg isa Expr && arg.head === Symbol("kw") && arg.args[1] === Symbol("maxiters")
+            return x
+          end
+        end
+
+        # ...and insert it otherwise.
+        push!(x.args, Expr(Symbol("kw"), Symbol("maxiters"), maxiters_default))
+      end
+    end
+    return x
+  end
+
+  return expr
+end
 
 # Replace assignments to `key` in `expr` by `key = val` for all `(key,val)` in `kwargs`.
 function replace_assignments(expr; kwargs...)


### PR DESCRIPTION
This will be helpful for #954.

# Example

https://github.com/trixi-framework/Trixi.jl/blob/82ea6d4b0ec388e547018f46bd74b17f63875fae/examples/tree_1d_dgsem/elixir_advection_basic.jl#L54-L56

https://github.com/trixi-framework/Trixi.jl/blob/82ea6d4b0ec388e547018f46bd74b17f63875fae/examples/tree_1d_dgsem/elixir_hypdiff_harmonic_nonperiodic.jl#L82-L84

With this PR:
```julia
julia> using Trixi

julia> trixi_include(joinpath(examples_dir(), "tree_1d_dgsem", "elixir_advection_basic.jl"), maxiters=1)
[...]
┌ Warning: Interrupted. Larger maxiters is needed.
└ @ SciMLBase ~/.julia/packages/SciMLBase/x3z0g/src/integrator_interface.jl:331
[...]

julia> trixi_include(joinpath(examples_dir(), "tree_1d_dgsem", "elixir_hypdiff_harmonic_nonperiodic.jl"), maxiters=1)
[...]
────────────────────────────────────────────────────────────────────────────────────────────────────
Trixi simulation finished.  Final time: 0.04177817256162253  Time steps: 1 (accepted), 1 (total)
────────────────────────────────────────────────────────────────────────────────────────────────────

┌ Warning: Interrupted. Larger maxiters is needed.
└ @ Trixi ~/.julia/dev/Trixi/src/time_integration/methods_3Sstar.jl:215
[...]
```
