### PR TITLE
specialize 3D Cartesian `split_form_kernel!` on `flux_shima_etal`

### DIFF
--- a/src/solvers/dgsem_tree/dg.jl
+++ b/src/solvers/dgsem_tree/dg.jl
@@ -65,7 +65,9 @@ include("dg_2d_parallel.jl")
 include("dg_3d.jl")
 
 # Auxiliary functions that are specialized on this solver
+# as well as specialized implementations used to improve performance
 include("dg_2d_compressible_euler.jl")
+include("dg_3d_compressible_euler.jl")
 
 
 end # @muladd

--- a/src/solvers/dgsem_tree/dg_3d_compressible_euler.jl
+++ b/src/solvers/dgsem_tree/dg_3d_compressible_euler.jl
@@ -1,0 +1,264 @@
+
+# From here on, this file contains specializations of DG methods on the
+# TreeMesh3D to the compressible Euler equations.
+#
+# The specialized methods contain relatively verbose and ugly code in the sense
+# that we do not use the common "pointwise physics" interface of Trixi.jl.
+# However, this is currently (November 2021) necessary to get a significant
+# speed-up by using SIMD instructions via LoopVectorization.jl.
+#
+# TODO: SIMD. We could get even more speed-up if we did not need to permute
+#             array dimensions, i.e., if we changed the basic memory layout.
+#
+# We do not wrap this code in `@muladd begin ... end` block. Optimizations like
+# this are handled automatically by LoopVectorization.jl.
+
+
+# We specialize on `PtrArray` since these will be returned by `Trixi.wrap_array`
+# if LoopVectorization.jl can handle the array types. This ensures that `@turbo`
+# works efficiently here.
+@inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
+                                    element, mesh::TreeMesh{3},
+                                    nonconservative_terms::Val{false},
+                                    equations::CompressibleEulerEquations3D,
+                                    volume_flux::typeof(flux_shima_etal),
+                                    dg::DGSEM, cache,
+                                    alpha=true)
+  # true * [some floating point value] == [exactly the same floating point value]
+  # This can (hopefully) be optimized away due to constant propagation.
+  @unpack derivative_split = dg.basis
+
+  # Create a temporary array that will be used to store the RHS with permuted
+  # indices `[i, j, k, v]` to allow using SIMD instructions.
+  # `StrideArray`s with purely static dimensions do not allocate on the heap.
+  du = StrideArray{eltype(u_cons)}(undef,
+    (ntuple(_ -> StaticInt(nnodes(dg)), ndims(mesh))...,
+     StaticInt(nvariables(equations))))
+
+  # Convert conserved to primitive variables on the given `element`.
+  u_prim = StrideArray{eltype(u_cons)}(undef,
+    (ntuple(_ -> StaticInt(nnodes(dg)), ndims(mesh))...,
+     StaticInt(nvariables(equations))))
+
+  @turbo for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
+    rho    = u_cons[1, i, j, k, element]
+    rho_v1 = u_cons[2, i, j, k, element]
+    rho_v2 = u_cons[3, i, j, k, element]
+    rho_v3 = u_cons[4, i, j, k, element]
+    rho_e  = u_cons[5, i, j, k, element]
+
+    v1 = rho_v1 / rho
+    v2 = rho_v2 / rho
+    v3 = rho_v3 / rho
+    p = (equations.gamma - 1) * (rho_e - 0.5 * (rho_v1 * v1 + rho_v2 * v2 + rho_v3 * v3))
+
+    u_prim[i, j, k, 1] = rho
+    u_prim[i, j, k, 2] = v1
+    u_prim[i, j, k, 3] = v2
+    u_prim[i, j, k, 4] = v3
+    u_prim[i, j, k, 5] = p
+  end
+
+
+  # x direction
+  # At first, we create new temporary arrays with permuted memory layout to
+  # allow using SIMD instructions along the first dimension (which is contiguous
+  # in memory).
+  du_permuted = StrideArray{eltype(u_cons)}(undef,
+    (StaticInt(nnodes(dg)^2), StaticInt(nnodes(dg)),
+     StaticInt(nvariables(equations))))
+
+  u_prim_permuted = StrideArray{eltype(u_cons)}(undef,
+    (StaticInt(nnodes(dg)^2), StaticInt(nnodes(dg)),
+     StaticInt(nvariables(equations))))
+
+  @turbo for v in eachvariable(equations),
+             k in eachnode(dg),
+             j in eachnode(dg),
+             i in eachnode(dg)
+    jk = j + nnodes(dg) * (k- 1)
+    u_prim_permuted[jk, i, v] = u_prim[i, j, k, v]
+  end
+  fill!(du_permuted, zero(eltype(du_permuted)))
+
+  # Next, we basically inline the volume flux. To allow SIMD vectorization and
+  # still use the symmetry of the volume flux and the derivative matrix, we
+  # loop over the triangular part in an outer loop and use a plain inner loop.
+  for i in eachnode(dg), ii in (i+1):nnodes(dg)
+    @turbo for jk in Base.OneTo(nnodes(dg)^2)
+      rho_ll = u_prim_permuted[jk, i, 1]
+      v1_ll  = u_prim_permuted[jk, i, 2]
+      v2_ll  = u_prim_permuted[jk, i, 3]
+      v3_ll  = u_prim_permuted[jk, i, 4]
+      p_ll   = u_prim_permuted[jk, i, 5]
+
+      rho_rr = u_prim_permuted[jk, ii, 1]
+      v1_rr  = u_prim_permuted[jk, ii, 2]
+      v2_rr  = u_prim_permuted[jk, ii, 3]
+      v3_rr  = u_prim_permuted[jk, ii, 4]
+      p_rr   = u_prim_permuted[jk, ii, 5]
+
+      # Compute required mean values
+      rho_avg = 0.5 * (rho_ll + rho_rr)
+      v1_avg  = 0.5 * ( v1_ll +  v1_rr)
+      v2_avg  = 0.5 * ( v2_ll +  v2_rr)
+      v3_avg  = 0.5 * ( v3_ll +  v3_rr)
+      p_avg   = 0.5 * (  p_ll +   p_rr)
+      kin_avg = 0.5 * (v1_ll * v1_rr + v2_ll * v2_rr + v3_ll * v3_rr)
+      pv1_avg = 0.5 * (p_ll * v1_rr + p_rr * v1_ll)
+
+      # Calculate fluxes depending on Cartesian orientation
+      f1 = rho_avg * v1_avg
+      f2 = f1 * v1_avg + p_avg
+      f3 = f1 * v2_avg
+      f4 = f1 * v3_avg
+      f5 = p_avg * v1_avg * equations.inv_gamma_minus_one + f1 * kin_avg + pv1_avg
+
+      # Add scaled fluxes to RHS
+      factor_i = alpha * derivative_split[i, ii]
+      du_permuted[jk, i, 1] += factor_i * f1
+      du_permuted[jk, i, 2] += factor_i * f2
+      du_permuted[jk, i, 3] += factor_i * f3
+      du_permuted[jk, i, 4] += factor_i * f4
+      du_permuted[jk, i, 5] += factor_i * f5
+
+      factor_ii = alpha * derivative_split[ii, i]
+      du_permuted[jk, ii, 1] += factor_ii * f1
+      du_permuted[jk, ii, 2] += factor_ii * f2
+      du_permuted[jk, ii, 3] += factor_ii * f3
+      du_permuted[jk, ii, 4] += factor_ii * f4
+      du_permuted[jk, ii, 5] += factor_ii * f5
+    end
+  end
+
+  @turbo for v in eachvariable(equations),
+             k in eachnode(dg),
+             j in eachnode(dg),
+             i in eachnode(dg)
+    jk = j + nnodes(dg) * (k- 1)
+    du[i, j, k, v] = du_permuted[jk, i, v]
+  end
+
+
+  # y direction
+  # A possible permutation of array dimensions with improved opportunities for
+  # SIMD vectorization appeared to be slower than the direct version used here
+  # in preliminary numerical experiments on an AVX2 system.
+  for j in eachnode(dg), jj in (j+1):nnodes(dg)
+    @turbo for k in eachnode(dg), i in eachnode(dg)
+      rho_ll = u_prim[i, j, k, 1]
+      v1_ll  = u_prim[i, j, k, 2]
+      v2_ll  = u_prim[i, j, k, 3]
+      v3_ll  = u_prim[i, j, k, 4]
+      p_ll   = u_prim[i, j, k, 5]
+
+      rho_rr = u_prim[i, jj, k, 1]
+      v1_rr  = u_prim[i, jj, k, 2]
+      v2_rr  = u_prim[i, jj, k, 3]
+      v3_rr  = u_prim[i, jj, k, 4]
+      p_rr   = u_prim[i, jj, k, 5]
+
+      # Compute required mean values
+      rho_avg = 0.5 * (rho_ll + rho_rr)
+      v1_avg  = 0.5 * ( v1_ll +  v1_rr)
+      v2_avg  = 0.5 * ( v2_ll +  v2_rr)
+      v3_avg  = 0.5 * ( v3_ll +  v3_rr)
+      p_avg   = 0.5 * (  p_ll +   p_rr)
+      kin_avg = 0.5 * (v1_ll * v1_rr + v2_ll * v2_rr + v3_ll * v3_rr)
+      pv2_avg = 0.5 * (p_ll * v2_rr + p_rr * v2_ll)
+
+      # Calculate fluxes depending on Cartesian orientation
+      f1 = rho_avg * v2_avg
+      f2 = f1 * v1_avg
+      f3 = f1 * v2_avg + p_avg
+      f4 = f1 * v3_avg
+      f5 = p_avg*v2_avg * equations.inv_gamma_minus_one + f1 * kin_avg + pv2_avg
+
+      # Add scaled fluxes to RHS
+      factor_j = alpha * derivative_split[j, jj]
+      du[i, j, k, 1] += factor_j * f1
+      du[i, j, k, 2] += factor_j * f2
+      du[i, j, k, 3] += factor_j * f3
+      du[i, j, k, 4] += factor_j * f4
+      du[i, j, k, 5] += factor_j * f5
+
+      factor_jj = alpha * derivative_split[jj, j]
+      du[i, jj, k, 1] += factor_jj * f1
+      du[i, jj, k, 2] += factor_jj * f2
+      du[i, jj, k, 3] += factor_jj * f3
+      du[i, jj, k, 4] += factor_jj * f4
+      du[i, jj, k, 5] += factor_jj * f5
+    end
+  end
+
+
+  # z direction
+  # The memory layout is already optimal for SIMD vectorization in this loop.
+  # We just squeeze the first two dimensions to make the code slightly faster.
+  GC.@preserve u_prim begin
+    u_prim_reshaped = PtrArray(pointer(u_prim),
+      (StaticInt(nnodes(dg)^2), StaticInt(nnodes(dg)),
+       StaticInt(nvariables(equations))))
+
+    du_reshaped = PtrArray(pointer(du),
+      (StaticInt(nnodes(dg)^2), StaticInt(nnodes(dg)),
+       StaticInt(nvariables(equations))))
+
+    for k in eachnode(dg), kk in (k+1):nnodes(dg)
+      @turbo for ij in Base.OneTo(nnodes(dg)^2)
+        rho_ll = u_prim_reshaped[ij, k, 1]
+        v1_ll  = u_prim_reshaped[ij, k, 2]
+        v2_ll  = u_prim_reshaped[ij, k, 3]
+        v3_ll  = u_prim_reshaped[ij, k, 4]
+        p_ll   = u_prim_reshaped[ij, k, 5]
+
+        rho_rr = u_prim_reshaped[ij, kk, 1]
+        v1_rr  = u_prim_reshaped[ij, kk, 2]
+        v2_rr  = u_prim_reshaped[ij, kk, 3]
+        v3_rr  = u_prim_reshaped[ij, kk, 4]
+        p_rr   = u_prim_reshaped[ij, kk, 5]
+
+        # Compute required mean values
+        rho_avg = 0.5 * (rho_ll + rho_rr)
+        v1_avg  = 0.5 * ( v1_ll +  v1_rr)
+        v2_avg  = 0.5 * ( v2_ll +  v2_rr)
+        v3_avg  = 0.5 * ( v3_ll +  v3_rr)
+        p_avg   = 0.5 * (  p_ll +   p_rr)
+        kin_avg = 0.5 * (v1_ll * v1_rr + v2_ll * v2_rr + v3_ll * v3_rr)
+        pv3_avg = 0.5 * (p_ll * v3_rr + p_rr * v3_ll)
+
+        # Calculate fluxes depending on Cartesian orientation
+        f1 = rho_avg * v3_avg
+        f2 = f1 * v1_avg
+        f3 = f1 * v2_avg
+        f4 = f1 * v3_avg + p_avg
+        f5 = p_avg*v3_avg * equations.inv_gamma_minus_one + f1 * kin_avg + pv3_avg
+
+        # Add scaled fluxes to RHS
+        factor_k = alpha * derivative_split[k, kk]
+        du_reshaped[ij, k, 1] += factor_k * f1
+        du_reshaped[ij, k, 2] += factor_k * f2
+        du_reshaped[ij, k, 3] += factor_k * f3
+        du_reshaped[ij, k, 4] += factor_k * f4
+        du_reshaped[ij, k, 5] += factor_k * f5
+
+        factor_kk = alpha * derivative_split[kk, k]
+        du_reshaped[ij, kk, 1] += factor_kk * f1
+        du_reshaped[ij, kk, 2] += factor_kk * f2
+        du_reshaped[ij, kk, 3] += factor_kk * f3
+        du_reshaped[ij, kk, 4] += factor_kk * f4
+        du_reshaped[ij, kk, 5] += factor_kk * f5
+      end
+    end
+  end # GC.@preserve u_prim
+
+
+  # Finally, we add the temporary RHS computed here to the global RHS in the
+  # given `element`.
+  @turbo for v in eachvariable(equations),
+             k in eachnode(dg),
+             j in eachnode(dg),
+             i in eachnode(dg)
+    _du[v, i, j, k, element] += du[i, j, k, v]
+  end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,6 +87,7 @@ const TRIXI_NTHREADS   = clamp(Sys.CPU_THREADS, 2, 3)
 
   @time if TRIXI_TEST == "all" || TRIXI_TEST == "misc_part2"
     include("test_special_elixirs.jl")
