### PR TITLE
WIP: Add tutorial about `DGMulti` solver and mesh

### DIFF
--- a/docs/literate/src/files/DGMulti_solver_mesh.jl
+++ b/docs/literate/src/files/DGMulti_solver_mesh.jl
@@ -1,0 +1,197 @@
+#src # `DGMulti` solver and mesh
+
+# The basic idea and implementation of the solver [`DGMulti`](@ref) is already explained in
+# section ["Meshes"](@ref DGMulti).
+# Here, we want to give some examples and a quick overview about the options with `DGMulti`.
+
+# We start with a simple example we already used in the [tutorial about flux differencing](@ref fluxDiffExample).
+# There, we implemented a simulation with [`initial_condition_weak_blast_wave`](@ref) for the
+# 2D compressible Euler equations [`CompressibleEulerEquations2D`](@ref) and used the DG formulation
+# with flux differencing using volume flux [`flux_ranocha`](@ref) and surface flux [`flux_lax_friedrichs`](@ref).
+
+# Here, we want to implement the equivalent example, only now using the solver `DGMulti`
+# instead of [`DGSEM`](@ref).
+
+using Trixi, OrdinaryDiffEq
+
+equations = CompressibleEulerEquations2D(1.4)
+
+initial_condition = initial_condition_weak_blast_wave
+
+# To use the Gauss-Lobatto nodes again, we choose `approximation_type=SBP()` in the solver.
+# Since we want to start with a Cartesian domain discretized with squares, we use the element
+# type `Quad()`.
+dg = DGMulti(polydeg = 3,
+             element_type = Quad(),
+             approximation_type = SBP(),
+             surface_flux = flux_lax_friedrichs,
+             volume_integral = VolumeIntegralFluxDifferencing(flux_ranocha))
+
+mesh = DGMultiMesh(dg,
+                   cells_per_dimension=(32, 32), # initial_refinement_level = 5
+                   coordinates_min=(-2.0, -2.0),
+                   coordinates_max=( 2.0,  2.0),
+                   periodicity=true)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, dg,
+                                    boundary_conditions=boundary_condition_periodic)
+tspan = (0.0, 0.4)
+ode = semidiscretize(semi, tspan)
+
+alive_callback = AliveCallback(alive_interval=10)
+analysis_callback = AnalysisCallback(semi, interval=100, uEltype=real(dg))
+callbacks = CallbackSet(analysis_callback, alive_callback);
+
+# Run the simulation with the same time integration algorithm as before.
+sol = solve(ode, RDPK3SpFSAL49(), abstol=1.0e-6, reltol=1.0e-6,
+            callback=callbacks, save_everystep=false);
+#-
+using Plots
+pd = PlotData2D(sol)
+plot(pd)
+#-
+plot(pd["rho"])
+plot!(getmesh(pd))
+
+# This simulation is not as fast as the equivalent with `TreeMesh` since the functions are not
+# implemented that efficient. On the other hand, the functions are more general and thus we
+# have more option we can choose from.
+
+
+# ## Simulation with Gauss nodes
+# For instance, we can change the approximation type of our simulation.
+using Trixi, OrdinaryDiffEq
+equations = CompressibleEulerEquations2D(1.4)
+initial_condition = initial_condition_weak_blast_wave
+
+# We now use Gauss nodes instead of Gauss-Lobatto nodes which can be done for the element types
+# `Quad()` and `Hex()`. Therefore, we set `approximation_type=GaussSBP()`. Alternatively, we
+# can use a modal approach using the approximation type `Polynomial()`.
+dg = DGMulti(polydeg = 3,
+             element_type = Quad(),
+             approximation_type = GaussSBP(),
+             surface_flux = flux_lax_friedrichs,
+             volume_integral = VolumeIntegralFluxDifferencing(flux_ranocha))
+
+mesh = DGMultiMesh(dg,
+             cells_per_dimension=(32, 32), # initial_refinement_level = 5
+             coordinates_min=(-2.0, -2.0),
+             coordinates_max=( 2.0,  2.0),
+             periodicity=true)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, dg,
+                              boundary_conditions=boundary_condition_periodic)
+tspan = (0.0, 0.4)
+ode = semidiscretize(semi, tspan)
+
+alive_callback = AliveCallback(alive_interval=10)
+analysis_callback = AnalysisCallback(semi, interval=100, uEltype=real(dg))
+callbacks = CallbackSet(analysis_callback, alive_callback);
+
+sol = solve(ode, RDPK3SpFSAL49(), abstol=1.0e-6, reltol=1.0e-6,
+      callback=callbacks, save_everystep=false);
+#-
+using Plots
+pd = PlotData2D(sol)
+plot(pd)
+#-
+plot(pd["rho"])
+plot!(getmesh(pd)) # TODO BB weglassen?
+
+
+# ## Simulation with triangular elements
+# Also, we can set another element type. We want to use triangles now.
+using Trixi, OrdinaryDiffEq
+equations = CompressibleEulerEquations2D(1.4)
+initial_condition = initial_condition_weak_blast_wave
+
+# We are using Gauss-Lobatto nodes again, so `approximation_type = SBP()`.
+dg = DGMulti(polydeg = 3,
+             element_type = Tri(),
+             approximation_type = SBP(),
+             surface_flux = flux_lax_friedrichs,
+             volume_integral = VolumeIntegralFluxDifferencing(flux_ranocha))
+
+mesh = DGMultiMesh(dg,
+             cells_per_dimension=(32, 32), # initial_refinement_level = 5
+             coordinates_min=(-2.0, -2.0),
+             coordinates_max=( 2.0,  2.0),
+             periodicity=true)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, dg,
+                              boundary_conditions=boundary_condition_periodic)
+tspan = (0.0, 0.4)
+ode = semidiscretize(semi, tspan)
+
+alive_callback = AliveCallback(alive_interval=10)
+analysis_callback = AnalysisCallback(semi, interval=100, uEltype=real(dg))
+callbacks = CallbackSet(analysis_callback, alive_callback);
+
+sol = solve(ode, RDPK3SpFSAL49(), abstol=1.0e-6, reltol=1.0e-6,
+            callback=callbacks, save_everystep=false);
+#-
+using Plots
+pd = PlotData2D(sol)
+plot(pd)
+#-
+plot(pd["rho"])
+plot!(getmesh(pd))
+
+
+# ## Triangular meshes on non-Cartesian domains
+# To use triangulate meshes on a non-Cartesian domain, Trixi uses the package [StartUpDG.jl](https://github.com/jlchan/StartUpDG.jl).
+# The following example is based on [`elixir_euler_triangulate_pkg_mesh.jl`](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/dgmulti_2d/elixir_euler_triangulate_pkg_mesh.jl))
+# and uses a pre-defined mesh from StartUpDG.jl.
+using Trixi, OrdinaryDiffEq
+
+# We want to simulate the smooth initial condition [`initial_condition_convergence_test`](@ref)
+# with source terms [`source_terms_convergence_test`](@ref) for the 2D compressible Euler equations.
+equations = CompressibleEulerEquations2D(1.4)
+initial_condition = initial_condition_convergence_test
+source_terms = source_terms_convergence_test
+
+# We create the solver `DGMulti` with triangular elements (`Tri()`) as before.
+dg = DGMulti(polydeg = 3, element_type = Tri(),
+             surface_flux = flux_lax_friedrichs,
+             volume_integral = VolumeIntegralFluxDifferencing(flux_ranocha))
+
+# StartUpDG.jl provides for instance a pre-defined Triangulate geometry for a rectangular domain with
+# hole. Other pre-defined Triangulate geometries are e.g., `SquareDomain`, `RectangularDomainWithHole`,
+# `Scramjet`, and `CircularDomain`.
+meshIO = StartUpDG.triangulate_domain(StartUpDG.RectangularDomainWithHole());
+
+# The pre-defined Triangulate geometry in StartUpDG has integer boundary tags. With [`DGMultiMesh`](@ref)
+# we assign boundary faces based on these integer boundary tags and create a mesh compatible with Trixi.
+mesh = DGMultiMesh(meshIO, dg, Dict(:bottom=>1, :right=>2, :top=>3, :left=>4))
+
+boundary_condition_convergence_test = BoundaryConditionDirichlet(initial_condition)
+boundary_conditions = (; :bottom => boundary_condition_convergence_test,
+                         :right => boundary_condition_convergence_test,
+                         :top => boundary_condition_convergence_test,
+                         :left => boundary_condition_convergence_test)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, dg,
+                                    source_terms = source_terms,
+                                    boundary_conditions = boundary_conditions)
+
+tspan = (0.0, 0.2)
+ode = semidiscretize(semi, tspan)
+
+alive_callback = AliveCallback(alive_interval=20)
+analysis_callback = AnalysisCallback(semi, interval=200, uEltype=real(dg))
+callbacks = CallbackSet(alive_callback, analysis_callback);
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false), # TODO BB: anderes Zeitintegrationsverfahren wie oben immer?
+            dt = 0.5 * estimate_dt(mesh, dg), save_everystep=false, callback=callbacks);
+#-
+using Plots
+pd = PlotData2D(sol)
+plot(pd["rho"])
+plot!(getmesh(pd))
+
+# For more information please have a look in the [StartUpDG.jl documentation](https://jlchan.github.io/StartUpDG.jl/stable/).
+
+
+# ## "Esoteric" methods such as `FD SBP`, `CGSEM` and `GaussSBP`
+# ### Methods via SummationByPartsOperators.jl
+# [`elixir_euler_fdsbp_periodic.jl`](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/dgmulti_2d/elixir_euler_fdsbp_periodic.jl)

