### PR TITLE
Extend burgers

### DIFF
--- a/examples/tree_1d_dgsem/elixir_burgers_shock.jl
+++ b/examples/tree_1d_dgsem/elixir_burgers_shock.jl
@@ -1,0 +1,94 @@
+
+using OrdinaryDiffEq
+using Trixi
+
+###############################################################################
+# semidiscretization of the (inviscid) Burgers' equation
+
+equations = InviscidBurgersEquation1D()
+
+basis = LobattoLegendreBasis(3)
+# Use shock capturing techniques to supress oscillations at discontinuities
+indicator_sc = IndicatorHennemannGassner(equations, basis,
+                                         alpha_max=1.0,
+                                         alpha_min=0.001,
+                                         alpha_smooth=true,
+                                         variable=Trixi.scalar)
+
+# Use same flux for DG & FV in this example
+numerical_flux = flux_lax_friedrichs
+
+volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
+                                                 volume_flux_dg=numerical_flux,
+                                                 volume_flux_fv=numerical_flux)
+
+# Use 'numerical_flux' as surface flux                                              
+solver = DGSEM(basis, numerical_flux, volume_integral)
+
+coordinate_min = 0.0
+coordinate_max = 1.0
+
+# Make sure to turn periodicity explicitly off as special boundary conditions are specified
+mesh = TreeMesh(coordinate_min, coordinate_max,
+                initial_refinement_level=6,
+                n_cells_max=10_000,
+                periodicity=false)
+
+
+###############################################################################
+# Specify non-periodic boundary conditions
+
+function inflow(x, t, equations::InviscidBurgersEquation1D)
+  return Trixi.initial_condition_shock(coordinate_min, t, equations)
+end
+boundary_condition_inflow = BoundaryConditionDirichlet(inflow)
+
+
+function boundary_condition_outflow(u_inner, orientation, normal_direction, x, t,
+                                    surface_flux_function, equations::InviscidBurgersEquation1D)
+  # Calculate the boundary flux entirely from the internal solution state
+  flux = Trixi.flux(u_inner, normal_direction, equations)
+
+  return flux
+end
+
+
+boundary_conditions = (x_neg=boundary_condition_inflow,
+                       x_pos=boundary_condition_outflow)                
+
+initial_condition = Trixi.initial_condition_shock                       
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                    boundary_conditions=boundary_conditions)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 0.2)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval,
+                                     extra_analysis_errors=(:conservation_error,))
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+stepsize_callback = StepsizeCallback(cfl=0.9)
+
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        stepsize_callback)
+
+###############################################################################
+# run the simulation
+
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=42, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+
+summary_callback() # print the timer summary

--- a/examples/tree_1d_dgsem/elixir_burgers_shock.jl
+++ b/examples/tree_1d_dgsem/elixir_burgers_shock.jl
@@ -71,8 +71,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval=analysis_interval,
-                                     extra_analysis_errors=(:conservation_error,))
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
 
 alive_callback = AliveCallback(analysis_interval=analysis_interval)
 


### PR DESCRIPTION
I though it would be nice to have an example where the classic Riemann problem

$$ \partial_t u + \partial_x(0.5 u^2) = 0, \quad u_0(x) = \begin{cases} u_L &  x < \tilde{x} \\ u_R & x \geq \tilde{x} \end{cases} \$$

leads to a shock, which can be accurately simulated using the `VolumeIntegralShockCapturingHG` when the `scalar` indicator 

```
# For shock capturing
@inline function scalar(u, equations::InviscidBurgersEquation1D)
  return u[1]
end
```
is added.

For completeness, I also added some numerical fluxes.