### PR TITLE
Fix typos in Upwind solver

### DIFF
--- a/examples/tree_2d_fdsbp/elixir_euler_vortex.jl
+++ b/examples/tree_2d_fdsbp/elixir_euler_vortex.jl
@@ -20,8 +20,8 @@ The classical isentropic vortex test case of
 """
 function initial_condition_isentropic_vortex(x, t, equations::CompressibleEulerEquations2D)
   # needs appropriate mesh size, e.g. [-10,-10]x[10,10]
-  # for error convergence: make sure that the end time such, that the is back at the initial state!!
-  # for the current vel and domain size: t_end should be a multiple of 20s
+  # for error convergence: make sure that the end time is such that the is back at the initial state!!
+  # for the current velocity and domain size: t_end should be a multiple of 20s
   # initial center of the vortex
   inicenter = SVector(0.0, 0.0)
   # size and strength of the vortex

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -912,7 +912,7 @@ end
 
   a = sqrt(equations.gamma * p / rho)
   H = (rho_e + p) / rho
-  lambda = 0.5 * (sqrt(v1^2+v2^2) + a)
+  lambda = 0.5 * (sqrt(v1^2 + v2^2) + a)
 
   if orientation == 1
     #lambda = 0.5 * (abs(v1) + a)

--- a/src/equations/inviscid_burgers_1d.jl
+++ b/src/equations/inviscid_burgers_1d.jl
@@ -155,7 +155,6 @@ end
                                           equations::InviscidBurgersEquation1D)
   f = 0.5 * u[1]^2
   lambda = abs(u[1])
-
   return SVector(0.5 * (f - lambda * u[1]))
 end
 

--- a/src/solvers/dg.jl
+++ b/src/solvers/dg.jl
@@ -127,6 +127,9 @@ See also [`splitting_steger_warming`](@ref), [`splitting_lax_friedrichs`](@ref),
 - Mattsson (2017)
   Diagonal-norm upwind SBP operators
   [doi: 10.1016/j.jcp.2017.01.042](https://doi.org/10.1016/j.jcp.2017.01.042)
+
+!!! warning "Experimental implementation"
+    This is an experimental feature and may change in future releases.
 """
 struct VolumeIntegralUpwind{FluxSplitting} <: AbstractVolumeIntegral
   splitting::FluxSplitting
@@ -259,6 +262,9 @@ that use a particular flux `splitting`, e.g.,
 [`splitting_steger_warming`](@ref).
 
 See also [`VolumeIntegralUpwind`](@ref).
+
+!!! warning "Experimental implementation"
+    This is an experimental feature and may change in future releases.
 """
 struct SurfaceIntegralUpwind{FluxSplitting} <: AbstractSurfaceIntegral
   splitting::FluxSplitting

--- a/src/solvers/fdsbp_tree/fdsbp_1d.jl
+++ b/src/solvers/fdsbp_tree/fdsbp_1d.jl
@@ -152,7 +152,7 @@ end
 # Specialized interface flux computation because the upwind solver does
 # not require a standard numerical flux (Riemann solver). The flux splitting
 # already separates the solution infomation into right-traveling and
-# left traveling information. So we only need to compute the approriate
+# left-traveling information. So we only need to compute the appropriate
 # flux information at each side of an interface.
 function calc_interface_flux!(surface_flux_values,
                               mesh::TreeMesh{1},
@@ -181,7 +181,7 @@ function calc_interface_flux!(surface_flux_values,
     flux_minus_rr = splitting(u_rr, Val{:minus}(), orientations[interface], equations)
     flux_plus_ll  = splitting(u_ll, Val{:plus}(),  orientations[interface], equations)
 
-    # Save the upwind coupling into the approriate side of the elements
+    # Save the upwind coupling into the appropriate side of the elements
     for v in eachvariable(equations)
       surface_flux_values[v, left_direction,  left_id]  = flux_minus_rr[v]
       surface_flux_values[v, right_direction, right_id] = flux_plus_ll[v]
@@ -190,6 +190,7 @@ function calc_interface_flux!(surface_flux_values,
 
   return nothing
 end
+
 
 # Implementation of fully upwind SATs. The surface flux values are pre-computed
 # in the specialized `calc_interface_flux` routine. These SATs are still of

--- a/src/solvers/fdsbp_tree/fdsbp_2d.jl
+++ b/src/solvers/fdsbp_tree/fdsbp_2d.jl
@@ -189,7 +189,7 @@ end
 # Specialized interface flux computation because the upwind solver does
 # not require a standard numerical flux (Riemann solver). The flux splitting
 # already separates the solution infomation into right-traveling and
-# left traveling information. So we only need to compute the approriate
+# left-traveling information. So we only need to compute the appropriate
 # flux information at each side of an interface.
 function calc_interface_flux!(surface_flux_values,
                               mesh::TreeMesh{2},
@@ -220,7 +220,7 @@ function calc_interface_flux!(surface_flux_values,
       flux_minus_rr = splitting(u_rr, Val{:minus}(), orientations[interface], equations)
       flux_plus_ll  = splitting(u_ll, Val{:plus}(),  orientations[interface], equations)
 
-      # Save the upwind coupling into the approriate side of the elements
+      # Save the upwind coupling into the appropriate side of the elements
       for v in eachvariable(equations)
         surface_flux_values[v, i, left_direction,  left_id]  = flux_minus_rr[v]
         surface_flux_values[v, i, right_direction, right_id] = flux_plus_ll[v]
@@ -230,6 +230,7 @@ function calc_interface_flux!(surface_flux_values,
 
   return nothing
 end
+
 
 # Implementation of fully upwind SATs. The surface flux values are pre-computed
 # in the specialized `calc_interface_flux` routine. These SATs are still of

--- a/src/solvers/fdsbp_tree/fdsbp_3d.jl
+++ b/src/solvers/fdsbp_tree/fdsbp_3d.jl
@@ -220,7 +220,7 @@ end
 # Specialized interface flux computation because the upwind solver does
 # not require a standard numerical flux (Riemann solver). The flux splitting
 # already separates the solution infomation into right-traveling and
-# left traveling information. So we only need to compute the approriate
+# left-traveling information. So we only need to compute the appropriate
 # flux information at each side of an interface.
 function calc_interface_flux!(surface_flux_values,
                               mesh::TreeMesh{3},
@@ -252,7 +252,7 @@ function calc_interface_flux!(surface_flux_values,
       flux_minus_rr = splitting(u_rr, Val{:minus}(), orientations[interface], equations)
       flux_plus_ll  = splitting(u_ll, Val{:plus}(),  orientations[interface], equations)
 
-      # Save the upwind coupling into the approriate side of the elements
+      # Save the upwind coupling into the appropriate side of the elements
       for v in eachvariable(equations)
         surface_flux_values[v, i, j, left_direction,  left_id]  = flux_minus_rr[v]
         surface_flux_values[v, i, j, right_direction, right_id] = flux_plus_ll[v]
@@ -262,6 +262,7 @@ function calc_interface_flux!(surface_flux_values,
 
   return nothing
 end
+
 
 # Implementation of fully upwind SATs. The surface flux values are pre-computed
 # in the specialized `calc_interface_flux` routine. These SATs are still of


### PR DESCRIPTION
Adjust for typos and weird spacing in the upwind solver cleanup.