### PR TITLE
fixing deprecated syntax for StartUpDG

### DIFF
--- a/examples/dgmulti_2d/elixir_euler_bilinear.jl
+++ b/examples/dgmulti_2d/elixir_euler_bilinear.jl
@@ -20,7 +20,7 @@ function mapping(xi, eta)
   return SVector(x, y)
 end
 cells_per_dimension = (16, 16)
-vertex_coordinates, EToV = StartUpDG.uniform_mesh(dg.basis.elementType, cells_per_dimension...)
+vertex_coordinates, EToV = StartUpDG.uniform_mesh(dg.basis.element_type, cells_per_dimension...)
 for i in eachindex(vertex_coordinates[1])
   vx, vy = getindex.(vertex_coordinates, i)
   setindex!.(vertex_coordinates, mapping(vx, vy), i)

--- a/src/solvers/dgmulti/flux_differencing.jl
+++ b/src/solvers/dgmulti/flux_differencing.jl
@@ -383,7 +383,7 @@ end
 # Designed to be extendable to include specialized `approximation_types` too.
 @inline function has_sparse_operators(dg::DGMultiFluxDiff)
   rd = dg.basis
-  return has_sparse_operators(rd.elementType, rd.approximation_type)
+  return has_sparse_operators(rd.element_type, rd.approximation_type)
 end
 
 # General fallback for DGMulti solvers:

