### PR TITLE
additional information about time stepping in summary output

### DIFF
--- a/src/callbacks_step/summary.jl
+++ b/src/callbacks_step/summary.jl
@@ -181,7 +181,15 @@ function initialize_summary_callback(cb::DiscreteCallback, u, t, integrator)
            "Start time" => first(integrator.sol.prob.tspan),
            "Final time" => last(integrator.sol.prob.tspan),
            "time integrator" => integrator.alg |> typeof |> nameof,
+           "adaptive" => integrator.opts.adaptive,
           ]
+  if integrator.opts.adaptive
+    push!(setup,
+      "abstol" => integrator.opts.abstol,
+      "reltol" => integrator.opts.reltol,
+      "controller" => integrator.opts.controller,
+    )
+  end
   summary_box(io, "Time integration", setup)
   println()
 


### PR DESCRIPTION
I just recognized this when looking at some log files of @andrewwinters5000. This creates output of the form
```
┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Time integration                                                                                 │
│ ════════════════                                                                                 │
│ Start time: ………………………………………………… 0.0                                                              │
│ Final time: ………………………………………………… 0.0                                                              │
│ time integrator: …………………………………… CarpenterKennedy2N54                                             │
│ adaptive: ……………………………………………………… false                                                            │
└──────────────────────────────────────────────────────────────────────────────────────────────────┘
```
and
```
┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Time integration                                                                                 │
│ ════════════════                                                                                 │
│ Start time: ………………………………………………… 0.0                                                              │
│ Final time: ………………………………………………… 0.0                                                              │
│ time integrator: …………………………………… SSPRK43                                                          │
│ adaptive: ……………………………………………………… true                                                             │
│ abstol: …………………………………………………………… 1.0e-6                                                           │
│ reltol: …………………………………………………………… 0.001                                                            │
│ controller: ………………………………………………… PIController{Rational{Int64}}(7//30, 2//15)                      │
└──────────────────────────────────────────────────────────────────────────────────────────────────┘
```