### PR TITLE
Update nonconservative_advection.jl

### DIFF
--- a/docs/literate/src/files/adding_new_equations/nonconservative_advection.jl
+++ b/docs/literate/src/files/adding_new_equations/nonconservative_advection.jl
@@ -9,7 +9,7 @@ using Test: @test #src
 # \begin{aligned}&\partial_t u(t,x) + a(x) \partial_x u(t,x) = 0 \\
 # &u(0,x)=\sin(x) \\
 # &u(t,-\pi)=u(t,\pi)
-# \end{}
+# \end{aligned}
 # \right.
 # ```
 # where $a(x) = 2 + \cos(x)$. The analytic solution is
@@ -28,7 +28,7 @@ using Test: @test #src
 # &u(0,x)=\sin(x) \\
 # &a(0,x)=2+\cos(x) \\
 # &u(t,-\pi)=u(t,\pi)
-# \end{}
+# \end{aligned}
 # \right.
 #```
 


### PR DESCRIPTION
fix the latex formula. This time it's checked with Documenter.jl:
![1](https://user-images.githubusercontent.com/7373095/142639443-bf9ac75e-4cef-4584-bbd7-6ad966d32def.png)

![2](https://user-images.githubusercontent.com/7373095/142639465-1ca25770-7df2-4924-a7f2-75c075471af2.png)


