### PR TITLE
Add elixir for the KPP problem

### DIFF
--- a/examples/tree_2d_dgsem/elixir_kpp.jl
+++ b/examples/tree_2d_dgsem/elixir_kpp.jl
@@ -9,6 +9,7 @@ using LinearAlgebra
 # See: Kurganov, A., Petrova, G., and Popov, B. (2007).
 # Adaptive Semidiscrete Central-Upwind Schemes for Nonconvex Hyperbolic Conservation Laws,
 # SIAM Journal on Scientific Computing, 29(6), 2381--2401
+# DOI: https://doi.org/10.1137/040614189
 
 struct KPPEquation2D <: Trixi.AbstractEquations{2, 1} end
 
@@ -23,6 +24,7 @@ end
 
 # Since the KPP problem is a scalar equation, the entropy-conservative flux is uniquely determined
 @inline function Trixi.flux_ec(u_ll, u_rr, orientation::Integer, ::KPPEquation2D)
+    # The tolerance of 1e-12 is based on experience and somewhat arbitrarily chosen
     if abs(u_ll[1] - u_rr[1]) < 1e-12
         return 0.5 * (flux(u_ll, orientation, KPPEquation2D()) + flux(u_rr, orientation, KPPEquation2D()))
     else
@@ -133,7 +135,7 @@ save_solution = SaveSolutionCallback(interval=200,
 
 callbacks = CallbackSet(summary_callback,
                         analysis_callback, alive_callback,
-                        amr_callback, save_solution)
+                        save_solution, amr_callback)
 
 ###############################################################################
 # run the simulation

--- a/examples/tree_2d_dgsem/elixir_kpp.jl
+++ b/examples/tree_2d_dgsem/elixir_kpp.jl
@@ -24,9 +24,9 @@ end
 # Since the KPP problem is a scalar equation, the entropy-conservative flux is uniquely determined
 @inline function Trixi.flux_ec(u_ll, u_rr, orientation::Integer, ::KPPEquation2D)
     if abs(u_ll[1] - u_rr[1]) < 1e-12
-        return 0.5*(flux(u_ll, orientation, KPPEquation2D())+flux(u_rr, orientation, KPPEquation2D()))
+        return 0.5 * (flux(u_ll, orientation, KPPEquation2D()) + flux(u_rr, orientation, KPPEquation2D()))
     else
-        factor = 1.0/(u_rr[1] - u_ll[1])
+        factor = 1.0 / (u_rr[1] - u_ll[1])
         if orientation == 1
             return SVector(factor*(-cos(u_rr[1]) + cos(u_ll[1])))
         else
@@ -63,9 +63,9 @@ Trixi.varnames(::Any, ::KPPEquation2D) = ("u",)
 # Standard KPP test problem with discontinuous initial condition
 function initial_condition_kpp(x, t, ::KPPEquation2D)
     if x[1]^2 + x[2]^2 < 1
-        return SVector(0.25*14.0*pi)
+        return SVector(0.25 * 14.0 * pi)
     else
-        return SVector(0.25*pi)
+        return SVector(0.25 * pi)
     end
 end
 

--- a/examples/tree_2d_dgsem/elixir_kpp.jl
+++ b/examples/tree_2d_dgsem/elixir_kpp.jl
@@ -106,10 +106,12 @@ amr_indicator = IndicatorHennemannGassner(semi,
                                           alpha_smooth=false,
                                           variable=first)
 
