### PR TITLE
reduce CI time by adding another misc job

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,7 @@
 # https://docs.codecov.io/docs/codecovyml-reference
 
 # We have
-#   15 * [number of basic OS] + 2 * [number of additional OS]
+#   16 * [number of basic OS] + 2 * [number of additional OS]
 # with
 # [number of basic OS] = 1 (Linux)
 # [number of additional OS] = 2 (Windows, MacOS)
@@ -9,9 +9,9 @@
 codecov:
   branch: main
   notify:
-    after_n_builds: 19
+    after_n_builds: 20
 comment:
-  after_n_builds: 19
+  after_n_builds: 20
 
 coverage:
   range: 80..95 # set 95% and above as solid green, everything below 80% as red

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           - paper_self_gravitating_gas_dynamics
           - misc_part1
           - misc_part2
+          - misc_part3
           - mpi
           - threaded
         include:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,6 +93,9 @@ const TRIXI_NTHREADS   = clamp(Sys.CPU_THREADS, 2, 3)
 
   @time if TRIXI_TEST == "all" || TRIXI_TEST == "misc_part2"
     include("test_special_elixirs.jl")
+  end
+
+  @time if TRIXI_TEST == "all" || TRIXI_TEST == "misc_part3"
     include("test_performance_specializations.jl")
   end
 


### PR DESCRIPTION
This should reduce the time of `misc_part2` quite a bit. The coverage tests of our performance specializations are expensive due to the use of LoopVectorization.jl with coverage.

## TODO

- [ ] Update required checks