### PR TITLE
remove `elixir_euler_density_wave.jl` from MPI tests

### DIFF
--- a/test/test_mpi.jl
+++ b/test/test_mpi.jl
@@ -116,13 +116,6 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
       coverage_override = (maxiters=10^5,))
   end
 
-  @trixi_testset "elixir_euler_density_wave.jl" begin
-    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_density_wave.jl"),
-      l2   = [0.0010600778457965205, 0.00010600778457646603, 0.0002120155691588112, 2.6501946142012653e-5],
-      linf = [0.006614198043407127, 0.0006614198043931596, 0.001322839608845383, 0.00016535495117153687],
-      tspan = (0.0, 0.5))
-  end
-
   @trixi_testset "elixir_euler_source_terms_nonperiodic.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms_nonperiodic.jl"),
       l2   = [2.259440511766445e-6, 2.318888155713922e-6, 2.3188881557894307e-6, 6.3327863238858925e-6],


### PR DESCRIPTION
I removed this elixir since it was always the last file name shown before crashes on Windows in CI. The basic numerical setup (weak form) is still used in other MPI tests.

Xref #901