### PR TITLE
avoid precompiling all dependencies of Trixi for coverage merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,9 +170,10 @@ jobs:
       # Next, we merge the individual coverage files and upload
       # the combined results to Coveralls.
       - name: Merge lcov files using Coverage.jl
-        shell: julia --color=yes --project=. {0}
+        shell: julia --color=yes {0}
         run: |
           using Pkg
+          Pkg.activate(temp=true)
           Pkg.add("Coverage")
           using Coverage
           coverage = LCOV.readfolder(".")


### PR DESCRIPTION
I realised that the "finish" step (where we merge individual coverage reports to upload them together to Coveralls) used the default project - which meant we needed to precompile all dependencies of Trixi.jl again, which takes nearly five minutes in CI, e.g. [here](https://github.com/trixi-framework/Trixi.jl/runs/4125793182?check_suite_focus=true). I fixed this by just using a temporary project. Now, the last CI step should also be faster.