### PR TITLE
Improve performance of surface integral

### DIFF
--- a/docs/literate/src/files/differentiable_programming.jl
+++ b/docs/literate/src/files/differentiable_programming.jl
@@ -93,7 +93,7 @@ relative_maximum = maximum(real, λ) / maximum(abs, λ)
 
 λ, V = eigen(J)
 condition_number = cond(V)
-@test 200 < condition_number < 300 #src
+@test 200 < condition_number < 400 #src
 
 # If we add dissipation, the maximal real part is still approximately zero.
 

--- a/examples/p4est_3d_dgsem/elixir_euler_ec.jl
+++ b/examples/p4est_3d_dgsem/elixir_euler_ec.jl
@@ -14,14 +14,12 @@ boundary_conditions = Dict(
   :all => boundary_condition_slip_wall
 )
 
-###############################################################################
 # Get the DG approximation space
 
 volume_flux = flux_ranocha
-solver = DGSEM(polydeg=5, surface_flux=FluxRotated(flux_ranocha),
+solver = DGSEM(polydeg=5, surface_flux=flux_ranocha,
                volume_integral=VolumeIntegralFluxDifferencing(volume_flux))
 
-###############################################################################
 # Get the curved quad mesh from a file
 
 # Mapping as described in https://arxiv.org/abs/2012.12040
@@ -55,8 +53,7 @@ mesh = P4estMesh{3}(mesh_file, polydeg=5,
                     mapping=mapping,
                     initial_refinement_level=0)
 
-###############################################################################
-# create the semi discretization object
+# create the semidiscretization object
 
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver, boundary_conditions=boundary_conditions)
 

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -8,7 +8,7 @@
 @doc raw"""
     CompressibleEulerEquations2D(gamma)
 
-The compressible Euler equations 
+The compressible Euler equations
 ```math
 \partial t
 \begin{pmatrix}
@@ -287,8 +287,10 @@ Details about the 1D pressure Riemann solution can be found in Section 6.3.3 of 
 
 Should be used together with [`UnstructuredMesh2D`](@ref).
 """
-function boundary_condition_slip_wall(u_inner, normal_direction::AbstractVector, x, t,
-                                      surface_flux_function, equations::CompressibleEulerEquations2D)
+@inline function boundary_condition_slip_wall(u_inner, normal_direction::AbstractVector,
+                                              x, t,
+                                              surface_flux_function,
+                                              equations::CompressibleEulerEquations2D)
 
   norm_ = norm(normal_direction)
   # Normalize the vector without using `normalize` since we need to multiply by the `norm_` later
@@ -327,8 +329,10 @@ end
 
 Should be used together with [`TreeMesh`](@ref).
 """
-function boundary_condition_slip_wall(u_inner, orientation, direction, x, t,
-                                      surface_flux_function, equations::CompressibleEulerEquations2D)
+@inline function boundary_condition_slip_wall(u_inner, orientation,
+                                              direction, x, t,
+                                              surface_flux_function,
+                                              equations::CompressibleEulerEquations2D)
   # get the appropriate normal vector from the orientation
   if orientation == 1
     normal = SVector(1, 0)
@@ -346,8 +350,10 @@ end
 
 Should be used together with [`StructuredMesh`](@ref).
 """