+    include("test_performance_specializations.jl")
   end
 
   @time if TRIXI_TEST == "all" || TRIXI_TEST == "paper_self_gravitating_gas_dynamics"

--- a/test/test_performance_specializations.jl
+++ b/test/test_performance_specializations.jl
@@ -19,6 +19,7 @@ isdir(outdir) && rm(outdir, recursive=true)
     u_ode = copy(sol.u[end])
     du_ode = zero(u_ode)
 
+    # Preserve original memory since it will be `unsafe_wrap`ped and might thus otherwise be garbage collected
     GC.@preserve u_ode du_ode begin
       u = Trixi.wrap_array(u_ode, semi)
       du = Trixi.wrap_array(du_ode, semi)

--- a/test/test_performance_specializations.jl
+++ b/test/test_performance_specializations.jl
@@ -14,32 +14,38 @@ isdir(outdir) && rm(outdir, recursive=true)
   @timed_testset "TreeMesh3D, flux_shima_etal" begin
     trixi_include(@__MODULE__,
       joinpath(examples_dir(), "tree_3d_dgsem", "elixir_euler_ec.jl"),
-      initial_refinement_level=1, tspan=(0.0, 0.0),
+      initial_refinement_level=0, tspan=(0.0, 0.0),
       volume_flux=flux_shima_etal, surface_flux=flux_shima_etal)
     u_ode = copy(sol.u[end])
     du_ode = zero(u_ode)
