### PR TITLE
fix CI by updating maxiters warning

### DIFF
--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -63,8 +63,8 @@ macro test_trixi_include(elixir, args...)
     # run only a few steps - ignore possible warnings coming from that
     if any(==(:maxiters) ∘ first, $kwargs)
       additional_ignore_content = [
-        r"┌ Warning: Interrupted\. Larger maxiters is needed\..+\n└ @ SciMLBase .+\n",
-        r"┌ Warning: Interrupted\. Larger maxiters is needed\.\n└ @ Trixi .+\n"]
+        r"┌ Warning: Interrupted\. Larger maxiters is needed\..*\n└ @ SciMLBase .+\n",
+        r"┌ Warning: Interrupted\. Larger maxiters is needed\..*\n└ @ Trixi .+\n"]
     else
       additional_ignore_content = []
     end

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -64,7 +64,7 @@ macro test_trixi_include(elixir, args...)
     if any(==(:maxiters) ∘ first, $kwargs)
       additional_ignore_content = [
         r"┌ Warning: Interrupted\. Larger maxiters is needed\..+\n└ @ SciMLBase .+\n",
-        r"┌ Warning: Interrupted\. Larger maxiters is needed\..+\n└ @ Trixi .+\n"]
+        r"┌ Warning: Interrupted\. Larger maxiters is needed\.\n└ @ Trixi .+\n"]
     else
       additional_ignore_content = []
     end

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -63,8 +63,8 @@ macro test_trixi_include(elixir, args...)
     # run only a few steps - ignore possible warnings coming from that
     if any(==(:maxiters) ∘ first, $kwargs)
       additional_ignore_content = [
-        r"┌ Warning: Interrupted\. Larger maxiters is needed\.\n└ @ SciMLBase .+\n",
-        r"┌ Warning: Interrupted\. Larger maxiters is needed\.\n└ @ Trixi .+\n"]
+        r"┌ Warning: Interrupted\. Larger maxiters is needed\..+\n└ @ SciMLBase .+\n",
+        r"┌ Warning: Interrupted\. Larger maxiters is needed\..+\n└ @ Trixi .+\n"]
     else
       additional_ignore_content = []
     end


### PR DESCRIPTION
SciMLBase made a warning about `maxiters` more verbose. Thus, we need to update our regex checks for no warnings accordingly to make tests pass again on `main`.