### PR TITLE
Bug fix in div(B) computation

### DIFF
--- a/src/callbacks_step/analysis_dg2d.jl
+++ b/src/callbacks_step/analysis_dg2d.jl
@@ -250,7 +250,7 @@ function analyze(::Val{:l2_divb}, du, u, t,
       divb += ( derivative_matrix[i, k] * (Ja11 * u[6, k, j, element] + Ja12 * u[7, k, j, element]) +
                 derivative_matrix[j, k] * (Ja21 * u[6, i, k, element] + Ja22 * u[7, i, k, element]) )
     end
-    divb *= cache.elements.inverse_jacobian[element]
+    divb *= cache.elements.inverse_jacobian[i, j, element]
     divb^2
   end |> sqrt
 end
@@ -319,7 +319,7 @@ function analyze(::Val{:linf_divb}, du, u, t,
         divb += ( derivative_matrix[i, k] * (Ja11 * u[6, k, j, element] + Ja12 * u[7, k, j, element]) +
                   derivative_matrix[j, k] * (Ja21 * u[6, i, k, element] + Ja22 * u[7, i, k, element]) )
       end
-      divb *= cache.elements.inverse_jacobian[element]
+      divb *= cache.elements.inverse_jacobian[i, j, element]
       linf_divb = max(linf_divb, abs(divb))
     end
   end

--- a/src/callbacks_step/analysis_dg3d.jl
+++ b/src/callbacks_step/analysis_dg3d.jl
@@ -243,7 +243,7 @@ function analyze(::Val{:l2_divb}, du, u, t,
                 derivative_matrix[j, l] * (Ja21 * u[6, i, l, k, element] + Ja22 * u[7, i, l, k, element] + Ja23 * u[8, i, l, k, element]) +
                 derivative_matrix[k, l] * (Ja31 * u[6, i, j, l, element] + Ja32 * u[7, i, j, l, element] + Ja33 * u[8, i, j, l, element]) )
     end
-    divb *= cache.elements.inverse_jacobian[element]
+    divb *= cache.elements.inverse_jacobian[i, j, k, element]
     divb^2
   end |> sqrt
 end
@@ -293,7 +293,7 @@ function analyze(::Val{:linf_divb}, du, u, t,
                   derivative_matrix[j, l] * (Ja21 * u[6, i, l, k, element] + Ja22 * u[7, i, l, k, element] + Ja23 * u[8, i, l, k, element]) +
                   derivative_matrix[k, l] * (Ja31 * u[6, i, j, l, element] + Ja32 * u[7, i, j, l, element] + Ja33 * u[8, i, j, l, element]) )
       end
-      divb *= cache.elements.inverse_jacobian[element]
+      divb *= cache.elements.inverse_jacobian[i, j, k, element]
       linf_divb = max(linf_divb, abs(divb))
     end
   end


### PR DESCRIPTION
On curved meshes the `inverse_jacobian` carries multiple indices not only the current `element` as is the case for the tree mesh. 