### PR TITLE
WIP: split CI into two parts

### DIFF
--- a/.github/workflows/ci_coverage.yml
+++ b/.github/workflows/ci_coverage.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI with coverage
 
 on:
   push:
@@ -42,7 +42,6 @@ concurrency:
 
 jobs:
   test:
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
     # We could also include the Julia version as in
     # name: ${{ matrix.trixi_test }} - ${{ matrix.os }} - Julia ${{ matrix.version }} - ${{ matrix.arch }} - ${{ github.event_name }}
     # to be more specific. However, that requires us updating the required CI tests whenever we update Julia.
@@ -59,38 +58,8 @@ jobs:
         arch:
           - x64
         trixi_test:
-          - tree_part1
-          - tree_part2
-          - tree_part3
-          - tree_part4
-          - tree_part5
-          - tree_part6
-          - structured
-          - p4est_part1
-          - p4est_part2
-          - unstructured_dgmulti
-          - paper_self_gravitating_gas_dynamics
           - misc_part1
           - misc_part2
-          - mpi
-          - threaded
-        include:
-          - version: '1.6'
-            os: macOS-latest
-            arch: x64
-            trixi_test: mpi
-          - version: '1.6'
-            os: macOS-latest
-            arch: x64
-            trixi_test: threaded
-          - version: '1.6'
-            os: windows-latest
-            arch: x64
-            trixi_test: mpi
-          - version: '1.6'
-            os: windows-latest
-            arch: x64
-            trixi_test: threaded
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -102,14 +71,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
         env:
           PYTHON: ""
-      - name: Run tests without coverage
-        uses: julia-actions/julia-runtest@v1
-        with:
-          coverage: false
-        env:
-          PYTHON: ""
-          TRIXI_TEST: ${{ matrix.trixi_test }}
-      - name: Run tests with coverage
+      - name: Run coverage tests
         uses: julia-actions/julia-runtest@v1
         with:
           coverage: true
@@ -118,7 +80,7 @@ jobs:
           TRIXI_TEST: ${{ matrix.trixi_test }}
       - uses: julia-actions/julia-processcoverage@v1
         with:
-          directories: src,examples
+          directories: src # We do not collect coverage for `examples`
       - uses: codecov/codecov-action@v1
         with:
           file: ./lcov.info

--- a/.github/workflows/ci_examples.yml
+++ b/.github/workflows/ci_examples.yml
@@ -1,0 +1,108 @@
+name: CI checking examples
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'AUTHORS.md'
+      - 'CITATION.bib'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE.md'
+      - 'NEWS.md'
+      - 'README.md'
+      - '.zenodo.json'
+      - '.github/workflows/benchmark.yml'
+      - '.github/workflows/CompatHelper.yml'
+      - '.github/workflows/TagBot.yml'
+      - 'benchmark/**'
+      - 'docs/**'
+      - 'utils/**'
+  pull_request:
+    paths-ignore:
+      - 'AUTHORS.md'
+      - 'CITATION.bib'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE.md'
+      - 'NEWS.md'
+      - 'README.md'
+      - '.zenodo.json'
+      - '.github/workflows/benchmark.yml'
+      - '.github/workflows/CompatHelper.yml'
+      - '.github/workflows/TagBot.yml'
+      - 'benchmark/**'
+      - 'docs/**'
+      - 'utils/**'
+  workflow_dispatch:
+
+# Cancel redundant CI tests automatically
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    # We could also include the Julia version as in
+    # name: ${{ matrix.trixi_test }} - ${{ matrix.os }} - Julia ${{ matrix.version }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    # to be more specific. However, that requires us updating the required CI tests whenever we update Julia.
+    name: ${{ matrix.trixi_test }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.6'
+          # - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+        trixi_test:
+          - tree_part1
+          - tree_part2
+          - tree_part3
+          - tree_part4
+          - tree_part5
+          - tree_part6
+          - structured
+          - p4est_part1
+          - p4est_part2
+          - unstructured_dgmulti
+          - paper_self_gravitating_gas_dynamics
+          - mpi
+          - threaded
+        include:
+          - version: '1.6'
+            os: macOS-latest
+            arch: x64
+            trixi_test: mpi
+          - version: '1.6'
+            os: macOS-latest
+            arch: x64
+            trixi_test: threaded
+          - version: '1.6'
+            os: windows-latest
+            arch: x64
+            trixi_test: mpi
+          - version: '1.6'
+            os: windows-latest
+            arch: x64
+            trixi_test: threaded
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+        env:
+          PYTHON: ""
+      - name: Test examples without coverage
+        uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: false
+        env:
+          PYTHON: ""
+          TRIXI_TEST: ${{ matrix.trixi_test }}


### PR DESCRIPTION
Since our first attempt in #1056 wasn't really successful, we will probably need to pursue another approach to reduce our CI times. This could be one way forward:
This splits our CI jobs into two parts, one with coverage and one without coverage collection. We run all examples without collecting coverage information. We can also move the more involved Jacobian/convergence/visualization tests there. The other job collects coverage information and will need to be updated to include a lot of basic unit tests.

## TODO

- [ ] Merge example tests into fewer CI jobs to achieve approximately uniform CI times
  - Documentation takes up to 30 minutes, so we shouldn't aim for less time of each CI job
- [ ] Add unit tests with coverage collection to achieve ca. 94% coverage (status quo of `src`)
  - [ ] Move all initial conditions, source terms (and specific boundary conditions?) to elixirs - *BREAKING!*
  - [ ] Cover basic functionality of `equations` via unit tests
  - [ ] How can we create appropriate unit tests for other parts?