### PR TITLE
Relax `DGMulti` `<:Polynomial` type restriction

### DIFF
--- a/src/solvers/dgmulti/flux_differencing.jl
+++ b/src/solvers/dgmulti/flux_differencing.jl
@@ -397,7 +397,7 @@ end
 # Polynomial-based solvers use hybridized SBP operators, which have blocks scaled by outward
 # normal components. This implies that operators for different coordinate directions have
 # different sparsity patterns. We default to using sum factorization (which is faster when
-# operators are sparse) for all `<:Polynomial` approximation types.
+# operators are sparse) for all `DGMulti` / `StartUpDG.jl` approximation types.
 @inline has_sparse_operators(element_type, approx_type) = Val{true}()
 
 # SBP/GaussSBP operators on quads/hexes use tensor-product operators. Thus, sum factorization is

--- a/src/solvers/dgmulti/flux_differencing.jl
+++ b/src/solvers/dgmulti/flux_differencing.jl
@@ -504,8 +504,9 @@ end
   end
 end
 
-# calculates volume integral for <:Polynomial approximation types (e.g., we
-# do not assume any additional structure in RefElemData, such as)
+# calculates volume integral for <:Polynomial approximation types. We
+# do not assume any additional structure (such as collocated volume or
+# face nodes, tensor product structure, etc) in `DGMulti`.
 function calc_volume_integral!(du, u, mesh::DGMultiMesh,
                                have_nonconservative_terms, equations,
                                volume_integral, dg::DGMultiFluxDiff,

--- a/src/solvers/dgmulti/flux_differencing.jl
+++ b/src/solvers/dgmulti/flux_differencing.jl
@@ -386,19 +386,16 @@ end
   return has_sparse_operators(rd.elementType, rd.approximation_type)
 end
 
-# The general fallback does not assume sparse operators
-@inline has_sparse_operators(element_type, approximation_type) = Val{false}()
-
-# For traditional SBP operators on triangles, the operators are fully dense. We avoid using
-# sum factorization here, which is slower for fully dense matrices.
-@inline has_sparse_operators(::Union{Tri, Tet}, approx_type::AT) where {AT <: SBP} = Val{false}()
-
 # General fallback for DGMulti solvers:
 # Polynomial-based solvers use hybridized SBP operators, which have blocks scaled by outward
 # normal components. This implies that operators for different coordinate directions have
 # different sparsity patterns. We default to using sum factorization (which is faster when
 # operators are sparse) for all `DGMulti` / `StartUpDG.jl` approximation types.
 @inline has_sparse_operators(element_type, approx_type) = Val{true}()
+
+# For traditional SBP operators on triangles, the operators are fully dense. We avoid using
+# sum factorization here, which is slower for fully dense matrices.
+@inline has_sparse_operators(::Union{Tri, Tet}, approx_type::AT) where {AT <: SBP} = Val{false}()
 
 # SBP/GaussSBP operators on quads/hexes use tensor-product operators. Thus, sum factorization is
 # more efficient and we use the sparsity structure.


### PR DESCRIPTION
Currently, `DGMulti` specializes `rhs!` on the `approximation_type`. The default is `Polynomial`; however, the implementation of `rhs!` for `Polynomial` types should run for any `DGMulti` discretization built using StartUpDG.jl, though it may be slow (this is because StartUpDG.jl just represents an approximation using multi-dimensional matrix operators). 

This PR removes the `<:Polynomial` type restriction, and instead makes the `Polynomial` implementation of `rhs!` the default `DGMulti` implementation. This way, if we introduce a new approximation type in StartUpDG.jl, Trixi.jl should automatically be able to accommodate it.