### PR TITLE
Remove JuliaCon notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@
   <img width="300px" src="docs/src/assets/logo.png">
 </p>
 
-**>> Trixi was present at JuliaCon 2021: Watch the talk on
-[YouTube](https://www.youtube.com/watch?v=hoViWRAhCBE) or revisit the
-[live demonstration](https://github.com/trixi-framework/talk-2021-juliacon)! <<**
-
 **Trixi.jl** is a numerical simulation framework for hyperbolic conservation
 laws written in [Julia](https://julialang.org). A key objective for the
 framework is to be useful to both scientists and students. Therefore, next to


### PR DESCRIPTION
Rationale: We are closer to JuliaCon 2022 than 2021.

The removed links are still accessible [here](https://trixi-framework.github.io/#talks).