### PR TITLE
Small additions to docs

### DIFF
--- a/docs/literate/src/files/DGSEM_FluxDiff.jl
+++ b/docs/literate/src/files/DGSEM_FluxDiff.jl
@@ -86,7 +86,7 @@
 # ```math
 # (D \underline{f})_i = \sum_j D_{i,j} \underline{f}_j
 # = 2\sum_j \frac{1}{2} D_{i,j} (\underline{f}_j + \underline{f}_i)
-# \eqqcolon 2\sum_j  D_{i,j} f_\text{cent}(u_i, u_j),
+# \eqqcolon 2\sum_j  D_{i,j} f_\text{central}(u_i, u_j),
 # ```
 # we replace $D \underline{f}$ in the strong form by $2D \underline{f}_{vol}(u^-, u^+)$ with
 # the consistent two-point volume flux $f_{vol}$ and receive the DGSEM formulation with flux differencing

--- a/docs/literate/src/files/DGSEM_FluxDiff.jl
+++ b/docs/literate/src/files/DGSEM_FluxDiff.jl
@@ -82,7 +82,13 @@
 # When using the diagonal SBP property it is possible to rewrite the application of the derivative
 # operator $D$ in the calculation of the volume integral into a subcell based finite volume type
 # differencing formulation ([Fisher, Carpenter (2013)](https://doi.org/10.1016/j.jcp.2013.06.014)).
-# We replace $D \underline{f}$ in the strong form by $2D \underline{f}_{vol}(u^-, u^+)$ with
+# Generalizing
+# ```math
+# (D \underline{f})_i = \sum_j D_{i,j} \underline{f}_j
+# = 2\sum_j \frac{1}{2} D_{i,j} (\underline{f}_j + \underline{f}_i)
+# \eqqcolon 2\sum_j  D_{i,j} f_\text{cent}(u_i, u_j),
+# ```
+# we replace $D \underline{f}$ in the strong form by $2D \underline{f}_{vol}(u^-, u^+)$ with
 # the consistent two-point volume flux $f_{vol}$ and receive the DGSEM formulation with flux differencing
 # (split form DGSEM) ([Gassner, Winters, Kopriva (2016)](https://doi.org/10.1016/j.jcp.2016.09.013)).
 

--- a/docs/literate/src/files/time_stepping.jl
+++ b/docs/literate/src/files/time_stepping.jl
@@ -46,8 +46,8 @@
 # ```math
 # \Delta t_n = \text{CFL} * \min_i \frac{\Delta x_i}{\lambda_{\max}(u_i^n)}
 # ```
-# We compute $\Delta x_i$ by scaling the element size by a factor of $1/(N+1)$, as in 
-# [ Ranocha, Dalcin, Parsani, Ketcheson (2021) ](https://link.springer.com/article/10.1007/s42967-021-00159-w).
+# We compute $\Delta x_i$ by scaling the element size by a factor of $1/(N+1)$, cf. 
+# [Gassne and Kopriva (2011)](https://doi.org/10.1137/100807211), Section 5.
 
 # Trixi provides such a CFL-based step size control. It is implemented as the callback
 # [`StepsizeCallback`](@ref).

--- a/docs/literate/src/files/time_stepping.jl
+++ b/docs/literate/src/files/time_stepping.jl
@@ -46,6 +46,8 @@
 # ```math
 # \Delta t_n = \text{CFL} * \min_i \frac{\Delta x_i}{\lambda_{\max}(u_i^n)}
 # ```
+# We compute $\Delta x_i$ by scaling the element size by a factor of $1/(N+1)$, as in 
+# [ Ranocha, Dalcin, Parsani, Ketcheson (2021) ](https://link.springer.com/article/10.1007/s42967-021-00159-w).
 
 # Trixi provides such a CFL-based step size control. It is implemented as the callback
 # [`StepsizeCallback`](@ref).

--- a/docs/literate/src/files/time_stepping.jl
+++ b/docs/literate/src/files/time_stepping.jl
@@ -47,7 +47,7 @@
 # \Delta t_n = \text{CFL} * \min_i \frac{\Delta x_i}{\lambda_{\max}(u_i^n)}
 # ```
 # We compute $\Delta x_i$ by scaling the element size by a factor of $1/(N+1)$, cf. 
-# [Gassne and Kopriva (2011)](https://doi.org/10.1137/100807211), Section 5.
+# [Gassner and Kopriva (2011)](https://doi.org/10.1137/100807211), Section 5.
 
 # Trixi provides such a CFL-based step size control. It is implemented as the callback
 # [`StepsizeCallback`](@ref).


### PR DESCRIPTION
This PR has some small additions to the documentation that would have been helpful to me

1. Give a motivation for replacement of $D \underline{f}$ by $2D\underline{f}\_\text{vol}$ in [DGSEM with flux differencing](https://trixi-framework.github.io/Trixi.jl/stable/tutorials/DGSEM_FluxDiff/#DGSEM-with-flux-differencing),. The motivation being that the expression can be seen as a generalization of 
$$\sum\_j D\_{i,j} \underline{f}\_{j} = 2\sum\_j \frac{1}{2} D\_{i,j} (\underline{f}\_j + \underline{f}\_i) \eqqcolon 2\sum\_j  D\_{i,j} f\_\text{cent}(u\_i, u\_j) $$
2. Add a line mentioning that $\Delta x_i$ denotes the element size scaled by a factor of $1/(N+1)$