### PR TITLE
Add amplitude `A` in `InvisicidBurgers1D`: `source_terms_convergence_test`

### DIFF
--- a/src/equations/inviscid_burgers_1d.jl
+++ b/src/equations/inviscid_burgers_1d.jl
@@ -62,7 +62,7 @@ Source terms used for convergence tests in combination with
   L = 1
   f = 1/L
   omega = 2 * pi * f
-  du = omega * cos(omega * (x[1] - t)) * (1 + sin(omega * (x[1] - t)))
+  du = omega * A * cos(omega * (x[1] - t)) * (1 + A * sin(omega * (x[1] - t)))
 
   return SVector(du)
 end

--- a/src/equations/inviscid_burgers_1d.jl
+++ b/src/equations/inviscid_burgers_1d.jl
@@ -62,7 +62,7 @@ Source terms used for convergence tests in combination with
   L = 1
   f = 1/L
   omega = 2 * pi * f
-  du = omega * A * cos(omega * (x[1] - t)) * (1 + A * sin(omega * (x[1] - t)))
+  du = omega * A * cos(omega * (x[1] - t)) * (c - 1 + A * sin(omega * (x[1] - t)))
 
   return SVector(du)
 end


### PR DESCRIPTION
Although not relevant for amplitudes `A=1` , I think the source term should also be valid for other values when they are used in the initial condition:

https://github.com/trixi-framework/Trixi.jl/blob/7a4ca66054ca6d935eaf95ede7331bf2eed69771/src/equations/inviscid_burgers_1d.jl#L42-L46