### PR TITLE
dirty workaround for at-threaded nested macro hygiene

### DIFF
--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -185,7 +185,7 @@ macro threaded(expr)
   # !!! danger "Heisenbug"
   #     Look at the comments for `wrap_array` when considering to change this macro.
 
-  return esc(quote @batch $(expr) end)
+  return esc(quote Trixi.@batch $(expr) end)
 end
 
 


### PR DESCRIPTION
Let's see whether this works... :crossed_fingers: 