### PR TITLE
Add discussion about AMR via P4estMesh to HOHQMesh tutorial

### DIFF
--- a/docs/literate/src/files/hohqmesh_tutorial.jl
+++ b/docs/literate/src/files/hohqmesh_tutorial.jl
@@ -563,4 +563,4 @@ mesh = UnstructuredMesh2D(mesh_file);
 
 # We can then post-process the solution file at the final time on the new mesh with `Trixi2Vtk` and visualize with ParaView.
 
-# ![simulation_straight_sides_p4est_amr](https://user-images.githubusercontent.com/25242486/129733926-6ef80676-779b-4f1e-9826-3ebf750cf382.png) TODO
+# ![simulation_straight_sides_p4est_amr](https://user-images.githubusercontent.com/74359358/168049930-8abce6ac-cd47-4d04-b40b-0fa459bbd98d.png)

--- a/docs/literate/src/files/hohqmesh_tutorial.jl
+++ b/docs/literate/src/files/hohqmesh_tutorial.jl
@@ -561,7 +561,8 @@ mesh = UnstructuredMesh2D(mesh_file);
 # callbacks = CallbackSet(..., amr_callback)
 # ```
 
-# We can then post-process the solution file at the final time on the new mesh with `Trixi2Vtk` and visualize 
-with ParaView, see the appropriate [visualization section](https://trixi-framework.github.io/Trixi.jl/stable/visualization/#Trixi2Vtk) for details. 
+# We can then post-process the solution file at the final time on the new mesh with `Trixi2Vtk` and visualize
+# with ParaView, see the appropriate [visualization section](https://trixi-framework.github.io/Trixi.jl/stable/visualization/#Trixi2Vtk)
+# for details.
 
 # ![simulation_straight_sides_p4est_amr](https://user-images.githubusercontent.com/74359358/168049930-8abce6ac-cd47-4d04-b40b-0fa459bbd98d.png)

--- a/docs/literate/src/files/hohqmesh_tutorial.jl
+++ b/docs/literate/src/files/hohqmesh_tutorial.jl
@@ -561,6 +561,7 @@ mesh = UnstructuredMesh2D(mesh_file);
 # callbacks = CallbackSet(..., amr_callback)
 # ```
 
-# We can then post-process the solution file at the final time on the new mesh with `Trixi2Vtk` and visualize with ParaView.
+# We can then post-process the solution file at the final time on the new mesh with `Trixi2Vtk` and visualize 
+with ParaView, see the appropriate [visualization section](https://trixi-framework.github.io/Trixi.jl/stable/visualization/#Trixi2Vtk) for details. 
 
 # ![simulation_straight_sides_p4est_amr](https://user-images.githubusercontent.com/74359358/168049930-8abce6ac-cd47-4d04-b40b-0fa459bbd98d.png)

--- a/docs/literate/src/files/index.jl
+++ b/docs/literate/src/files/index.jl
@@ -74,6 +74,7 @@
 # quadrilateral mesh example. Then, the tutorial will demonstrate how to conceptualize a problem
 # with curved boundaries, generate a curvilinear mesh using the available [HOHQMesh](https://github.com/trixi-framework/HOHQMesh)
 # software in the Trixi.jl ecosystem, and then run a simulation using Trixi.jl on said mesh.
+# In the end, the tutorial briefly explains how to simulate an example using AMR via `P4estMesh`.
 
 # ### [10 Differentiable programming](@ref differentiable_programming)
 #-


### PR DESCRIPTION
This PR adds a short discussion about the use of AMR for an unstructured mesh with HOHQMesh.jl via `P4estMesh` to the end of the existing HOHQMesh tutorial.
Visualization of the solution file for `ice_cream_straight_sides.control` using AMR via `P4estMesh`:
![simulation_straight_sides_p4est_amr](https://user-images.githubusercontent.com/74359358/168049930-8abce6ac-cd47-4d04-b40b-0fa459bbd98d.png)

Closes #1123.