### PR TITLE
Add support for non-conforming `ParallelP4estMesh`es in 2D

### DIFF
--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -429,8 +429,7 @@ function (amr_callback::AMRCallback)(u_ode::AbstractVector, mesh::P4estMesh,
     if mpi_isparallel() && amr_callback.dynamic_load_balancing
       @trixi_timeit timer() "dynamic load balancing" begin
         global_first_quadrant = unsafe_wrap(Array, mesh.p4est.global_first_quadrant, mpi_nranks() + 1)
-        old_global_first_quadrant = Vector{eltype(global_first_quadrant)}(undef, mpi_nranks() + 1)
-        old_global_first_quadrant .= global_first_quadrant
+        old_global_first_quadrant = copy(global_first_quadrant)
         partition!(mesh)
         rebalance_solver!(u_ode, mesh, equations, dg, cache, old_global_first_quadrant)
       end

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -415,11 +415,26 @@ function (amr_callback::AMRCallback)(u_ode::AbstractVector, mesh::P4estMesh,
     coarsened_original_cells = Int[]
   end
 
-  # Store whether there were any cells coarsened or refined
+  # Store whether there were any cells coarsened or refined and perform load balancing
   has_changed = !isempty(refined_original_cells) || !isempty(coarsened_original_cells)
+  # Check if mesh changed on other processes
+  if mpi_isparallel()
+    has_changed = MPI.Allreduce!(Ref(has_changed), |, mpi_comm())[]
+  end
+
   if has_changed # TODO: Taal decide, where shall we set this?
     # don't set it to has_changed since there can be changes from earlier calls
     mesh.unsaved_changes = true
+
+    if mpi_isparallel() && amr_callback.dynamic_load_balancing
+      @trixi_timeit timer() "dynamic load balancing" begin
+        global_first_quadrant = unsafe_wrap(Array, mesh.p4est.global_first_quadrant, mpi_nranks() + 1)
+        old_global_first_quadrant = Vector{eltype(global_first_quadrant)}(undef, mpi_nranks() + 1)
+        old_global_first_quadrant .= global_first_quadrant
+        partition!(mesh)
+        rebalance_solver!(u_ode, mesh, equations, dg, cache, old_global_first_quadrant)
+      end
+    end
 
     reinitialize_boundaries!(semi.boundary_conditions, cache)
   end

--- a/src/callbacks_step/amr_dg2d.jl
+++ b/src/callbacks_step/amr_dg2d.jl
@@ -71,6 +71,75 @@ function rebalance_solver!(u_ode::AbstractVector, mesh::TreeMesh{2}, equations,
 end
 
 
+# Redistribute data for load balancing after partitioning the mesh
+function rebalance_solver!(u_ode::AbstractVector, mesh::ParallelP4estMesh{2}, equations,
+                           dg::DGSEM, cache, old_global_first_quadrant)
+  # mpi ranks are 0-based, this array uses 1-based indices
+  global_first_quadrant = unsafe_wrap(Array, mesh.p4est.global_first_quadrant, mpi_nranks() + 1)
+  if global_first_quadrant[mpi_rank()+1] == old_global_first_quadrant[mpi_rank()+1] &&
+     global_first_quadrant[mpi_rank()+2] == old_global_first_quadrant[mpi_rank()+2]
+    # Global ids of first and last local quadrants are the same for newly partitioned mesh so the
+    # solver does not need to be rebalanced on this rank.
+    # Container init uses all-to-all communication -> reinitialize even if there is nothing to do
+    reinitialize_containers!(mesh, equations, dg, cache)
+    return
+  end
+
+  # Retain current solution data
+  old_n_elements = nelements(dg, cache)
+  old_u_ode = copy(u_ode)
+  GC.@preserve old_u_ode begin # OBS! If we don't GC.@preserve old_u_ode, it might be GC'ed
+    # Use `wrap_array_native` instead of `wrap_array` since MPI might not interact
+    # nicely with non-base array types
+    old_u = wrap_array_native(old_u_ode, mesh, equations, dg, cache)
+
+    @trixi_timeit timer() "reinitialize data structures" reinitialize_containers!(mesh, equations, dg, cache)
+
+    resize!(u_ode, nvariables(equations) * nnodes(dg)^ndims(mesh) * nelements(dg, cache))
+    u = wrap_array_native(u_ode, mesh, equations, dg, cache)
+
+    @trixi_timeit timer() "exchange data" begin
+      # Collect MPI requests for MPI_Waitall
+      requests = Vector{MPI.Request}()
+      # Find elements that will change their rank and send their data to the new rank
+      for old_element_id in 1:old_n_elements
+        # Get global quad ID of old element; local quad id is element id - 1
+        global_quad_id = old_global_first_quadrant[mpi_rank()+1] + old_element_id - 1
+        if !(global_first_quadrant[mpi_rank()+1] <= global_quad_id < global_first_quadrant[mpi_rank()+2])
+          # Send element data to new rank, use global_quad_id as tag (non-blocking)
+          dest = findfirst(r -> global_first_quadrant[r] <= global_quad_id < global_first_quadrant[r+1],
+                           1:mpi_nranks()) - 1 # mpi ranks 0-based
+          request = MPI.Isend(@view(old_u[:, .., old_element_id]), dest, global_quad_id, mpi_comm())
+          push!(requests, request)
+        end
+      end
+
+      # Loop over all elements in new container and either copy them from old container
+      # or receive them with MPI
+      for element in eachelement(dg, cache)
+        # Get global quad ID of element; local quad id is element id - 1
+        global_quad_id = global_first_quadrant[mpi_rank()+1] + element - 1
+        if old_global_first_quadrant[mpi_rank()+1] <= global_quad_id < old_global_first_quadrant[mpi_rank()+2]
+          # Quad ids are 0-based, element ids are 1-based, hence add 1
+          old_element_id = global_quad_id - old_global_first_quadrant[mpi_rank()+1] + 1
+          # Copy old element data to new element container
+          @views u[:, .., element] .= old_u[:, .., old_element_id]
+        else
+          # Receive old element data
+          src = findfirst(r -> old_global_first_quadrant[r] <= global_quad_id < old_global_first_quadrant[r+1],
+                          1:mpi_nranks()) - 1 # mpi ranks 0-based
+          request = MPI.Irecv!(@view(u[:, .., element]), src, global_quad_id, mpi_comm())
+          push!(requests, request)
+        end
+      end
+
+      # Wait for all non-blocking MPI send/receive operations to finish
+      MPI.Waitall!(requests)
+    end
+  end # GC.@preserve old_u_ode
+end
+
+
 # Refine elements in the DG solver based on a list of cell_ids that should be refined
 function refine!(u_ode::AbstractVector, adaptor, mesh::Union{TreeMesh{2}, P4estMesh{2}},
                  equations, dg::DGSEM, cache, elements_to_refine)

--- a/src/meshes/p4est_mesh.jl
+++ b/src/meshes/p4est_mesh.jl
@@ -11,10 +11,10 @@
 An unstructured curved mesh based on trees that uses the C library `p4est`
 to manage trees and mesh refinement.
 """
-mutable struct P4estMesh{NDIMS, RealT<:Real, IsParallel, P, G, NDIMSP2, NNODES} <: AbstractMesh{NDIMS}
+mutable struct P4estMesh{NDIMS, RealT<:Real, IsParallel, P, Ghost, NDIMSP2, NNODES} <: AbstractMesh{NDIMS}
   p4est                 ::P # Either Ptr{p4est_t} or Ptr{p8est_t}
   is_parallel           ::IsParallel
-  ghost                 ::G # Either Ptr{p4est_ghost_t} or Ptr{p8est_ghost_t}
+  ghost                 ::Ghost # Either Ptr{p4est_ghost_t} or Ptr{p8est_ghost_t}
   # Coordinates at the nodes specified by the tensor product of `nodes` (NDIMS times).
   # This specifies the geometry interpolation for each tree.
   tree_node_coordinates ::Array{RealT, NDIMSP2} # [dimension, i, j, k, tree]

--- a/src/solvers/dgsem_p4est/containers.jl
+++ b/src/solvers/dgsem_p4est/containers.jl
@@ -442,7 +442,7 @@ function init_surfaces_iter_face_inner(info, user_data)
     # Extract surface data
     sides = (unsafe_load_side(info, 1), unsafe_load_side(info, 2))
 
-    if sides[1].is_hanging == 0 && sides[2].is_hanging == 0
+    if sides[1].is_hanging == false && sides[2].is_hanging == false
       # No hanging nodes => normal interface
       if interfaces !== nothing
         init_interfaces_iter_face_inner(info, sides, user_data)
@@ -603,7 +603,7 @@ function count_surfaces_iter_face(info, user_data)
     # Extract surface data
     sides = (unsafe_load_side(info, 1), unsafe_load_side(info, 2))
 
-    if sides[1].is_hanging == 0 && sides[2].is_hanging == 0
+    if sides[1].is_hanging == false && sides[2].is_hanging == false
       # No hanging nodes => normal interface
       # Unpack user_data = [interface_count] and increment interface_count
       ptr = Ptr{Int}(user_data)

--- a/src/solvers/dgsem_p4est/containers_2d.jl
+++ b/src/solvers/dgsem_p4est/containers_2d.jl
@@ -141,8 +141,7 @@ end
 
 # Initialize node_indices of mortar container
 # faces[1] is expected to be the face of the small side.
-@inline function init_mortar_node_indices!(mortars::P4estMortarContainer{2},
-                                           faces, orientation, mortar_id)
+@inline function init_mortar_node_indices!(mortars, faces, orientation, mortar_id)
   for side in 1:2
     # Align mortar in positive coordinate direction of small side.
     # For orientation == 1, the large side needs to be indexed backwards

--- a/src/solvers/dgsem_p4est/containers_parallel.jl
+++ b/src/solvers/dgsem_p4est/containers_parallel.jl
@@ -217,13 +217,13 @@ function reinitialize_containers!(mesh::ParallelP4estMesh, equations, dg::DGSEM,
   # the number of iterations over the mesh in p4est
   init_surfaces!(interfaces, mortars, boundaries, mpi_interfaces, mpi_mortars, mesh)
 
-  # re-initialize mpi cache
+  # re-initialize MPI cache
   @unpack mpi_cache = cache
   init_mpi_cache!(mpi_cache, mesh, mpi_interfaces, mpi_mortars,
                   nvariables(equations), nnodes(dg), eltype(elements))
 
-  # re-initialize and distribute normal directions of mpi mortars; requires mpi communication, so
-  # the mpi cache must be re-initialized before
+  # re-initialize and distribute normal directions of MPI mortars; requires MPI communication, so
+  # the MPI cache must be re-initialized before
   init_normal_directions!(mpi_mortars, dg.basis, elements)
   exchange_normal_directions!(mpi_mortars, mpi_cache, mesh, nnodes(dg))
 end

--- a/src/solvers/dgsem_p4est/containers_parallel.jl
+++ b/src/solvers/dgsem_p4est/containers_parallel.jl
@@ -66,27 +66,120 @@ function init_mpi_interfaces(mesh::ParallelP4estMesh, equations, basis, elements
 end
 
 function init_mpi_interfaces!(mpi_interfaces, mesh::ParallelP4estMesh)
-  init_surfaces!(nothing, nothing, nothing, mpi_interfaces, mesh)
+  init_surfaces!(nothing, nothing, nothing, mpi_interfaces, nothing, mesh)
 
   return mpi_interfaces
 end
 
-# Overload init! function for boundaries and regular interfaces since it must call the appropriate
-# init_surfaces! function for parallel p4est meshes
+
+# Container data structure (structure-of-arrays style) for DG L2 mortars
+#
+# Similar to `P4estMortarContainer`. The field `neighbor_ids` has been split up into
+# `local_element_ids` and `local_element_positions` to describe the ids and positions of the locally
+# available elements belonging to a particular MPI mortar. Furthermore, `normal_directions` holds
+# the normal vectors on the surface of the small elements for each mortar.
+mutable struct P4estMPIMortarContainer{NDIMS, uEltype<:Real, RealT<:Real, NDIMSP1, NDIMSP2, NDIMSP3} <: AbstractContainer
+  u                      ::Array{uEltype, NDIMSP3} # [small/large side, variable, position, i, j, mortar]
+  local_element_ids      ::Vector{Vector{Int}} # [mortar]
+  local_element_positions::Vector{Vector{Int}} # [mortar]
+  node_indices           ::Matrix{NTuple{NDIMS, Symbol}} # [small/large, mortar]
+  normal_directions      ::Array{RealT, NDIMSP2} # [dimension, i, j, position, mortar]
+  # internal `resize!`able storage
+  _u                     ::Vector{uEltype}
+  _node_indices          ::Vector{NTuple{NDIMS, Symbol}}
+  _normal_directions     ::Vector{RealT}
+end
+
+@inline nmpimortars(mpi_mortars::P4estMPIMortarContainer) = length(mpi_mortars.local_element_ids)
+@inline Base.ndims(::P4estMPIMortarContainer{NDIMS}) where NDIMS = NDIMS
+
+function Base.resize!(mpi_mortars::P4estMPIMortarContainer, capacity)
+  @unpack _u, _node_indices = mpi_mortars
+
+  n_dims = ndims(mpi_mortars)
+  n_nodes = size(mpi_mortars.u, 4)
+  n_variables = size(mpi_mortars.u, 2)
+
+  resize!(_u, 2 * n_variables * 2^(n_dims-1) * n_nodes^(n_dims-1) * capacity)
+  mortars.u = unsafe_wrap(Array, pointer(_u),
+    (2, n_variables, 2^(n_dims-1), ntuple(_ -> n_nodes, n_dims-1)..., capacity))
+
+  resize!(local_element_ids, capacity)
+  resize!(local_element_positions, capacity)
+
+  resize!(_node_indices, 2 * capacity)
+  mortars.node_indices = unsafe_wrap(Array, pointer(_node_indices), (2, capacity))
+end
+
+
+# Create MPI mortar container and initialize MPI mortar data
+function init_mpi_mortars(mesh::ParallelP4estMesh, equations, basis, elements)
+  NDIMS = ndims(mesh)
+  RealT = real(mesh)
+  uEltype = eltype(elements)
+
+  # Initialize container
+  n_mpi_mortars = count_required_surfaces(mesh).mpi_mortars
+
+  _u = Vector{uEltype}(undef,
+    2 * nvariables(equations) * 2^(NDIMS-1) * nnodes(basis)^(NDIMS-1) * n_mpi_mortars)
+  u = unsafe_wrap(Array, pointer(_u),
+    (2, nvariables(equations), 2^(NDIMS-1), ntuple(_ -> nnodes(basis), NDIMS-1)..., n_mpi_mortars))
+
+  local_element_ids = fill(Vector{Int}(), n_mpi_mortars)
+  local_element_positions = fill(Vector{Int}(), n_mpi_mortars)
+
+  _node_indices = Vector{NTuple{NDIMS, Symbol}}(undef, 2 * n_mpi_mortars)
+  node_indices = unsafe_wrap(Array, pointer(_node_indices), (2, n_mpi_mortars))
+
+  _normal_directions = Vector{RealT}(undef, NDIMS * nnodes(basis)^(NDIMS-1) * 2^(NDIMS-1) * n_mpi_mortars)
+  normal_directions = unsafe_wrap(Array, pointer(_normal_directions),
+    (NDIMS, ntuple(_ -> nnodes(basis), NDIMS-1)..., 2^(NDIMS-1), n_mpi_mortars))
+
+  mpi_mortars = P4estMPIMortarContainer{NDIMS, uEltype, RealT, NDIMS+1, NDIMS+2, NDIMS+3}(
+    u, local_element_ids, local_element_positions, node_indices, normal_directions,
+    _u, _node_indices, _normal_directions)
+
+  if n_mpi_mortars > 0
+    init_mpi_mortars!(mpi_mortars, mesh, basis, elements)
+  end
+
+  return mpi_mortars
+end
+
+function init_mpi_mortars!(mpi_mortars, mesh::ParallelP4estMesh, basis, elements)
+  init_surfaces!(nothing, nothing, nothing, nothing, mpi_mortars, mesh)
+  init_normal_directions!(mpi_mortars, basis, elements)
+
+  return mpi_mortars
+end
+
+
+# Overload init! function for regular interfaces, regular mortars and boundaries since they must
+# call the appropriate init_surfaces! function for parallel p4est meshes
 function init_interfaces!(interfaces, mesh::ParallelP4estMesh)
-  init_surfaces!(interfaces, nothing, nothing, nothing, mesh)
+  init_surfaces!(interfaces, nothing, nothing, nothing, nothing, mesh)
 
   return interfaces
 end
 
+function init_mortars!(mortars, mesh::ParallelP4estMesh)
+  init_surfaces!(nothing, mortars, nothing, nothing, nothing, mesh)
+
+  return mortars
+end
+
 function init_boundaries!(boundaries, mesh::ParallelP4estMesh)
-  init_surfaces!(nothing, nothing, boundaries, nothing, mesh)
+  init_surfaces!(nothing, nothing, boundaries, nothing, nothing, mesh)
 
   return boundaries
 end
 
 
 function reinitialize_containers!(mesh::ParallelP4estMesh, equations, dg::DGSEM, cache)
+  # Make sure to re-create ghost layer before reinitializing MPI-related containers
+  update_ghost_layer!(mesh)
+
   # Re-initialize elements container
   @unpack elements = cache
   resize!(elements, ncells(mesh))
@@ -110,14 +203,22 @@ function reinitialize_containers!(mesh::ParallelP4estMesh, equations, dg::DGSEM,
   @unpack mpi_interfaces = cache
   resize!(mpi_interfaces, required.mpi_interfaces)
 
+  # resize mpi_mortars container
+  @unpack mpi_mortars = cache
+  resize!(mpi_mortars, required.mpi_mortars)
+
   # re-initialize containers together to reduce
   # the number of iterations over the mesh in p4est
-  init_surfaces!(interfaces, mortars, boundaries, mpi_interfaces, mesh)
+  init_surfaces!(interfaces, mortars, boundaries, mpi_interfaces, mpi_mortars, mesh)
+
+  # re-initialize mpi cache
+  init_mpi_cache!(mpi_cache, mesh, elements, mpi_interfaces,
+                  nvariables(equations), nnodes(dg), eltype(elements))
 end
 
 
 # A helper struct used in initialization methods below
-mutable struct ParallelInitSurfacesIterFaceUserData{Interfaces, Mortars, Boundaries, MPIInterfaces, Mesh}
+mutable struct ParallelInitSurfacesIterFaceUserData{Interfaces, Mortars, Boundaries, MPIInterfaces, MPIMortars, Mesh}
   interfaces      ::Interfaces
   interface_id    ::Int
   mortars         ::Mortars
@@ -126,13 +227,16 @@ mutable struct ParallelInitSurfacesIterFaceUserData{Interfaces, Mortars, Boundar
   boundary_id     ::Int
   mpi_interfaces  ::MPIInterfaces
   mpi_interface_id::Int
+  mpi_mortars     ::MPIMortars
+  mpi_mortar_id   ::Int
   mesh            ::Mesh
 end
 
-function ParallelInitSurfacesIterFaceUserData(interfaces, mortars, boundaries, mpi_interfaces, mesh)
+function ParallelInitSurfacesIterFaceUserData(interfaces, mortars, boundaries,
+                                              mpi_interfaces, mpi_mortars, mesh)
   return ParallelInitSurfacesIterFaceUserData{
-    typeof(interfaces), typeof(mortars), typeof(boundaries), typeof(mpi_interfaces), typeof(mesh)}(
-      interfaces, 1, mortars, 1, boundaries, 1, mpi_interfaces, 1, mesh)
+    typeof(interfaces), typeof(mortars), typeof(boundaries), typeof(mpi_interfaces), typeof(mpi_mortars), typeof(mesh)}(
+      interfaces, 1, mortars, 1, boundaries, 1, mpi_interfaces, 1, mpi_mortars, 1, mesh)
 end
 
 
@@ -151,7 +255,7 @@ cfunction(::typeof(init_surfaces_iter_face_parallel), ::Val{3}) = @cfunction(ini
 
 # Function barrier for type stability, overload for parallel P4estMesh
 function init_surfaces_iter_face_inner(info, user_data::ParallelInitSurfacesIterFaceUserData)
-  @unpack interfaces, boundaries, mpi_interfaces = user_data
+  @unpack interfaces, mortars, boundaries, mpi_interfaces, mpi_mortars = user_data
 
   if info.sides.elem_count == 2
     # Two neighboring elements => Interface or mortar
@@ -171,8 +275,32 @@ function init_surfaces_iter_face_inner(info, user_data::ParallelInitSurfacesIter
         end
       end
     else
-      # Hanging nodes => mortar
-      error("ParallelP4estMesh does not support non-conforming meshes.")
+      # Hanging nodes => mortar or MPI mortar
+      if (mortars !== nothing && ndims(mortars) == 3) || (mpi_mortars !== nothing && ndims(mpi_mortars) == 3)
+        error("ParallelP4estMesh does not support non-conforming meshes in 3D.")
+      end
+      # Check if one of the sides is ghost
+      if sides[1].is_hanging == true
+        @assert sides[2].is_hanging == false
+        if any(sides[1].is.hanging.is_ghost .== 1) || sides[2].is.full.is_ghost == 1
+          face_has_ghost_side = true
+        else
+          face_has_ghost_side = false
+        end
+      else # sides[2].is_hanging == 1
+        @assert sides[1].is_hanging == false
+        if sides[1].is.full.is_ghost == 1 || any(sides[2].is.hanging.is_ghost .== 1)
+          face_has_ghost_side = true
+        else
+          face_has_ghost_side = false
+        end
+      end
+      # Initialize mortar or MPI mortar
+      if face_has_ghost_side && mpi_mortars !== nothing
+        init_mpi_mortars_iter_face_inner(info, sides, user_data)
+      elseif !face_has_ghost_side && mortars !== nothing
+        init_mortars_iter_face_inner(info, sides, user_data)
+      end
     end
   elseif info.sides.elem_count == 1
     # One neighboring elements => boundary
@@ -184,13 +312,14 @@ function init_surfaces_iter_face_inner(info, user_data::ParallelInitSurfacesIter
   return nothing
 end
 
-function init_surfaces!(interfaces, mortars, boundaries, mpi_interfaces, mesh::ParallelP4estMesh)
+function init_surfaces!(interfaces, mortars, boundaries, mpi_interfaces, mpi_mortars,
+                        mesh::ParallelP4estMesh)
   # Let p4est iterate over all interfaces and call init_surfaces_iter_face
   iter_face_c = cfunction(init_surfaces_iter_face_parallel, Val(ndims(mesh)))
-  user_data = ParallelInitSurfacesIterFaceUserData(interfaces, mortars, boundaries, mpi_interfaces,
-                                                   mesh)
+  user_data = ParallelInitSurfacesIterFaceUserData(interfaces, mortars, boundaries,
+                                                   mpi_interfaces, mpi_mortars, mesh)
 
-  iterate_p4est(mesh.p4est, user_data; iter_face_c=iter_face_c)
+  iterate_p4est(mesh.p4est, user_data; ghost_layer=mesh.ghost, iter_face_c=iter_face_c)
 
   return nothing
 end
@@ -232,11 +361,71 @@ function init_mpi_interfaces_iter_face_inner(info, sides, user_data)
 end
 
 
+# Initialization of MPI mortars after the function barrier
+function init_mpi_mortars_iter_face_inner(info, sides, user_data)
+  @unpack mpi_mortars, mpi_mortar_id, mesh = user_data
+  user_data.mpi_mortar_id += 1
+
+  # Get Tuple of adjacent trees, one-based indexing
+  trees = (unsafe_load_tree(mesh.p4est, sides[1].treeid + 1),
+           unsafe_load_tree(mesh.p4est, sides[2].treeid + 1))
+  # Quadrant numbering offsets of the quadrants at this mortar
+  offsets = SVector(trees[1].quadrants_offset,
+                    trees[2].quadrants_offset)
+
+  if sides[1].is_hanging == true
+    hanging_side = 1
+    full_side = 2
+  else # sides[2].is_hanging == true
+    hanging_side = 2
+    full_side = 1
+  end
+  # Just be sure before accessing is.full or is.hanging later
+  @assert sides[full_side].is_hanging == false
+  @assert sides[hanging_side].is_hanging == true
+
+  # Find small quads that are locally available
+  local_small_quad_positions = findall(sides[hanging_side].is.hanging.is_ghost .== 0)
+
+  # Get id of local small quadrants within their tree
+  # Indexing CBinding.Caccessor via a Vector does not work here -> use map instead
+  tree_small_quad_ids = map(p->sides[hanging_side].is.hanging.quadid[p], local_small_quad_positions)
+  local_small_quad_ids = offsets[hanging_side] .+ tree_small_quad_ids # ids cumulative over local trees
+
+  # Determine if large quadrant is available and if yes, determine its id
+  if sides[full_side].is.full.is_ghost == 0
+    local_large_quad_id = offsets[full_side] + sides[full_side].is.full.quadid
+  else
+    local_large_quad_id = -1 # large quad is ghost
+  end
+
+  # Write data to mortar container, convert to 1-based indexing
+  # Start with small elements
+  local_element_ids = local_small_quad_ids .+ 1
+  local_element_positions = local_small_quad_positions
+  # Add large element information if it is locally available
+  if local_large_quad_id > -1
+    push!(local_element_ids, local_large_quad_id + 1) # convert to 1-based index
+    push!(local_element_positions, 2^(ndims(mesh)-1) + 1)
+  end
+
+  mpi_mortars.local_element_ids[mpi_mortar_id] = local_element_ids
+  mpi_mortars.local_element_positions[mpi_mortar_id] = local_element_positions
+
+  # init_mortar_node_indices! expects side 1 to contain small elements
+  faces = (sides[hanging_side].face, sides[full_side].face)
+  init_mortar_node_indices!(mpi_mortars, faces, info.orientation, mpi_mortar_id)
+
+  return nothing
+end
+
+
 # Iterate over all interfaces and count
 # - (inner) interfaces
 # - mortars
 # - boundaries
 # - (MPI) interfaces at subdomain boundaries
+# - (MPI) mortars at subdomain boundaries
 # and collect the numbers in `user_data` in this order.
 function count_surfaces_iter_face_parallel(info, user_data)
   if info.sides.elem_count == 2
@@ -245,7 +434,7 @@ function count_surfaces_iter_face_parallel(info, user_data)
     # Extract surface data
     sides = (unsafe_load_side(info, 1), unsafe_load_side(info, 2))
 
-    if sides[1].is_hanging == 0 && sides[2].is_hanging == 0
+    if sides[1].is_hanging == false && sides[2].is_hanging == false
       # No hanging nodes => normal interface or MPI interface
       if sides[1].is.full.is_ghost == 1 || sides[2].is.full.is_ghost == 1 # remote side => MPI interface
         # Unpack user_data = [mpi_interface_count] and increment mpi_interface_count
@@ -259,8 +448,34 @@ function count_surfaces_iter_face_parallel(info, user_data)
         unsafe_store!(ptr, id + 1, 1)
       end
     else
-      # Hanging nodes => mortar
-      error("ParallelP4estMesh does not support non-conforming meshes.")
+      # Hanging nodes => mortar or MPI mortar
+      # Check if one of the sides is ghost
+      if sides[1].is_hanging == true
+        @assert sides[2].is_hanging == false
+        if any(sides[1].is.hanging.is_ghost .== 1) || sides[2].is.full.is_ghost == 1
+          face_has_ghost_side = true
+        else
+          face_has_ghost_side = false
+        end
+      else # sides[2].is_hanging == 1
+        @assert sides[1].is_hanging == false
+        if sides[1].is.full.is_ghost == 1 || any(sides[2].is.hanging.is_ghost .== 1)
+          face_has_ghost_side = true
+        else
+          face_has_ghost_side = false
+        end
+      end
+      if face_has_ghost_side
+        # Unpack user_data = [mpi_mortar_count] and increment mpi_mortar_count
+        ptr = Ptr{Int}(user_data)
+        id = unsafe_load(ptr, 5)
+        unsafe_store!(ptr, id + 1, 5)
+      else
+        # Unpack user_data = [mortar_count] and increment mortar_count
+        ptr = Ptr{Int}(user_data)
+        id = unsafe_load(ptr, 2)
+        unsafe_store!(ptr, id + 1, 2)
+      end
     end
   elseif info.sides.elem_count == 1
     # One neighboring elements => boundary
@@ -283,16 +498,17 @@ function count_required_surfaces(mesh::ParallelP4estMesh)
   # Let p4est iterate over all interfaces and call count_surfaces_iter_face_parallel
   iter_face_c = cfunction(count_surfaces_iter_face_parallel, Val(ndims(mesh)))
 
-  # interfaces, mortars, boundaries, mpi_interfaces
-  user_data = [0, 0, 0, 0]
+  # interfaces, mortars, boundaries, mpi_interfaces, mpi_mortars
+  user_data = [0, 0, 0, 0, 0]
 
-  iterate_p4est(mesh.p4est, user_data; iter_face_c=iter_face_c)
+  iterate_p4est(mesh.p4est, user_data; ghost_layer=mesh.ghost, iter_face_c=iter_face_c)
 
   # Return counters
   return (interfaces     = user_data[1],
           mortars        = user_data[2],
           boundaries     = user_data[3],
-          mpi_interfaces = user_data[4])
+          mpi_interfaces = user_data[4],
+          mpi_mortars    = user_data[5])
 end
 
 

--- a/src/solvers/dgsem_p4est/containers_parallel_2d.jl
+++ b/src/solvers/dgsem_p4est/containers_parallel_2d.jl
@@ -38,4 +38,42 @@
 end
 
 
+# Normal directions of small element surfaces are needed to calculate the mortar fluxes. Initialize
+# them for locally available small elements.
+function init_normal_directions!(mpi_mortars::P4estMPIMortarContainer{2}, basis, elements)
+  @unpack local_element_ids, local_element_positions, node_indices = mpi_mortars
+  @unpack contravariant_vectors = elements
+  index_range = eachnode(basis)
+
+  @threaded for mortar in 1:nmpimortars(mpi_mortars)
+    small_indices = node_indices[1, mortar]
+    small_direction = indices2direction(small_indices)
+
+    i_small_start, i_small_step = index_to_start_step_2d(small_indices[1], index_range)
+    j_small_start, j_small_step = index_to_start_step_2d(small_indices[2], index_range)
+
+    for (element, position) in zip(local_element_ids[mortar], local_element_positions[mortar])
+      # ignore large elements
+      if position == 3
+        continue
+      end
+
+      i_small = i_small_start
+      j_small = j_small_start
+      for node in eachnode(basis)
+        # Get the normal direction on the small element.
+        # Note, contravariant vectors at interfaces in negative coordinate direction
+        # are pointing inwards. This is handled by `get_normal_direction`.
+        normal_direction = get_normal_direction(small_direction, contravariant_vectors,
+                                                i_small, j_small, element)
+        @views mpi_mortars.normal_directions[:, node, position, mortar] .= normal_direction
+
+        i_small += i_small_step
+        j_small += j_small_step
+      end
+    end
+  end
+end
+
+
 end # muladd

--- a/src/solvers/dgsem_p4est/dg_2d_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_2d_parallel.jl
@@ -18,6 +18,10 @@ function rhs!(du, u, t,
   @trixi_timeit timer() "prolong2mpiinterfaces" prolong2mpiinterfaces!(
     cache, u, mesh, equations, dg.surface_integral, dg)
 
+  # Prolong solution to MPI mortars
+  @trixi_timeit timer() "prolong2mpimortars" prolong2mpimortars!(
+    cache, u, mesh, equations, dg.mortar, dg.surface_integral, dg)
+
   # Start to send MPI data
   @trixi_timeit timer() "start MPI send" start_mpi_send!(
     cache.mpi_cache, mesh, equations, dg, cache)
@@ -68,6 +72,12 @@ function rhs!(du, u, t,
     cache.elements.surface_flux_values, mesh,
     have_nonconservative_terms(equations), equations,
     dg.surface_integral, dg, cache)
+
+  # Calculate MPI mortar fluxes
+  @trixi_timeit timer() "MPI mortar flux" calc_mpi_mortar_flux!(
+    cache.elements.surface_flux_values, mesh,
+    have_nonconservative_terms(equations), equations,
+    dg.mortar, dg.surface_integral, dg, cache)
 
   # Calculate surface integrals
   @trixi_timeit timer() "surface integral" calc_surface_integral!(
@@ -204,6 +214,194 @@ end
   end
 end
 
+
+function prolong2mpimortars!(cache, u,
+                             mesh::ParallelP4estMesh{2}, equations,
+                             mortar_l2::LobattoLegendreMortarL2,
+                             surface_integral, dg::DGSEM)
+  @unpack node_indices = cache.mpi_mortars
+  index_range = eachnode(dg)
+
+  @threaded for mortar in eachmpimortar(dg, cache)
+    local_elements = cache.mpi_mortars.local_element_ids[mortar]
+    local_element_positions = cache.mpi_mortars.local_element_positions[mortar]
+
+    # Get start value and step size for indices on both sides to get the correct face
+    # and orientation
+    small_indices = node_indices[1, mortar]
+    i_small_start, i_small_step = index_to_start_step_2d(small_indices[1], index_range)
+    j_small_start, j_small_step = index_to_start_step_2d(small_indices[2], index_range)
+
+    large_indices = node_indices[2, mortar]
+    i_large_start, i_large_step = index_to_start_step_2d(large_indices[1], index_range)
+    j_large_start, j_large_step = index_to_start_step_2d(large_indices[2], index_range)
+
+    for (element, position) in zip(local_elements, local_element_positions)
+      if position == 3 # -> large element
+        # Buffer to copy solution values of the large element in the correct orientation
+        # before interpolating
+        u_buffer = cache.u_threaded[Threads.threadid()]
+        i_large = i_large_start
+        j_large = j_large_start
+        for i in eachnode(dg)
+          for v in eachvariable(equations)
+            u_buffer[v, i] = u[v, i_large, j_large, element]
+          end
+
+          i_large += i_large_step
+          j_large += j_large_step
+        end
+
+        # Interpolate large element face data from buffer to small face locations
+        multiply_dimensionwise!(view(cache.mpi_mortars.u, 2, :, 1, :, mortar),
+                                mortar_l2.forward_lower,
+                                u_buffer)
+        multiply_dimensionwise!(view(cache.mpi_mortars.u, 2, :, 2, :, mortar),
+                                mortar_l2.forward_upper,
+                                u_buffer)
+      else # position in (1, 2) -> small element
+        # Copy solution data from the small elements
+        i_small = i_small_start
+        j_small = j_small_start
+        for i in eachnode(dg)
+          for v in eachvariable(equations)
+            cache.mpi_mortars.u[1, v, position, i, mortar] = u[v, i_small, j_small, element]
+          end
+          i_small += i_small_step
+          j_small += j_small_step
+        end
+      end
+    end
+  end
+
+  return nothing
+end
+
+
+function calc_mpi_mortar_flux!(surface_flux_values,
+                               mesh::ParallelP4estMesh{2},
+                               nonconservative_terms, equations,
+                               mortar_l2::LobattoLegendreMortarL2,
+                               surface_integral, dg::DG, cache)
+  @unpack local_element_ids, local_element_positions, node_indices = cache.mpi_mortars
+  @unpack contravariant_vectors = cache.elements
+  @unpack fstar_upper_threaded, fstar_lower_threaded = cache
+  index_range = eachnode(dg)
+
+  @threaded for mortar in eachmpimortar(dg, cache)
+    # Choose thread-specific pre-allocated container
+    fstar = (fstar_lower_threaded[Threads.threadid()],
+             fstar_upper_threaded[Threads.threadid()])
+
+    # Get index information on the small elements
+    small_indices = node_indices[1, mortar]
+
+    i_small_start, i_small_step = index_to_start_step_2d(small_indices[1], index_range)
+    j_small_start, j_small_step = index_to_start_step_2d(small_indices[2], index_range)
+
+    for position in 1:2
+      i_small = i_small_start
+      j_small = j_small_start
+      for node in eachnode(dg)
+        # Get the normal direction on the small element.
+        normal_direction = get_normal_direction(cache.mpi_mortars, node, position, mortar)
+
+        calc_mpi_mortar_flux!(fstar, mesh, nonconservative_terms, equations,
+                              surface_integral, dg, cache,
+                              mortar, position, normal_direction,
+                              node)
+
+        i_small += i_small_step
+        j_small += j_small_step
+      end
+    end
+
+    # Buffer to interpolate flux values of the large element to before
+    # copying in the correct orientation
+    u_buffer = cache.u_threaded[Threads.threadid()]
+
+    mpi_mortar_fluxes_to_elements!(surface_flux_values,
+                                   mesh, equations, mortar_l2, dg, cache,
+                                   mortar, fstar, u_buffer)
+  end
+
+  return nothing
+end
+
+
+# Inlined version of the mortar flux computation on small elements for conservation laws
+@inline function calc_mpi_mortar_flux!(fstar,
+                                       mesh::ParallelP4estMesh{2},
+                                       nonconservative_terms::Val{false}, equations,
+                                       surface_integral, dg::DG, cache,
+                                       mortar_index, position_index, normal_direction,
+                                       node_index)
+  @unpack u = cache.mpi_mortars
+  @unpack surface_flux = surface_integral
+
+  u_ll, u_rr = get_surface_node_vars(u, equations, dg, position_index, node_index, mortar_index)
+
+  flux = surface_flux(u_ll, u_rr, normal_direction, equations)
+
+  # Copy flux to buffer
+  set_node_vars!(fstar[position_index], flux, equations, dg, node_index)
+end
+
+
+@inline function mpi_mortar_fluxes_to_elements!(surface_flux_values,
+                                                mesh::ParallelP4estMesh{2}, equations,
+                                                mortar_l2::LobattoLegendreMortarL2,
+                                                dg::DGSEM, cache, mortar, fstar, u_buffer)
+  @unpack local_element_ids, local_element_positions, node_indices = cache.mpi_mortars
+
+  small_indices   = node_indices[1, mortar]
+  small_direction = indices2direction(small_indices)
+  large_indices   = node_indices[2, mortar]
+  large_direction = indices2direction(large_indices)
+
+  for (element, position) in zip(local_element_ids[mortar], local_element_positions[mortar])
+    if position == 3 # -> large element
+      # Project small fluxes to large element.
+      multiply_dimensionwise!(u_buffer,
+                              mortar_l2.reverse_upper, fstar[2],
+                              mortar_l2.reverse_lower, fstar[1])
+      # The flux is calculated in the outward direction of the small elements,
+      # so the sign must be switched to get the flux in outward direction
+      # of the large element.
+      # The contravariant vectors of the large element (and therefore the normal
+      # vectors of the large element as well) are twice as large as the
+      # contravariant vectors of the small elements. Therefore, the flux needs
+      # to be scaled by a factor of 2 to obtain the flux of the large element.
+      u_buffer .*= -2
+      # Copy interpolated flux values from buffer to large element face in the
+      # correct orientation.
+      # Note that the index of the small sides will always run forward but
+      # the index of the large side might need to run backwards for flipped sides.
+      if :i_backward in large_indices
+        for i in eachnode(dg)
+          for v in eachvariable(equations)
+            surface_flux_values[v, end + 1 - i, large_direction, element] = u_buffer[v, i]
+          end
+        end
+      else
+        for i in eachnode(dg)
+          for v in eachvariable(equations)
+            surface_flux_values[v, i, large_direction, element] = u_buffer[v, i]
+          end
+        end
+      end
+    else # position in (1, 2) -> small element
+      # Copy solution small to small
+      for i in eachnode(dg)
+        for v in eachvariable(equations)
+          surface_flux_values[v, i, small_direction, element] = fstar[position][v, i]
+        end
+      end
+    end
+  end
+
+  return nothing
+end
 
 
 end # muladd

--- a/src/solvers/dgsem_p4est/dg_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_parallel.jl
@@ -155,9 +155,9 @@ end
 
 
 # Returns a tuple `indices` where indices[position] is a (first, last) pair for accessing the
-# data corresponding to the `position` part of a mortar in an mpi buffer. `data_size` is the size of
+# data corresponding to the `position` part of a mortar in an MPI buffer. `data_size` is the size of
 # the data corresponding to each small position and the data associated with the mortar must begin
-# at `index_base`+1 in the mpi buffer.
+# at `index_base`+1 in the MPI buffer.
 @inline function buffer_mortar_indices(mesh::ParallelP4estMesh{2}, index_base, data_size)
   return (
     # first, last for local element in position 1 (small element)
@@ -343,7 +343,7 @@ function init_neighbor_rank_connectivity_iter_face_inner(info, user_data)
       proc_offsets = unsafe_wrap(Array, info.ghost_layer.proc_offsets, mpi_nranks() + 1)
       ghost_id = sides[remote_side].is.full.quadid # indexes the ghost layer, 0-based
       neighbor_rank = findfirst(r -> proc_offsets[r] <= ghost_id < proc_offsets[r+1],
-                                1:mpi_nranks()) - 1 # mpi ranks are 0-based
+                                1:mpi_nranks()) - 1 # MPI ranks are 0-based
       neighbor_ranks_interface[interface_id] = neighbor_rank
 
       # Global interface id is the globally unique quadrant id of the quadrant on the primary
@@ -385,14 +385,14 @@ function init_neighbor_rank_connectivity_iter_face_inner(info, user_data)
       ghost_ids = map(pos -> sides[hanging_side].is.hanging.quadid[pos], remote_small_quad_positions)
       neighbor_ranks = map(ghost_ids) do ghost_id
         return findfirst(r -> proc_offsets[r] <= ghost_id < proc_offsets[r+1],
-                         1:mpi_nranks()) - 1 # mpi ranks are 0-based
+                         1:mpi_nranks()) - 1 # MPI ranks are 0-based
       end
       # Determine global quad id of large element to determine global MPI mortar id
       # Furthermore, if large element is ghost, add its owner rank to neighbor_ranks
       if sides[full_side].is.full.is_ghost == 1
         ghost_id = sides[full_side].is.full.quadid
         large_quad_owner_rank = findfirst(r -> proc_offsets[r] <= ghost_id < proc_offsets[r+1],
-                                          1:mpi_nranks()) - 1 # mpi ranks are 0-based
+                                          1:mpi_nranks()) - 1 # MPI ranks are 0-based
         push!(neighbor_ranks, large_quad_owner_rank)
 
         offset = unsafe_load(mesh.p4est.global_first_quadrant, large_quad_owner_rank + 1) # one-based indexing
@@ -436,8 +436,8 @@ function init_mpi_data_structures(mpi_neighbor_interfaces, mpi_neighbor_mortars,
 end
 
 
-# Exchange normal directions of small elements of the mpi mortars. They are needed on all involved
-# mpi ranks to calculate the mortar fluxes.
+# Exchange normal directions of small elements of the MPI mortars. They are needed on all involved
+# MPI ranks to calculate the mortar fluxes.
 function exchange_normal_directions!(mpi_mortars, mpi_cache, mesh::ParallelP4estMesh, n_nodes)
   RealT = real(mesh)
   n_dims = ndims(mesh)

--- a/src/solvers/dgsem_p4est/dg_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_parallel.jl
@@ -63,6 +63,7 @@ function start_mpi_send!(mpi_cache::P4estMPICache, mesh, equations, dg, cache)
     # data exists
     interfaces_data_size = length(mpi_cache.mpi_neighbor_interfaces[d]) * data_size
     mortars_data_size = length(mpi_cache.mpi_neighbor_mortars[d]) * n_small_elements * 2 * data_size
+    # `NaN |> eltype(...)` ensures that the NaN's are of the appropriate floating point type
     send_buffer[interfaces_data_size+1:interfaces_data_size+mortars_data_size] .= NaN |> eltype(mpi_cache)
 
     for (index, mortar) in enumerate(mpi_cache.mpi_neighbor_mortars[d])

--- a/src/solvers/dgsem_p4est/dg_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_parallel.jl
@@ -154,10 +154,11 @@ function finish_mpi_receive!(mpi_cache::P4estMPICache, mesh, equations, dg, cach
 end
 
 
-# Returns a tuple `indices` where indices[position] is a (first, last) pair for accessing the
-# data corresponding to the `position` part of a mortar in an MPI buffer. `data_size` is the size of
-# the data corresponding to each small position and the data associated with the mortar must begin
-# at `index_base`+1 in the MPI buffer.
+# Return a tuple `indices` where indices[position] is a `(first, last)` tuple for accessing the
+# data associated with the element at `position` of a mortar in an MPI buffer. The data must begin
+# at `index_base`+1 in the MPI buffer. `data_size` is the data size for each small element
+# (i.e. position 1 or 2). The data corresponding to the large element (i.e. position 3) has size
+# `2 * data_size`.
 @inline function buffer_mortar_indices(mesh::ParallelP4estMesh{2}, index_base, data_size)
   return (
     # first, last for local element in position 1 (small element)

--- a/src/solvers/dgsem_p4est/dg_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_parallel.jl
@@ -207,9 +207,9 @@ function create_cache(mesh::ParallelP4estMesh, equations::AbstractEquations, dg:
 end
 
 
-function init_mpi_cache(mesh::ParallelP4estMesh, elements, mpi_interfaces, nvars, nnodes, uEltype)
+function init_mpi_cache(mesh::ParallelP4estMesh, mpi_interfaces, mpi_mortars, nvars, nnodes, uEltype)
   mpi_cache = P4estMPICache(uEltype)
-  init_mpi_cache!(mpi_cache, mesh, elements, mpi_interfaces, nvars, nnodes, uEltype)
+  init_mpi_cache!(mpi_cache, mesh, mpi_interfaces, mpi_mortars, nvars, nnodes, uEltype)
 
   return mpi_cache
 end

--- a/src/solvers/dgsem_p4est/dg_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_parallel.jl
@@ -156,10 +156,10 @@ end
 
 
 # Return a tuple `indices` where indices[position] is a `(first, last)` tuple for accessing the
-# data associated with the element at `position` of a mortar in an MPI buffer. The data must begin
-# at `index_base`+1 in the MPI buffer. `data_size` is the data size for each small element
-# (i.e. position 1 or 2). The data corresponding to the large element (i.e. position 3) has size
-# `2 * data_size`.
+# data corresponding to the `position` part of a mortar in an MPI buffer. The mortar data must begin
+# at `index_base`+1 in the MPI buffer. `data_size` is the data size associated with each small
+# position (i.e. position 1 or 2). The data corresponding to the large side (i.e. position 3) has
+# size `2 * data_size`.
 @inline function buffer_mortar_indices(mesh::ParallelP4estMesh{2}, index_base, data_size)
   return (
     # first, last for local element in position 1 (small element)

--- a/src/solvers/dgsem_p4est/dg_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_parallel.jl
@@ -8,6 +8,7 @@
 mutable struct P4estMPICache{uEltype}
   mpi_neighbor_ranks::Vector{Int}
   mpi_neighbor_interfaces::Vector{Vector{Int}}
+  mpi_neighbor_mortars::Vector{Vector{Int}}
   mpi_send_buffers::Vector{Vector{uEltype}}
   mpi_recv_buffers::Vector{Vector{uEltype}}
   mpi_send_requests::Vector{MPI.Request}
@@ -25,6 +26,7 @@ function P4estMPICache(uEltype)
 
   mpi_neighbor_ranks = Vector{Int}(undef, 0)
   mpi_neighbor_interfaces = Vector{Vector{Int}}(undef, 0)
+  mpi_neighbor_mortars = Vector{Vector{Int}}(undef, 0)
   mpi_send_buffers = Vector{Vector{uEltype}}(undef, 0)
   mpi_recv_buffers = Vector{Vector{uEltype}}(undef, 0)
   mpi_send_requests = Vector{MPI.Request}(undef, 0)
@@ -33,16 +35,19 @@ function P4estMPICache(uEltype)
   n_elements_global = 0
   first_element_global_id = 0
 
-  P4estMPICache{uEltype}(mpi_neighbor_ranks, mpi_neighbor_interfaces,
+  P4estMPICache{uEltype}(mpi_neighbor_ranks, mpi_neighbor_interfaces, mpi_neighbor_mortars,
                          mpi_send_buffers, mpi_recv_buffers,
                          mpi_send_requests, mpi_recv_requests,
                          n_elements_by_rank, n_elements_global,
                          first_element_global_id)
 end
 
+@inline Base.eltype(::P4estMPICache{uEltype}) where uEltype = uEltype
+
 
 function start_mpi_send!(mpi_cache::P4estMPICache, mesh, equations, dg, cache)
   data_size = nvariables(equations) * nnodes(dg)^(ndims(mesh) - 1)
+  n_small_elems = 2^(ndims(mesh)-1)
 
   for d in 1:length(mpi_cache.mpi_neighbor_ranks)
     send_buffer = mpi_cache.mpi_send_buffers[d]
@@ -53,8 +58,29 @@ function start_mpi_send!(mpi_cache::P4estMPICache, mesh, equations, dg, cache)
       local_side = cache.mpi_interfaces.local_sides[interface]
       @views send_buffer[first:last] .= vec(cache.mpi_interfaces.u[local_side, .., interface])
     end
+
+    # Set send_buffer corresponding to mortar data to NaN and overwrite the parts where local
+    # data exists
+    interfaces_data_size = length(mpi_cache.mpi_neighbor_interfaces[d]) * data_size
+    mortars_data_size = length(mpi_cache.mpi_neighbor_mortars[d]) * n_small_elems * 2 * data_size
+    send_buffer[interfaces_data_size+1:interfaces_data_size+mortars_data_size] .= NaN |> eltype(mpi_cache)
+
+    for (index, mortar) in enumerate(mpi_cache.mpi_neighbor_mortars[d])
+      index_base = interfaces_data_size + (index - 1) * n_small_elems * 2 * data_size
+      indices = buffer_mortar_indices(mesh, index_base, data_size)
+
+      for position in cache.mpi_mortars.local_element_positions[mortar]
+        first, last = indices[position]
+        if position > n_small_elems # large element
+          @views send_buffer[first:last] .= vec(cache.mpi_mortars.u[2, :, :, .., mortar])
+        else # small element
+          @views send_buffer[first:last] .= vec(cache.mpi_mortars.u[1, :, position, .., mortar])
+        end
+      end
+    end
   end
 
+  # Start sending
   for (index, d) in enumerate(mpi_cache.mpi_neighbor_ranks)
     mpi_cache.mpi_send_requests[index] = MPI.Isend(
       mpi_cache.mpi_send_buffers[index], d, mpi_rank(), mpi_comm())
@@ -81,6 +107,8 @@ end
 
 function finish_mpi_receive!(mpi_cache::P4estMPICache, mesh, equations, dg, cache)
   data_size = nvariables(equations) * nnodes(dg)^(ndims(mesh) - 1)
+  n_small_elems = 2^(ndims(mesh)-1)
+  n_positions = n_small_elems + 1
 
   # Start receiving and unpack received data until all communication is finished
   d, _ = MPI.Waitany!(mpi_cache.mpi_recv_requests)
@@ -98,6 +126,27 @@ function finish_mpi_receive!(mpi_cache::P4estMPICache, mesh, equations, dg, cach
       end
     end
 
+    interfaces_data_size = length(mpi_cache.mpi_neighbor_interfaces[d]) * data_size
+    for (index, mortar) in enumerate(mpi_cache.mpi_neighbor_mortars[d])
+      index_base = interfaces_data_size + (index - 1) * n_small_elems * 2 * data_size
+      indices = buffer_mortar_indices(mesh, index_base, data_size)
+
+      for position in 1:n_positions
+        # Skip if received data for `position` is NaN as no real data has been sent for the
+        # corresponding element
+        if isnan(recv_buffer[Base.first(indices[position])])
+          continue
+        end
+
+        first, last = indices[position]
+        if position == n_positions # large element
+          @views vec(cache.mpi_mortars.u[2, :, :, .., mortar]) .= recv_buffer[first:last]
+        else # small element
+          @views vec(cache.mpi_mortars.u[1, :, position, .., mortar]) .= recv_buffer[first:last]
+        end
+      end
+    end
+
     d, _ = MPI.Waitany!(mpi_cache.mpi_recv_requests)
   end
 
@@ -105,23 +154,50 @@ function finish_mpi_receive!(mpi_cache::P4estMPICache, mesh, equations, dg, cach
 end
 
 
+# Returns a tuple `indices` where indices[position] is a (first, last) pair for accessing the
+# data corresponding to the `position` part of a mortar in an mpi buffer. `data_size` is the size of
+# the data corresponding to each small position and the data associated with the mortar must begin
+# at `index_base`+1 in the mpi buffer.
+@inline function buffer_mortar_indices(mesh::ParallelP4estMesh{2}, index_base, data_size)
+  return (
+    # first, last for local element in position 1 (small element)
+    (index_base + 1,
+     index_base + 1 * data_size),
+    # first, last for local element in position 2 (small element)
+    (index_base + 1 * data_size + 1,
+     index_base + 2 * data_size),
+    # first, last for local element in position 3 (large element)
+    (index_base + 2 * data_size + 1,
+     index_base + 4 * data_size),
+  )
+end
+
+
 # This method is called when a SemidiscretizationHyperbolic is constructed.
 # It constructs the basic `cache` used throughout the simulation to compute
 # the RHS etc.
 function create_cache(mesh::ParallelP4estMesh, equations::AbstractEquations, dg::DG, ::Any, ::Type{uEltype}) where {uEltype<:Real}
-  # Make sure to balance the p4est before creating any containers
-  # in case someone has tampered with the p4est after creating the mesh
+  # Make sure to balance and partition the p4est and create a new ghost layer before creating any
+  # containers in case someone has tampered with the p4est after creating the mesh
   balance!(mesh)
+  partition!(mesh)
+  update_ghost_layer!(mesh)
 
   elements       = init_elements(mesh, equations, dg.basis, uEltype)
-  interfaces     = init_interfaces(mesh, equations, dg.basis, elements)
+
   mpi_interfaces = init_mpi_interfaces(mesh, equations, dg.basis, elements)
-  boundaries     = init_boundaries(mesh, equations, dg.basis, elements)
-  mortars        = init_mortars(mesh, equations, dg.basis, elements)
-  mpi_cache      = init_mpi_cache(mesh, elements, mpi_interfaces,
+  mpi_mortars    = init_mpi_mortars(mesh, equations, dg.basis, elements)
+  mpi_cache      = init_mpi_cache(mesh, mpi_interfaces, mpi_mortars,
                                   nvariables(equations), nnodes(dg), uEltype)
 
-  cache = (; elements, interfaces, mpi_interfaces, boundaries, mortars, mpi_cache)
+  exchange_normal_directions!(mpi_mortars, mpi_cache, mesh, nnodes(dg))
+
+  interfaces     = init_interfaces(mesh, equations, dg.basis, elements)
+  boundaries     = init_boundaries(mesh, equations, dg.basis, elements)
+  mortars        = init_mortars(mesh, equations, dg.basis, elements)
+
+
+  cache = (; elements, interfaces, mpi_interfaces, boundaries, mortars, mpi_mortars, mpi_cache)
 
   # Add specialized parts of the cache required to compute the volume integral etc.
   cache = (; cache..., create_cache(mesh, equations, dg.volume_integral, dg, uEltype)...)
@@ -138,13 +214,14 @@ function init_mpi_cache(mesh::ParallelP4estMesh, elements, mpi_interfaces, nvars
   return mpi_cache
 end
 
-function init_mpi_cache!(mpi_cache::P4estMPICache, mesh::ParallelP4estMesh, elements, mpi_interfaces,
-                         nvars, n_nodes, uEltype)
-  mpi_neighbor_ranks, mpi_neighbor_interfaces =
-    init_mpi_neighbor_connectivity(mpi_interfaces, mesh)
+function init_mpi_cache!(mpi_cache::P4estMPICache, mesh::ParallelP4estMesh,
+                         mpi_interfaces, mpi_mortars, nvars, n_nodes, uEltype)
+  mpi_neighbor_ranks, mpi_neighbor_interfaces, mpi_neighbor_mortars =
+    init_mpi_neighbor_connectivity(mpi_interfaces, mpi_mortars, mesh)
 
   mpi_send_buffers, mpi_recv_buffers, mpi_send_requests, mpi_recv_requests =
-    init_mpi_data_structures(mpi_neighbor_interfaces, ndims(mesh), nvars, n_nodes, uEltype, nothing)
+    init_mpi_data_structures(mpi_neighbor_interfaces, mpi_neighbor_mortars,
+                             ndims(mesh), nvars, n_nodes, uEltype)
 
   # Determine local and total number of elements
   n_elements_global = Int(mesh.p4est.global_num_quadrants)
@@ -156,59 +233,71 @@ function init_mpi_cache!(mpi_cache::P4estMPICache, mesh::ParallelP4estMesh, elem
   @assert n_elements_global == sum(n_elements_by_rank) "error in total number of elements"
 
   # TODO reuse existing structures
-  @pack! mpi_cache = mpi_neighbor_ranks, mpi_neighbor_interfaces,
+  @pack! mpi_cache = mpi_neighbor_ranks, mpi_neighbor_interfaces, mpi_neighbor_mortars,
                      mpi_send_buffers, mpi_recv_buffers,
                      mpi_send_requests, mpi_recv_requests,
                      n_elements_by_rank, n_elements_global,
                      first_element_global_id
-
 end
 
-function init_mpi_neighbor_connectivity(mpi_interfaces, mesh::ParallelP4estMesh)
+function init_mpi_neighbor_connectivity(mpi_interfaces, mpi_mortars, mesh::ParallelP4estMesh)
   # Let p4est iterate over all interfaces and call init_neighbor_rank_connectivity_iter_face
   # to collect connectivity information
   iter_face_c = cfunction(init_neighbor_rank_connectivity_iter_face, Val(ndims(mesh)))
-  user_data = InitNeighborRankConnectivityIterFaceUserData(mpi_interfaces, mesh)
+  user_data = InitNeighborRankConnectivityIterFaceUserData(mpi_interfaces, mpi_mortars, mesh)
 
-  # Ghost layer is required to determine owner ranks of quadrants on neighboring processes
-  ghost_layer = ghost_new_p4est(mesh.p4est)
-  @assert ghost_is_valid_p4est(mesh.p4est, ghost_layer) == 1
-  iterate_p4est(mesh.p4est, user_data; ghost_layer=ghost_layer, iter_face_c=iter_face_c)
-  ghost_destroy_p4est(ghost_layer)
+  iterate_p4est(mesh.p4est, user_data; ghost_layer=mesh.ghost, iter_face_c=iter_face_c)
 
   # Build proper connectivity data structures from information gathered by iterating over p4est
-  @unpack global_interface_ids, neighbor_ranks_interface = user_data
-  mpi_neighbor_ranks = neighbor_ranks_interface |> sort |> unique
+  @unpack global_interface_ids, neighbor_ranks_interface, global_mortar_ids, neighbor_ranks_mortar = user_data
+
+  mpi_neighbor_ranks = vcat(neighbor_ranks_interface, neighbor_ranks_mortar...) |> sort |> unique
+
   p = sortperm(global_interface_ids)
   neighbor_ranks_interface .= neighbor_ranks_interface[p]
   interface_ids = collect(1:nmpiinterfaces(mpi_interfaces))[p]
 
+  p = sortperm(global_mortar_ids)
+  neighbor_ranks_mortar .= neighbor_ranks_mortar[p]
+  mortar_ids = collect(1:nmpimortars(mpi_mortars))[p]
+
   # For each neighbor rank, init connectivity data structures
   mpi_neighbor_interfaces = Vector{Vector{Int}}(undef, length(mpi_neighbor_ranks))
+  mpi_neighbor_mortars = Vector{Vector{Int}}(undef, length(mpi_neighbor_ranks))
   for (index, d) in enumerate(mpi_neighbor_ranks)
     mpi_neighbor_interfaces[index] = interface_ids[findall(==(d), neighbor_ranks_interface)]
+    mpi_neighbor_mortars[index] = mortar_ids[findall(x->(d in x), neighbor_ranks_mortar)]
   end
 
   # Check that all interfaces were counted exactly once
   @assert sum(length(v) for v in mpi_neighbor_interfaces) == nmpiinterfaces(mpi_interfaces)
 
-  return mpi_neighbor_ranks, mpi_neighbor_interfaces
+  return mpi_neighbor_ranks, mpi_neighbor_interfaces, mpi_neighbor_mortars
 end
 
-mutable struct InitNeighborRankConnectivityIterFaceUserData{MPIInterfaces, Mesh}
+mutable struct InitNeighborRankConnectivityIterFaceUserData{MPIInterfaces, MPIMortars, Mesh}
   interfaces::MPIInterfaces
   interface_id::Int
   global_interface_ids::Vector{Int}
   neighbor_ranks_interface::Vector{Int}
+  mortars::MPIMortars
+  mortar_id::Int
+  global_mortar_ids::Vector{Int}
+  neighbor_ranks_mortar::Vector{Vector{Int}}
   mesh::Mesh
 end
 
-function InitNeighborRankConnectivityIterFaceUserData(mpi_interfaces, mesh)
+function InitNeighborRankConnectivityIterFaceUserData(mpi_interfaces, mpi_mortars, mesh)
   global_interface_ids = fill(-1, nmpiinterfaces(mpi_interfaces))
   neighbor_ranks_interface = fill(-1, nmpiinterfaces(mpi_interfaces))
+  global_mortar_ids = fill(-1, nmpimortars(mpi_mortars))
+  neighbor_ranks_mortar = Vector{Vector{Int}}(undef, nmpimortars(mpi_mortars))
 
-  return InitNeighborRankConnectivityIterFaceUserData{typeof(mpi_interfaces), typeof(mesh)}(
-    mpi_interfaces, 1, global_interface_ids, neighbor_ranks_interface, mesh)
+  return InitNeighborRankConnectivityIterFaceUserData{
+    typeof(mpi_interfaces), typeof(mpi_mortars), typeof(mesh)}(
+      mpi_interfaces, 1, global_interface_ids, neighbor_ranks_interface,
+      mpi_mortars, 1, global_mortar_ids, neighbor_ranks_mortar,
+      mesh)
 end
 
 function init_neighbor_rank_connectivity_iter_face(info, user_data)
@@ -225,10 +314,12 @@ cfunction(::typeof(init_neighbor_rank_connectivity_iter_face), ::Val{3}) = @cfun
 
 # Function barrier for type stability
 function init_neighbor_rank_connectivity_iter_face_inner(info, user_data)
-  @unpack interfaces, interface_id, global_interface_ids, neighbor_ranks_interface, mesh = user_data
+  @unpack interfaces, interface_id, global_interface_ids, neighbor_ranks_interface,
+          mortars, mortar_id, global_mortar_ids, neighbor_ranks_mortar, mesh = user_data
 
-  # Get the global interface ids and neighbor rank if current face belongs to an MPI interface
-  if info.sides.elem_count == 2 # MPI interfaces have two neighboring elements
+  # Get the global interface/mortar ids and neighbor rank if current face belongs to an MPI
+  # interface/mortar
+  if info.sides.elem_count == 2 # MPI interfaces/mortars have two neighboring elements
     # Extract surface data
     sides = (unsafe_load_side(info, 1), unsafe_load_side(info, 2))
 
@@ -268,30 +359,160 @@ function init_neighbor_rank_connectivity_iter_face_inner(info, user_data)
       global_interface_ids[interface_id] = global_interface_id
 
       user_data.interface_id += 1
+    else # hanging node
+      if sides[1].is_hanging == 1
+        hanging_side = 1
+        full_side = 2
+      else
+        hanging_side = 2
+        full_side = 1
+      end
+      # Verify before accessing is.full / is.hanging
+      @assert sides[hanging_side].is_hanging == 1 && sides[full_side].is_hanging == 0
+
+      # If all quadrants are locally available, this is a regular mortar -> skip
+      if sides[full_side].is.full.is_ghost == 0 && all(sides[hanging_side].is.hanging.is_ghost .== 0)
+        return nothing
+      end
+
+      trees = (unsafe_load_tree(mesh.p4est, sides[1].treeid + 1),
+               unsafe_load_tree(mesh.p4est, sides[2].treeid + 1))
+
+      # Find small quads that are remote and determine which rank owns them
+      remote_small_quad_positions = findall(sides[hanging_side].is.hanging.is_ghost .== 1)
+      proc_offsets = unsafe_wrap(Array, info.ghost_layer.proc_offsets, mpi_nranks() + 1)
+      # indices of small remote quads inside the ghost layer, 0-based
+      ghost_ids = map(pos -> sides[hanging_side].is.hanging.quadid[pos], remote_small_quad_positions)
+      neighbor_ranks = map(ghost_ids) do ghost_id
+        return findfirst(r -> proc_offsets[r] <= ghost_id < proc_offsets[r+1],
+                         1:mpi_nranks()) - 1 # mpi ranks are 0-based
+      end
+      # Determine global quad id of large element to determine global MPI mortar id
+      # Furthermore, if large element is ghost, add its owner rank to neighbor_ranks
+      if sides[full_side].is.full.is_ghost == 1
+        ghost_id = sides[full_side].is.full.quadid
+        large_quad_owner_rank = findfirst(r -> proc_offsets[r] <= ghost_id < proc_offsets[r+1],
+                                          1:mpi_nranks()) - 1 # mpi ranks are 0-based
+        push!(neighbor_ranks, large_quad_owner_rank)
+
+        offset = unsafe_load(mesh.p4est.global_first_quadrant, large_quad_owner_rank + 1) # one-based indexing
+        large_quad_id = offset + sides[full_side].is.full.quad.p.piggy3.local_num
+      else
+        offset = unsafe_load(mesh.p4est.global_first_quadrant, mpi_rank() + 1) # one-based indexing
+        large_quad_id = offset + trees[full_side].quadrants_offset + sides[full_side].is.full.quadid
+      end
+      neighbor_ranks_mortar[mortar_id] = neighbor_ranks
+      # Global mortar id is the globally unique quadrant id of the large quadrant multiplied by the
+      # number of faces per quadrant plus face
+      global_mortar_ids[mortar_id] = 2 * ndims(mesh) * large_quad_id + sides[full_side].face
+
+      user_data.mortar_id += 1
     end
   end
 
   return nothing
 end
 
-# TODO: ::Any is a temporary hack. This method is already defined in the TreeMesh
-# code. It uses `mpi_neighbor_mortars` as an argument but not uEltype, thus the number
-# of arguments would be the same without ::Any which would break precompilation.
+# Once the TreeMesh supports custom `uEltype`s, the following method could be used for both
+# mesh types.
 # See https://github.com/trixi-framework/Trixi.jl/pull/977#discussion_r793694635 for further
 # discussion.
-function init_mpi_data_structures(mpi_neighbor_interfaces, n_dims, nvars, n_nodes, uEltype, ::Any)
+function init_mpi_data_structures(mpi_neighbor_interfaces, mpi_neighbor_mortars, n_dims, nvars, n_nodes, uEltype)
   data_size = nvars * n_nodes^(n_dims - 1)
+  n_small_elems = 2^(n_dims-1)
   mpi_send_buffers = Vector{Vector{uEltype}}(undef, length(mpi_neighbor_interfaces))
   mpi_recv_buffers = Vector{Vector{uEltype}}(undef, length(mpi_neighbor_interfaces))
   for index in 1:length(mpi_neighbor_interfaces)
-    mpi_send_buffers[index] = Vector{uEltype}(undef, length(mpi_neighbor_interfaces[index]) * data_size)
-    mpi_recv_buffers[index] = Vector{uEltype}(undef, length(mpi_neighbor_interfaces[index]) * data_size)
+    mpi_send_buffers[index] = Vector{uEltype}(undef, length(mpi_neighbor_interfaces[index]) * data_size +
+                                                     length(mpi_neighbor_mortars[index]) * n_small_elems * 2 * data_size)
+    mpi_recv_buffers[index] = Vector{uEltype}(undef, length(mpi_neighbor_interfaces[index]) * data_size +
+                                                     length(mpi_neighbor_mortars[index]) * n_small_elems * 2 * data_size)
   end
 
   mpi_send_requests = Vector{MPI.Request}(undef, length(mpi_neighbor_interfaces))
   mpi_recv_requests = Vector{MPI.Request}(undef, length(mpi_neighbor_interfaces))
 
   return mpi_send_buffers, mpi_recv_buffers, mpi_send_requests, mpi_recv_requests
+end
+
+
+# Exchange normal directions of small elements of the mpi mortars. They are needed on all involved
+# mpi ranks to calculate the mortar fluxes.
+function exchange_normal_directions!(mpi_mortars, mpi_cache, mesh::ParallelP4estMesh, n_nodes)
+  RealT = real(mesh)
+  n_dims = ndims(mesh)
+  @unpack mpi_neighbor_mortars, mpi_neighbor_ranks = mpi_cache
+  n_small_elems = 2^(n_dims-1)
+  data_size = n_nodes^(n_dims - 1) * n_dims
+
+  # Create buffers and requests
+  send_buffers = Vector{Vector{RealT}}(undef, length(mpi_neighbor_mortars))
+  recv_buffers = Vector{Vector{RealT}}(undef, length(mpi_neighbor_mortars))
+  for index in 1:length(mpi_neighbor_mortars)
+    send_buffers[index] = Vector{RealT}(undef, length(mpi_neighbor_mortars[index]) * n_small_elems * data_size)
+    send_buffers[index] .= NaN |> RealT
+    recv_buffers[index] = Vector{RealT}(undef, length(mpi_neighbor_mortars[index]) * n_small_elems * data_size)
+    recv_buffers[index] .= NaN |> RealT
+  end
+  send_requests = Vector{MPI.Request}(undef, length(mpi_neighbor_mortars))
+  recv_requests = Vector{MPI.Request}(undef, length(mpi_neighbor_mortars))
+
+  # Fill send buffers
+  for d in 1:length(mpi_neighbor_ranks)
+    send_buffer = send_buffers[d]
+
+    for (index, mortar) in enumerate(mpi_neighbor_mortars[d])
+      index_base = (index - 1) * n_small_elems * data_size
+      indices = buffer_mortar_indices(mesh, index_base, data_size)
+      for position in mpi_mortars.local_element_positions[mortar]
+        if position <= n_small_elems # element is small
+          first, last = indices[position]
+          @views send_buffer[first:last] .= vec(mpi_mortars.normal_directions[:, .., position, mortar])
+        end
+      end
+    end
+  end
+
+  # Start data exchange
+  for (index, d) in enumerate(mpi_neighbor_ranks)
+    send_requests[index] = MPI.Isend(send_buffers[index], d, mpi_rank(), mpi_comm())
+    recv_requests[index] = MPI.Irecv!(recv_buffers[index], d, d, mpi_comm())
+  end
+
+  # Unpack data from receive buffers
+  d, _ = MPI.Waitany!(recv_requests)
+  while d != 0
+    recv_buffer = recv_buffers[d]
+
+    for (index, mortar) in enumerate(mpi_neighbor_mortars[d])
+      index_base = (index - 1) * n_small_elems * data_size
+      indices = buffer_mortar_indices(mesh, index_base, data_size)
+      for position in 1:n_small_elems
+        # Skip if received data for `position` is NaN as no real data has been sent for the
+        # corresponding element
+        if isnan(recv_buffer[Base.first(indices[position])])
+          continue
+        end
+
+        first, last = indices[position]
+        @views vec(mpi_mortars.normal_directions[:, .., position, mortar]) .= recv_buffer[first:last]
+      end
+    end
+
+    d, _ = MPI.Waitany!(recv_requests)
+  end
+
+  # Wait for communication to finish
+  MPI.Waitall!(send_requests)
+
+  return nothing
+end
+
+
+# Get normal direction of MPI mortar
+@inline function get_normal_direction(mpi_mortars::P4estMPIMortarContainer, indices...)
+  SVector(ntuple(@inline(dim -> mpi_mortars.normal_directions[dim, indices...]),
+                 Val(ndims(mpi_mortars))))
 end
 
 

--- a/test/test_mpi_p4est_2d.jl
+++ b/test/test_mpi_p4est_2d.jl
@@ -32,6 +32,21 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
       linf = [0.007438525029884735])
   end
 
+  @trixi_testset "elixir_advection_amr_solution_independent.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr_solution_independent.jl"),
+      # Expected errors are exactly the same as with TreeMesh!
+      l2   = [4.949660644033807e-5],
+      linf = [0.0004867846262313763],
+      coverage_override = (maxiters=6,))
+  end
+
+  @trixi_testset "elixir_advection_amr_unstructured_flag.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr_unstructured_flag.jl"),
+      l2   = [0.0012766060609964525],
+      linf = [0.01750280631586159],
+      coverage_override = (maxiters=6,))
+  end
+
   @trixi_testset "elixir_advection_restart.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_restart.jl"),
       l2   = [4.507575525876275e-6],

--- a/test/test_mpi_p4est_2d.jl
+++ b/test/test_mpi_p4est_2d.jl
@@ -20,6 +20,12 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
       linf = [6.627000273229378e-5])
   end
 
+  @trixi_testset "elixir_advection_nonconforming_flag.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_nonconforming_flag.jl"),
+      l2   = [3.198940059144588e-5],
+      linf = [0.00030636069494005547])
+  end
+
   @trixi_testset "elixir_advection_unstructured_flag.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_unstructured_flag.jl"),
       l2   = [0.0005379687442422346],
@@ -30,6 +36,12 @@ const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_restart.jl"),
       l2   = [4.507575525876275e-6],
       linf = [6.21489667023134e-5])
+  end
+
+  @trixi_testset "elixir_euler_source_terms_nonconforming_unstructured_flag.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms_nonconforming_unstructured_flag.jl"),
+    l2   = [0.0034516244508588046, 0.0023420334036925493, 0.0024261923964557187, 0.004731710454271893],
+    linf = [0.04155789011775046, 0.024772109862748914, 0.03759938693042297, 0.08039824959535657])
   end
 end
 


### PR DESCRIPTION
Similar to the existing TreeMesh-code, an additional container for MPI
mortars, i.e. mortars whose adjacent elements are distributed across
several processes, was added. This container holds lists containing
the IDs and corresponding positions of locally available elements adjacent
to the mortar. Since the P4estMesh is curved, the normal directions on the
element surfaces are needed to calculate the mortar fluxes. For the serial
mortars, the normal directions from the small elements are used. In the
parallel case, these may not be available, hence the normal directions
are calculated once during container initialization and then distributed
to the other involved processes.

Conceptually, the solver functions for calculating the MPI mortar fluxes
work the same way as their serial counterparts.

The functions related to MPI communication and connectivity work the same
as their TreeMesh counterparts. In particular, NaNs are used as
sentinel values to determine if data has been received for a particular
position of a mortar.

In addition, the handling of p4est ghost layers was adjusted.
Previously it was only constructed during initialization of the MPI
communication and connectivity data structures and destroyed
afterwards. Now the P4estMesh has an additional field for the ghost layer
and it is automatically constructed when creating the mesh. In addition,
the ghost layer gets updated when the containers are (re-)initialized.
This change was necessary because hanging ghost sides are not always
correctly identified as such during `iterate_p4est` when no ghost layer
is passed and thus the ghost layer is necessary for all `iterate_p4est`
calls when creating the cache.