### PR TITLE
Change default DGMulti interface flux behavior

### DIFF
--- a/src/solvers/dgmulti/dg.jl
+++ b/src/solvers/dgmulti/dg.jl
@@ -208,13 +208,9 @@ function calc_interface_flux!(cache, surface_integral::SurfaceIntegralWeakForm,
     # inner (idM -> minus) and outer (idP -> plus) indices
     idM, idP = mapM[face_node_index], mapP[face_node_index]
     uM = u_face_values[idM]
-
-    # compute flux if node is not a boundary node
-    if idM != idP
-      uP = u_face_values[idP]
-      normal = SVector{NDIMS}(getindex.(nxyzJ, idM)) / Jf[idM]
-      flux_face_values[idM] = surface_flux(uM, uP, normal, equations) * Jf[idM]
-    end
+    uP = u_face_values[idP]
+    normal = SVector{NDIMS}(getindex.(nxyzJ, idM)) / Jf[idM]
+    flux_face_values[idM] = surface_flux(uM, uP, normal, equations) * Jf[idM]
   end
 end
 


### PR DESCRIPTION
Previously, DGMulti solvers skipped computing interface fluxes for boundary nodes. For advection, this meant that an outflow boundary condition had to be specified. 

This PR modifies the behavior so that interface fluxes are computed at boundary nodes too. Thus, one does not need to specify an outflow BC anymore