### PR TITLE
fix `boundary_condition_slip_wall` for 2D `TreeMesh`

### DIFF
--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -335,13 +335,14 @@ Should be used together with [`TreeMesh`](@ref).
                                               equations::CompressibleEulerEquations2D)
   # get the appropriate normal vector from the orientation
   if orientation == 1
-    normal = SVector(1, 0)
+    normal_direction = SVector(1, 0)
   else # orientation == 2
-    normal = SVector(0, 1)
+    normal_direction = SVector(0, 1)
   end
 
   # compute and return the flux using `boundary_condition_slip_wall` routine above
-  return boundary_condition_slip_wall(u_inner, normal, x, t, surface_flux_function, equations)
+  return boundary_condition_slip_wall(u_inner, normal_direction, direction,
+                                      x, t, surface_flux_function, equations)
 end
 
 """


### PR DESCRIPTION
Closes #1190 

CC @andrewwinters5000 

The problem was that this is an instance where the boundary flux does not simply change its sign when changing the sign of the normal direction. Thus, we need to use the same logic based on the `direction` as the `StructuredMesh`.