### PR TITLE
fix `convergence_test` for elixirs without trailing new line

### DIFF
--- a/src/auxiliary/special_elixirs.jl
+++ b/src/auxiliary/special_elixirs.jl
@@ -222,7 +222,7 @@ end
 # searches the parameter that specifies the mesh reslution in the elixir
 function extract_initial_resolution(elixir, kwargs)
   code = read(elixir, String)
-  expr = Meta.parse("begin $code end")
+  expr = Meta.parse("begin \n$code \nend")
 
   try
     # get the initial_refinement_level from the elixir


### PR DESCRIPTION
Fixes the problem mentioned in https://github.com/trixi-framework/Trixi.jl/pull/1251#issuecomment-1330193369