### PR TITLE
WIP: Reduce CI (no coverage for applications)

### DIFF
--- a/test/test_unstructured_2d.jl
+++ b/test/test_unstructured_2d.jl
@@ -64,7 +64,8 @@ isdir(outdir) && rm(outdir, recursive=true)
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_sedov.jl"),
       l2   = [2.19945600e-01, 1.71050453e-01, 1.71050453e-01, 1.21719195e+00],
       linf = [7.44218635e-01, 7.02887039e-01, 7.02887039e-01, 6.11732719e+00],
-      tspan = (0.0, 0.3))
+      tspan = (0.0, 0.3),
+      skip_coverage = true)
   end
 
   @trixi_testset "elixir_acoustics_gauss_wall.jl" begin
@@ -95,7 +96,8 @@ isdir(outdir) && rm(outdir, recursive=true)
       linf = [0.00039334982566352483, 0.14144904937275282, 0.14144904937277897, 0.20003315928443416,
               6.826863293230012e-5, 0.14146512909995967, 0.14146512909994702, 0.20006706837452526,
               0.00013645610312810813],
-      tspan = (0.0, 0.5))
+      tspan = (0.0, 0.5),
+      skip_coverage = true)
   end
 
   @trixi_testset "elixir_shallowwater_ec.jl" begin


### PR DESCRIPTION
This PR is meant to be a demonstration of reducing CI by removing coverage tests for "applications". For now, we can set `skip_coverage = true` in `@test_trixi_include` for every elixir test that we think should not be run with coverage.

For now, I used a kind of arbitrary definition of "applications", since this is quite difficult - as discussed in our last meeting. In the first version of the adapted tests in `test_unstructured_2d.jl`, I just set the Sedov blast wave (Euler) and the Alfvén wave (MHD) as well-known applications.

Contribution welcome! If you work on this, please commit one test file at a time and check the corresponding box below.

### TODO 

- [ ] test_dgmulti_1d.jl
- [ ] test_dgmulti_2d.jl
- [ ] test_dgmulti_3d.jl
- [ ] test_mpi_p4est.jl
- [ ] test_mpi_tree.jl
- [ ] test_p4est_2d.jl
- [ ] test_p4est_3d.jl
- [ ] test_paper_self_gravitating_gas_dynamics.jl
- [ ] test_performance_specializations.jl
- [ ] test_special_elixirs.jl
- [ ] test_structured_1d.jl
- [ ] test_structured_2d.jl
- [ ] test_structured_3d.jl
- [ ] test_tree_1d_advection.jl
- [ ] test_tree_1d_burgers.jl
- [ ] test_tree_1d_eulergravity.jl
- [ ] test_tree_1d_euler.jl
- [ ] test_tree_1d_eulermulti.jl
- [ ] test_tree_1d_hypdiff.jl
- [ ] test_tree_1d_mhd.jl
- [ ] test_tree_1d_mhdmulti.jl
- [ ] test_tree_2d_acoustics.jl
- [ ] test_tree_2d_advection.jl
- [ ] test_tree_2d_euleracoustics.jl
- [ ] test_tree_2d_euler.jl
- [ ] test_tree_2d_eulermulti.jl
- [ ] test_tree_2d_fdsbp.jl
- [ ] test_tree_2d_hypdiff.jl
- [ ] test_tree_2d_kpp.jl
- [ ] test_tree_2d_lbm.jl
- [ ] test_tree_2d_mhd.jl
- [ ] test_tree_2d_mhdmulti.jl
- [ ] test_tree_2d_shallowwater.jl
- [ ] test_tree_3d_advection.jl
- [ ] test_tree_3d_eulergravity.jl
- [ ] test_tree_3d_euler.jl
- [ ] test_tree_3d_hypdiff.jl
- [ ] test_tree_3d_lbm.jl
- [ ] test_tree_3d_mhd.jl
- [x] test_unstructured_2d.jl
- [ ] test_visualization.jl