--- a/docs/literate/src/files/DGSEM_FluxDiff.jl
+++ b/docs/literate/src/files/DGSEM_FluxDiff.jl
@@ -109,7 +109,7 @@
 
 
 
-# ## Implementation in Trixi
+# ## [Implementation in Trixi](@id fluxDiffExample)
 # Now, we have a look at the implementation of DGSEM with flux differencing with [Trixi.jl](https://github.com/trixi-framework/Trixi.jl).
 using OrdinaryDiffEq, Trixi
 

--- a/docs/literate/src/files/index.jl
+++ b/docs/literate/src/files/index.jl
@@ -46,7 +46,9 @@
 # This tutorial is about the more general DG solver [`DGMulti`](@ref), introduced [here](@ref DGMulti).
 # We are showing some examples for this solver, for instance with discretization nodes by Gauss or
 # triangular elements. Moreover, we present a simple way to include pre-defined triangulate meshes for
-# non-Cartesian domains using the package [StartUpDG.jl](https://github.com/jlchan/StartUpDG.jl).
+# non-Cartesian domains using the package [StartUpDG.jl](https://github.com/jlchan/StartUpDG.jl) and
+# show other types of methods such as finite differences and CGSEM via the package
+# [SummationByPartsOperators.jl](https://github.com/ranocha/SummationByPartsOperators.jl).
 
 # ### [6 Adding a new scalar conservation law](@ref adding_new_scalar_equations)
 #-