+max_refinement_level = 8
+
 amr_controller = ControllerThreeLevelCombined(semi, amr_indicator, shock_indicator,
                                               base_level=2,
                                               med_level=0, med_threshold=0.0003,
-                                              max_level=8, max_threshold=0.003,
+                                              max_level=max_refinement_level, max_threshold=0.003,
                                               max_threshold_secondary=shock_indicator.alpha_max)
 
 amr_callback = AMRCallback(semi, amr_controller,

--- a/examples/tree_2d_dgsem/elixir_kpp.jl
+++ b/examples/tree_2d_dgsem/elixir_kpp.jl
@@ -90,7 +90,7 @@ coordinates_min = (-2.0, -2.0)
 coordinates_max = ( 2.0,  2.0)
 
 mesh = TreeMesh(coordinates_min, coordinates_max,
-                initial_refinement_level=6,
+                initial_refinement_level=2,
                 periodicity=true,
                 n_cells_max=500_000)
 

--- a/examples/tree_2d_dgsem/elixir_kpp.jl
+++ b/examples/tree_2d_dgsem/elixir_kpp.jl
@@ -38,10 +38,10 @@ end
 end
 
 # Wavespeeds
-const kpp_wavespeed = 1.0
-@inline Trixi.max_abs_speeds(u, ::KPPEquation2D) = (kpp_wavespeed, kpp_wavespeed)
-@inline Trixi.max_abs_speed_naive(u_ll, u_rr, orientation::Integer, ::KPPEquation2D) = kpp_wavespeed
-@inline Trixi.max_abs_speed_naive(u_ll, u_rr, normal_direction::AbstractVector, ::KPPEquation2D) = kpp_wavespeed * norm(normal_direction)
+@inline wavespeed(::KPPEquation2D) = 1.0
+@inline Trixi.max_abs_speeds(u, equation::KPPEquation2D) = (wavespeed(equation), wavespeed(equation))
+@inline Trixi.max_abs_speed_naive(u_ll, u_rr, orientation::Integer, equation::KPPEquation2D) = wavespeed(equation)
+@inline Trixi.max_abs_speed_naive(u_ll, u_rr, normal_direction::AbstractVector, equation::KPPEquation2D) = wavespeed(equation) * norm(normal_direction)
 
 # Compute entropy: we use the square entropy
 @inline Trixi.entropy(u::Real, ::KPPEquation2D) = 0.5 * u^2

--- a/examples/tree_2d_dgsem/elixir_kpp.jl
+++ b/examples/tree_2d_dgsem/elixir_kpp.jl
@@ -90,7 +90,7 @@ coordinates_min = (-2.0, -2.0)
 coordinates_max = ( 2.0,  2.0)
 
 mesh = TreeMesh(coordinates_min, coordinates_max,
-                initial_refinement_level=2,
+                initial_refinement_level=6,
                 periodicity=true,
                 n_cells_max=500_000)
 

--- a/examples/tree_2d_dgsem/elixir_kpp.jl
+++ b/examples/tree_2d_dgsem/elixir_kpp.jl
@@ -1,0 +1,151 @@
+using Trixi
+using OrdinaryDiffEq
+using Plots
+using LinearAlgebra
+
+###############################################################################
+# Definition of the 2D scalar "KPP equation"
+#
+# See: Kurganov, A., Petrova, G., and Popov, B. (2007).
+# Adaptive Semidiscrete Central-Upwind Schemes for Nonconvex Hyperbolic Conservation Laws,
+# SIAM Journal on Scientific Computing, 29(6), 2381--2401
+
+struct KPPEquation2D <: Trixi.AbstractEquations{2, 1} end
+
+# The KPP flux is F(u) = (sin(u), cos(u))
+@inline function Trixi.flux(u, orientation::Integer, ::KPPEquation2D)
+    if orientation == 1
+        return SVector(sin(u[1]))
+    else
+        return SVector(cos(u[1]))
+    end
+end
+
+# Since the KPP problem is a scalar equation, the entropy-conservative flux is uniquely determined
+@inline function Trixi.flux_ec(u_ll, u_rr, orientation::Integer, ::KPPEquation2D)
+    if abs(u_ll[1] - u_rr[1]) < 1e-12
+        return 0.5*(flux(u_ll, orientation, KPPEquation2D())+flux(u_rr, orientation, KPPEquation2D()))
+    else
+        factor = 1.0/(u_rr[1] - u_ll[1])
+        if orientation == 1
+            return SVector(factor*(-cos(u_rr[1]) + cos(u_ll[1])))
+        else
+            return SVector(factor*(sin(u_rr[1]) - sin(u_ll[1])))
+        end
+    end
+end
+
+# Wavespeeds
+const kpp_wavespeed = 1.0
+@inline Trixi.max_abs_speeds(u, ::KPPEquation2D) = (kpp_wavespeed, kpp_wavespeed)
+@inline Trixi.max_abs_speed_naive(u_ll, u_rr, orientation::Integer, ::KPPEquation2D) = kpp_wavespeed
+@inline Trixi.max_abs_speed_naive(u_ll, u_rr, normal_direction::AbstractVector, ::KPPEquation2D) = kpp_wavespeed * norm(normal_direction)
+
+# Compute entropy: we use the square entropy
+@inline Trixi.entropy(u::Real, ::KPPEquation2D) = 0.5 * u^2
+@inline Trixi.entropy(u, ::KPPEquation2D) = entropy(u[1], equation)
+
+# Convert between conservative, primitive, and entropy variables. The conserved quantity "u" is also
+# considered the "primitive variable". Since we use the square entropy, "u" is also the entropy
+# variable.
+@inline Trixi.cons2prim(u, ::KPPEquation2D) = u
+@inline Trixi.cons2entropy(u, ::KPPEquation2D) = u
+
+# Total energy
+@inline Trixi.energy_total(u::Real, ::KPPEquation2D) = 0.5 * u^2
+@inline Trixi.energy_total(u, equation::KPPEquation2D) = energy_total(u[1], equation)
+
+Trixi.varnames(::Any, ::KPPEquation2D) = ("u",)
+
+# Extract the solution as a scalar, for use in the indicator
+@inline cons_sol(u, ::KPPEquation2D) = u[1]
+
+# Standard KPP test problem with discontinuous initial condition
+function initial_condition_kpp(x, t, ::KPPEquation2D)
+    if x[1]^2 + x[2]^2 < 1
+        return SVector(0.25*14.0*pi)
+    else
+        return SVector(0.25*pi)
+    end
+end
+
+###############################################################################
+# semidiscretization of the KPP problem
+equation = KPPEquation2D()
+surface_flux = flux_lax_friedrichs
+volume_flux = flux_ec
+# Can also compare solution obtained without using entropy-conservative flux. This will not converge
+# to the correct (entropy) solution!
+# volume_flux = flux_central
+polydeg = 3
+basis = LobattoLegendreBasis(polydeg)
+shock_indicator = IndicatorHennemannGassner(equation, basis,
+                                            alpha_max=0.5,
+                                            alpha_min=0.001,
+                                            alpha_smooth=true,
+                                            variable=cons_sol)
+volume_integral = VolumeIntegralShockCapturingHG(shock_indicator;
+                                                 volume_flux_dg=volume_flux,
+                                                 volume_flux_fv=surface_flux)
+solver = DGSEM(polydeg=polydeg, surface_flux=surface_flux, volume_integral=volume_integral)
+
+###############################################################################
+# Set up the tree mesh (initially a Cartesian grid of [-2,2]^2)
+coordinates_min = (-2.0, -2.0)
+coordinates_max = ( 2.0,  2.0)
+cells_per_dimension = (64, 64)
+
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level=6,
+                periodicity=true,
+                n_cells_max=500_000)
+
+dt = 1e-4
+
+###############################################################################
+# Create the semi discretization object
+semi = SemidiscretizationHyperbolic(mesh, equation, initial_condition_kpp, solver)
+
+###############################################################################
+# Set up adaptive mesh refinement
+amr_indicator = IndicatorHennemannGassner(semi,
+                                          alpha_max=1.0,
+                                          alpha_min=0.0001,
+                                          alpha_smooth=false,
+                                          variable=cons_sol)
+
+amr_controller = ControllerThreeLevelCombined(semi, amr_indicator, shock_indicator,
+                                              base_level=2,
+                                              med_level=0, med_threshold=0.0003,
+                                              max_level=8, max_threshold=0.003,
+                                              max_threshold_secondary=shock_indicator.alpha_max)
+
+amr_callback = AMRCallback(semi, amr_controller,
+                           interval=1,
+                           adapt_initial_condition=true,
+                           adapt_initial_condition_only_refine=true)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+ode = semidiscretize(semi, (0.0, 1.0))
+
+summary_callback = SummaryCallback()
+
+analysis_callback = AnalysisCallback(semi, interval=200)
+
+alive_callback = AliveCallback(analysis_interval=200)
+
+save_solution = SaveSolutionCallback(interval=200,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=cons2cons)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        amr_callback, save_solution)
+
+###############################################################################
+# run the simulation
+sol = solve(ode, SSPRK43(), save_everystep=false, callback=callbacks)
+
+summary_callback() # Print the timer summary

