### PR TITLE
New section in Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 **Trixi.jl at JuliaCon 2022**<br/>
 At this year's JuliaCon 2022, we have been present with two contributions that involve Trixi.jl:
 
-* [Running Julia code in parallel with MPI: Lessons learned](https://live.juliacon.org/talk/LUWYRJ), 
+* [Running Julia code in parallel with MPI: Lessons learned](https://live.juliacon.org/talk/LUWYRJ),
   26th July 2022. [Watch on YouTube](https://youtu.be/fog1x9rs71Q?t=5172), [repo](https://github.com/JuliaParallel/juliacon-2022-julia-for-hpc-minisymposium)
-* [From Mesh Generation to Adaptive Simulation: A Journey in Julia](https://live.juliacon.org/talk/YSLKZJ), 
+* [From Mesh Generation to Adaptive Simulation: A Journey in Julia](https://live.juliacon.org/talk/YSLKZJ),
   27th July 2022. [Watch on YouTube](https://youtu.be/_N4ozHr-t9E), [repo](https://github.com/trixi-framework/talk-2022-juliacon_toolchain)
 
 If you have questions about Trixi.jl or our other projects, feel free to get in touch via Slack or open an issue ♥️
@@ -168,6 +168,13 @@ of a Julia method is typically slow, with subsequent runs being much faster. For
 instance, in the example above the first execution of `trixi_include` takes about
 20 seconds, while subsequent runs require less than 60 *milli*seconds.
 
+### Showcase of advanced features
+The presentation [From Mesh Generation to Adaptive Simulation: A Journey in Julia](https://youtu.be/_N4ozHr-t9E),
+originally given as part of JuliaCon 2022, outlines how to use Trixi for an adaptive simulation
+of the compressible Euler equations in two spatial dimensions on a complex domain. More details
+as well as code to run the simulation presented can be found at the
+[reproducibility repository](https://github.com/trixi-framework/talk-2022-juliacon_toolchain)
+for the presentation.
 
 ## Documentation
 Additional documentation is available that contains more information on how to

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -269,6 +269,13 @@ mean      3.94      mean      3.94      mean      3.94      mean      3.93
 --------------------------------------------------------------------------------
 ```
 
+### Showcase of advanced features
+The presentation [From Mesh Generation to Adaptive Simulation: A Journey in Julia](https://youtu.be/_N4ozHr-t9E),
+originally given as part of JuliaCon 2022, outlines how to use Trixi for an adaptive simulation
+of the compressible Euler equations in two spatial dimensions on a complex domain. More details
+as well as code to run the simulation presented can be found at the
+[reproducibility repository](https://github.com/trixi-framework/talk-2022-juliacon_toolchain)
+for the presentation.
 
 ## Referencing
 If you use Trixi in your own research or write a paper using results obtained


### PR DESCRIPTION
This adds a brief description and links to the JuliaCon talk about how to setup and run Trixi on an adaptive, curvilinear domain. There is also a link for the reproducibility repository. 