--- a/docs/literate/src/files/index.jl
+++ b/docs/literate/src/files/index.jl
@@ -41,33 +41,40 @@
 # non-periodic boundaries. This tutorial presents the implementation of the classical Dirichlet
 # boundary condition with a following example. Then, other non-periodic boundaries are mentioned.
 
-# ### [5 Adding a new scalar conservation law](@ref adding_new_scalar_equations)
+# ### [5 `DGMulti` solver and mesh](@ref DGMulti_solver_mesh)
+#-
+# This tutorial is about the more general DG solver [`DGMulti`](@ref), introduced [here](@ref DGMulti).
+# We are showing some examples for this solver, for instance with discretization nodes by Gauss or
+# triangular elements. Moreover, we present a simple way to include pre-defined triangulate meshes for
+# non-Cartesian domains using the package [StartUpDG.jl](https://github.com/jlchan/StartUpDG.jl).
+
+# ### [6 Adding a new scalar conservation law](@ref adding_new_scalar_equations)
 #-
 # This tutorial explains how to add a new physics model using the example of the cubic conservation
 # law. First, we define the equation using a `struct` `CubicEquation` and the physical flux. Then,
 # the corresponding standard setup in Trixi.jl (`mesh`, `solver`, `semi` and `ode`) is implemented
 # and the ODE problem is solved by OrdinaryDiffEq's `solve` method.
 
-# #### [6 Adding a non-conservative equation](@ref adding_nonconservative_equation)
+# #### [7 Adding a non-conservative equation](@ref adding_nonconservative_equation)
 #-
 # In this part, another physics model is implemented, the nonconservative linear advection equation.
 # We run two different simulations with different levels of refinement and compare the resulting errors.
 