--- a/examples/tree_2d_dgsem/elixir_kpp.jl
+++ b/examples/tree_2d_dgsem/elixir_kpp.jl
@@ -127,7 +127,8 @@ amr_callback = AMRCallback(semi, amr_controller,
 
 ###############################################################################
 # ODE solvers, callbacks etc.
-ode = semidiscretize(semi, (0.0, 1.0))
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/test/test_tree_2d_kpp.jl
+++ b/test/test_tree_2d_kpp.jl
@@ -10,9 +10,10 @@ EXAMPLES_DIR = joinpath(examples_dir(), "tree_2d_dgsem")
 @testset "KPP" begin
   @trixi_testset "elixir_kpp.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_kpp.jl"),
-      l2   = [5.17986197e-01],
-      linf = [8.93080899e+00],
-      tspan = (0.0, 0.1),
+      l2   = [0.36563290910786106],
+      linf = [9.116732052340398],
+      max_refinement_level = 6,
+      tspan = (0.0, 0.01),
       atol = 1e-6,
       rtol = 1e-6)
   end

--- a/test/test_tree_2d_kpp.jl
+++ b/test/test_tree_2d_kpp.jl
@@ -15,7 +15,8 @@ EXAMPLES_DIR = joinpath(examples_dir(), "tree_2d_dgsem")
       max_refinement_level = 6,
       tspan = (0.0, 0.01),
       atol = 1e-6,
