### PR TITLE
reduce CI times

### DIFF
--- a/test/test_structured_2d.jl
+++ b/test/test_structured_2d.jl
@@ -210,14 +210,16 @@ isdir(outdir) && rm(outdir, recursive=true)
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hypdiff_nonperiodic.jl"),
       l2   = [0.8799744480157664, 0.8535008397034816, 0.7851383019164209],
       linf = [1.0771947577311836, 1.9143913544309838, 2.149549109115789],
-      tspan = (0.0, 0.1))
+      tspan = (0.0, 0.1),
+      coverage_override = (polydeg=3,)) # Prevent long compile time in CI
   end
 
   @trixi_testset "elixir_hypdiff_harmonic_nonperiodic.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hypdiff_harmonic_nonperiodic.jl"),
       l2   = [0.19357947606509474, 0.47041398037626814, 0.4704139803762686],
       linf = [0.35026352556630114, 0.8344372248051408, 0.8344372248051408],
-      tspan = (0.0, 0.1))
+      tspan = (0.0, 0.1),
+      coverage_override = (polydeg=3,)) # Prevent long compile time in CI
   end
 
   @trixi_testset "elixir_mhd_ec.jl" begin

--- a/test/test_structured_3d.jl
+++ b/test/test_structured_3d.jl
@@ -70,7 +70,8 @@ isdir(outdir) && rm(outdir, recursive=true)
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_ec.jl"),
       l2   = [0.011367083018614027, 0.007022020327490176, 0.006759580335962235, 0.006820337637760632, 0.02912659127566544],
       linf = [0.2761764220925329, 0.20286331858055706, 0.18763944865434593, 0.19313636558790004, 0.707563913727584],
-      tspan = (0.0, 0.25))
+      tspan = (0.0, 0.25),
+      coverage_override = (polydeg=3,)) # Prevent long compile time in CI
   end
 
   @trixi_testset "elixir_euler_sedov.jl" begin

--- a/test/test_tree_3d_advection.jl
+++ b/test/test_tree_3d_advection.jl
@@ -53,7 +53,7 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_3
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr.jl"),
       l2   = [9.773852895157622e-6],
       linf = [0.0005853874124926162],
-      coverage_override = (maxiters=6,))
+      coverage_override = (maxiters=6, initial_refinement_level=1, base_level=1, med_level=1, max_level=3))
   end
 end
 

--- a/test/test_tree_3d_euler.jl
+++ b/test/test_tree_3d_euler.jl
@@ -45,7 +45,7 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_3
       l2   = [0.0038281920613404716, 0.003828192061340465, 0.0038281920613404694, 0.0038281920613404672, 0.005742288092010652],
       linf = [0.07390396464027349, 0.07390396464027305, 0.07390396464027305, 0.07390396464027305, 0.11085594696041134],
       tspan=(0.0, 0.1),
-      coverage_override = (maxiters=6,))
+      coverage_override = (maxiters=6, initial_refinement_level=0, base_level=0, med_level=0, max_level=1))
   end
 
   @trixi_testset "elixir_euler_taylor_green_vortex.jl" begin
@@ -127,7 +127,7 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_3
       l2   = [0.0007127163978031706, 0.0023166296394624025, 0.002316629639462401, 0.0023166296394624038, 0.010200581509653256],
       linf = [0.06344190883105805, 0.6292607955969378, 0.6292607955969377, 0.6292607955969377, 2.397746252817731],
       maxiters=5, max_level=6,
-      coverage_override = (maxiters=2,))
+      coverage_override = (maxiters=2, initial_refinement_level=1, base_level=1, max_level=3))
   end
 end
 

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -210,7 +210,7 @@ isdir(outdir) && rm(outdir, recursive=true)
 
   @timed_testset "adapt_to_mesh_level" begin
     @test_nowarn_debug trixi_include(@__MODULE__, joinpath(examples_dir(), "tree_2d_dgsem", "elixir_advection_basic.jl"),
-                                     tspan=(0,0.1))
+                                     tspan=(0,0.1), analysis_callback=Trixi.TrivialCallback())
     @test adapt_to_mesh_level(sol, 5) isa Tuple
 
     u_ode_level5, semi_level5 = adapt_to_mesh_level(sol, 5)
@@ -223,7 +223,7 @@ isdir(outdir) && rm(outdir, recursive=true)
 
   @timed_testset "plot 3D" begin
     @test_nowarn_debug trixi_include(@__MODULE__, joinpath(examples_dir(), "tree_3d_dgsem", "elixir_advection_basic.jl"),
-                                     tspan=(0,0.1))
+                                     tspan=(0,0.1), analysis_callback=Trixi.TrivialCallback(), initial_refinement_level=1)
     @test PlotData2D(sol) isa Trixi.PlotData2DCartesian
     @test PlotData2D(sol, slice =:yz) isa Trixi.PlotData2DCartesian
     @test PlotData2D(sol, slice =:xz) isa Trixi.PlotData2DCartesian
@@ -239,8 +239,8 @@ isdir(outdir) && rm(outdir, recursive=true)
       end
 
       @testset "Create 1D plot along curve" begin
-        curve = zeros(3,10)
-        curve[1,:] = range(-1,-0.5,length=10)
+        curve = zeros(3, 10)
+        curve[1, :] = range(-1.0, -0.5, length=10)
         @test_nowarn_debug PlotData1D(sol, curve=curve) isa PlotData1D
         pd1D = PlotData1D(sol, curve=curve)
         @test_nowarn_debug Plots.plot(pd1D)
@@ -249,7 +249,8 @@ isdir(outdir) && rm(outdir, recursive=true)
   end
 
   @timed_testset "plotting TimeIntegratorSolution" begin
-    @test_nowarn_debug trixi_include(@__MODULE__, joinpath(examples_dir(), "tree_2d_dgsem", "elixir_hypdiff_lax_friedrichs.jl"))
+    @test_nowarn_debug trixi_include(@__MODULE__, joinpath(examples_dir(), "tree_2d_dgsem", "elixir_hypdiff_lax_friedrichs.jl"),
+                                     maxiters=1, analysis_callback=Trixi.TrivialCallback(), initial_refinement_level=1)
     @test_nowarn_debug Plots.plot(sol)
   end
 


### PR DESCRIPTION
Xref #970

- `CI / tree_part4 - ubuntu-latest - x64 - pull_request (pull_request)` reduced by ca. 3 minutes by reducing a single test case
- `CI / structured - ubuntu-latest - x64 - pull_request (pull_request) Successful in 57m` reduced by ca. 15 minutes compared to latest CI run on `main`
- `CI / misc_part1 - ubuntu-latest - x64 - pull_request (pull_request) Successful in 50m` significantly faster than latest CI run on `main`, but that may also just be due to another runner etc.