--- a/src/solvers/dgmulti/flux_differencing_gauss_sbp.jl
+++ b/src/solvers/dgmulti/flux_differencing_gauss_sbp.jl
@@ -59,7 +59,7 @@ function TensorProductGaussFaceOperator(operator::AbstractGaussOperator,
 
   # Permutation of indices in a tensor product form
   indices = reshape(1:length(rd.rf), nnodes_1d, rd.Nfaces)
-  face_indices_tensor_product = zeros(Int, 2, nnodes_1d, ndims(rd.elementType))
+  face_indices_tensor_product = zeros(Int, 2, nnodes_1d, ndims(rd.element_type))
   for i in 1:nnodes_1d # loop over nodes in one face
     face_indices_tensor_product[:, i, 1] .= indices[i, 1:2]
     face_indices_tensor_product[:, i, 2] .= indices[i, 3:4]
@@ -88,7 +88,7 @@ function TensorProductGaussFaceOperator(operator::AbstractGaussOperator,
 
   # Permutation of indices in a tensor product form
   indices = reshape(1:length(rd.rf), nnodes_1d, nnodes_1d, rd.Nfaces)
-  face_indices_tensor_product = zeros(Int, 2, nnodes_1d, nnodes_1d, ndims(rd.elementType))
+  face_indices_tensor_product = zeros(Int, 2, nnodes_1d, nnodes_1d, ndims(rd.element_type))
   for j in 1:nnodes_1d, i in 1:nnodes_1d # loop over nodes in one face
     face_indices_tensor_product[:, i, j, 1] .= indices[i, j, 1:2]
     face_indices_tensor_product[:, i, j, 2] .= indices[i, j, 3:4]
@@ -379,7 +379,7 @@ function create_cache(mesh::DGMultiMesh, equations,
   rq1D, _ = StartUpDG.gauss_quad(0, 0, polydeg(dg))
   interp_matrix_lobatto_to_gauss_1D = polynomial_interpolation_matrix(r1D, rq1D)
   interp_matrix_gauss_to_lobatto_1D = polynomial_interpolation_matrix(rq1D, r1D)
-  NDIMS = ndims(rd.elementType)
+  NDIMS = ndims(rd.element_type)
   interp_matrix_lobatto_to_gauss = SimpleKronecker(NDIMS, interp_matrix_lobatto_to_gauss_1D, uEltype)
   interp_matrix_gauss_to_lobatto = SimpleKronecker(NDIMS, interp_matrix_gauss_to_lobatto_1D, uEltype)
   inv_gauss_weights = inv.(rd.wq)

--- a/src/solvers/dgmulti/sbp.jl
+++ b/src/solvers/dgmulti/sbp.jl
@@ -298,12 +298,12 @@ function Base.show(io::IO, mime::MIME"text/plain", rd::RefElemData{NDIMS, Elemen
   @nospecialize rd
   print(io, "RefElemData for an approximation using an ")
   show(IOContext(io, :compact => true), rd.approximation_type)
-  print(io, " on $(rd.elementType) element")
+  print(io, " on $(rd.element_type) element")
 end
 
 function Base.show(io::IO, rd::RefElemData{NDIMS, ElementType, ApproximationType}) where {NDIMS, ElementType<:StartUpDG.AbstractElemShape, ApproximationType<:AbstractDerivativeOperator}
   @nospecialize rd
-  print(io, "RefElemData{", summary(rd.approximation_type), ", ", rd.elementType, "}")
+  print(io, "RefElemData{", summary(rd.approximation_type), ", ", rd.element_type, "}")
 end
 
 function StartUpDG.inverse_trace_constant(rd::RefElemData{NDIMS, ElementType, ApproximationType})  where {NDIMS, ElementType<:Union{Line, Quad, Hex}, ApproximationType<:AbstractDerivativeOperator}
@@ -400,7 +400,7 @@ function DGMultiMesh(dg::DGMultiPeriodicFDSBP{NDIMS};
                 periodicity)
 
   boundary_faces = []
-  return DGMultiMesh{NDIMS, rd.elementType, typeof(md), typeof(boundary_faces)}(md, boundary_faces)
+  return DGMultiMesh{NDIMS, rd.element_type, typeof(md), typeof(boundary_faces)}(md, boundary_faces)
 end
 
 # By default, Julia/LLVM does not use fused multiply-add operations (FMAs).

--- a/src/solvers/dgmulti/types.jl
+++ b/src/solvers/dgmulti/types.jl
@@ -108,7 +108,7 @@ function DGMultiMesh(vertex_coordinates::NTuple{NDIMS, Vector{Tv}}, EToV::Array{
     md = StartUpDG.make_periodic(md, periodicity)
   end
   boundary_faces = StartUpDG.tag_boundary_faces(md, is_on_boundary)
-  return DGMultiMesh{NDIMS, typeof(rd.elementType), typeof(md), typeof(boundary_faces)}(md, boundary_faces)
+  return DGMultiMesh{NDIMS, typeof(rd.element_type), typeof(md), typeof(boundary_faces)}(md, boundary_faces)
 end
 
 function DGMultiMesh(triangulateIO, rd::RefElemData{2, Tri}, boundary_dict::Dict{Symbol, Int})
@@ -116,7 +116,7 @@ function DGMultiMesh(triangulateIO, rd::RefElemData{2, Tri}, boundary_dict::Dict
   vertex_coordinates, EToV = StartUpDG.triangulateIO_to_VXYEToV(triangulateIO)
   md = MeshData(vertex_coordinates, EToV, rd)
   boundary_faces = StartUpDG.tag_boundary_faces(triangulateIO, rd, md, boundary_dict)
-  return DGMultiMesh{2, typeof(rd.elementType), typeof(md), typeof(boundary_faces)}(md, boundary_faces)
+  return DGMultiMesh{2, typeof(rd.element_type), typeof(md), typeof(boundary_faces)}(md, boundary_faces)
 end
 
 # TODO: DGMulti, v0.5. Remove deprecated constructor
@@ -133,7 +133,7 @@ struct Affine <: GeometricTermsType end # mesh produces constant geometric terms
 struct NonAffine <: GeometricTermsType end # mesh produces non-constant geometric terms
 
 # choose MeshType based on the constructor and element type
-GeometricTermsType(mesh_type, dg::DGMulti) = GeometricTermsType(mesh_type, dg.basis.elementType)
+GeometricTermsType(mesh_type, dg::DGMulti) = GeometricTermsType(mesh_type, dg.basis.element_type)
 GeometricTermsType(mesh_type::Cartesian, element_type::AbstractElemShape) = Affine()
 GeometricTermsType(mesh_type::TriangulateIO, element_type::Tri) = Affine()
 GeometricTermsType(mesh_type::VertexMapped, element_type::Union{Tri, Tet}) = Affine()
@@ -202,7 +202,7 @@ end
                 is_on_boundary=nothing,
                 periodicity=ntuple(_ -> false, NDIMS))
 
-Constructs a Cartesian [`DGMultiMesh`](@ref) with element type `dg.basis.elementType`. The domain is
+Constructs a Cartesian [`DGMultiMesh`](@ref) with element type `dg.basis.element_type`. The domain is
 the tensor product of the intervals `[coordinates_min[i], coordinates_max[i]]`.
 - `is_on_boundary` specifies boundary using a `Dict{Symbol, <:Function}`
 - `periodicity` is a tuple of `Bool`s specifying periodicity = `true`/`false` in the (x,y,z) direction.
@@ -219,7 +219,7 @@ function DGMultiMesh(dg::DGMulti{NDIMS}; cells_per_dimension,
     periodicity=kwargs[:is_periodic]
   end
 
-  vertex_coordinates, EToV = StartUpDG.uniform_mesh(dg.basis.elementType, cells_per_dimension...)
+  vertex_coordinates, EToV = StartUpDG.uniform_mesh(dg.basis.element_type, cells_per_dimension...)
   domain_lengths = coordinates_max .- coordinates_min
   for i in 1:NDIMS
     @. vertex_coordinates[i] = 0.5 * (vertex_coordinates[i] + 1) * domain_lengths[i] + coordinates_min[i]
@@ -241,7 +241,7 @@ end
                 is_on_boundary=nothing,
                 periodicity=ntuple(_ -> false, NDIMS), kwargs...) where {NDIMS}
 
-Constructs a `Curved()` [`DGMultiMesh`](@ref) with element type `dg.basis.elementType`.
+Constructs a `Curved()` [`DGMultiMesh`](@ref) with element type `dg.basis.element_type`.
 - `mapping` is a function which maps from a reference [-1, 1]^NDIMS domain to a mapped domain,
    e.g., `xy = mapping(x, y)` in 2D.
 - `is_on_boundary` specifies boundary using a `Dict{Symbol, <:Function}`
@@ -251,7 +251,7 @@ function DGMultiMesh(dg::DGMulti{NDIMS}, cells_per_dimension, mapping;
                      is_on_boundary=nothing,
                      periodicity=ntuple(_ -> false, NDIMS), kwargs...) where {NDIMS}
 
-  vertex_coordinates, EToV = StartUpDG.uniform_mesh(dg.basis.elementType, cells_per_dimension...)
+  vertex_coordinates, EToV = StartUpDG.uniform_mesh(dg.basis.element_type, cells_per_dimension...)
   md = MeshData(vertex_coordinates, EToV, dg.basis)
   md = NDIMS==1 ? StartUpDG.make_periodic(md, periodicity...) : StartUpDG.make_periodic(md, periodicity)
 

--- a/src/visualization/utilities.jl
+++ b/src/visualization/utilities.jl
@@ -107,12 +107,12 @@ function mesh_plotting_wireframe(u::StructArray, mesh, equations, dg::DGMulti, c
 
   # Construct 1D plotting interpolation matrix `Vp1D` for a single face
   @unpack N, Fmask = rd
-  num_face_points = length(Fmask) ÷ num_faces(rd.elementType)
+  num_face_points = length(Fmask) ÷ num_faces(rd.element_type)
   vandermonde_matrix_1D = StartUpDG.vandermonde(Line(), N, StartUpDG.nodes(Line(), num_face_points - 1))
   rplot = LinRange(-1, 1, nvisnodes)
   Vp1D = StartUpDG.vandermonde(Line(), N, rplot) / vandermonde_matrix_1D
 
-  num_faces_total = num_faces(rd.elementType) * md.num_elements
+  num_faces_total = num_faces(rd.element_type) * md.num_elements
   xf, yf = map(x->reshape(view(x, Fmask, :), num_face_points, num_faces_total), md.xyz)
   uf = similar(u, size(xf))
   apply_to_each_field((out, x)->out .= reshape(view(x, Fmask, :), num_face_points, num_faces_total), uf, u)
@@ -202,7 +202,7 @@ function mesh_plotting_wireframe(u::ScalarData, mesh, equations, dg::DGMulti, ca
   Vp1D = StartUpDG.vandermonde(Line(), N, rplot) / vandermonde_matrix_1D
 
   num_face_points = N+1
-  num_faces_total = num_faces(rd.elementType) * md.num_elements
+  num_faces_total = num_faces(rd.element_type) * md.num_elements
   xf, yf, uf = map(x->reshape(view(x, Fmask, :), num_face_points, num_faces_total), (md.xyz..., u.data))
 
   num_face_plotting_points = size(Vp1D, 1)
@@ -924,7 +924,7 @@ function distances_from_single_point(nodes, point)
   _, n_nodes, _, _, n_elements = size(nodes)
   shifted_data = nodes.-point
   distances = zeros(n_nodes, n_nodes, n_nodes, n_elements)
-    
+
   # Iterate over every entry.
   for element in 1:n_elements
     for x in 1:n_nodes


### PR DESCRIPTION
Replaces deprecated syntax `rd.elementType` with `rd.element_type`.