### PR TITLE
remove redundant definition of `cons2prim`

### DIFF
--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -225,7 +225,7 @@ Return the conserved variables `u`. While this function is as trivial as `identi
 it is also as useful.
 """
 @inline cons2cons(u, ::AbstractEquations) = u
-function cons2prim#=(u, ::AbstractEquations)=# end
+                                                                            
 @inline Base.first(u, ::AbstractEquations) = first(u)
 
 """


### PR DESCRIPTION
`cons2prim` is already defined in
https://github.com/trixi-framework/Trixi.jl/blob/3ea50d1d108d9c3b4d5ce463a40a20bfa7937633/src/equations/equations.jl#L231-L240