### PR TITLE
Extend `ParallelP4estMesh` to 3D

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@ for human readability.
 - Support for (periodic and non-periodic) SBP operators of
   [SummationByPartsOperators.jl](https://github.com/ranocha/SummationByPartsOperators.jl)
   as approximation type in `DGMulti` solvers
+- Basic support for MPI-based parallel simulations using conforming meshes of type `P4estMesh`
+  in 2D and 3D
 
 #### Removed
 

--- a/src/auxiliary/p4est.jl
+++ b/src/auxiliary/p4est.jl
@@ -116,9 +116,9 @@ coarsen_p4est!(p8est::Ptr{p8est_t}, recursive, coarsen_fn_c, init_fn_c) = p8est_
 
 # Create new ghost layer from p4est, only connections via faces are relevant
 # 2D
-new_ghost_p4est(p4est::Ptr{p4est_t}) = p4est_ghost_new(p4est, P4est.P4EST_CONNECT_FACE)
+ghost_new_p4est(p4est::Ptr{p4est_t}) = p4est_ghost_new(p4est, P4est.P4EST_CONNECT_FACE)
 # 3D
-new_ghost_p4est(p8est::Ptr{p8est_t}) = p8est_ghost_new(p8est, P4est.P8EST_CONNECT_FACE)
+ghost_new_p4est(p8est::Ptr{p8est_t}) = p8est_ghost_new(p8est, P4est.P8EST_CONNECT_FACE)
 
 # Check if ghost layer is valid
 # 2D

--- a/src/auxiliary/p4est.jl
+++ b/src/auxiliary/p4est.jl
@@ -116,9 +116,25 @@ coarsen_p4est!(p8est::Ptr{p8est_t}, recursive, coarsen_fn_c, init_fn_c) = p8est_
 
 # Create new ghost layer from p4est, only connections via faces are relevant
 # 2D
-new_ghost_layer_p4est(p4est::Ptr{p4est_t}) = p4est_ghost_new(p4est, P4est.P4EST_CONNECT_FACE)
+new_ghost_p4est(p4est::Ptr{p4est_t}) = p4est_ghost_new(p4est, P4est.P4EST_CONNECT_FACE)
 # 3D
-new_ghost_layer_p4est(p8est::Ptr{p8est_t}) = p8est_ghost_new(p8est, P4est.P8EST_CONNECT_FACE)
+new_ghost_p4est(p8est::Ptr{p8est_t}) = p8est_ghost_new(p8est, P4est.P8EST_CONNECT_FACE)
+
+# Check if ghost layer is valid
+# 2D
+function ghost_is_valid_p4est(p4est::Ptr{p4est_t}, ghost_layer::Ptr{p4est_ghost_t})
+  return p4est_ghost_is_valid(p4est, ghost_layer)
+end
+# 3D
+function ghost_is_valid_p4est(p4est::Ptr{p8est_t}, ghost_layer::Ptr{p8est_ghost_t})
+  return p8est_ghost_is_valid(p4est, ghost_layer)
+end
+
+# Destroy ghost layer
+# 2D
+ghost_destroy_p4est(ghost_layer::Ptr{p4est_ghost_t}) = p4est_ghost_destroy(ghost_layer)
+# 3D
+ghost_destroy_p4est(ghost_layer::Ptr{p8est_ghost_t}) = p8est_ghost_destroy(ghost_layer)
 
 
 # Let `p4est` iterate over each cell volume and cell face.
@@ -147,7 +163,7 @@ function iterate_p4est(p4est::Ptr{p4est_t}, user_data; ghost_layer=C_NULL,
 end
 
 # 3D
-function iterate_p4est(p8est::Ptr{p8est_t}, user_data;
+function iterate_p4est(p8est::Ptr{p8est_t}, user_data; ghost_layer=C_NULL,
                        iter_volume_c=C_NULL, iter_face_c=C_NULL)
   if user_data === C_NULL
     user_data_ptr = user_data
@@ -159,7 +175,7 @@ function iterate_p4est(p8est::Ptr{p8est_t}, user_data;
 
   GC.@preserve user_data begin
     p8est_iterate(p8est,
-                  C_NULL, # ghost layer
+                  ghost_layer,
                   user_data_ptr,
                   iter_volume_c, # iter_volume
                   iter_face_c, # iter_face

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -504,6 +504,7 @@ include("analysis_dg1d.jl")
 include("analysis_dg2d.jl")
 include("analysis_dg2d_parallel.jl")
 include("analysis_dg3d.jl")
+include("analysis_dg3d_parallel.jl")
 
 
 end # @muladd

--- a/src/callbacks_step/analysis_dg3d_parallel.jl
+++ b/src/callbacks_step/analysis_dg3d_parallel.jl
@@ -1,0 +1,95 @@
+# By default, Julia/LLVM does not use fused multiply-add operations (FMAs).
+# Since these FMAs can increase the performance of many numerical algorithms,
+# we need to opt-in explicitly.
+# See https://ranocha.de/blog/Optimizing_EC_Trixi for further details.
+@muladd begin
+
+
+function calc_error_norms(func, u, t, analyzer,
+                          mesh::ParallelP4estMesh{3}, equations,
+                          initial_condition, dg::DGSEM, cache, cache_analysis)
+  @unpack vandermonde, weights = analyzer
+  @unpack node_coordinates, inverse_jacobian = cache.elements
+  @unpack u_local, u_tmp1, u_tmp2, x_local, x_tmp1, x_tmp2, jacobian_local, jacobian_tmp1, jacobian_tmp2 = cache_analysis
+
+  # Set up data structures
+  l2_error   = zero(func(get_node_vars(u, equations, dg, 1, 1, 1, 1), equations))
+  linf_error = copy(l2_error)
+  volume = zero(real(mesh))
+
+  # Iterate over all elements for error calculations
+  for element in eachelement(dg, cache)
+    # Interpolate solution and node locations to analysis nodes
+    multiply_dimensionwise!(u_local, vandermonde, view(u,                :, :, :, :, element), u_tmp1, u_tmp2)
+    multiply_dimensionwise!(x_local, vandermonde, view(node_coordinates, :, :, :, :, element), x_tmp1, x_tmp2)
+    multiply_scalar_dimensionwise!(jacobian_local, vandermonde, inv.(view(inverse_jacobian, :, :, :, element)), jacobian_tmp1, jacobian_tmp2)
+
+    # Calculate errors at each analysis node
+    @. jacobian_local = abs(jacobian_local)
+
+    for k in eachnode(analyzer), j in eachnode(analyzer), i in eachnode(analyzer)
+      u_exact = initial_condition(get_node_coords(x_local, equations, dg, i, j, k), t, equations)
+      diff = func(u_exact, equations) - func(get_node_vars(u_local, equations, dg, i, j, k), equations)
+      l2_error += diff.^2 * (weights[i] * weights[j] * weights[k] * jacobian_local[i, j, k])
+      linf_error = @. max(linf_error, abs(diff))
+      volume += weights[i] * weights[j] * weights[k] * jacobian_local[i, j, k]
+    end
+  end
+
+  # Accumulate local results on root process
+  global_l2_error = Vector(l2_error)
+  global_linf_error = Vector(linf_error)
+  MPI.Reduce!(global_l2_error, +, mpi_root(), mpi_comm())
+  MPI.Reduce!(global_linf_error, max, mpi_root(), mpi_comm())
+  total_volume = MPI.Reduce(volume, +, mpi_root(), mpi_comm())
+  if mpi_isroot()
+    l2_error   = convert(typeof(l2_error),   global_l2_error)
+    linf_error = convert(typeof(linf_error), global_linf_error)
+    # For L2 error, divide by total volume
+    l2_error = @. sqrt(l2_error / total_volume)
+  else
+    l2_error   = convert(typeof(l2_error),   NaN * global_l2_error)
+    linf_error = convert(typeof(linf_error), NaN * global_linf_error)
+  end
+
+  return l2_error, linf_error
+end
+
+
+function integrate_via_indices(func::Func, u,
+                               mesh::ParallelP4estMesh{3}, equations,
+                               dg::DGSEM, cache, args...; normalize=true) where {Func}
+  @unpack weights = dg.basis
+
+  # Initialize integral with zeros of the right shape
+  integral = zero(func(u, 1, 1, 1, 1, equations, dg, args...))
+  volume = zero(real(mesh))
+
+  # Use quadrature to numerically integrate over entire domain
+  for element in eachelement(dg, cache)
+    for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
+      volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, k, element]))
+      integral += volume_jacobian * weights[i] * weights[j] * weights[k] * func(u, i, j, k, element, equations, dg, args...)
+      volume += volume_jacobian * weights[i] * weights[j] * weights[k]
+    end
+  end
+
+  global_integral = MPI.Reduce!(Ref(integral), +, mpi_root(), mpi_comm())
+  total_volume = MPI.Reduce(volume, +, mpi_root(), mpi_comm())
+  if mpi_isroot()
+    integral = convert(typeof(integral), global_integral[])
+  else
+    integral = convert(typeof(integral), NaN * integral)
+    total_volume = volume # non-root processes receive nothing from reduce -> overwrite
+  end
+
+  # Normalize with total volume
+  if normalize
+    integral = integral / total_volume
+  end
+
+  return integral
+end
+
+
+end # @muladd

--- a/src/callbacks_step/stepsize_dg3d.jl
+++ b/src/callbacks_step/stepsize_dg3d.jl
@@ -111,7 +111,7 @@ end
 
 function max_dt(u, t, mesh::ParallelP4estMesh{3},
                 constant_speed::Val{false}, equations, dg::DG, cache)
-  # call the method accepting a general `mesh::P4estMesh{2}`
+  # call the method accepting a general `mesh::P4estMesh{3}`
   # TODO: MPI, we should improve this; maybe we should dispatch on `u`
   #       and create some MPI array type, overloading broadcasting and mapreduce etc.
   #       Then, this specific array type should also work well with DiffEq etc.
@@ -127,7 +127,7 @@ end
 
 function max_dt(u, t, mesh::ParallelP4estMesh{3},
                 constant_speed::Val{true}, equations, dg::DG, cache)
-  # call the method accepting a general `mesh::P4estMesh{2}`
+  # call the method accepting a general `mesh::P4estMesh{3}`
   # TODO: MPI, we should improve this; maybe we should dispatch on `u`
   #       and create some MPI array type, overloading broadcasting and mapreduce etc.
   #       Then, this specific array type should also work well with DiffEq etc.

--- a/src/solvers/dgsem_p4est/containers.jl
+++ b/src/solvers/dgsem_p4est/containers.jl
@@ -672,5 +672,6 @@ include("containers_2d.jl")
 include("containers_3d.jl")
 include("containers_parallel.jl")
 include("containers_parallel_2d.jl")
+include("containers_parallel_3d.jl")
 
 end # @muladd

--- a/src/solvers/dgsem_p4est/containers_parallel.jl
+++ b/src/solvers/dgsem_p4est/containers_parallel.jl
@@ -146,6 +146,8 @@ end
 
 # 2D
 cfunction(::typeof(init_surfaces_iter_face_parallel), ::Val{2}) = @cfunction(init_surfaces_iter_face_parallel, Cvoid, (Ptr{p4est_iter_face_info_t}, Ptr{Cvoid}))
+# 3D
+cfunction(::typeof(init_surfaces_iter_face_parallel), ::Val{3}) = @cfunction(init_surfaces_iter_face_parallel, Cvoid, (Ptr{p8est_iter_face_info_t}, Ptr{Cvoid}))
 
 # Function barrier for type stability, overload for parallel P4estMesh
 function init_surfaces_iter_face_inner(info, user_data::ParallelInitSurfacesIterFaceUserData)
@@ -219,11 +221,11 @@ function init_mpi_interfaces_iter_face_inner(info, sides, user_data)
   mpi_interfaces.local_element_ids[mpi_interface_id] = local_quad_id + 1
   mpi_interfaces.local_sides[mpi_interface_id] = local_side
 
-  # Local face at which the interface lies
-  local_face = sides[local_side].face
+  # Face at which the interface lies
+  faces = (sides[1].face, sides[2].face)
 
   # Save mpi_interfaces.node_indices dimension specific in containers_[23]d_parallel.jl
-  init_mpi_interface_node_indices!(mpi_interfaces, local_face, local_side, info.orientation,
+  init_mpi_interface_node_indices!(mpi_interfaces, faces, local_side, info.orientation,
                                    mpi_interface_id)
 
   return nothing
@@ -274,6 +276,8 @@ end
 
 # 2D
 cfunction(::typeof(count_surfaces_iter_face_parallel), ::Val{2}) = @cfunction(count_surfaces_iter_face_parallel, Cvoid, (Ptr{p4est_iter_face_info_t}, Ptr{Cvoid}))
+# 3D
+cfunction(::typeof(count_surfaces_iter_face_parallel), ::Val{3}) = @cfunction(count_surfaces_iter_face_parallel, Cvoid, (Ptr{p8est_iter_face_info_t}, Ptr{Cvoid}))
 
 function count_required_surfaces(mesh::ParallelP4estMesh)
   # Let p4est iterate over all interfaces and call count_surfaces_iter_face_parallel

--- a/src/solvers/dgsem_p4est/containers_parallel_2d.jl
+++ b/src/solvers/dgsem_p4est/containers_parallel_2d.jl
@@ -7,7 +7,7 @@
 
 # Initialize node_indices of MPI interface container
 @inline function init_mpi_interface_node_indices!(mpi_interfaces::P4estMPIInterfaceContainer{2},
-                                                  local_face, local_side, orientation,
+                                                  faces, local_side, orientation,
                                                   mpi_interface_id)
   # Align interface in positive coordinate direction of primary element.
   # For orientation == 1, the secondary element needs to be indexed backwards
@@ -20,16 +20,16 @@
     i = :i_backward
   end
 
-  if local_face == 0
+  if faces[local_side] == 0
     # Index face in negative x-direction
     mpi_interfaces.node_indices[mpi_interface_id] = (:begin, i)
-  elseif local_face == 1
+  elseif faces[local_side] == 1
     # Index face in positive x-direction
     mpi_interfaces.node_indices[mpi_interface_id] = (:end, i)
-  elseif local_face == 2
+  elseif faces[local_side] == 2
     # Index face in negative y-direction
     mpi_interfaces.node_indices[mpi_interface_id] = (i, :begin)
-  else # local_face == 3
+  else # faces[local_side] == 3
     # Index face in positive y-direction
     mpi_interfaces.node_indices[mpi_interface_id] = (i, :end)
   end

--- a/src/solvers/dgsem_p4est/containers_parallel_3d.jl
+++ b/src/solvers/dgsem_p4est/containers_parallel_3d.jl
@@ -1,0 +1,45 @@
+# By default, Julia/LLVM does not use fused multiply-add operations (FMAs).
+# Since these FMAs can increase the performance of many numerical algorithms,
+# we need to opt-in explicitly.
+# See https://ranocha.de/blog/Optimizing_EC_Trixi for further details.
+@muladd begin
+
+
+  # Initialize node_indices of MPI interface container
+  @inline function init_mpi_interface_node_indices!(mpi_interfaces::P4estMPIInterfaceContainer{3},
+                                                    faces, local_side, orientation,
+                                                    mpi_interface_id)
+    # Align interface at the primary element (primary element has surface indices (:i_forward, :j_forward)).
+    # The secondary element needs to be indexed differently.
+    if local_side == 1
+      surface_index1 = :i_forward
+      surface_index2 = :j_forward
+    else # local_side == 2
+      surface_index1, surface_index2 = orientation_to_indices_p4est(faces[2], faces[1], orientation)
+    end
+
+    if faces[local_side] == 0
+      # Index face in negative x-direction
+      mpi_interfaces.node_indices[mpi_interface_id] = (:begin, surface_index1, surface_index2)
+    elseif faces[local_side] == 1
+      # Index face in positive x-direction
+      mpi_interfaces.node_indices[mpi_interface_id] = (:end, surface_index1, surface_index2)
+    elseif faces[local_side] == 2
+      # Index face in negative y-direction
+      mpi_interfaces.node_indices[mpi_interface_id] = (surface_index1, :begin, surface_index2)
+    elseif faces[local_side] == 3
+      # Index face in positive y-direction
+      mpi_interfaces.node_indices[mpi_interface_id] = (surface_index1, :end, surface_index2)
+    elseif faces[local_side] == 4
+      # Index face in negative z-direction
+      mpi_interfaces.node_indices[mpi_interface_id] = (surface_index1, surface_index2, :begin)
+    else # faces[local_side] == 5
+      # Index face in positive z-direction
+      mpi_interfaces.node_indices[mpi_interface_id] = (surface_index1, surface_index2, :end)
+    end
+
+    return mpi_interfaces
+  end
+
+
+  end # muladd

--- a/src/solvers/dgsem_p4est/containers_parallel_3d.jl
+++ b/src/solvers/dgsem_p4est/containers_parallel_3d.jl
@@ -5,41 +5,41 @@
 @muladd begin
 
 
-  # Initialize node_indices of MPI interface container
-  @inline function init_mpi_interface_node_indices!(mpi_interfaces::P4estMPIInterfaceContainer{3},
-                                                    faces, local_side, orientation,
-                                                    mpi_interface_id)
-    # Align interface at the primary element (primary element has surface indices (:i_forward, :j_forward)).
-    # The secondary element needs to be indexed differently.
-    if local_side == 1
-      surface_index1 = :i_forward
-      surface_index2 = :j_forward
-    else # local_side == 2
-      surface_index1, surface_index2 = orientation_to_indices_p4est(faces[2], faces[1], orientation)
-    end
-
-    if faces[local_side] == 0
-      # Index face in negative x-direction
-      mpi_interfaces.node_indices[mpi_interface_id] = (:begin, surface_index1, surface_index2)
-    elseif faces[local_side] == 1
-      # Index face in positive x-direction
-      mpi_interfaces.node_indices[mpi_interface_id] = (:end, surface_index1, surface_index2)
-    elseif faces[local_side] == 2
-      # Index face in negative y-direction
-      mpi_interfaces.node_indices[mpi_interface_id] = (surface_index1, :begin, surface_index2)
-    elseif faces[local_side] == 3
-      # Index face in positive y-direction
-      mpi_interfaces.node_indices[mpi_interface_id] = (surface_index1, :end, surface_index2)
-    elseif faces[local_side] == 4
-      # Index face in negative z-direction
-      mpi_interfaces.node_indices[mpi_interface_id] = (surface_index1, surface_index2, :begin)
-    else # faces[local_side] == 5
-      # Index face in positive z-direction
-      mpi_interfaces.node_indices[mpi_interface_id] = (surface_index1, surface_index2, :end)
-    end
-
-    return mpi_interfaces
+# Initialize node_indices of MPI interface container
+@inline function init_mpi_interface_node_indices!(mpi_interfaces::P4estMPIInterfaceContainer{3},
+                                                  faces, local_side, orientation,
+                                                  mpi_interface_id)
+  # Align interface at the primary element (primary element has surface indices (:i_forward, :j_forward)).
+  # The secondary element needs to be indexed differently.
+  if local_side == 1
+    surface_index1 = :i_forward
+    surface_index2 = :j_forward
+  else # local_side == 2
+    surface_index1, surface_index2 = orientation_to_indices_p4est(faces[2], faces[1], orientation)
   end
 
+  if faces[local_side] == 0
+    # Index face in negative x-direction
+    mpi_interfaces.node_indices[mpi_interface_id] = (:begin, surface_index1, surface_index2)
+  elseif faces[local_side] == 1
+    # Index face in positive x-direction
+    mpi_interfaces.node_indices[mpi_interface_id] = (:end, surface_index1, surface_index2)
+  elseif faces[local_side] == 2
+    # Index face in negative y-direction
+    mpi_interfaces.node_indices[mpi_interface_id] = (surface_index1, :begin, surface_index2)
+  elseif faces[local_side] == 3
+    # Index face in positive y-direction
+    mpi_interfaces.node_indices[mpi_interface_id] = (surface_index1, :end, surface_index2)
+  elseif faces[local_side] == 4
+    # Index face in negative z-direction
+    mpi_interfaces.node_indices[mpi_interface_id] = (surface_index1, surface_index2, :begin)
+  else # faces[local_side] == 5
+    # Index face in positive z-direction
+    mpi_interfaces.node_indices[mpi_interface_id] = (surface_index1, surface_index2, :end)
+  end
 
-  end # muladd
+  return mpi_interfaces
+end
+
+
+end # muladd

--- a/src/solvers/dgsem_p4est/dg_3d_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_3d_parallel.jl
@@ -1,0 +1,228 @@
+# By default, Julia/LLVM does not use fused multiply-add operations (FMAs).
+# Since these FMAs can increase the performance of many numerical algorithms,
+# we need to opt-in explicitly.
+# See https://ranocha.de/blog/Optimizing_EC_Trixi for further details.
+@muladd begin
+
+
+function rhs!(du, u, t,
+              mesh::ParallelP4estMesh{3}, equations,
+              initial_condition, boundary_conditions, source_terms,
+              dg::DG, cache)
+  # Start to receive MPI data
+  @trixi_timeit timer() "start MPI receive" start_mpi_receive!(cache.mpi_cache)
+
+  # Prolong solution to MPI interfaces
+  @trixi_timeit timer() "prolong2mpiinterfaces" prolong2mpiinterfaces!(
+    cache, u, mesh, equations, dg.surface_integral, dg)
+
+  # Start to send MPI data
+  @trixi_timeit timer() "start MPI send" start_mpi_send!(
+    cache.mpi_cache, mesh, equations, dg, cache)
+
+  # Reset du
+  @trixi_timeit timer() "reset ∂u/∂t" reset_du!(du, dg, cache)
+
+  # Calculate volume integral
+  @trixi_timeit timer() "volume integral" calc_volume_integral!(
+    du, u, mesh,
+    have_nonconservative_terms(equations), equations,
+    dg.volume_integral, dg, cache)
+
+  # Prolong solution to interfaces
+  @trixi_timeit timer() "prolong2interfaces" prolong2interfaces!(
+    cache, u, mesh, equations, dg.surface_integral, dg)
+
+  # Calculate interface fluxes
+  @trixi_timeit timer() "interface flux" calc_interface_flux!(
+    cache.elements.surface_flux_values, mesh,
+    have_nonconservative_terms(equations), equations,
+    dg.surface_integral, dg, cache)
+
+  # Prolong solution to boundaries
+  @trixi_timeit timer() "prolong2boundaries" prolong2boundaries!(
+    cache, u, mesh, equations, dg.surface_integral, dg)
+
+  # Calculate boundary fluxes
+  @trixi_timeit timer() "boundary flux" calc_boundary_flux!(
+    cache, t, boundary_conditions, mesh, equations, dg.surface_integral, dg)
+
+  # Prolong solution to mortars
+  @trixi_timeit timer() "prolong2mortars" prolong2mortars!(
+    cache, u, mesh, equations, dg.mortar, dg.surface_integral, dg)
+
+  # Calculate mortar fluxes
+  @trixi_timeit timer() "mortar flux" calc_mortar_flux!(
+    cache.elements.surface_flux_values, mesh,
+    have_nonconservative_terms(equations), equations,
+    dg.mortar, dg.surface_integral, dg, cache)
+
+  # Finish to receive MPI data
+  @trixi_timeit timer() "finish MPI receive" finish_mpi_receive!(
+    cache.mpi_cache, mesh, equations, dg, cache)
+
+  # Calculate MPI interface fluxes
+  @trixi_timeit timer() "MPI interface flux" calc_mpi_interface_flux!(
+    cache.elements.surface_flux_values, mesh,
+    have_nonconservative_terms(equations), equations,
+    dg.surface_integral, dg, cache)
+
+  # Calculate surface integrals
+  @trixi_timeit timer() "surface integral" calc_surface_integral!(
+    du, u, mesh, equations, dg.surface_integral, dg, cache)
+
+  # Apply Jacobian from mapping to reference element
+  @trixi_timeit timer() "Jacobian" apply_jacobian!(
+    du, mesh, equations, dg, cache)
+
+  # Calculate source terms
+  @trixi_timeit timer() "source terms" calc_sources!(
+    du, u, t, source_terms, equations, dg, cache)
+
+  # Finish to send MPI data
+  @trixi_timeit timer() "finish MPI send" finish_mpi_send!(cache.mpi_cache)
+
+  return nothing
+end
+
+
+function prolong2mpiinterfaces!(cache, u,
+                                mesh::ParallelP4estMesh{3},
+                                equations, surface_integral, dg::DG)
+  @unpack mpi_interfaces = cache
+  index_range = eachnode(dg)
+
+  @threaded for interface in eachmpiinterface(dg, cache)
+    # Copy solution data from the local element using "delayed indexing" with
+    # a start value and a step size to get the correct face and orientation.
+    # Note that in the current implementation, the interface will be
+    # "aligned at the primary element", i.e., the index of the primary side
+    # will always run forwards.
+    local_side = mpi_interfaces.local_sides[interface]
+    local_element = mpi_interfaces.local_element_ids[interface]
+    local_indices = mpi_interfaces.node_indices[interface]
+
+    i_element_start, i_element_step_i, i_element_step_j = index_to_start_step_3d(local_indices[1], index_range)
+    j_element_start, j_element_step_i, j_element_step_j = index_to_start_step_3d(local_indices[2], index_range)
+    k_element_start, k_element_step_i, k_element_step_j = index_to_start_step_3d(local_indices[3], index_range)
+
+    i_element = i_element_start
+    j_element = j_element_start
+    k_element = k_element_start
+    for j in eachnode(dg)
+      for i in eachnode(dg)
+        for v in eachvariable(equations)
+          mpi_interfaces.u[local_side, v, i, j, interface] = u[v, i_element, j_element, k_element, local_element]
+        end
+        i_element += i_element_step_i
+        j_element += j_element_step_i
+        k_element += k_element_step_i
+      end
+      i_element += i_element_step_j
+      j_element += j_element_step_j
+      k_element += k_element_step_j
+    end
+  end
+
+  return nothing
+end
+
+
+function calc_mpi_interface_flux!(surface_flux_values,
+                                  mesh::ParallelP4estMesh{3},
+                                  nonconservative_terms,
+                                  equations, surface_integral, dg::DG, cache)
+  @unpack local_element_ids, node_indices, local_sides = cache.mpi_interfaces
+  @unpack contravariant_vectors = cache.elements
+  index_range = eachnode(dg)
+
+  @threaded for interface in eachmpiinterface(dg, cache)
+    # Get element and side index information on the local element
+    local_element = local_element_ids[interface]
+    local_indices = node_indices[interface]
+    local_direction = indices2direction(local_indices)
+    local_side = local_sides[interface]
+
+    # Create the local i,j,k indexing on the local element used to pull normal direction information
+    i_element_start, i_element_step_i, i_element_step_j = index_to_start_step_3d(local_indices[1], index_range)
+    j_element_start, j_element_step_i, j_element_step_j = index_to_start_step_3d(local_indices[2], index_range)
+    k_element_start, k_element_step_i, k_element_step_j = index_to_start_step_3d(local_indices[3], index_range)
+
+    i_element = i_element_start
+    j_element = j_element_start
+    k_element = k_element_start
+
+    # Initiate the node indices to be used in the surface for loop,
+    # the surface flux storage must be indexed in alignment with the local element indexing
+    local_surface_indices = surface_indices(local_indices)
+    i_surface_start, i_surface_step_i, i_surface_step_j = index_to_start_step_3d(local_surface_indices[1], index_range)
+    j_surface_start, j_surface_step_i, j_surface_step_j = index_to_start_step_3d(local_surface_indices[2], index_range)
+    i_surface = i_surface_start
+    j_surface = j_surface_start
+
+    for j in eachnode(dg)
+      for i in eachnode(dg)
+        # Get the normal direction on the local element
+        # Contravariant vectors at interfaces in negative coordinate direction
+        # are pointing inwards. This is handled by `get_normal_direction`.
+        normal_direction = get_normal_direction(local_direction, contravariant_vectors,
+                                                i_element, j_element, k_element,
+                                                local_element)
+
+        calc_mpi_interface_flux!(surface_flux_values, mesh, nonconservative_terms, equations,
+                                 surface_integral, dg, cache,
+                                 interface, normal_direction,
+                                 i, j, local_side,
+                                 i_surface, j_surface, local_direction, local_element)
+
+        # Increment local element indices to pull the normal direction
+        i_element += i_element_step_i
+        j_element += j_element_step_i
+        k_element += k_element_step_i
+        # Increment the surface node indices along the local element
+        i_surface += i_surface_step_i
+        j_surface += j_surface_step_i
+      end
+      # Increment local element indices to pull the normal direction
+      i_element += i_element_step_j
+      j_element += j_element_step_j
+      k_element += k_element_step_j
+      # Increment the surface node indices along the local element
+      i_surface += i_surface_step_j
+      j_surface += j_surface_step_j
+    end
+  end
+
+  return nothing
+end
+
+# Inlined version of the interface flux computation for conservation laws
+@inline function calc_mpi_interface_flux!(surface_flux_values,
+                                          mesh::P4estMesh{3},
+                                          nonconservative_terms::Val{false}, equations,
+                                          surface_integral, dg::DG, cache,
+                                          interface_index, normal_direction,
+                                          interface_i_node_index, interface_j_node_index, local_side,
+                                          surface_i_node_index, surface_j_node_index,
+                                          local_direction_index, local_element_index)
+  @unpack u = cache.mpi_interfaces
+  @unpack surface_flux = surface_integral
+
+  u_ll, u_rr = get_surface_node_vars(u, equations, dg,
+                                     interface_i_node_index, interface_j_node_index, interface_index)
+
+  if local_side == 1
+    flux_ = surface_flux(u_ll, u_rr, normal_direction, equations)
+  else # local_side == 2
+    flux_ = -surface_flux(u_ll, u_rr, -normal_direction, equations)
+  end
+
+  for v in eachvariable(equations)
+    surface_flux_values[v, surface_i_node_index, surface_j_node_index,
+                        local_direction_index, local_element_index] = flux_[v]
+  end
+end
+
+
+
+end # muladd

--- a/src/solvers/dgsem_p4est/dg_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_parallel.jl
@@ -171,7 +171,7 @@ function init_mpi_neighbor_connectivity(mpi_interfaces, mesh::ParallelP4estMesh)
   user_data = InitNeighborRankConnectivityIterFaceUserData(mpi_interfaces, mesh)
 
   # Ghost layer is required to determine owner ranks of quadrants on neighboring processes
-  ghost_layer = new_ghost_p4est(mesh.p4est)
+  ghost_layer = ghost_new_p4est(mesh.p4est)
   @assert ghost_is_valid_p4est(mesh.p4est, ghost_layer) == 1
   iterate_p4est(mesh.p4est, user_data; ghost_layer=ghost_layer, iter_face_c=iter_face_c)
   ghost_destroy_p4est(ghost_layer)

--- a/src/solvers/dgsem_p4est/dg_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_parallel.jl
@@ -92,9 +92,9 @@ function finish_mpi_receive!(mpi_cache::P4estMPICache, mesh, equations, dg, cach
       last  = (index - 1) * data_size + data_size
 
       if cache.mpi_interfaces.local_sides[interface] == 1 # local element on primary side
-        @views vec(cache.mpi_interfaces.u[2, :, :, interface]) .= recv_buffer[first:last]
+        @views vec(cache.mpi_interfaces.u[2, .., interface]) .= recv_buffer[first:last]
       else # local element at secondary side
-        @views vec(cache.mpi_interfaces.u[1, :, :, interface]) .= recv_buffer[first:last]
+        @views vec(cache.mpi_interfaces.u[1, .., interface]) .= recv_buffer[first:last]
       end
     end
 
@@ -171,10 +171,10 @@ function init_mpi_neighbor_connectivity(mpi_interfaces, mesh::ParallelP4estMesh)
   user_data = InitNeighborRankConnectivityIterFaceUserData(mpi_interfaces, mesh)
 
   # Ghost layer is required to determine owner ranks of quadrants on neighboring processes
-  ghost_layer = new_ghost_layer_p4est(mesh.p4est)
-  @assert p4est_ghost_is_valid(mesh.p4est, ghost_layer) == 1
+  ghost_layer = new_ghost_p4est(mesh.p4est)
+  @assert ghost_is_valid_p4est(mesh.p4est, ghost_layer) == 1
   iterate_p4est(mesh.p4est, user_data; ghost_layer=ghost_layer, iter_face_c=iter_face_c)
-  p4est_ghost_destroy(ghost_layer)
+  ghost_destroy_p4est(ghost_layer)
 
   # Build proper connectivity data structures from information gathered by iterating over p4est
   @unpack global_interface_ids, neighbor_ranks_interface = user_data
@@ -220,6 +220,8 @@ end
 
 # 2D
 cfunction(::typeof(init_neighbor_rank_connectivity_iter_face), ::Val{2}) = @cfunction(init_neighbor_rank_connectivity_iter_face, Cvoid, (Ptr{p4est_iter_face_info_t}, Ptr{Cvoid}))
+# 3D
+cfunction(::typeof(init_neighbor_rank_connectivity_iter_face), ::Val{3}) = @cfunction(init_neighbor_rank_connectivity_iter_face, Cvoid, (Ptr{p8est_iter_face_info_t}, Ptr{Cvoid}))
 
 # Function barrier for type stability
 function init_neighbor_rank_connectivity_iter_face_inner(info, user_data)

--- a/src/solvers/dgsem_p4est/dg_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_parallel.jl
@@ -296,5 +296,6 @@ end
 
 
 include("dg_2d_parallel.jl")
+include("dg_3d_parallel.jl")
 
 end # muladd

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,9 +19,12 @@ const TRIXI_NTHREADS   = clamp(Sys.CPU_THREADS, 2, 3)
     # https://github.com/trixi-framework/Trixi.jl/issues/901
     # To reduce their impact, we do not test MPI with coverage on Windows.
     # This reduces the chance to hit a spurious test failure by one half.
+    # In addition, it looks like the Linux GitHub runners run out of memory during the 3D tests
+    # with coverage, so we currently do not test MPI with coverage on Linux. For more details,
+    # see the discussion at https://github.com/trixi-framework/Trixi.jl/pull/1062#issuecomment-1035901020
     cmd = string(Base.julia_cmd())
     coverage = occursin("--code-coverage", cmd) && !occursin("--code-coverage=none", cmd)
-    if !(coverage && Sys.iswindows())
+    if !(coverage && Sys.iswindows()) && !(coverage && Sys.islinux())
       mpiexec() do cmd
         run(`$cmd -n $TRIXI_MPI_NPROCS $(Base.julia_cmd()) --threads=1 --check-bounds=yes $(abspath("test_mpi.jl"))`)
       end

--- a/test/test_mpi.jl
+++ b/test/test_mpi.jl
@@ -14,8 +14,9 @@ Trixi.mpi_isroot() && isdir(outdir) && rm(outdir, recursive=true)
   include("test_mpi_tree.jl")
 
   # P4estMesh tests
-  include("test_mpi_p4est.jl")
-end # MPI 2D
+  include("test_mpi_p4est_2d.jl")
+  include("test_mpi_p4est_3d.jl")
+end # MPI
 
 # Clean up afterwards: delete Trixi output directory
 Trixi.mpi_isroot() && @test_nowarn rm(outdir, recursive=true)

--- a/test/test_mpi_p4est_2d.jl
+++ b/test/test_mpi_p4est_2d.jl
@@ -1,4 +1,4 @@
-module TestExamplesMPIP4estMesh
+module TestExamplesMPIP4estMesh2D
 
 using Test
 using Trixi
@@ -8,7 +8,7 @@ include("test_trixi.jl")
 # pathof(Trixi) returns /path/to/Trixi/src/Trixi.jl, dirname gives the parent directory
 const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "p4est_2d_dgsem")
 
-@testset "P4estMesh MPI" begin
+@testset "P4estMesh MPI 2D" begin
 
 # Run basic tests
 @testset "Examples 2D" begin

--- a/test/test_mpi_p4est_3d.jl
+++ b/test/test_mpi_p4est_3d.jl
@@ -1,0 +1,60 @@
+module TestExamplesMPIP4estMesh3D
+
+using Test
+using Trixi
+
+include("test_trixi.jl")
+
+# pathof(Trixi) returns /path/to/Trixi/src/Trixi.jl, dirname gives the parent directory
+const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "p4est_3d_dgsem")
+
+@testset "P4estMesh MPI 3D" begin
+
+# Run basic tests
+@testset "Examples 3D" begin
+  # Linear scalar advection
+  @trixi_testset "elixir_advection_basic.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_basic.jl"),
+      # Expected errors are exactly the same as with TreeMesh!
+      l2   = [0.00016263963870641478],
+      linf = [0.0014537194925779984])
+  end
+
+  @trixi_testset "elixir_advection_restart.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_restart.jl"),
+      l2   = [0.002590388934758452],
+      linf = [0.01840757696885409])
+  end
+
+  @trixi_testset "elixir_advection_cubed_sphere.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_cubed_sphere.jl"),
+      l2   = [0.002006918015656413],
+      linf = [0.027655117058380085])
+  end
+
+  # Compressible Euler
+  @trixi_testset "elixir_euler_source_terms_nonperiodic.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms_nonperiodic.jl"),
+      l2   = [0.0015106060984283647, 0.0014733349038567685, 0.00147333490385685, 0.001473334903856929, 0.0028149479453087093],
+      linf = [0.008070806335238156, 0.009007245083113125, 0.009007245083121784, 0.009007245083102688, 0.01562861968368434],
+      tspan = (0.0, 1.0))
+  end
+
+  @trixi_testset "elixir_euler_ec.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_ec.jl"),
+      l2   = [0.010380390326164493, 0.006192950051354618, 0.005970674274073704, 0.005965831290564327, 0.02628875593094754],
+      linf = [0.3326911600075694, 0.2824952141320467, 0.41401037398065543, 0.45574161423218573, 0.8099577682187109],
+      tspan = (0.0, 0.2),
+      coverage_override = (polydeg=3,)) # Prevent long compile time in CI
+  end
+
+  @trixi_testset "elixir_euler_source_terms_nonperiodic_hohqmesh.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms_nonperiodic_hohqmesh.jl"),
+      l2   = [0.0042023406458005464, 0.004122532789279737, 0.0042448149597303616, 0.0036361316700401765, 0.007389845952982495],
+      linf = [0.04530610539892499, 0.02765695110527666, 0.05670295599308606, 0.048396544302230504, 0.1154589758186293])
+  end
+end
+
+end # P4estMesh MPI
+
+end # module


### PR DESCRIPTION
This PR adds basic support for running parallel simulations on conforming `P4estMeshes` in 3D. 