### PR TITLE
WIP: store GaussSBP solution at Gauss nodes

### DIFF
--- a/src/solvers/dgmulti/flux_differencing_gauss_sbp.jl
+++ b/src/solvers/dgmulti/flux_differencing_gauss_sbp.jl
@@ -37,7 +37,7 @@ end
 # Specialized constructor for GaussSBP approximation type on quad elements. Restricting to
 # VolumeIntegralFluxDifferencing for now since there isn't a way to exploit this structure
 # for VolumeIntegralWeakForm yet.
-function DGMulti(element_type::Union{Quad, Hex},
+function DGMulti(element_type::Union{Hex},
                  approximation_type::GaussSBP,
                  volume_integral::VolumeIntegralFluxDifferencing,
                  surface_integral=SurfaceIntegralWeakForm(surface_flux);
@@ -78,8 +78,8 @@ function create_cache(mesh::VertexMappedMesh, equations,
                  mesh, equations, dg, RealT, uEltype)
 
   # for change of basis prior to the volume integral and entropy projection
-  r1D, _ = StartUpDG.gauss_lobatto_quad(0, 0, polydeg(dg))
-  rq1D, _ = StartUpDG.gauss_quad(0, 0, polydeg(dg))
+  r1D, w1D = StartUpDG.gauss_lobatto_quad(0, 0, polydeg(dg))
+  rq1D, wq1D = StartUpDG.gauss_quad(0, 0, polydeg(dg))
   interp_matrix_lobatto_to_gauss_1D = polynomial_interpolation_matrix(r1D, rq1D)
   interp_matrix_gauss_to_lobatto_1D = polynomial_interpolation_matrix(rq1D, r1D)
   NDIMS = ndims(rd.elementType)
@@ -92,12 +92,23 @@ function create_cache(mesh::VertexMappedMesh, equations,
   inv_gauss_weights = inv.(rd.wq)
   Pf = diagm(inv_gauss_weights) * interp_matrix_gauss_to_face'
 
+  # Lift matrix to transfer surface fluxes to the volume
+  # This is also available as dense matrix as `rd.LIFT`. However, we can get
+  # a significant speed-up by using the tensor product structure explicitly,
+  # in particular for higher polynomial degrees such as `polydeg >= 7` in 3D.
+  boundary_nodes = [-one(eltype(r1D)), one(eltype(r1D))]
+  interp_matrix_lobatto_to_face_1d = polynomial_interpolation_matrix(r1D, boundary_nodes)
+  interp_matrix_gauss_to_face_1d = polynomial_interpolation_matrix(rq1D, boundary_nodes)
+  # lift_1d = #=interp_matrix_gauss_to_lobatto_1D * diagm(inv.(wq1D)) * interp_matrix_gauss_to_lobatto_1D' *=# interp_matrix_lobatto_to_face_1d'
+  lift_1d = diagm(inv.(wq1D)) * interp_matrix_gauss_to_face_1d'
+
   nvars = nvariables(equations)
   rhs_volume_local_threaded = [allocate_nested_array(uEltype, nvars, (rd.Nq,), dg)  for _ in 1:Threads.nthreads()]
 
   return (; cache..., Pf, inv_gauss_weights, rhs_volume_local_threaded,
          interp_matrix_lobatto_to_gauss, interp_matrix_gauss_to_lobatto,
-         interp_matrix_gauss_to_face)
+         interp_matrix_gauss_to_face,
+         lift_1d, wq_1d=wq1D, interp_matrix_gauss_to_face_1d)
 end
 
 # TODO: DGMulti. Address hard-coding of `entropy2cons!` and `cons2entropy!` for this function.
@@ -193,6 +204,50 @@ function calc_volume_integral!(du, u, volume_integral, mesh::VertexMappedMesh,
                         view(du, :, e), rhs_volume_local)
   end
 
+end
+
+
+function StartUpDG.RefElemData(elem::Quad, approxType::GaussSBP, N;
+                               quad_rule_vol = StartUpDG.quad_nodes(elem, N),
+                               quad_rule_face = StartUpDG.quad_nodes(StartUpDG.face_type(elem), N),
+                               Nplot = 10)
+
+    fv = StartUpDG.face_vertices(elem)
+
+    # Construct matrices on reference elements
+    r,s = StartUpDG.quad_nodes(elem, N)
+    Fmask = Int[]
+
+    VDM,Vr,Vs = StartUpDG.basis(elem,N,r,s)
+    Dr = Vr/VDM
+    Ds = Vs/VDM
+
+    # low order interpolation nodes
+    r1,s1 = StartUpDG.nodes(elem,1)
+    V1 = StartUpDG.vandermonde(elem,1,r,s)/StartUpDG.vandermonde(elem,1,r1,s1)
+
+    rf,sf,wf,nrJ,nsJ = StartUpDG.init_face_data(elem, N, quad_rule_face = quad_rule_face)
+
+    rq,sq,wq = quad_rule_vol
+    Vq = StartUpDG.vandermonde(elem,N,rq,sq)/VDM
+    M = Vq'*diagm(wq)*Vq
+    Pq = M\(Vq'*diagm(wq))
+
+    Vf = StartUpDG.vandermonde(elem,N,rf,sf)/VDM # interpolates from nodes to face nodes
+    LIFT = M\(Vf'*diagm(wf)) # lift matrix used in rhs evaluation
+
+    # plotting nodes
+    rp, sp = StartUpDG.equi_nodes(elem,Nplot)
+    Vp = StartUpDG.vandermonde(elem,N,rp,sp)/VDM
+
+    Drs = (Dr,Ds)
+
+    return RefElemData(elem, approxType, N, fv, V1,
+                       tuple(r, s), VDM, Fmask,
+                       Nplot, tuple(rp, sp), Vp,
+                       tuple(rq, sq), wq, Vq,
+                       tuple(rf, sf), wf, Vf, tuple(nrJ, nsJ),
+                       M, Pq, Drs, LIFT)
 end
 
 


### PR DESCRIPTION
See https://github.com/trixi-framework/Trixi.jl/pull/966#issuecomment-963843452

This may be a first step to get really efficient tensor product structure operations for `GaussSBP()`. However, I will not continue to work on this soon since the default storage scheme (of surface stuff) in StartUpDG.jl does not really fit to my mental model of simple tensor product operations. For example, the boundary nodes are stored in counter-clockwise order in 2D. It might be better if someone more familiar with the internals of StartUpDG.jl works on these tensor product structures - @jlchan?