### PR TITLE
workaround for `code_string`

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -31,7 +31,7 @@ import SciMLBase: get_du, get_tmp_cache, u_modified!,
                   AbstractODEIntegrator, init, step!, check_error,
                   get_proposed_dt, set_proposed_dt!,
                   terminate!, remake
-using CodeTracking: code_string
+using CodeTracking: CodeTracking
 using ConstructionBase: ConstructionBase
 @reexport using EllipsisNotation # ..
 using ForwardDiff: ForwardDiff

--- a/src/meshes/structured_mesh.jl
+++ b/src/meshes/structured_mesh.jl
@@ -132,6 +132,19 @@ end
 # Extract a string of the code that defines the mapping function
 mapping2string(mapping, ndims) = string(code_string(mapping, ntuple(_ -> Float64, ndims)))
 
+# An internal function wrapping `CodeTracking.code_string` with additional
+# error checking to avoid some problems when calling this function in
+# Jupyter notebooks or Documenter.jl environments. See
+# - https://github.com/trixi-framework/Trixi.jl/issues/931
+# - https://github.com/trixi-framework/Trixi.jl/pull/1084
+function code_string(f, t)
+  try
+    return CodeTracking.code_string(f, t)
+  catch e
+    @warn "code_string threw an error" e
+    return ""
+  end
+end
 
 # Interpolate linearly between left and right value where s should be between -1 and 1
 linear_interpolate(s, left_value, right_value) = 0.5 * ((1 - s) * left_value + (1 + s) * right_value)


### PR DESCRIPTION
@bennibolm This should help you with #1084. Could you please have a look at this PR? If it looks good to you, we can go ahead and merge it. Then, you can check whether everything works in #1084.

Related to #931. I didn't mark the issue as closed since the code might run but saved mesh files are not really readable when written from Jupyter notebooks because `code_string` still does not work correctly.