-function boundary_condition_slip_wall(u_inner, normal_direction::AbstractVector, direction, x, t,
-                                      surface_flux_function, equations::CompressibleEulerEquations2D)
+@inline function boundary_condition_slip_wall(u_inner, normal_direction::AbstractVector,
+                                              direction, x, t,
+                                              surface_flux_function,
+                                              equations::CompressibleEulerEquations2D)
   # flip sign of normal to make it outward pointing, then flip the sign of the normal flux back
   # to be inward pointing on the -x and -y sides due to the orientation convention used by StructuredMesh
   if isodd(direction)

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -277,8 +277,10 @@ Details about the 1D pressure Riemann solution can be found in Section 6.3.3 of 
   3rd edition
   [DOI: 10.1007/b79761](https://doi.org/10.1007/b79761)
 """
-function boundary_condition_slip_wall(u_inner, normal_direction::AbstractVector, x, t,
-                                      surface_flux_function, equations::CompressibleEulerEquations3D)
+@inline function boundary_condition_slip_wall(u_inner, normal_direction::AbstractVector,
+                                              x, t,
+                                              surface_flux_function,
+                                              equations::CompressibleEulerEquations3D)
 
   norm_ = norm(normal_direction)
   # Normalize the vector without using `normalize` since we need to multiply by the `norm_` later

--- a/src/equations/shallow_water_2d.jl
+++ b/src/equations/shallow_water_2d.jl
@@ -177,8 +177,10 @@ For details see Section 9.2.5 of the book:
   1st edition
   ISBN 0471987662
 """
-function boundary_condition_slip_wall(u_inner, normal_direction::AbstractVector, x, t,
-                                      surface_flux_function, equations::ShallowWaterEquations2D)
+@inline function boundary_condition_slip_wall(u_inner, normal_direction::AbstractVector,
+                                              x, t,
+                                              surface_flux_function,
+                                              equations::ShallowWaterEquations2D)
   # normalize the outward pointing direction
   normal = normal_direction / norm(normal_direction)
 

--- a/src/solvers/dgsem_p4est/dg_2d.jl
+++ b/src/solvers/dgsem_p4est/dg_2d.jl
@@ -595,22 +595,30 @@ function calc_surface_integral!(du, u,
   @unpack boundary_interpolation = dg.basis
   @unpack surface_flux_values = cache.elements
 
-  # Note that all fluxes have been computed with outward-pointing normal vectors
+  # Note that all fluxes have been computed with outward-pointing normal vectors.
+  # Access the factors only once before beginning the loop to increase performance.
+  # We also use explicit assignments instead of `+=` to let `@muladd` turn these
+  # into FMAs (see comment at the top of the file).
+  factor_1 = boundary_interpolation[1,          1]
+  factor_2 = boundary_interpolation[nnodes(dg), 2]
   @threaded for element in eachelement(dg, cache)
     for l in eachnode(dg)
       for v in eachvariable(equations)
         # surface at -x
-        du[v, 1,          l, element] += (surface_flux_values[v, l, 1, element]
-                                          * boundary_interpolation[1, 1])
+        du[v, 1,          l, element] = (
+          du[v, 1,          l, element] + surface_flux_values[v, l, 1, element] * factor_1)
+
         # surface at +x
-        du[v, nnodes(dg), l, element] += (surface_flux_values[v, l, 2, element]
-                                          * boundary_interpolation[nnodes(dg), 2])
+        du[v, nnodes(dg), l, element] = (
+          du[v, nnodes(dg), l, element] + surface_flux_values[v, l, 2, element] * factor_2)
+
         # surface at -y
-        du[v, l, 1,          element] += (surface_flux_values[v, l, 3, element]
-                                          * boundary_interpolation[1, 1])
+        du[v, l, 1,          element] = (
+          du[v, l, 1,          element] + surface_flux_values[v, l, 3, element] * factor_1)
+
         # surface at +y
-        du[v, l, nnodes(dg), element] += (surface_flux_values[v, l, 4, element]
-                                          * boundary_interpolation[nnodes(dg), 2])
+        du[v, l, nnodes(dg), element] = (
+          du[v, l, nnodes(dg), element] + surface_flux_values[v, l, 4, element] * factor_2)
       end
     end
   end

--- a/src/solvers/dgsem_p4est/dg_3d.jl
+++ b/src/solvers/dgsem_p4est/dg_3d.jl
@@ -678,28 +678,38 @@ function calc_surface_integral!(du, u,
   @unpack boundary_interpolation = dg.basis
   @unpack surface_flux_values = cache.elements
 
-  # Note that all fluxes have been computed with outward-pointing normal vectors
+  # Note that all fluxes have been computed with outward-pointing normal vectors.
+  # Access the factors only once before beginning the loop to increase performance.
+  # We also use explicit assignments instead of `+=` to let `@muladd` turn these
+  # into FMAs (see comment at the top of the file).
+  factor_1 = boundary_interpolation[1,          1]
+  factor_2 = boundary_interpolation[nnodes(dg), 2]
   @threaded for element in eachelement(dg, cache)
     for m in eachnode(dg), l in eachnode(dg)
       for v in eachvariable(equations)
         # surface at -x
-        du[v, 1,          l, m, element] += (surface_flux_values[v, l, m, 1, element]
-                                             * boundary_interpolation[1, 1])
+        du[v, 1,          l, m, element] = (
+          du[v, 1,          l, m, element] + surface_flux_values[v, l, m, 1, element] * factor_1)
+
         # surface at +x
-        du[v, nnodes(dg), l, m, element] += (surface_flux_values[v, l, m, 2, element]
-                                             * boundary_interpolation[nnodes(dg), 2])
+        du[v, nnodes(dg), l, m, element] = (
+          du[v, nnodes(dg), l, m, element] + surface_flux_values[v, l, m, 2, element] * factor_2)
+
         # surface at -y
-        du[v, l, 1,          m, element] += (surface_flux_values[v, l, m, 3, element]
-                                             * boundary_interpolation[1, 1])
+        du[v, l, 1,          m, element] = (
+          du[v, l, 1,          m, element] + surface_flux_values[v, l, m, 3, element] * factor_1)
+
         # surface at +y
-        du[v, l, nnodes(dg), m, element] += (surface_flux_values[v, l, m, 4, element]
-                                             * boundary_interpolation[nnodes(dg), 2])
+        du[v, l, nnodes(dg), m, element] = (
+          du[v, l, nnodes(dg), m, element] + surface_flux_values[v, l, m, 4, element] * factor_2)
+
         # surface at -z
-        du[v, l, m, 1,          element] += (surface_flux_values[v, l, m, 5, element]
-                                             * boundary_interpolation[1,          1])
+        du[v, l, m, 1,          element] = (
+          du[v, l, m, 1,          element] + surface_flux_values[v, l, m, 5, element] * factor_1)
+
         # surface at +z
-        du[v, l, m, nnodes(dg), element] += (surface_flux_values[v, l, m, 6, element]
-                                             * boundary_interpolation[nnodes(dg), 2])
+        du[v, l, m, nnodes(dg), element] = (
+          du[v, l, m, nnodes(dg), element] + surface_flux_values[v, l, m, 6, element] * factor_2)
       end
     end
   end

--- a/src/solvers/dgsem_tree/dg_2d.jl
+++ b/src/solvers/dgsem_tree/dg_2d.jl
@@ -967,17 +967,30 @@ function calc_surface_integral!(du, u, mesh::Union{TreeMesh{2}, StructuredMesh{2
   @unpack boundary_interpolation = dg.basis
   @unpack surface_flux_values = cache.elements
 
+  # Note that all fluxes have been computed with outward-pointing normal vectors.
+  # Access the factors only once before beginning the loop to increase performance.
+  # We also use explicit assignments instead of `+=` to let `@muladd` turn these
+  # into FMAs (see comment at the top of the file).
+  factor_1 = boundary_interpolation[1,          1]
+  factor_2 = boundary_interpolation[nnodes(dg), 2]
   @threaded for element in eachelement(dg, cache)
     for l in eachnode(dg)
       for v in eachvariable(equations)
         # surface at -x
-        du[v, 1,          l, element] -= surface_flux_values[v, l, 1, element] * boundary_interpolation[1,          1]
+        du[v, 1,          l, element] = (
+          du[v, 1,          l, element] - surface_flux_values[v, l, 1, element] * factor_1)
+
         # surface at +x
-        du[v, nnodes(dg), l, element] += surface_flux_values[v, l, 2, element] * boundary_interpolation[nnodes(dg), 2]
+        du[v, nnodes(dg), l, element] = (
+          du[v, nnodes(dg), l, element] + surface_flux_values[v, l, 2, element] * factor_2)
+
         # surface at -y
-        du[v, l, 1,          element] -= surface_flux_values[v, l, 3, element] * boundary_interpolation[1,          1]
+        du[v, l, 1,          element] = (
+          du[v, l, 1,          element] - surface_flux_values[v, l, 3, element] * factor_1)
+
         # surface at +y
-        du[v, l, nnodes(dg), element] += surface_flux_values[v, l, 4, element] * boundary_interpolation[nnodes(dg), 2]
+        du[v, l, nnodes(dg), element] = (
+          du[v, l, nnodes(dg), element] + surface_flux_values[v, l, 4, element] * factor_2)
       end
     end
   end

--- a/test/test_structured_2d.jl
+++ b/test/test_structured_2d.jl
@@ -95,9 +95,9 @@ isdir(outdir) && rm(outdir, recursive=true)
 
   @trixi_testset "elixir_advection_restart.jl with waving flag mesh" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_restart.jl"),
-      l2   = [0.00016265538283059892],
-      linf = [0.0015194298895079283],
-      rtol = 5e-7, # Higher tolerance to make tests pass in CI
+      l2   = [0.00016265538265929818],
+      linf = [0.0015194252169410394],
+      rtol = 5e-6, # Higher tolerance to make tests pass in CI
       elixir_file="elixir_advection_waving_flag.jl",
       restart_file="restart_000021.h5")
   end

--- a/test/test_tree_1d_hypdiff.jl
+++ b/test/test_tree_1d_hypdiff.jl
@@ -13,13 +13,15 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1
   @trixi_testset "elixir_hypdiff_nonperiodic.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hypdiff_nonperiodic.jl"),
       l2   = [1.3655114954641076e-7, 1.0200345025539218e-6],
-      linf = [7.173286515893551e-7, 4.507116363683394e-6])
+      linf = [7.173286515893551e-7, 4.507116363683394e-6],
+      atol = 2.5e-13)
   end
 
   @trixi_testset "elixir_hypdiff_harmonic_nonperiodic.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hypdiff_harmonic_nonperiodic.jl"),
       l2   = [3.0130941075207524e-12, 2.6240829677090014e-12],
-      linf = [4.054534485931072e-12, 3.8826719617190975e-12])
+      linf = [4.054534485931072e-12, 3.8826719617190975e-12],
+      atol = 2.5e-13)
   end
 end
 

--- a/test/test_tree_2d_euler.jl
+++ b/test/test_tree_2d_euler.jl
@@ -251,9 +251,10 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2
 
   @trixi_testset "elixir_euler_ec.jl with boundary_condition_slip_wall" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_ec.jl"),
-      l2   = [0.06176845600430613, 0.05020624043492084, 0.05021389111189423, 0.22592682624517807],
-      linf = [0.29347582879609024, 0.3108124923286465, 0.3107380389949771, 1.054035804988522],
-      periodicity = false, boundary_conditions = boundary_condition_slip_wall)
+      l2   = [0.03341239373099515, 0.026673245711492915, 0.026678871434568822, 0.12397486476145089],
+      linf = [0.3290981764688339, 0.3812055782309788, 0.3812041851225023, 1.168251216556933],
+      periodicity = false, boundary_conditions = boundary_condition_slip_wall,
+      cfl = 0.3, tspan = (0.0, 0.1)) # this test is sensitive to the CFL factor
   end
 end
 


### PR DESCRIPTION
When SIMD optimizations land in Trixi.jl, the other parts become relatively more expensive. This is a simple way to increase the performance of the surface integral by reducing the number of memory accesses and total floating point operations.