### PR TITLE
Revert "restrict ArrayInterface to working version"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Michael Schlottke-Lakemper <m.schlottke-lakemper@hlrs.de>", "Gregor 
 version = "0.4.39-pre"
 
 [deps]
-ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9" # see https://github.com/JuliaArrays/ArrayInterface.jl/issues/304
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
@@ -42,7 +41,6 @@ TriplotRecipes = "808ab39a-a642-4abf-81ff-4cb34ebbffa3"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-ArrayInterface = "6.0.0 - 6.0.11" # see https://github.com/JuliaArrays/ArrayInterface.jl/issues/304
 CodeTracking = "1.0.5"
 ConstructionBase = "1.3"
 EllipsisNotation = "1.0"


### PR DESCRIPTION
Reverts trixi-framework/Trixi.jl#1170. Tests should hopefully pass with ArrayInterface.jl v6.0.15. See https://github.com/JuliaArrays/ArrayInterface.jl/issues/304 and https://github.com/JuliaArrays/ArrayInterface.jl/pull/307