### PR TITLE
fix parabolic PID

### DIFF
--- a/examples/tree_2d_dgsem/elixir_navier_stokes_convergence.jl
+++ b/examples/tree_2d_dgsem/elixir_navier_stokes_convergence.jl
@@ -202,7 +202,7 @@ summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval=10)
 analysis_interval = 100
 analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
-callbacks = CallbackSet(summary_callback, alive_callback)
+callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback)
 
 ###############################################################################
 # run the simulation

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -64,7 +64,7 @@ struct PerformanceCounterList{N}
   counters::NTuple{N, PerformanceCounter}
 end
 
-function PerformanceCounterList{N}()
+function PerformanceCounterList{N}() where {N}
   counters = ntuple(_ -> PerformanceCounter(), Val{N}())
   return PerformanceCounterList{N}(counters)
 end

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -24,9 +24,9 @@ timer() = main_timer
 
 
 """
-    PerformanceCounter
+    PerformanceCounter()
 
-A `PerformanceCounter` be used to track the runtime performance of some calls.
+A `PerformanceCounter` can be used to track the runtime performance of some calls.
 Add a new runtime measurement via `put!(counter, runtime)` and get the averaged
 runtime of all measurements added so far via `take!(counter)`, resetting the
 `counter`.
@@ -49,6 +49,34 @@ function Base.put!(counter::PerformanceCounter, runtime::Real)
   counter.ncalls_since_readout += 1
   counter.runtime += runtime
 end
+
+
+"""
+    PerformanceCounterList{N}()
+
+A `PerformanceCounterList{N}` can be used to track the runtime performance of
+calls to multiple functions, adding them up.
+Add a new runtime measurement via `put!(counter.counters[i], runtime)` and get
+the averaged runtime of all measurements added so far via `take!(counter)`,
+resetting the `counter`.
+"""
+struct PerformanceCounterList{N}
+  counters::NTuple{N, PerformanceCounter}
+end
+
+function PerformanceCounterList{N}()
+  counters = ntuple(_ -> PerformanceCounter(), Val{N}())
+  return PerformanceCounterList{N}(counters)
+end
+
+function Base.take!(counter::PerformanceCounterList)
+  time_per_call = 0.0
+  for c in counter.counters
+    time_per_call += take!(c)
+  end
+  return time_per_call
+end
+
 
 
 

--- a/src/semidiscretization/semidiscretization_hyperbolic_parabolic.jl
+++ b/src/semidiscretization/semidiscretization_hyperbolic_parabolic.jl
@@ -35,7 +35,7 @@ struct SemidiscretizationHyperbolicParabolic{Mesh, Equations, EquationsParabolic
   cache::Cache
   cache_parabolic::CacheParabolic
 
-  performance_counter::PerformanceCounter
+  performance_counter::PerformanceCounterList{2}
 
   function SemidiscretizationHyperbolicParabolic{Mesh, Equations, EquationsParabolic, InitialCondition, BoundaryConditions, BoundaryConditionsParabolic, SourceTerms, Solver, SolverParabolic, Cache, CacheParabolic}(
       mesh::Mesh, equations::Equations, equations_parabolic::EquationsParabolic, initial_condition::InitialCondition,
@@ -45,7 +45,7 @@ struct SemidiscretizationHyperbolicParabolic{Mesh, Equations, EquationsParabolic
 
     # Todo: assert nvariables(equations)==nvariables(equations_parabolic)
 
-    performance_counter = PerformanceCounter()
+    performance_counter = PerformanceCounterList{2}()
 
     new(mesh, equations, equations_parabolic, initial_condition,
         boundary_conditions, boundary_conditions_parabolic,
@@ -237,7 +237,7 @@ function rhs!(du_ode, u_ode, semi::SemidiscretizationHyperbolicParabolic, t)
   @trixi_timeit timer() "rhs!" rhs!(du, u, t, mesh, equations, initial_condition,
                                     boundary_conditions, source_terms, solver, cache)
   runtime = time_ns() - time_start
-  put!(semi.performance_counter, runtime)
+  put!(semi.performance_counter.counters[1], runtime)
 
   return nothing
 end
@@ -254,7 +254,7 @@ function rhs_parabolic!(du_ode, u_ode, semi::SemidiscretizationHyperbolicParabol
                                                         boundary_conditions_parabolic, source_terms,
                                                         solver, solver_parabolic, cache, cache_parabolic)
   runtime = time_ns() - time_start
-  put!(semi.performance_counter, runtime)
+  put!(semi.performance_counter.counters[2], runtime)
 
   return nothing
 end


### PR DESCRIPTION
The problem was that the performance counter got the times of both the hyperbolic and the parabolic RHS one after another, averaging them in the end instead of adding them. This fixes this problem by adding a new wrapper of performance counters.

Current `dev`:
```julia
julia> include("examples/tree_2d_dgsem/elixir_navier_stokes_convergence.jl")
...
 #timesteps:                 49                run time:       9.78864301e-01 s
 Δt:             1.33466151e-02                time/DOF/rhs!:  2.65453616e-07 s
 sim. time:      5.00000000e-01
 #DOF:                     4096
 #elements:                 256
...
```

This PR:
```julia
julia> include("examples/tree_2d_dgsem/elixir_navier_stokes_convergence.jl")
...
 #timesteps:                 49                run time:       9.69013664e-01 s
 Δt:             1.33466151e-02                time/DOF/rhs!:  5.25956734e-07 s
 sim. time:      5.00000000e-01
 #DOF:                     4096
 #elements:                 256

 Variable:       rho              rho_v1           rho_v2           rho_e         
 L2 error:       4.28526103e-06   2.06791438e-05   1.43361343e-05   7.80074488e-06
 Linf error:     3.57085377e-05   3.44816339e-04   8.59318847e-05   1.06569138e-04
 ∑∂S/∂U ⋅ Uₜ :   2.43830274e-07
...
```

Thanks for noticing this issue, @gregorgassner :+1: