### PR TITLE
allow other RHS in analysis callback

### DIFF
--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -219,7 +219,7 @@ function (analysis_callback::AnalysisCallback)(integrator)
 
     # Calculate current time derivative (needed for semidiscrete entropy time derivative, residual, etc.)
     du_ode = first(get_tmp_cache(integrator))
-    @notimeit timer() rhs!(du_ode, integrator.u, semi, t)
+    @notimeit timer() integrator.f(du_ode, integrator.u, semi, t)
     u  = wrap_array(integrator.u, mesh, equations, solver, cache)
     du = wrap_array(du_ode,       mesh, equations, solver, cache)
     l2_error, linf_error = analysis_callback(io, du, u, integrator.u, t, semi)

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -219,6 +219,10 @@ function (analysis_callback::AnalysisCallback)(integrator)
 
     # Calculate current time derivative (needed for semidiscrete entropy time derivative, residual, etc.)
     du_ode = first(get_tmp_cache(integrator))
+    # `integrator.f` is usually just a call to `rhs!`
+    # However, we want to allow users to modify the ODE RHS outside of Trixi.jl
+    # and allow us to pass a combined ODE RHS to OrdinaryDiffEq, e.g., for
+    # hyperbolic-parabolic systems.
     @notimeit timer() integrator.f(du_ode, integrator.u, semi, t)
     u  = wrap_array(integrator.u, mesh, equations, solver, cache)
     du = wrap_array(du_ode,       mesh, equations, solver, cache)

--- a/src/time_integration/methods_3Sstar.jl
+++ b/src/time_integration/methods_3Sstar.jl
@@ -105,7 +105,7 @@ function SimpleIntegrator3SstarOptions(callback, tspan; maxiters=typemax(Int), k
     callback, false, Inf, maxiters, [last(tspan)])
 end
 
-mutable struct SimpleIntegrator3Sstar{RealT<:Real, uType, Params, Sol, Alg, SimpleIntegrator3SstarOptions}
+mutable struct SimpleIntegrator3Sstar{RealT<:Real, uType, Params, Sol, F, Alg, SimpleIntegrator3SstarOptions}
   u::uType #
   du::uType
   u_tmp1::uType
@@ -116,6 +116,7 @@ mutable struct SimpleIntegrator3Sstar{RealT<:Real, uType, Params, Sol, Alg, Simp
   iter::Int # current number of time step (iteration)
   p::Params # will be the semidiscretization from Trixi
   sol::Sol # faked
+  f::F
   alg::Alg
   opts::SimpleIntegrator3SstarOptions
   finalstep::Bool # added for convenience
@@ -140,7 +141,7 @@ function solve(ode::ODEProblem, alg::T;
   t = first(ode.tspan)
   iter = 0
   integrator = SimpleIntegrator3Sstar(u, du, u_tmp1, u_tmp2, t, dt, zero(dt), iter, ode.p,
-                  (prob=ode,), alg,
+                  (prob=ode,), ode.f, alg,
                   SimpleIntegrator3SstarOptions(callback, ode.tspan; kwargs...), false)
 
   # initialize callbacks


### PR DESCRIPTION
This fixes the problem brought up in https://github.com/trixi-framework/Trixi.jl/pull/1202#issuecomment-1211021834. It allows us to use an ODE RHS different from our `rhs!` function. This can be very nice, e.g., for hyperbolic-parabolic systems set up as `SplitODEProblem` with `rhs!` and `rhs_parabolic!` in #1149 or when the user wants to modify the RHS call as in https://discourse.julialang.org/t/ann-trixi-jl-v0-3-sciml-integration-and-a-new-modular-approach-for-easy-extension/50419/43.

I made this a PR to `main` instead of `dev` or so since it is generally useful and should be shipped right now.

This is a cleaned-up version of #1204.