### PR TITLE
do not test MPI on Windows with coverage

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,13 +15,16 @@ const TRIXI_NTHREADS   = clamp(Sys.CPU_THREADS, 2, 3)
     # cf. https://github.com/JuliaParallel/MPI.jl/pull/391
     @test true
 
-    # Based on `runtests.jl` from `MPI.jl` and `PencilArrays.jl`
-    # On Julia v1.5 and before, precompilation is strictly serial and any attempt
-    # to use it in parallel will result in race conditions and probably errors.
-    # Hence, the additional flag `--compiled-modules=no` is required for Julia
-    # versions older than v1.6.
-    mpiexec() do cmd
-      run(`$cmd -n $TRIXI_MPI_NPROCS $(Base.julia_cmd()) --threads=1 --check-bounds=yes $(abspath("test_mpi.jl"))`)
+    # There are spurious test failures of Trixi.jl with MPI on Windows, see
+    # https://github.com/trixi-framework/Trixi.jl/issues/901
+    # To reduce their impact, we do not test MPI with coverage on Windows.
+    # This reduces the chance to hit a speurious test failure by one half.
+    cmd = string(Base.julia_cmd())
+    coverage = occursin("--code-coverage", cmd) && !occursin("--code-coverage=none", cmd)
+    if !(coverage && Sys.iswindows())
+      mpiexec() do cmd
+        run(`$cmd -n $TRIXI_MPI_NPROCS $(Base.julia_cmd()) --threads=1 --check-bounds=yes $(abspath("test_mpi.jl"))`)
+      end
     end
   end
 


### PR DESCRIPTION
There are spurious test failures of Trixi.jl with MPI on Windows, see
https://github.com/trixi-framework/Trixi.jl/issues/901
To reduce their impact, we do not test MPI with coverage on Windows.
This reduces the chance to hit a speurious test failure by one half.