-    u = Trixi.wrap_array(u_ode, semi)
-    du = Trixi.wrap_array(du_ode, semi)
-    nonconservative_terms = Trixi.have_nonconservative_terms(semi.equations)
 
-    du .= 0
-    Trixi.split_form_kernel!(
-      du, u, 1, semi.mesh,
-      nonconservative_terms, semi.equations,
-      semi.solver.volume_integral.volume_flux, semi.solver, semi.cache)
-    du_specialized = du[:, :, :, :, 1]
+    GC.@preserve u_ode du_ode begin
+      u = Trixi.wrap_array(u_ode, semi)
+      du = Trixi.wrap_array(du_ode, semi)
+      nonconservative_terms = Trixi.have_nonconservative_terms(semi.equations)
 
-    du .= 0
-    invoke(Trixi.split_form_kernel!,
-      Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
-      typeof(nonconservative_terms), typeof(semi.equations),
-      Function, typeof(semi.solver), typeof(semi.cache)},
-      du, u, 1, semi.mesh,
-      nonconservative_terms, semi.equations,
-      semi.solver.volume_integral.volume_flux, semi.solver, semi.cache)
-    du_baseline = du[:, :, :, :, 1]
+      # Call the optimized default version
+      du .= 0
+      Trixi.split_form_kernel!(
+        du, u, 1, semi.mesh,
+        nonconservative_terms, semi.equations,
+        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
+      du_specialized = du[:, :, :, :, 1]
 
-    @test du_specialized ≈ du_baseline
+      # Call the plain version - note the argument type `Function` of
+      # `semi.solver.volume_integral.volume_flux`
+      du .= 0
+      invoke(Trixi.split_form_kernel!,
+        Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
+        typeof(nonconservative_terms), typeof(semi.equations),
+        Function, typeof(semi.solver), typeof(semi.cache), Bool},
+        du, u, 1, semi.mesh,
+        nonconservative_terms, semi.equations,
+        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
+      du_baseline = du[:, :, :, :, 1]
+
+      @test du_specialized ≈ du_baseline
+    end
   end
 end
 

--- a/test/test_performance_specializations.jl
+++ b/test/test_performance_specializations.jl
@@ -1,0 +1,50 @@
+module TestPerformanceSpecializations
+
+using Test
+using Trixi
+
+include("test_trixi.jl")
+
+# Start with a clean environment: remove Trixi output directory if it exists
+outdir = "out"
+isdir(outdir) && rm(outdir, recursive=true)
+
+
+@testset "Performance specializations" begin
+  @timed_testset "TreeMesh3D, flux_shima_etal" begin
+    trixi_include(@__MODULE__,
+      joinpath(examples_dir(), "tree_3d_dgsem", "elixir_euler_ec.jl"),
+      initial_refinement_level=1, tspan=(0.0, 0.0),
+      volume_flux=flux_shima_etal, surface_flux=flux_shima_etal)
+    u_ode = copy(sol.u[end])
+    du_ode = zero(u_ode)
+    u = Trixi.wrap_array(u_ode, semi)
+    du = Trixi.wrap_array(du_ode, semi)
+    nonconservative_terms = Trixi.have_nonconservative_terms(semi.equations)
+
+    du .= 0
+    Trixi.split_form_kernel!(
+      du, u, 1, semi.mesh,
+      nonconservative_terms, semi.equations,
+      semi.solver.volume_integral.volume_flux, semi.solver, semi.cache)
+    du_specialized = du[:, :, :, :, 1]
+
+    du .= 0
+    invoke(Trixi.split_form_kernel!,
+      Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
+      typeof(nonconservative_terms), typeof(semi.equations),
+      Function, typeof(semi.solver), typeof(semi.cache)},
+      du, u, 1, semi.mesh,
+      nonconservative_terms, semi.equations,
+      semi.solver.volume_integral.volume_flux, semi.solver, semi.cache)
+    du_baseline = du[:, :, :, :, 1]
+
+    @test du_specialized ≈ du_baseline
+  end
+end
+
+
+# Clean up afterwards: delete Trixi output directory
+@test_nowarn rm(outdir, recursive=true)
+
+end #module


### PR DESCRIPTION
This enables explicit SIMD optimizations for `flux_shima_etal` on the `TreeMesh3D`. Depending on the architecture, we get between 2x and 4x speed-up in micro-benchmarks of the volume terms. This results in a speedup of ca. 2x for full RHS evaluations.
I would like to get a review of this version first. When this is iterated until convergence, we can merge it into the temporary target branch `hr/SIMD` and I can make PRs with similar improvements for `flux_ranocha` and curved meshes. When everything is settled, we can merge `hr/SIMD` into `main` cleanly. If you prefer another development plan, we can of course also merge this directly into `main`.