### PR TITLE
Fix `DGMulti` triangulate example

### DIFF
--- a/examples/dgmulti_2d/elixir_euler_triangulate_pkg_mesh.jl
+++ b/examples/dgmulti_2d/elixir_euler_triangulate_pkg_mesh.jl
@@ -13,13 +13,11 @@ meshIO = StartUpDG.triangulate_domain(StartUpDG.RectangularDomainWithHole())
 
 # the pre-defined Triangulate geometry in StartUpDG has integer boundary tags. this routine
 # assigns boundary faces based on these integer boundary tags.
-mesh = DGMultiMesh(meshIO, dg, Dict(:bottom=>1, :right=>2, :top=>3, :left=>4))
+mesh = DGMultiMesh(meshIO, dg, Dict(:outer_boundary=>1, :inner_boundary=>2))
 
 boundary_condition_convergence_test = BoundaryConditionDirichlet(initial_condition)
-boundary_conditions = (; :bottom => boundary_condition_convergence_test,
-                         :right => boundary_condition_convergence_test,
-                         :top => boundary_condition_convergence_test,
-                         :left => boundary_condition_convergence_test)
+boundary_conditions = (; :outer_boundary => boundary_condition_convergence_test,
+                         :inner_boundary => boundary_condition_convergence_test)
 
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, dg,
                                     source_terms = source_terms,


### PR DESCRIPTION
Fixes the boundary tags in `examples/dgmulti_2d/elixir_euler_triangulate_pkg_mesh.jl` (4 boundary tags are specified, but the geometry only provides 2 for the `RectangularDomainWithHole` geometry).