### PR TITLE
restrict CPUSummary.jl to v0.1.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.4.24-pre"
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
 EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
@@ -42,6 +43,7 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 [compat]
 CodeTracking = "1.0.5"
 ConstructionBase = "1.3"
+CPUSummary = "=0.1.8" # see https://github.com/JuliaSIMD/CPUSummary.jl/issues/6
 EllipsisNotation = "1.0"
 ForwardDiff = "0.10.18"
 GeometryBasics = "0.3, 0.4"


### PR DESCRIPTION
See https://github.com/JuliaSIMD/CPUSummary.jl/issues/6. This is a quick workaround and should be fixed properly somewhere upstream.