-# ### [7 Adaptive mesh refinement](@ref adaptive_mesh_refinement)
+# ### [8 Adaptive mesh refinement](@ref adaptive_mesh_refinement)
 #-
 # Adaptive mesh refinement (AMR) helps to increase the accuracy in sensitive or turbolent regions while
 # not wasting ressources for less interesting parts of the domain. This leads to much more efficient
 # simulations. This tutorial presents the implementation strategy of AMR in Trixi, including the use of
 # different indicators and controllers.
 
-# ### [8 Structured mesh with curvilinear mapping](@ref structured_mesh_mapping)
+# ### [9 Structured mesh with curvilinear mapping](@ref structured_mesh_mapping)
 #-
 # In this tutorial, the use of Trixi's structured curved mesh type [`StructuredMesh`](@ref) is explained.
 # We present the two basic option to initialize such a mesh. First, the curved domain boundaries
 # of a circular cylinder are set by explicit boundary functions. Then, a fully curved mesh is
 # defined by passing the transformation mapping.
 
-# ### [9 Unstructured meshes with HOHQMesh.jl](@ref hohqmesh_tutorial)
+# ### [10 Unstructured meshes with HOHQMesh.jl](@ref hohqmesh_tutorial)
 #-
 # The purpose of this tutorial is to demonstrate how to use the [`UnstructuredMesh2D`](@ref)
 # functionality of Trixi.jl. This begins by running and visualizing an available unstructured
@@ -75,7 +82,7 @@
 # with curved boundaries, generate a curvilinear mesh using the available [HOHQMesh](https://github.com/trixi-framework/HOHQMesh)
 # software in the Trixi.jl ecosystem, and then run a simulation using Trixi.jl on said mesh.
 
-# ### [10 Differentiable programming](@ref differentiable_programming)
+# ### [11 Differentiable programming](@ref differentiable_programming)
 #-
 # This part deals with some basic differentiable programming topics. For example, a Jacobian, its
 # eigenvalues and a curve of total energy (through the simulation) are calculated and plotted for

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,15 +29,20 @@ DocMeta.setdocmeta!(Trixi2Vtk, :DocTestSetup, :(using Trixi2Vtk); recursive=true
 #   "title" => ["subtitle 1" => ("folder 1", "filename 1.jl"),
 #               "subtitle 2" => ("folder 2", "filename 2.jl")]
 files = [
+    # Topic: DG semidiscretizations
     "Introduction to DG methods" => "scalar_linear_advection_1d.jl",
     "DGSEM with flux differencing" => "DGSEM_FluxDiff.jl",
     "Shock capturing with flux differencing and stage limiter" => "shock_capturing.jl",
     "Non-periodic boundaries" => "non_periodic_boundaries.jl",
+    "`DGMulti` solver and mesh" => "DGMulti_solver_mesh.jl",
+    # Topic: equations
     "Adding a new scalar conservation law" => "adding_new_scalar_equations.jl",
     "Adding a non-conservative equation" => "adding_nonconservative_equation.jl",
+    # Topic: meshes
     "Adaptive mesh refinement" => "adaptive_mesh_refinement.jl",
     "Structured mesh with curvilinear mapping" => "structured_mesh_mapping.jl",
     "Unstructured meshes with HOHQMesh.jl" => "hohqmesh_tutorial.jl",
+    # Topic: other stuff
     "Differentiable programming" => "differentiable_programming.jl",
     ]
 tutorials = create_tutorials(files)

--- a/docs/src/meshes/dgmulti_mesh.md
+++ b/docs/src/meshes/dgmulti_mesh.md
@@ -1,4 +1,4 @@
-# Unstructured meshes and the `DGMulti` solver
+# [Unstructured meshes and the `DGMulti` solver](@id DGMulti)
 
 Trixi includes support for simplicial and tensor product meshes via the `DGMulti` solver type,
 which is based on the [StartUpDG.jl](https://github.com/jlchan/StartUpDG.jl) package.


### PR DESCRIPTION
This PR adds a tutorial about the `DGMulti` solver.
It starts with sections about different approximation nodes (LGL and Gauss) and different element shapes (`Quad()`, `Tri()`) for Cartesian meshes. Then, we introduce triangulate meshes on non-Cartesian domains using [StartUpDG.jl](https://github.com/jlchan/StartUpDG.jl). In the end, other SBP methods are used via [SummationByPartsOperators.jl](https://github.com/ranocha/SummationByPartsOperators.jl).