-      rtol = 1e-6)
+      rtol = 1e-6,
+      skip_coverage = true)
   end
 end
 

--- a/test/test_tree_2d_kpp.jl
+++ b/test/test_tree_2d_kpp.jl
@@ -10,7 +10,7 @@ EXAMPLES_DIR = joinpath(examples_dir(), "tree_2d_dgsem")
 @testset "KPP" begin
   @trixi_testset "elixir_kpp.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_kpp.jl"),
-      l2   = [0.36563290910786106],
+      l2   = [0.365621500852156],
       linf = [9.116732052340398],
       max_refinement_level = 6,
       tspan = (0.0, 0.01),

--- a/test/test_tree_2d_kpp.jl
+++ b/test/test_tree_2d_kpp.jl
@@ -1,0 +1,22 @@
+module TestExamplesKPP
+
+using Test
+using Trixi
+
+include("test_trixi.jl")
+
+# pathof(Trixi) returns /path/to/Trixi/src/Trixi.jl, dirname gives the parent directory
+EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+
+@testset "KPP" begin
+  @trixi_testset "elixir_kpp.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_kpp.jl"),
+      l2   = [5.17986197e-01],
+      linf = [8.93080899e+00],
+      tspan = (0.0, 0.1),
+      atol = 1e-6,
+      rtol = 1e-6)
+  end
+end
+
+end # module

--- a/test/test_tree_2d_kpp.jl
+++ b/test/test_tree_2d_kpp.jl
@@ -10,7 +10,7 @@ EXAMPLES_DIR = joinpath(examples_dir(), "tree_2d_dgsem")
 @testset "KPP" begin
   @trixi_testset "elixir_kpp.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_kpp.jl"),
-      l2   = [0.365621500852156],
+      l2   = [0.36563290910786106],
       linf = [9.116732052340398],
       max_refinement_level = 6,
       tspan = (0.0, 0.01),

--- a/test/test_tree_2d_kpp.jl
+++ b/test/test_tree_2d_kpp.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = joinpath(examples_dir(), "tree_2d_dgsem")
 
 @testset "KPP" begin
   @trixi_testset "elixir_kpp.jl" begin

--- a/test/test_tree_2d_part2.jl
+++ b/test/test_tree_2d_part2.jl
@@ -24,6 +24,9 @@ isdir(outdir) && rm(outdir, recursive=true)
 
   # Compressible Euler coupled with acoustic perturbation equations
   include("test_tree_2d_euleracoustics.jl")
+
+  # KPP problem
+  include("test_tree_2d_kpp.jl")
 end
 
 # Clean up afterwards: delete Trixi output directory


### PR DESCRIPTION
The [KPP problem](https://doi.org/10.1137%2F040614189) is a scalar hyperbolic problem with a non-convex flux function. It is challenging because methods that are not guaranteed to satisfy the discrete entropy inequality may converge to the wrong solution.

This PR adds a short elixir (with thanks to @gregorgassner for the shock capturing and AMR) to run the standard KPP test case using the entropy conservative volume flux and Lax-Friedrichs surface flux (without the EC flux, the wrong solution will be obtained).