### PR TITLE
Add time spent in GC and memory allocations to analysis output

### DIFF
--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -203,7 +203,7 @@ function (analysis_callback::AnalysisCallback)(integrator)
                 " run time:       " * @sprintf("%10.8e s", runtime_absolute))
     mpi_println(" Δt:             " * @sprintf("%10.8e", dt) *
                 "               " *
-                " └── GC time:    " * @sprintf("%10.8e s (%4.2f%%)", gc_time_absolute, gc_time_percentage))
+                " └── GC time:    " * @sprintf("%10.8e s (%5.3f%%)", gc_time_absolute, gc_time_percentage))
     mpi_println(" sim. time:      " * @sprintf("%10.8e", t) *
                 "               " *
                 " time/DOF/rhs!:  " * @sprintf("%10.8e s", runtime_relative))

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -25,6 +25,10 @@ Further scalar functions `func` in `extra_analysis_integrals` are applied to the
 solution and integrated over the computational domain.
 See `Trixi.analyze`, `Trixi.pretty_form_utf`, `Trixi.pretty_form_ascii` for further
 information on how to create custom analysis quantities.
+
+In addition, the analysis callback records and outputs a number of quantitites that are useful for
+evaluating the computational performance, such as the total runtime, the performance index
+(time/DOF/rhs!), or the current memory usage (alloc'd memory).
 """
 mutable struct AnalysisCallback{Analyzer, AnalysisIntegrals, InitialStateIntegrals, Cache}
   start_time::Float64

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -28,7 +28,8 @@ information on how to create custom analysis quantities.
 
 In addition, the analysis callback records and outputs a number of quantitites that are useful for
 evaluating the computational performance, such as the total runtime, the performance index
-(time/DOF/rhs!), or the current memory usage (alloc'd memory).
+(time/DOF/rhs!), the time spent in garbage collection (GC), or the current memory usage (alloc'd
+memory).
 """
 mutable struct AnalysisCallback{Analyzer, AnalysisIntegrals, InitialStateIntegrals, Cache}
   start_time::Float64

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -512,6 +512,9 @@ pretty_form_ascii(::Val{:linf_divb}) = "linf_divb"
 pretty_form_utf(::typeof(lake_at_rest_error)) = "∑|H₀-(h+b)|"
 pretty_form_ascii(::typeof(lake_at_rest_error)) = "|H0-(h+b)|"
 
+
+end # @muladd
+
 # specialized implementations specific to some solvers
 include("analysis_dg1d.jl")
 include("analysis_dg2d.jl")
@@ -519,5 +522,3 @@ include("analysis_dg2d_parallel.jl")
 include("analysis_dg3d.jl")
 include("analysis_dg3d_parallel.jl")
 
-
-end # @muladd


### PR DESCRIPTION
This will augment the output of the analysis callback with information on the time spent in garbage collection (GC) and on the total amount of memory allocated within Julia. Usually these numbers are probably not relevant, but on some occasions I thought it would be helpful to have them, and the overhead (computational and visual) is minimal (imho). But I'm open to discuss what and how such data should be presented.

This is sample output from an Euler/AMR simulation:
```
────────────────────────────────────────────────────────────────────────────────────────────────────
 Simulation running 'CompressibleEulerEquations2D' with DGSEM(polydeg=3)
────────────────────────────────────────────────────────────────────────────────────────────────────
 #timesteps:                500                run time:       7.41227200e+00 s
 Δt:             7.98801704e-03                └── GC time:    4.87020420e-02 s (0.007%)
 sim. time:      3.40604792e+00                time/DOF/rhs!:  8.44459442e-08 s
 #DOF:                    35008                alloc'd memory:        772.817 MiB
 #elements:                2188
 ├── level 6:              1792
 ├── level 5:               336
 └── level 4:                60

 Variable:       rho              rho_v1           rho_v2           rho_e
 L2 error:       1.50683070e+00   2.28748394e-01   2.28747548e-01   7.11229624e-01
 Linf error:     1.06452231e+01   2.12612418e+00   2.12624539e+00   3.04922868e+00
 ∑∂S/∂U ⋅ Uₜ :  -7.21624878e-01
────────────────────────────────────────────────────────────────────────────────────────────────────
```
New are the `GC time` and the `alloc'd memory` fields.

**EDIT**: A particular motivation for the GC time is also to be able to counter questions from other HPC users about GC becoming a bottleneck in a simulation...