### PR TITLE
breaking changes for Trixi.jl v0.5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@ for human readability.
 
 #### Removed
 
+- Everything deprecated in Trixi.jl v0.4.x has been removed.
+
 
 ## Changes in the v0.4 lifecycle
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@ for human readability.
   with nonconservative terms are created. Change
   `Trixi.has_nonconservative_terms(::YourEquations) = Val{true}()` to
   `Trixi.has_nonconservative_terms(::YourEquations) = Trixi.True()`.
-
+- The (non-exported) DGSEM function `split_form_kernel!` has been renamed to `flux_differencing_kernel!`
 #### Deprecated
 
 - The signature of the `DGMultiMesh` constructors has changed - the `dg::DGMulti`

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,9 @@ for human readability.
 
 - The signature of the `DGMultiMesh` constructors has changed - the `dg::DGMulti`
   argument now comes first.
+- The undocumented and unused
+`DGMultiMesh(triangulateIO, rd::RefElemData{2, Tri}, boundary_dict::Dict{Symbol, Int})`
+constructor was removed.
 
 #### Removed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,8 +21,8 @@ for human readability.
 - The signature of the `DGMultiMesh` constructors has changed - the `dg::DGMulti`
   argument now comes first.
 - The undocumented and unused
-`DGMultiMesh(triangulateIO, rd::RefElemData{2, Tri}, boundary_dict::Dict{Symbol, Int})`
-constructor was removed.
+  `DGMultiMesh(triangulateIO, rd::RefElemData{2, Tri}, boundary_dict::Dict{Symbol, Int})`
+  constructor was removed.
 
 #### Removed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ for human readability.
   `Trixi.has_nonconservative_terms(::YourEquations) = Val{true}()` to
   `Trixi.has_nonconservative_terms(::YourEquations) = Trixi.True()`.
 - The (non-exported) DGSEM function `split_form_kernel!` has been renamed to `flux_differencing_kernel!`
+
 #### Deprecated
 
 - The signature of the `DGMultiMesh` constructors has changed - the `dg::DGMulti`

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@ for human readability.
 
 #### Deprecated
 
+- The signature of the `DGMultiMesh` constructors has changed - the `dg::DGMulti`
+  argument now comes first.
+
 #### Removed
 
 - Everything deprecated in Trixi.jl v0.4.x has been removed.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,22 @@ Trixi.jl follows the interpretation of [semantic versioning (semver)](https://ju
 used in the Julia ecosystem. Notable changes will be documented in this file
 for human readability.
 
+## Changes when updating to v0.5 from v0.4.x
+
+#### Added
+
+#### Changed
+
+- Compile-time boolean indicators have been changed from `Val{true}`/`Val{false}`
+  to `Trixi.True`/`Trixi.False`. This affects user code only if new equations
+  with nonconservative terms are created. Change
+  `Trixi.has_nonconservative_terms(::YourEquations) = Val{true}()` to
+  `Trixi.has_nonconservative_terms(::YourEquations) = Trixi.True()`.
+
+#### Deprecated
+
+#### Removed
+
 
 ## Changes in the v0.4 lifecycle
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Trixi"
 uuid = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 authors = ["Michael Schlottke-Lakemper <m.schlottke-lakemper@hlrs.de>", "Gregor Gassner <ggassner@uni-koeln.de>", "Hendrik Ranocha <mail@ranocha.de>", "Andrew R. Winters <andrew.ross.winters@liu.se>", "Jesse Chan <jesse.chan@rice.edu>"]
-version = "0.4.58-pre"
+version = "0.5.0-pre"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/docs/literate/src/files/adding_nonconservative_equation.jl
+++ b/docs/literate/src/files/adding_nonconservative_equation.jl
@@ -62,7 +62,7 @@ end
 
 
 ## We use nonconservative terms
-have_nonconservative_terms(::NonconservativeLinearAdvectionEquation) = Val(true)
+have_nonconservative_terms(::NonconservativeLinearAdvectionEquation) = Trixi.True()
 
 ## This "nonconservative numerical flux" implements the nonconservative terms.
 ## In general, nonconservative terms can be written in the form
@@ -219,7 +219,7 @@ end
 
 
 ## We use nonconservative terms
-have_nonconservative_terms(::NonconservativeLinearAdvectionEquation) = Val(true)
+have_nonconservative_terms(::NonconservativeLinearAdvectionEquation) = Trixi.True()
 
 ## This "nonconservative numerical flux" implements the nonconservative terms.
 ## In general, nonconservative terms can be written in the form

--- a/examples/dgmulti_2d/elixir_euler_bilinear.jl
+++ b/examples/dgmulti_2d/elixir_euler_bilinear.jl
@@ -26,7 +26,7 @@ for i in eachindex(vertex_coordinates[1])
   setindex!.(vertex_coordinates, mapping(vx, vy), i)
 end
 
-mesh = DGMultiMesh(vertex_coordinates, EToV, dg, is_on_boundary=is_on_boundary)
+mesh = DGMultiMesh(dg, vertex_coordinates, EToV, is_on_boundary=is_on_boundary)
 
 boundary_condition_convergence_test = BoundaryConditionDirichlet(initial_condition)
 boundary_conditions = (; :top => boundary_condition_convergence_test,

--- a/examples/dgmulti_2d/elixir_euler_triangulate_pkg_mesh.jl
+++ b/examples/dgmulti_2d/elixir_euler_triangulate_pkg_mesh.jl
@@ -13,7 +13,7 @@ meshIO = StartUpDG.triangulate_domain(StartUpDG.RectangularDomainWithHole())
 
 # the pre-defined Triangulate geometry in StartUpDG has integer boundary tags. this routine
 # assigns boundary faces based on these integer boundary tags.
-mesh = DGMultiMesh(meshIO, dg, Dict(:outer_boundary=>1, :inner_boundary=>2))
+mesh = DGMultiMesh(dg, meshIO, Dict(:outer_boundary=>1, :inner_boundary=>2))
 
 boundary_condition_convergence_test = BoundaryConditionDirichlet(initial_condition)
 boundary_conditions = (; :outer_boundary => boundary_condition_convergence_test,

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -235,7 +235,6 @@ export ode_norm, ode_unstable_check
 export convergence_test, jacobian_fd, jacobian_ad_forward, linear_structure
 
 export DGMulti, estimate_dt, DGMultiMesh, GaussSBP
-export VertexMappedMesh # TODO: DGMulti, v0.5. Remove deprecated VertexMappedMesh in next release
 
 export ViscousFormulationBassiRebay1, ViscousFormulationLocalDG
 

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -52,7 +52,7 @@ using P4est
 using Setfield: @set
 using RecipesBase: RecipesBase
 using Requires: @require
-using Static: Static, One
+using Static: Static, One, True, False
 @reexport using StaticArrays: SVector
 using StaticArrays: StaticArrays, MVector, MArray, SMatrix, @SMatrix
 using StrideArrays: PtrArray, StrideArray, StaticInt

--- a/src/auxiliary/mpi.jl
+++ b/src/auxiliary/mpi.jl
@@ -49,7 +49,13 @@ const MPI_IS_ROOT = Ref(true)
 # and it's not used in performance-critical parts. The alternative we used before,
 # calling something like `eval(:(mpi_parallel() = True()))` in `init_mpi()`,
 # causes invalidations and slows down the first call to Trixi.
-mpi_parallel()::Union{True, False} = Val(mpi_isparallel())
+function mpi_parallel()
+  if mpi_isparallel()
+    return True()
+  else
+    return False()
+  end
+end
 
 @inline mpi_isroot() = MPI_IS_ROOT[]
 

--- a/src/auxiliary/mpi.jl
+++ b/src/auxiliary/mpi.jl
@@ -47,9 +47,9 @@ const MPI_IS_ROOT = Ref(true)
 
 # This is not type-stable but that's okay since we want to get rid of it anyway
 # and it's not used in performance-critical parts. The alternative we used before,
-# calling something like `eval(:(mpi_parallel() = Val(true)))` in `init_mpi()`,
+# calling something like `eval(:(mpi_parallel() = True()))` in `init_mpi()`,
 # causes invalidations and slows down the first call to Trixi.
-mpi_parallel()::Union{Val{true}, Val{false}} = Val(mpi_isparallel())
+mpi_parallel()::Union{True, False} = Val(mpi_isparallel())
 
 @inline mpi_isroot() = MPI_IS_ROOT[]
 

--- a/src/callbacks_step/stepsize_dg1d.jl
+++ b/src/callbacks_step/stepsize_dg1d.jl
@@ -6,7 +6,7 @@
 
 
 function max_dt(u, t, mesh::TreeMesh{1},
-                constant_speed::Val{false}, equations, dg::DG, cache)
+                constant_speed::False, equations, dg::DG, cache)
   # to avoid a division by zero if the speed vanishes everywhere,
   # e.g. for steady-state linear advection
   max_scaled_speed = nextfloat(zero(t))
@@ -27,7 +27,7 @@ end
 
 
 function max_dt(u, t, mesh::TreeMesh{1},
-                constant_speed::Val{true}, equations, dg::DG, cache)
+                constant_speed::True, equations, dg::DG, cache)
   # to avoid a division by zero if the speed vanishes everywhere,
   # e.g. for steady-state linear advection
   max_scaled_speed = nextfloat(zero(t))
@@ -43,7 +43,7 @@ end
 
 
 function max_dt(u, t, mesh::StructuredMesh{1},
-                constant_speed::Val{false}, equations, dg::DG, cache)
+                constant_speed::False, equations, dg::DG, cache)
   # to avoid a division by zero if the speed vanishes everywhere,
   # e.g. for steady-state linear advection
   max_scaled_speed = nextfloat(zero(t))
@@ -68,7 +68,7 @@ end
 
 
 function max_dt(u, t, mesh::StructuredMesh{1},
-                constant_speed::Val{true}, equations, dg::DG, cache)
+                constant_speed::True, equations, dg::DG, cache)
   # to avoid a division by zero if the speed vanishes everywhere,
   # e.g. for steady-state linear advection
   max_scaled_speed = nextfloat(zero(t))

--- a/src/callbacks_step/stepsize_dg2d.jl
+++ b/src/callbacks_step/stepsize_dg2d.jl
@@ -6,7 +6,7 @@
 
 
 function max_dt(u, t, mesh::TreeMesh{2},
-                constant_speed::Val{false}, equations, dg::DG, cache)
+                constant_speed::False, equations, dg::DG, cache)
   # to avoid a division by zero if the speed vanishes everywhere,
   # e.g. for steady-state linear advection
   max_scaled_speed = nextfloat(zero(t))
@@ -28,7 +28,7 @@ end
 
 
 function max_dt(u, t, mesh::TreeMesh{2},
-                constant_speed::Val{true}, equations, dg::DG, cache)
+                constant_speed::True, equations, dg::DG, cache)
   # to avoid a division by zero if the speed vanishes everywhere,
   # e.g. for steady-state linear advection
   max_scaled_speed = nextfloat(zero(t))
@@ -44,7 +44,7 @@ end
 
 
 function max_dt(u, t, mesh::ParallelTreeMesh{2},
-                constant_speed::Val{false}, equations, dg::DG, cache)
+                constant_speed::False, equations, dg::DG, cache)
   # call the method accepting a general `mesh::TreeMesh{2}`
   # TODO: MPI, we should improve this; maybe we should dispatch on `u`
   #       and create some MPI array type, overloading broadcasting and mapreduce etc.
@@ -60,7 +60,7 @@ end
 
 
 function max_dt(u, t, mesh::ParallelTreeMesh{2},
-                constant_speed::Val{true}, equations, dg::DG, cache)
+                constant_speed::True, equations, dg::DG, cache)
   # call the method accepting a general `mesh::TreeMesh{2}`
   # TODO: MPI, we should improve this; maybe we should dispatch on `u`
   #       and create some MPI array type, overloading broadcasting and mapreduce etc.
@@ -76,7 +76,7 @@ end
 
 
 function max_dt(u, t, mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
-                constant_speed::Val{false}, equations, dg::DG, cache)
+                constant_speed::False, equations, dg::DG, cache)
   # to avoid a division by zero if the speed vanishes everywhere,
   # e.g. for steady-state linear advection
   max_scaled_speed = nextfloat(zero(t))
@@ -109,7 +109,7 @@ end
 
 
 function max_dt(u, t, mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
-                constant_speed::Val{true}, equations, dg::DG, cache)
+                constant_speed::True, equations, dg::DG, cache)
   @unpack contravariant_vectors, inverse_jacobian = cache.elements
 
   # to avoid a division by zero if the speed vanishes everywhere,
@@ -136,7 +136,7 @@ end
 
 
 function max_dt(u, t, mesh::ParallelP4estMesh{2},
-                constant_speed::Val{false}, equations, dg::DG, cache)
+                constant_speed::False, equations, dg::DG, cache)
   # call the method accepting a general `mesh::P4estMesh{2}`
   # TODO: MPI, we should improve this; maybe we should dispatch on `u`
   #       and create some MPI array type, overloading broadcasting and mapreduce etc.
@@ -152,7 +152,7 @@ end
 
 
 function max_dt(u, t, mesh::ParallelP4estMesh{2},
-                constant_speed::Val{true}, equations, dg::DG, cache)
+                constant_speed::True, equations, dg::DG, cache)
   # call the method accepting a general `mesh::P4estMesh{2}`
   # TODO: MPI, we should improve this; maybe we should dispatch on `u`
   #       and create some MPI array type, overloading broadcasting and mapreduce etc.

--- a/src/callbacks_step/stepsize_dg3d.jl
+++ b/src/callbacks_step/stepsize_dg3d.jl
@@ -6,7 +6,7 @@
 
 
 function max_dt(u, t, mesh::TreeMesh{3},
-                constant_speed::Val{false}, equations, dg::DG, cache)
+                constant_speed::False, equations, dg::DG, cache)
   # to avoid a division by zero if the speed vanishes everywhere,
   # e.g. for steady-state linear advection
   max_scaled_speed = nextfloat(zero(t))
@@ -29,7 +29,7 @@ end
 
 
 function max_dt(u, t, mesh::TreeMesh{3},
-                constant_speed::Val{true}, equations, dg::DG, cache)
+                constant_speed::True, equations, dg::DG, cache)
   # to avoid a division by zero if the speed vanishes everywhere,
   # e.g. for steady-state linear advection
   max_scaled_speed = nextfloat(zero(t))
@@ -45,7 +45,7 @@ end
 
 
 function max_dt(u, t, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
-                constant_speed::Val{false}, equations, dg::DG, cache)
+                constant_speed::False, equations, dg::DG, cache)
   # to avoid a division by zero if the speed vanishes everywhere,
   # e.g. for steady-state linear advection
   max_scaled_speed = nextfloat(zero(t))
@@ -80,7 +80,7 @@ end
 
 
 function max_dt(u, t, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
-                constant_speed::Val{true}, equations, dg::DG, cache)
+                constant_speed::True, equations, dg::DG, cache)
   # to avoid a division by zero if the speed vanishes everywhere,
   # e.g. for steady-state linear advection
   max_scaled_speed = nextfloat(zero(t))
@@ -110,7 +110,7 @@ end
 
 
 function max_dt(u, t, mesh::ParallelP4estMesh{3},
-                constant_speed::Val{false}, equations, dg::DG, cache)
+                constant_speed::False, equations, dg::DG, cache)
   # call the method accepting a general `mesh::P4estMesh{3}`
   # TODO: MPI, we should improve this; maybe we should dispatch on `u`
   #       and create some MPI array type, overloading broadcasting and mapreduce etc.
@@ -126,7 +126,7 @@ end
 
 
 function max_dt(u, t, mesh::ParallelP4estMesh{3},
-                constant_speed::Val{true}, equations, dg::DG, cache)
+                constant_speed::True, equations, dg::DG, cache)
   # call the method accepting a general `mesh::P4estMesh{3}`
   # TODO: MPI, we should improve this; maybe we should dispatch on `u`
   #       and create some MPI array type, overloading broadcasting and mapreduce etc.

--- a/src/equations/acoustic_perturbation_2d.jl
+++ b/src/equations/acoustic_perturbation_2d.jl
@@ -330,7 +330,7 @@ end
 end
 
 
-@inline have_constant_speed(::AcousticPerturbationEquations2D) = Val(false)
+@inline have_constant_speed(::AcousticPerturbationEquations2D) = False()
 
 @inline function max_abs_speeds(u, equations::AcousticPerturbationEquations2D)
   v1_mean = u[4]

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -204,10 +204,10 @@ with or without nonconservative terms. Classical conservation laws such as the
 [`CompressibleEulerEquations2D`](@ref) do not have nonconservative terms. The
 [`ShallowWaterEquations2D`](@ref) with non-constant bottom topography are an
 example of equations with nonconservative terms.
-The return value will be `Val(true)` or `Val(false)` to allow dispatching on the return type.
+The return value will be `True()` or `False()` to allow dispatching on the return type.
 """
-have_nonconservative_terms(::AbstractEquations) = Val(false)
-have_constant_speed(::AbstractEquations) = Val(false)
+have_nonconservative_terms(::AbstractEquations) = False()
+have_constant_speed(::AbstractEquations) = False()
 
 default_analysis_errors(::AbstractEquations)     = (:l2_error, :linf_error)
 """
@@ -225,7 +225,7 @@ Return the conserved variables `u`. While this function is as trivial as `identi
 it is also as useful.
 """
 @inline cons2cons(u, ::AbstractEquations) = u
-                                                                            
+
 @inline Base.first(u, ::AbstractEquations) = first(u)
 
 """

--- a/src/equations/hyperbolic_diffusion_1d.jl
+++ b/src/equations/hyperbolic_diffusion_1d.jl
@@ -166,7 +166,7 @@ end
 end
 
 
-@inline have_constant_speed(::HyperbolicDiffusionEquations1D) = Val(true)
+@inline have_constant_speed(::HyperbolicDiffusionEquations1D) = True()
 
 @inline function max_abs_speeds(eq::HyperbolicDiffusionEquations1D)
   return sqrt(eq.nu * eq.inv_Tr)

--- a/src/equations/hyperbolic_diffusion_2d.jl
+++ b/src/equations/hyperbolic_diffusion_2d.jl
@@ -206,7 +206,7 @@ end
 
 
 
-@inline have_constant_speed(::HyperbolicDiffusionEquations2D) = Val(true)
+@inline have_constant_speed(::HyperbolicDiffusionEquations2D) = True()
 
 @inline function max_abs_speeds(eq::HyperbolicDiffusionEquations2D)
   λ = sqrt(eq.nu * eq.inv_Tr)

--- a/src/equations/hyperbolic_diffusion_3d.jl
+++ b/src/equations/hyperbolic_diffusion_3d.jl
@@ -198,7 +198,7 @@ end
 
 
 
-@inline have_constant_speed(::HyperbolicDiffusionEquations3D) = Val(true)
+@inline have_constant_speed(::HyperbolicDiffusionEquations3D) = True()
 
 @inline function max_abs_speeds(eq::HyperbolicDiffusionEquations3D)
   λ = sqrt(eq.nu * eq.inv_Tr)

--- a/src/equations/ideal_glm_mhd_1d.jl
+++ b/src/equations/ideal_glm_mhd_1d.jl
@@ -25,7 +25,7 @@ struct IdealGlmMhdEquations1D{RealT<:Real} <: AbstractIdealGlmMhdEquations{1, 8}
   end
 end
 
-have_nonconservative_terms(::IdealGlmMhdEquations1D) = Val(false)
+have_nonconservative_terms(::IdealGlmMhdEquations1D) = False()
 varnames(::typeof(cons2cons), ::IdealGlmMhdEquations1D) = ("rho", "rho_v1", "rho_v2", "rho_v3", "rho_e", "B1", "B2", "B3")
 varnames(::typeof(cons2prim), ::IdealGlmMhdEquations1D) = ("rho", "v1", "v2", "v3", "p", "B1", "B2", "B3")
 default_analysis_integrals(::IdealGlmMhdEquations1D)  = (entropy_timederivative, Val(:l2_divb), Val(:linf_divb))

--- a/src/equations/ideal_glm_mhd_2d.jl
+++ b/src/equations/ideal_glm_mhd_2d.jl
@@ -28,7 +28,7 @@ function IdealGlmMhdEquations2D(gamma; initial_c_h=convert(typeof(gamma), NaN))
 end
 
 
-have_nonconservative_terms(::IdealGlmMhdEquations2D) = Val(true)
+have_nonconservative_terms(::IdealGlmMhdEquations2D) = True()
 varnames(::typeof(cons2cons), ::IdealGlmMhdEquations2D) = ("rho", "rho_v1", "rho_v2", "rho_v3", "rho_e", "B1", "B2", "B3", "psi")
 varnames(::typeof(cons2prim), ::IdealGlmMhdEquations2D) = ("rho", "v1", "v2", "v3", "p", "B1", "B2", "B3", "psi")
 default_analysis_integrals(::IdealGlmMhdEquations2D)  = (entropy_timederivative, Val(:l2_divb), Val(:linf_divb))

--- a/src/equations/ideal_glm_mhd_3d.jl
+++ b/src/equations/ideal_glm_mhd_3d.jl
@@ -28,7 +28,7 @@ function IdealGlmMhdEquations3D(gamma; initial_c_h=convert(typeof(gamma), NaN))
 end
 
 
-have_nonconservative_terms(::IdealGlmMhdEquations3D) = Val(true)
+have_nonconservative_terms(::IdealGlmMhdEquations3D) = True()
 varnames(::typeof(cons2cons), ::IdealGlmMhdEquations3D) = ("rho", "rho_v1", "rho_v2", "rho_v3", "rho_e", "B1", "B2", "B3", "psi")
 varnames(::typeof(cons2prim), ::IdealGlmMhdEquations3D) = ("rho", "v1", "v2", "v3", "p", "B1", "B2", "B3", "psi")
 default_analysis_integrals(::IdealGlmMhdEquations3D)  = (entropy_timederivative, Val(:l2_divb), Val(:linf_divb))

--- a/src/equations/ideal_glm_mhd_multicomponent_1d.jl
+++ b/src/equations/ideal_glm_mhd_multicomponent_1d.jl
@@ -45,7 +45,7 @@ end
 
 @inline Base.real(::IdealGlmMhdMulticomponentEquations1D{NVARS, NCOMP, RealT}) where {NVARS, NCOMP, RealT} = RealT
 
-have_nonconservative_terms(::IdealGlmMhdMulticomponentEquations1D) = Val(false)
+have_nonconservative_terms(::IdealGlmMhdMulticomponentEquations1D) = False()
 
 function varnames(::typeof(cons2cons), equations::IdealGlmMhdMulticomponentEquations1D)
 

--- a/src/equations/ideal_glm_mhd_multicomponent_2d.jl
+++ b/src/equations/ideal_glm_mhd_multicomponent_2d.jl
@@ -47,7 +47,7 @@ end
 
 @inline Base.real(::IdealGlmMhdMulticomponentEquations2D{NVARS, NCOMP, RealT}) where {NVARS, NCOMP, RealT} = RealT
 
-have_nonconservative_terms(::IdealGlmMhdMulticomponentEquations2D) = Val(true)
+have_nonconservative_terms(::IdealGlmMhdMulticomponentEquations2D) = True()
 
 function varnames(::typeof(cons2cons), equations::IdealGlmMhdMulticomponentEquations2D)
 

--- a/src/equations/lattice_boltzmann_2d.jl
+++ b/src/equations/lattice_boltzmann_2d.jl
@@ -360,7 +360,7 @@ end
 
 
 
-@inline have_constant_speed(::LatticeBoltzmannEquations2D) = Val(true)
+@inline have_constant_speed(::LatticeBoltzmannEquations2D) = True()
 
 @inline function max_abs_speeds(equations::LatticeBoltzmannEquations2D)
   @unpack c = equations

--- a/src/equations/lattice_boltzmann_3d.jl
+++ b/src/equations/lattice_boltzmann_3d.jl
@@ -368,7 +368,7 @@ end
 
 
 
-@inline have_constant_speed(::LatticeBoltzmannEquations3D) = Val(true)
+@inline have_constant_speed(::LatticeBoltzmannEquations3D) = True()
 
 @inline function max_abs_speeds(equations::LatticeBoltzmannEquations3D)
   @unpack c = equations

--- a/src/equations/linear_scalar_advection_1d.jl
+++ b/src/equations/linear_scalar_advection_1d.jl
@@ -151,10 +151,10 @@ function flux_godunov(u_ll, u_rr, orientation::Int, equation::LinearScalarAdvect
   u_L = u_ll[1]
   u_R = u_rr[1]
 
-  v_normal = equation.advection_velocity[orientation] 
+  v_normal = equation.advection_velocity[orientation]
   if v_normal >= 0
     return SVector(v_normal * u_L)
-  else 
+  else
     return SVector(v_normal * u_R)
   end
 end
@@ -166,12 +166,12 @@ function flux_engquist_osher(u_ll, u_rr, orientation::Int, equation::LinearScala
   u_L = u_ll[1]
   u_R = u_rr[1]
 
-  return SVector(0.5 * (flux(u_L, orientation, equation) + flux(u_R, orientation, equation) - 
+  return SVector(0.5 * (flux(u_L, orientation, equation) + flux(u_R, orientation, equation) -
                         abs(equation.advection_velocity[orientation]) * (u_R - u_L)))
 end
 
 
-@inline have_constant_speed(::LinearScalarAdvectionEquation1D) = Val(true)
+@inline have_constant_speed(::LinearScalarAdvectionEquation1D) = True()
 
 @inline function max_abs_speeds(equation::LinearScalarAdvectionEquation1D)
   return abs.(equation.advection_velocity)

--- a/src/equations/linear_scalar_advection_2d.jl
+++ b/src/equations/linear_scalar_advection_2d.jl
@@ -249,10 +249,10 @@ function flux_godunov(u_ll, u_rr, orientation::Integer, equation::LinearScalarAd
   u_L = u_ll[1]
   u_R = u_rr[1]
 
-  v_normal = equation.advection_velocity[orientation] 
+  v_normal = equation.advection_velocity[orientation]
   if v_normal >= 0
     return SVector(v_normal * u_L)
-  else 
+  else
     return SVector(v_normal * u_R)
   end
 end
@@ -266,13 +266,13 @@ function flux_godunov(u_ll, u_rr, normal_direction::AbstractVector, equation::Li
   a_normal = dot(equation.advection_velocity, normal_direction)
   if a_normal >= 0
     return SVector(a_normal * u_L)
-  else 
+  else
     return SVector(a_normal * u_R)
   end
 end
 
 
-@inline have_constant_speed(::LinearScalarAdvectionEquation2D) = Val(true)
+@inline have_constant_speed(::LinearScalarAdvectionEquation2D) = True()
 
 @inline function max_abs_speeds(equation::LinearScalarAdvectionEquation2D)
   return abs.(equation.advection_velocity)

--- a/src/equations/linear_scalar_advection_3d.jl
+++ b/src/equations/linear_scalar_advection_3d.jl
@@ -167,10 +167,10 @@ function flux_godunov(u_ll, u_rr, orientation::Integer, equation::LinearScalarAd
   u_L = u_ll[1]
   u_R = u_rr[1]
 
-  v_normal = equation.advection_velocity[orientation] 
+  v_normal = equation.advection_velocity[orientation]
   if v_normal >= 0
     return SVector(v_normal * u_L)
-  else 
+  else
     return SVector(v_normal * u_R)
   end
 end
@@ -184,13 +184,13 @@ function flux_godunov(u_ll, u_rr, normal_direction::AbstractVector, equation::Li
   a_normal = dot(equation.advection_velocity, normal_direction)
   if a_normal >= 0
     return SVector(a_normal * u_L)
-  else 
+  else
     return SVector(a_normal * u_R)
   end
 end
 
 
-@inline have_constant_speed(::LinearScalarAdvectionEquation3D) = Val(true)
+@inline have_constant_speed(::LinearScalarAdvectionEquation3D) = True()
 
 @inline function max_abs_speeds(equation::LinearScalarAdvectionEquation3D)
   return abs.(equation.advection_velocity)

--- a/src/equations/linearized_euler_2d.jl
+++ b/src/equations/linearized_euler_2d.jl
@@ -7,7 +7,7 @@
 
 @doc raw"""
     LinearizedEulerEquations2D(v_mean_global, c_mean_global, rho_mean_global)
-        
+
 Linearized euler equations in two space dimensions. The equations are given by
 ```math
 \partial t
@@ -29,7 +29,7 @@ Linearized euler equations in two space dimensions. The equations are given by
     0 \\ 0 \\ 0 \\ 0
 \end{pmatrix}
 ```
-The bar ``\bar{(\cdot)}`` indicates uniform mean flow variables and c is the speed of sound. 
+The bar ``\bar{(\cdot)}`` indicates uniform mean flow variables and c is the speed of sound.
 The unknowns are the acoustic velocities ``v' = (v_1', v_2')``, the pressure ``p'`` and the density ``\rho'``.
 """
 struct LinearizedEulerEquations2D{RealT<:Real} <: AbstractLinearizedEulerEquations{2, 4}
@@ -44,21 +44,21 @@ function LinearizedEulerEquations2D(v_mean_global::NTuple{2,<:Real}, c_mean_glob
     elseif c_mean_global < 0
       throw(ArgumentError("c_mean_global must be non-negative"))
     end
-    
+
     return LinearizedEulerEquations2D(SVector(v_mean_global), c_mean_global, rho_mean_global)
 end
-    
+
 function LinearizedEulerEquations2D(; v_mean_global::NTuple{2,<:Real}, c_mean_global::Real, rho_mean_global::Real)
     return LinearizedEulerEquations2D(SVector(v_mean_global), c_mean_global, rho_mean_global)
 end
-    
-    
+
+
 varnames(::typeof(cons2cons), ::LinearizedEulerEquations2D) = ("rho_prime", "v1_prime", "v2_prime", "p_prime")
 varnames(::typeof(cons2prim), ::LinearizedEulerEquations2D) = ("rho_prime", "v1_prime", "v2_prime", "p_prime")
-    
+
 """
     initial_condition_convergence_test(x, t, equations::LinearizedEulerEquations2D)
-    
+
 A smooth initial condition used for convergence tests.
 """
 function initial_condition_convergence_test(x, t, equations::LinearizedEulerEquations2D)
@@ -66,15 +66,15 @@ function initial_condition_convergence_test(x, t, equations::LinearizedEulerEqua
     v1_prime = sinpi(2*t) * cospi(2*x[1])
     v2_prime = sinpi(2*t) * cospi(2*x[2])
     p_prime = rho_prime
-    
+
     return SVector(rho_prime, v1_prime, v2_prime, p_prime)
 end
-    
-    
+
+
 """
     boundary_condition_wall(u_inner, orientation, direction, x, t, surface_flux_function,
                                 equations::LinearizedEulerEquations2D)
-    
+
 Boundary conditions for a solid wall.
 """
 function boundary_condition_wall(u_inner, orientation, direction, x, t, surface_flux_function,
@@ -88,18 +88,18 @@ function boundary_condition_wall(u_inner, orientation, direction, x, t, surface_
     else # y direction
         u_boundary = SVector(u_inner[1], u_inner[2], -u_inner[3], u_inner[4])
     end
-      
+
     # Calculate boundary flux
     if iseven(direction) # u_inner is "left" of boundary, u_boundary is "right" of boundary
         flux = surface_flux_function(u_inner, u_boundary, orientation, equations)
     else # u_boundary is "left" of boundary, u_inner is "right" of boundary
         flux = surface_flux_function(u_boundary, u_inner, orientation, equations)
     end
-      
+
     return flux
 end
-    
-    
+
+
 # Calculate 1D flux for a single point
 @inline function flux(u, orientation::Integer, equations::LinearizedEulerEquations2D)
     @unpack v_mean_global, c_mean_global, rho_mean_global = equations
@@ -115,18 +115,18 @@ end
         f3 = v_mean_global[2] * v2_prime + p_prime / rho_mean_global
         f4 = v_mean_global[2] * p_prime + c_mean_global^2 * rho_mean_global * v2_prime
     end
-      
+
     return SVector(f1, f2, f3, f4)
 end
-    
-    
-@inline have_constant_speed(::LinearizedEulerEquations2D) = Val(true)
-    
+
+
+@inline have_constant_speed(::LinearizedEulerEquations2D) = True()
+
 @inline function max_abs_speeds(equations::LinearizedEulerEquations2D)
     @unpack v_mean_global, c_mean_global = equations
     return abs(v_mean_global[1]) + c_mean_global, abs(v_mean_global[2]) + c_mean_global
 end
-    
+
 @inline function max_abs_speed_naive(u_ll, u_rr, orientation::Integer, equations::LinearizedEulerEquations2D)
     @unpack v_mean_global, c_mean_global = equations
     if orientation == 1
@@ -135,12 +135,11 @@ end
         return abs(v_mean_global[2]) + c_mean_global
     end
 end
-    
-    
+
+
 # Convert conservative variables to primitive
 @inline cons2prim(u, equations::LinearizedEulerEquations2D) = u
 @inline cons2entropy(u, ::LinearizedEulerEquations2D) = u
 
 
 end # muladd
-    

--- a/src/equations/numerical_fluxes.jl
+++ b/src/equations/numerical_fluxes.jl
@@ -182,7 +182,6 @@ end
 
 Base.show(io::IO, f::FluxLaxFriedrichs) = print(io, "FluxLaxFriedrichs(", f.dissipation.max_abs_speed, ")")
 
-# TODO: Shall we deprecate `flux_lax_friedrichs`?
 """
     flux_lax_friedrichs
 
@@ -238,7 +237,6 @@ end
 
 Base.show(io::IO, numflux::FluxHLL) = print(io, "FluxHLL(", numflux.min_max_speed, ")")
 
-# TODO: Shall we deprecate `flux_hll`?
 """
     flux_hll
 

--- a/src/equations/shallow_water_1d.jl
+++ b/src/equations/shallow_water_1d.jl
@@ -58,7 +58,7 @@ function ShallowWaterEquations1D(; gravity_constant, H0=0.0)
 end
 
 
-have_nonconservative_terms(::ShallowWaterEquations1D) = Val(true)
+have_nonconservative_terms(::ShallowWaterEquations1D) = True()
 varnames(::typeof(cons2cons), ::ShallowWaterEquations1D) = ("h", "h_v", "b")
 # Note, we use the total water height, H = h + b, as the first primitive variable for easier
 # visualization and setting initial conditions

--- a/src/equations/shallow_water_2d.jl
+++ b/src/equations/shallow_water_2d.jl
@@ -61,7 +61,7 @@ function ShallowWaterEquations2D(; gravity_constant, H0=0.0)
 end
 
 
-have_nonconservative_terms(::ShallowWaterEquations2D) = Val(true)
+have_nonconservative_terms(::ShallowWaterEquations2D) = True()
 varnames(::typeof(cons2cons), ::ShallowWaterEquations2D) = ("h", "h_v1", "h_v2", "b")
 # Note, we use the total water height, H = h + b, as the first primitive variable for easier
 # visualization and setting initial conditions
@@ -576,7 +576,7 @@ end
   v1_avg = 0.5 * (v1_ll  + v1_rr )
   v2_avg = 0.5 * (v2_ll  + v2_rr )
   h2_avg = 0.5 * (h_ll^2 + h_rr^2)
-  p_avg  = 0.5 * equations.gravity * h2_avg 
+  p_avg  = 0.5 * equations.gravity * h2_avg
   v_dot_n_avg = 0.5 * (v_dot_n_ll + v_dot_n_rr)
 
   # Calculate fluxes depending on normal_direction

--- a/src/meshes/mesh_io.jl
+++ b/src/meshes/mesh_io.jl
@@ -224,14 +224,13 @@ end
 Load the mesh from the `restart_file`.
 """
 function load_mesh(restart_file::AbstractString; n_cells_max=0, RealT=Float64)
-  # Determine mesh filename
-  mesh_file = get_restart_mesh_filename(restart_file, Val(mpi_isparallel()))
-
   if mpi_isparallel()
+    mesh_file = get_restart_mesh_filename(restart_file, True())
     return load_mesh_parallel(mesh_file; n_cells_max=n_cells_max, RealT=RealT)
+  else
+    mesh_file = get_restart_mesh_filename(restart_file, False())
+    load_mesh_serial(mesh_file; n_cells_max=n_cells_max, RealT=RealT)
   end
-
-  load_mesh_serial(mesh_file; n_cells_max=n_cells_max, RealT=RealT)
 end
 
 function load_mesh_serial(mesh_file::AbstractString; n_cells_max, RealT)

--- a/src/meshes/mesh_io.jl
+++ b/src/meshes/mesh_io.jl
@@ -11,7 +11,7 @@ function save_mesh_file(mesh::Union{TreeMesh, P4estMesh}, output_directory, time
 end
 
 function save_mesh_file(mesh::TreeMesh, output_directory, timestep,
-                        mpi_parallel::Val{false})
+                        mpi_parallel::False)
   # Create output directory (if it does not exist)
   mkpath(output_directory)
 
@@ -49,7 +49,7 @@ end
 
 # Save current mesh with some context information as an HDF5 file.
 function save_mesh_file(mesh::TreeMesh, output_directory, timestep,
-                        mpi_parallel::Val{true})
+                        mpi_parallel::True)
   # Create output directory (if it does not exist)
   mpi_isroot() && mkpath(output_directory)
 
@@ -142,7 +142,7 @@ end
 # of the mesh, like its size and the type of boundary mapping function.
 # Then, within Trixi2Vtk, the P4estMesh and its node coordinates are reconstructured from
 # these attributes for plotting purposes
-function save_mesh_file(mesh::P4estMesh, output_directory, timestep, mpi_parallel::Val{false})
+function save_mesh_file(mesh::P4estMesh, output_directory, timestep, mpi_parallel::False)
   # Create output directory (if it does not exist)
   mkpath(output_directory)
 
@@ -177,7 +177,7 @@ function save_mesh_file(mesh::P4estMesh, output_directory, timestep, mpi_paralle
   return filename
 end
 
-function save_mesh_file(mesh::P4estMesh, output_directory, timestep, mpi_parallel::Val{true})
+function save_mesh_file(mesh::P4estMesh, output_directory, timestep, mpi_parallel::True)
   # Create output directory (if it does not exist)
   mpi_isroot() && mkpath(output_directory)
 

--- a/src/meshes/p4est_mesh.jl
+++ b/src/meshes/p4est_mesh.jl
@@ -35,9 +35,9 @@ mutable struct P4estMesh{NDIMS, RealT<:Real, IsParallel, P, Ghost, NDIMSP2, NNOD
       if !P4est.uses_mpi()
         error("p4est library does not support MPI")
       end
-      is_parallel = Val(true)
+      is_parallel = True()
     else
-      is_parallel = Val(false)
+      is_parallel = False()
     end
 
     ghost = ghost_new_p4est(p4est)
@@ -52,11 +52,11 @@ mutable struct P4estMesh{NDIMS, RealT<:Real, IsParallel, P, Ghost, NDIMSP2, NNOD
   end
 end
 
-const SerialP4estMesh{NDIMS}   = P4estMesh{NDIMS, <:Real, <:Val{false}}
-const ParallelP4estMesh{NDIMS} = P4estMesh{NDIMS, <:Real, <:Val{true}}
+const SerialP4estMesh{NDIMS}   = P4estMesh{NDIMS, <:Real, <:False}
+const ParallelP4estMesh{NDIMS} = P4estMesh{NDIMS, <:Real, <:True}
 
-@inline mpi_parallel(mesh::SerialP4estMesh) = Val(false)
-@inline mpi_parallel(mesh::ParallelP4estMesh) = Val(true)
+@inline mpi_parallel(mesh::SerialP4estMesh) = False()
+@inline mpi_parallel(mesh::ParallelP4estMesh) = True()
 
 
 function destroy_mesh(mesh::P4estMesh{2})

--- a/src/meshes/parallel_tree_mesh.jl
+++ b/src/meshes/parallel_tree_mesh.jl
@@ -74,7 +74,7 @@ function partition!(mesh::ParallelTreeMesh; allow_coarsening=true)
 end
 
 
-function get_restart_mesh_filename(restart_filename, mpi_parallel::Val{true})
+function get_restart_mesh_filename(restart_filename, mpi_parallel::True)
   # Get directory name
   dirname, _ = splitdir(restart_filename)
 

--- a/src/meshes/tree_mesh.jl
+++ b/src/meshes/tree_mesh.jl
@@ -70,8 +70,8 @@ const TreeMesh3D = TreeMesh{3, TreeType} where {TreeType <: AbstractTree{3}}
 const SerialTreeMesh{NDIMS}   = TreeMesh{NDIMS, <:SerialTree{NDIMS}}
 const ParallelTreeMesh{NDIMS} = TreeMesh{NDIMS, <:ParallelTree{NDIMS}}
 
-@inline mpi_parallel(mesh::SerialTreeMesh) = Val(false)
-@inline mpi_parallel(mesh::ParallelTreeMesh) = Val(true)
+@inline mpi_parallel(mesh::SerialTreeMesh) = False()
+@inline mpi_parallel(mesh::ParallelTreeMesh) = True()
 
 partition!(mesh::SerialTreeMesh) = nothing
 
@@ -188,7 +188,7 @@ end
 
 
 # Obtain the mesh filename from a restart file
-function get_restart_mesh_filename(restart_filename, mpi_parallel::Val{false})
+function get_restart_mesh_filename(restart_filename, mpi_parallel::False)
   # Get directory name
   dirname, _ = splitdir(restart_filename)
 

--- a/src/solvers/dgmulti/dg.jl
+++ b/src/solvers/dgmulti/dg.jl
@@ -134,7 +134,7 @@ end
 
 # for the stepsize callback
 function max_dt(u, t, mesh::DGMultiMesh,
-                constant_speed::Val{false}, equations, dg::DGMulti{NDIMS}, cache) where {NDIMS}
+                constant_speed::False, equations, dg::DGMulti{NDIMS}, cache) where {NDIMS}
 
   @unpack md = mesh
   rd = dg.basis
@@ -158,7 +158,7 @@ function max_dt(u, t, mesh::DGMultiMesh,
 end
 
 function max_dt(u, t, mesh::DGMultiMesh,
-                constant_speed::Val{true}, equations, dg::DGMulti{NDIMS}, cache) where {NDIMS}
+                constant_speed::True, equations, dg::DGMulti{NDIMS}, cache) where {NDIMS}
 
   @unpack md = mesh
   rd = dg.basis
@@ -190,7 +190,7 @@ function prolong2interfaces!(cache, u, mesh::DGMultiMesh, equations,
 end
 
 function calc_volume_integral!(du, u, mesh::DGMultiMesh,
-                               have_nonconservative_terms::Val{false}, equations,
+                               have_nonconservative_terms::False, equations,
                                volume_integral::VolumeIntegralWeakForm, dg::DGMulti,
                                cache)
 
@@ -218,7 +218,7 @@ end
 
 function calc_interface_flux!(cache, surface_integral::SurfaceIntegralWeakForm,
                               mesh::DGMultiMesh,
-                              have_nonconservative_terms::Val{false}, equations,
+                              have_nonconservative_terms::False, equations,
                               dg::DGMulti{NDIMS}) where {NDIMS}
 
   @unpack surface_flux = surface_integral
@@ -239,7 +239,7 @@ end
 
 function calc_interface_flux!(cache, surface_integral::SurfaceIntegralWeakForm,
                               mesh::DGMultiMesh,
-                              have_nonconservative_terms::Val{true}, equations,
+                              have_nonconservative_terms::True, equations,
                               dg::DGMulti{NDIMS}) where {NDIMS}
 
   flux_conservative, flux_nonconservative = surface_integral.surface_flux

--- a/src/solvers/dgmulti/flux_differencing.jl
+++ b/src/solvers/dgmulti/flux_differencing.jl
@@ -231,7 +231,7 @@ end
   return SVector{NDIMS}(getindex.(rstxyzJ[:, orientation], 1, element))
 end
 
-@inline function get_contravariant_vector(element, orientation, mesh::DGMultiMesh{NDIMS, NonAffine()}) where {NDIMS}
+@inline function get_contravariant_vector(element, orientation, mesh::DGMultiMesh{NDIMS, NonAffine}) where {NDIMS}
   # note that rstxyzJ = [rxJ, sxJ, txJ; ryJ syJ tyJ; rzJ szJ tzJ]
 
   # assumes geometric terms vary spatially over each element

--- a/src/solvers/dgmulti/flux_differencing.jl
+++ b/src/solvers/dgmulti/flux_differencing.jl
@@ -22,7 +22,7 @@
 
 # Version for dense operators and symmetric fluxes
 @inline function hadamard_sum!(du, A,
-                               flux_is_symmetric::Val{true}, volume_flux,
+                               flux_is_symmetric::True, volume_flux,
                                orientation_or_normal_direction, u, equations)
   row_ids, col_ids = axes(A)
 
@@ -47,7 +47,7 @@ end
 
 # Version for dense operators and non-symmetric fluxes
 @inline function hadamard_sum!(du, A,
-                               flux_is_symmetric::Val{false}, volume_flux,
+                               flux_is_symmetric::False, volume_flux,
                                orientation::Integer, u, equations)
   row_ids, col_ids = axes(A)
 
@@ -64,7 +64,7 @@ end
 end
 
 @inline function hadamard_sum!(du, A,
-                               flux_is_symmetric::Val{false}, volume_flux,
+                               flux_is_symmetric::False, volume_flux,
                                normal_direction::AbstractVector, u, equations)
   row_ids, col_ids = axes(A)
 
@@ -85,7 +85,7 @@ end
 
 # Version for sparse operators and symmetric fluxes
 @inline function hadamard_sum!(du, A::LinearAlgebra.Adjoint{<:Any, <:AbstractSparseMatrixCSC},
-                               flux_is_symmetric::Val{true}, volume_flux,
+                               flux_is_symmetric::True, volume_flux,
                                orientation_or_normal_direction, u, equations)
   A_base = parent(A) # the adjoint of a SparseMatrixCSC is basically a SparseMatrixCSR
   row_ids = axes(A, 2)
@@ -115,7 +115,7 @@ end
 
 # Version for sparse operators and symmetric fluxes with curved meshes
 @inline function hadamard_sum!(du, A::LinearAlgebra.Adjoint{<:Any, <:AbstractSparseMatrixCSC},
-                               flux_is_symmetric::Val{true}, volume_flux,
+                               flux_is_symmetric::True, volume_flux,
                                normal_directions::AbstractVector{<:AbstractVector},
                                u, equations)
   A_base = parent(A) # the adjoint of a SparseMatrixCSC is basically a SparseMatrixCSR
@@ -151,7 +151,7 @@ end
 # TODO: DGMulti. Fix for curved meshes.
 # Version for sparse operators and non-symmetric fluxes
 @inline function hadamard_sum!(du, A::LinearAlgebra.Adjoint{<:Any, <:AbstractSparseMatrixCSC},
-                               flux_is_symmetric::Val{false}, volume_flux,
+                               flux_is_symmetric::False, volume_flux,
                                normal_direction::AbstractVector, u, equations)
   A_base = parent(A) # the adjoint of a SparseMatrixCSC is basically a SparseMatrixCSR
   row_ids = axes(A, 2)
@@ -249,7 +249,7 @@ function compute_flux_differencing_SBP_matrices(dg::DGMulti, sparse_operators)
   rd = dg.basis
   Qrst_hybridized, VhP, Ph = StartUpDG.hybridized_SBP_operators(rd)
   Qrst_skew = map(A -> 0.5 * (A - A'), Qrst_hybridized)
-  if sparse_operators isa Val{true}
+  if sparse_operators == true
     Qrst_skew = map(Qi -> droptol!(sparse(Qi'), 100 * eps(eltype(Qi)))', Qrst_skew)
   end
   return Qrst_skew, VhP, Ph
@@ -261,7 +261,7 @@ function compute_flux_differencing_SBP_matrices(dg::DGMultiFluxDiffSBP, sparse_o
   @unpack M, Drst, Pq = rd
   Qrst = map(D -> M * D, Drst)
   Qrst_skew = map(A -> 0.5 * (A - A'), Qrst)
-  if sparse_operators isa Val{true}
+  if sparse_operators == true
     Qrst_skew = map(Qi -> droptol!(sparse(Qi'), 100 * eps(eltype(Qi)))', Qrst_skew)
   end
   return Qrst_skew
@@ -391,54 +391,54 @@ end
 # normal components. This implies that operators for different coordinate directions have
 # different sparsity patterns. We default to using sum factorization (which is faster when
 # operators are sparse) for all `DGMulti` / `StartUpDG.jl` approximation types.
-@inline has_sparse_operators(element_type, approx_type) = Val{true}()
+@inline has_sparse_operators(element_type, approx_type) = True()
 
 # For traditional SBP operators on triangles, the operators are fully dense. We avoid using
 # sum factorization here, which is slower for fully dense matrices.
-@inline has_sparse_operators(::Union{Tri, Tet}, approx_type::AT) where {AT <: SBP} = Val{false}()
+@inline has_sparse_operators(::Union{Tri, Tet}, approx_type::AT) where {AT <: SBP} = False()
 
 # SBP/GaussSBP operators on quads/hexes use tensor-product operators. Thus, sum factorization is
 # more efficient and we use the sparsity structure.
-@inline has_sparse_operators(::Union{Quad, Hex}, approx_type::AT) where {AT <: SBP} = Val{true}()
-@inline has_sparse_operators(::Union{Quad, Hex}, approx_type::GaussSBP) = Val{true}()
+@inline has_sparse_operators(::Union{Quad, Hex}, approx_type::AT) where {AT <: SBP} = True()
+@inline has_sparse_operators(::Union{Quad, Hex}, approx_type::GaussSBP) = True()
 
 # FD SBP methods have sparse operators
-@inline has_sparse_operators(::Union{Line, Quad, Hex}, approx_type::AbstractDerivativeOperator) = Val{true}()
+@inline has_sparse_operators(::Union{Line, Quad, Hex}, approx_type::AbstractDerivativeOperator) = True()
 
 # Todo: DGMulti. Dispatch on curved/non-curved mesh types, this code only works for affine meshes (accessing rxJ[1,e],...)
 # Computes flux differencing contribution from each Cartesian direction over a single element.
 # For dense operators, we do not use sum factorization.
 @inline function local_flux_differencing!(fluxdiff_local, u_local, element_index,
-                                          has_nonconservative_terms::Val{false}, volume_integral,
-                                          has_sparse_operators::Val{false}, mesh,
+                                          has_nonconservative_terms::False, volume_integral,
+                                          has_sparse_operators::False, mesh,
                                           equations, dg, cache)
   @unpack volume_flux = volume_integral
   for dim in eachdim(mesh)
     Qi_skew = build_lazy_physical_derivative(element_index, dim, mesh, dg, cache)
-    # Val{true}() indicates the volume flux is symmetric
+    # True() indicates the volume flux is symmetric
     hadamard_sum!(fluxdiff_local, Qi_skew,
-                  Val{true}(), volume_flux,
+                  True(), volume_flux,
                   dim, u_local, equations)
   end
 end
 
 @inline function local_flux_differencing!(fluxdiff_local, u_local, element_index,
-                                          has_nonconservative_terms::Val{true}, volume_integral,
-                                          has_sparse_operators::Val{false}, mesh,
+                                          has_nonconservative_terms::True, volume_integral,
+                                          has_sparse_operators::False, mesh,
                                           equations, dg, cache)
   flux_conservative, flux_nonconservative = volume_integral.volume_flux
   for dim in eachdim(mesh)
     Qi_skew = build_lazy_physical_derivative(element_index, dim, mesh, dg, cache)
-    # Val{true}() indicates the flux is symmetric.
+    # True() indicates the flux is symmetric.
     hadamard_sum!(fluxdiff_local, Qi_skew,
-                  Val{true}(), flux_conservative,
+                  True(), flux_conservative,
                   dim, u_local, equations)
 
     # The final argument .5 scales the operator by 1/2 for the nonconservative terms.
     half_Qi_skew = build_lazy_physical_derivative(element_index, dim, mesh, dg, cache, 0.5)
-    # Val{false}() indicates the flux is non-symmetric.
+    # False() indicates the flux is non-symmetric.
     hadamard_sum!(fluxdiff_local, half_Qi_skew,
-                  Val{false}(), flux_nonconservative,
+                  False(), flux_nonconservative,
                   dim, u_local, equations)
   end
 end
@@ -447,8 +447,8 @@ end
 # When the operators are sparse, we use the sum-factorization approach to
 # computing flux differencing.
 @inline function local_flux_differencing!(fluxdiff_local, u_local, element_index,
-                                          has_nonconservative_terms::Val{false}, volume_integral,
-                                          has_sparse_operators::Val{true}, mesh,
+                                          has_nonconservative_terms::False, volume_integral,
+                                          has_sparse_operators::True, mesh,
                                           equations, dg, cache)
   @unpack Qrst_skew = cache
   @unpack volume_flux = volume_integral
@@ -470,16 +470,16 @@ end
     normal_direction = get_contravariant_vector(element_index, dim, mesh)
     Q_skew = Qrst_skew[dim]
 
-    # Val{true}() indicates the flux is symmetric
+    # True() indicates the flux is symmetric
     hadamard_sum!(fluxdiff_local, Q_skew,
-                  Val{true}(), volume_flux,
+                  True(), volume_flux,
                   normal_direction, u_local, equations)
   end
 end
 
 @inline function local_flux_differencing!(fluxdiff_local, u_local, element_index,
-                                          has_nonconservative_terms::Val{true}, volume_integral,
-                                          has_sparse_operators::Val{true}, mesh,
+                                          has_nonconservative_terms::True, volume_integral,
+                                          has_sparse_operators::True, mesh,
                                           equations, dg, cache)
   @unpack Qrst_skew = cache
   flux_conservative, flux_nonconservative = volume_integral.volume_flux
@@ -487,16 +487,16 @@ end
     normal_direction = get_contravariant_vector(element_index, dim, mesh)
     Q_skew = Qrst_skew[dim]
 
-    # Val{true}() indicates the flux is symmetric
+    # True() indicates the flux is symmetric
     hadamard_sum!(fluxdiff_local, Q_skew,
-                  Val{true}(), flux_conservative,
+                  True(), flux_conservative,
                   normal_direction, u_local, equations)
 
     # We scale the operator by 1/2 for the nonconservative terms.
     half_Q_skew = LazyMatrixLinearCombo((Q_skew, ), (0.5, ))
-    # Val{false}() indicates the flux is non-symmetric
+    # False() indicates the flux is non-symmetric
     hadamard_sum!(fluxdiff_local, half_Q_skew,
-                  Val{false}(), flux_nonconservative,
+                  False(), flux_nonconservative,
                   normal_direction, u_local, equations)
   end
 end

--- a/src/solvers/dgmulti/sbp.jl
+++ b/src/solvers/dgmulti/sbp.jl
@@ -444,7 +444,7 @@ end
 
 function calc_interface_flux!(cache, surface_integral::SurfaceIntegralWeakForm,
                               mesh::DGMultiMesh,
-                              have_nonconservative_terms::Val{false}, equations,
+                              have_nonconservative_terms::False, equations,
                               dg::DGMultiPeriodicFDSBP)
   @assert nelements(mesh, dg, cache) == 1
   nothing
@@ -470,7 +470,7 @@ end
 
 # Specialize calc_volume_integral for periodic SBP operators (assumes the operator is sparse).
 function calc_volume_integral!(du, u, mesh::DGMultiMesh,
-                               have_nonconservative_terms::Val{false}, equations,
+                               have_nonconservative_terms::False, equations,
                                volume_integral::VolumeIntegralFluxDifferencing,
                                dg::DGMultiFluxDiffPeriodicFDSBP, cache)
 
@@ -490,7 +490,7 @@ function calc_volume_integral!(du, u, mesh::DGMultiMesh,
       #       `= ∑_j (1 / M[i,i] * Q[i,j]) * volume_flux(u[i], u[j])`
       #       `= ∑_j        D[i,j]         * volume_flux(u[i], u[j])`
       # TODO: DGMulti.
-      # This would have to be changed if `has_nonconservative_terms = Val{false}()`
+      # This would have to be changed if `has_nonconservative_terms = False()`
       # because then `volume_flux` is non-symmetric.
       A = dg.basis.Drst[dim]
 
@@ -523,9 +523,9 @@ function calc_volume_integral!(du, u, mesh::DGMultiMesh,
 
       A = dg.basis.Drst[dim]
 
-      # since has_nonconservative_terms::Val{false},
+      # since has_nonconservative_terms::False,
       # the volume flux is symmetric.
-      flux_is_symmetric = Val{true}()
+      flux_is_symmetric = True()
       hadamard_sum!(du, A, flux_is_symmetric, volume_flux,
                     normal_direction, u, equations)
     end

--- a/src/solvers/dgmulti/types.jl
+++ b/src/solvers/dgmulti/types.jl
@@ -136,9 +136,6 @@ function DGMultiMesh(dg::DGMulti{NDIMS}, vertex_coordinates, EToV::AbstractArray
   return DGMultiMesh(dg, GeometricTermsType(VertexMapped(), dg), md, boundary_faces)
 end
 
-@deprecate DGMultiMesh(vertex_coordinates, EToV, dg::DGMulti{NDIMS}; kwargs...) where {NDIMS} =
-  DGMultiMesh(dg, vertex_coordinates, EToV; kwargs...)
-
 """
     DGMultiMesh(dg::DGMulti{2, Tri}, triangulateIO, boundary_dict::Dict{Symbol, Int})
 
@@ -156,9 +153,6 @@ function DGMultiMesh(dg::DGMulti{2, Tri}, triangulateIO, boundary_dict::Dict{Sym
   boundary_faces = StartUpDG.tag_boundary_faces(triangulateIO, dg.basis, md, boundary_dict)
   return DGMultiMesh(dg, GeometricTermsType(TriangulateIO(), dg), md, boundary_faces)
 end
-
-@deprecate DGMultiMesh(triangulateIO, dg::DGMulti{2, Tri}, boundary_dict::Dict{Symbol, Int}; kwargs...) =
-  DGMultiMesh(dg, triangulateIO, boundary_dict; kwargs...)
 
 # TODO: DGMulti. Make `cells_per_dimension` a non-keyword argument for easier dispatch.
 """
@@ -350,6 +344,7 @@ function LinearAlgebra.mul!(b_in, A_kronecker::SimpleKronecker{3}, x_in)
   return nothing
 end
 
-
-
 end # @muladd
+
+@deprecate DGMultiMesh(vertex_coordinates, EToV, dg::DGMulti{NDIMS}; kwargs...) where {NDIMS} DGMultiMesh(dg, vertex_coordinates, EToV; kwargs...)
+@deprecate DGMultiMesh(triangulateIO, dg::DGMulti{2, Tri}, boundary_dict::Dict{Symbol, Int}; kwargs...) DGMultiMesh(dg, triangulateIO, boundary_dict; kwargs...)

--- a/src/solvers/dgmulti/types.jl
+++ b/src/solvers/dgmulti/types.jl
@@ -122,7 +122,7 @@ GeometricTermsType(mesh_type::Curved, element_type::AbstractElemShape) = NonAffi
 - `periodicity` is a tuple of booleans specifying if the domain is periodic `true`/`false` in the
   (x,y,z) direction.
 """
-function DGMultiMesh(dg::DGMulti{NDIMS}, vertex_coordinates, EToV;
+function DGMultiMesh(dg::DGMulti{NDIMS}, vertex_coordinates, EToV::AbstractArray;
                      is_on_boundary=nothing,
                      periodicity=ntuple(_->false, NDIMS), kwargs...) where {NDIMS}
 

--- a/src/solvers/dgmulti/types.jl
+++ b/src/solvers/dgmulti/types.jl
@@ -112,7 +112,7 @@ GeometricTermsType(mesh_type::Curved, element_type::AbstractElemShape) = NonAffi
 """
   DGMultiMesh(dg::DGMulti{NDIMS}, vertex_coordinates, EToV;
               is_on_boundary=nothing,
-              periodicity=ntuple(_->false, NDIMS)) where {NDIMS, Tv}
+              periodicity=ntuple(_->false, NDIMS)) where {NDIMS}
 
 - `dg::DGMulti` contains information associated with to the reference element (e.g., quadrature,
   basis evaluation, differentiation, etc).
@@ -136,6 +136,9 @@ function DGMultiMesh(dg::DGMulti{NDIMS}, vertex_coordinates, EToV::AbstractArray
   return DGMultiMesh(dg, GeometricTermsType(VertexMapped(), dg), md, boundary_faces)
 end
 
+@deprecate DGMultiMesh(vertex_coordinates, EToV, dg::DGMulti{NDIMS}; kwargs...) where {NDIMS} =
+  DGMultiMesh(dg, vertex_coordinates, EToV; kwargs...)
+
 """
     DGMultiMesh(dg::DGMulti{2, Tri}, triangulateIO, boundary_dict::Dict{Symbol, Int})
 
@@ -153,6 +156,9 @@ function DGMultiMesh(dg::DGMulti{2, Tri}, triangulateIO, boundary_dict::Dict{Sym
   boundary_faces = StartUpDG.tag_boundary_faces(triangulateIO, dg.basis, md, boundary_dict)
   return DGMultiMesh(dg, GeometricTermsType(TriangulateIO(), dg), md, boundary_faces)
 end
+
+@deprecate DGMultiMesh(triangulateIO, dg::DGMulti{2, Tri}, boundary_dict::Dict{Symbol, Int}; kwargs...) =
+  DGMultiMesh(dg, triangulateIO, boundary_dict; kwargs...)
 
 # TODO: DGMulti. Make `cells_per_dimension` a non-keyword argument for easier dispatch.
 """

--- a/src/solvers/dgmulti/types.jl
+++ b/src/solvers/dgmulti/types.jl
@@ -85,7 +85,7 @@ end
 # now that `DGMulti` is defined, we can define constructors for `DGMultiMesh` which use `dg::DGMulti`
 
 function DGMultiMesh(dg::DGMulti, geometric_term_type, md::MeshData{NDIMS}, boundary_faces) where {NDIMS}
-  return DGMultiMesh{NDIMS, geometric_term_type, typeof(md), typeof(boundary_faces)}(md, boundary_faces)
+  return DGMultiMesh{NDIMS, typeof(geometric_term_type), typeof(md), typeof(boundary_faces)}(md, boundary_faces)
 end
 
 # Mesh types used internally for trait dispatch

--- a/src/solvers/dgmulti/types.jl
+++ b/src/solvers/dgmulti/types.jl
@@ -117,28 +117,22 @@ GeometricTermsType(mesh_type::Curved, element_type::AbstractElemShape) = NonAffi
 # other potential constructor types to add later: Bilinear, Isoparametric{polydeg_geo}, Rational/Exact?
 # other potential mesh types to add later: Polynomial{polydeg_geo}?
 
-# TODO: DGMulti v0.5. Standardize order of arguments, pass in `dg` first
 """
-  DGMultiMesh(vertex_coordinates, EToV, dg::DGMulti{NDIMS};
+  DGMultiMesh(dg::DGMulti{NDIMS}, vertex_coordinates, EToV;
               is_on_boundary=nothing,
               periodicity=ntuple(_->false, NDIMS)) where {NDIMS, Tv}
 
-- `vertex_coordinates` is a tuple of vectors containing x,y,... components of the vertex coordinates
-- `EToV` is a 2D array containing element-to-vertex connectivities for each element
 - `dg::DGMulti` contains information associated with to the reference element (e.g., quadrature,
   basis evaluation, differentiation, etc).
+- `vertex_coordinates` is a tuple of vectors containing x,y,... components of the vertex coordinates
+- `EToV` is a 2D array containing element-to-vertex connectivities for each element
 - `is_on_boundary` specifies boundary using a `Dict{Symbol, <:Function}`
 - `periodicity` is a tuple of booleans specifying if the domain is periodic `true`/`false` in the
   (x,y,z) direction.
 """
-function DGMultiMesh(vertex_coordinates, EToV, dg::DGMulti{NDIMS};
+function DGMultiMesh(dg::DGMulti{NDIMS}, vertex_coordinates, EToV;
                      is_on_boundary=nothing,
                      periodicity=ntuple(_->false, NDIMS), kwargs...) where {NDIMS}
-  if haskey(kwargs, :is_periodic)
-    # TODO: DGMulti, v0.5. Remove deprecated keyword
-    Base.depwarn("keyword argument `is_periodic` is now `periodicity`.", :DGMultiMesh)
-    periodicity=kwargs[:is_periodic]
-  end
 
   md = MeshData(vertex_coordinates, EToV, dg.basis)
   if NDIMS == 1
@@ -150,17 +144,16 @@ function DGMultiMesh(vertex_coordinates, EToV, dg::DGMulti{NDIMS};
   return DGMultiMesh(dg, GeometricTermsType(VertexMapped(), dg), md, boundary_faces)
 end
 
-# TODO: DGMulti v0.5, standardize order of arguments (`dg` first)
 """
-    DGMultiMesh(triangulateIO, dg::DGMulti{2, Tri}, boundary_dict::Dict{Symbol, Int})
+    DGMultiMesh(dg::DGMulti{2, Tri}, triangulateIO, boundary_dict::Dict{Symbol, Int})
 
-- `triangulateIO` is a `TriangulateIO` mesh representation
 - `dg::DGMulti` contains information associated with to the reference element (e.g., quadrature,
   basis evaluation, differentiation, etc).
+- `triangulateIO` is a `TriangulateIO` mesh representation
 - `boundary_dict` is a `Dict{Symbol, Int}` which associates each integer `TriangulateIO` boundary
   tag with a `Symbol`.
 """
-function DGMultiMesh(triangulateIO, dg::DGMulti{2, Tri}, boundary_dict::Dict{Symbol, Int};
+function DGMultiMesh(dg::DGMulti{2, Tri}, triangulateIO, boundary_dict::Dict{Symbol, Int};
                      periodicity=(false, false))
   vertex_coordinates, EToV = StartUpDG.triangulateIO_to_VXYEToV(triangulateIO)
   md = MeshData(vertex_coordinates, EToV, dg.basis)

--- a/src/solvers/dgmulti/types.jl
+++ b/src/solvers/dgmulti/types.jl
@@ -346,5 +346,6 @@ end
 
 end # @muladd
 
+# TODO: deprecations introduced in Trixi.jl v0.5
 @deprecate DGMultiMesh(vertex_coordinates, EToV, dg::DGMulti{NDIMS}; kwargs...) where {NDIMS} DGMultiMesh(dg, vertex_coordinates, EToV; kwargs...)
 @deprecate DGMultiMesh(triangulateIO, dg::DGMulti{2, Tri}, boundary_dict::Dict{Symbol, Int}; kwargs...) DGMultiMesh(dg, triangulateIO, boundary_dict; kwargs...)

--- a/src/solvers/dgmulti/types.jl
+++ b/src/solvers/dgmulti/types.jl
@@ -88,14 +88,6 @@ function DGMultiMesh(dg::DGMulti, geometric_term_type, md::MeshData{NDIMS}, boun
   return DGMultiMesh{NDIMS, geometric_term_type, typeof(md), typeof(boundary_faces)}(md, boundary_faces)
 end
 
-function DGMultiMesh(triangulateIO, rd::RefElemData{2, Tri}, boundary_dict::Dict{Symbol, Int})
-
-  vertex_coordinates, EToV = StartUpDG.triangulateIO_to_VXYEToV(triangulateIO)
-  md = MeshData(vertex_coordinates, EToV, rd)
-  boundary_faces = StartUpDG.tag_boundary_faces(triangulateIO, rd, md, boundary_dict)
-  return DGMultiMesh{2, typeof(rd.element_type), typeof(md), typeof(boundary_faces)}(md, boundary_faces)
-end
-
 # Mesh types used internally for trait dispatch
 struct Cartesian end
 struct VertexMapped end # where element geometry is determined by vertices.

--- a/src/solvers/dgsem_p4est/dg_2d.jl
+++ b/src/solvers/dgsem_p4est/dg_2d.jl
@@ -174,7 +174,7 @@ end
 # Inlined version of the interface flux computation for conservation laws
 @inline function calc_interface_flux!(surface_flux_values,
                                       mesh::P4estMesh{2},
-                                      nonconservative_terms::Val{false}, equations,
+                                      nonconservative_terms::False, equations,
                                       surface_integral, dg::DG, cache,
                                       interface_index, normal_direction,
                                       primary_node_index, primary_direction_index, primary_element_index,
@@ -195,7 +195,7 @@ end
 # Inlined version of the interface flux computation for equations with conservative and nonconservative terms
 @inline function calc_interface_flux!(surface_flux_values,
                                       mesh::P4estMesh{2},
-                                      nonconservative_terms::Val{true}, equations,
+                                      nonconservative_terms::True, equations,
                                       surface_integral, dg::DG, cache,
                                       interface_index, normal_direction,
                                       primary_node_index, primary_direction_index, primary_element_index,
@@ -297,7 +297,7 @@ end
 # inlined version of the boundary flux calculation along a physical interface
 @inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition,
                                      mesh::P4estMesh{2},
-                                     nonconservative_terms::Val{false}, equations,
+                                     nonconservative_terms::False, equations,
                                      surface_integral, dg::DG, cache,
                                      i_index, j_index,
                                      node_index, direction_index, element_index, boundary_index)
@@ -326,7 +326,7 @@ end
 # inlined version of the boundary flux with nonconservative terms calculation along a physical interface
 @inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition,
                                      mesh::P4estMesh{2},
-                                     nonconservative_terms::Val{true}, equations,
+                                     nonconservative_terms::True, equations,
                                      surface_integral, dg::DG, cache,
                                      i_index, j_index,
                                      node_index, direction_index, element_index, boundary_index)
@@ -485,7 +485,7 @@ end
 # Inlined version of the mortar flux computation on small elements for conservation laws
 @inline function calc_mortar_flux!(fstar,
                                    mesh::P4estMesh{2},
-                                   nonconservative_terms::Val{false}, equations,
+                                   nonconservative_terms::False, equations,
                                    surface_integral, dg::DG, cache,
                                    mortar_index, position_index, normal_direction,
                                    node_index)
@@ -504,7 +504,7 @@ end
 # nonconservative terms
 @inline function calc_mortar_flux!(fstar,
                                    mesh::P4estMesh{2},
-                                   nonconservative_terms::Val{true}, equations,
+                                   nonconservative_terms::True, equations,
                                    surface_integral, dg::DG, cache,
                                    mortar_index, position_index, normal_direction,
                                    node_index)

--- a/src/solvers/dgsem_p4est/dg_2d_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_2d_parallel.jl
@@ -100,7 +100,7 @@ end
 # Inlined version of the interface flux computation for conservation laws
 @inline function calc_mpi_interface_flux!(surface_flux_values,
                                           mesh::P4estMesh{2},
-                                          nonconservative_terms::Val{false}, equations,
+                                          nonconservative_terms::False, equations,
                                           surface_integral, dg::DG, cache,
                                           interface_index, normal_direction,
                                           interface_node_index, local_side,
@@ -239,7 +239,7 @@ end
 # Inlined version of the mortar flux computation on small elements for conservation laws
 @inline function calc_mpi_mortar_flux!(fstar,
                                        mesh::ParallelP4estMesh{2},
-                                       nonconservative_terms::Val{false}, equations,
+                                       nonconservative_terms::False, equations,
                                        surface_integral, dg::DG, cache,
                                        mortar_index, position_index, normal_direction,
                                        node_index)

--- a/src/solvers/dgsem_p4est/dg_3d.jl
+++ b/src/solvers/dgsem_p4est/dg_3d.jl
@@ -227,7 +227,7 @@ end
 # Inlined function for interface flux computation for conservative flux terms
 @inline function calc_interface_flux!(surface_flux_values,
                                       mesh::P4estMesh{3},
-                                      nonconservative_terms::Val{false}, equations,
+                                      nonconservative_terms::False, equations,
                                       surface_integral, dg::DG, cache,
                                       interface_index, normal_direction,
                                       primary_i_node_index, primary_j_node_index,
@@ -252,7 +252,7 @@ end
 # Inlined function for interface flux computation for flux + nonconservative terms
 @inline function calc_interface_flux!(surface_flux_values,
                                       mesh::P4estMesh{3},
-                                      nonconservative_terms::Val{true}, equations,
+                                      nonconservative_terms::True, equations,
                                       surface_integral, dg::DG, cache,
                                       interface_index, normal_direction,
                                       primary_i_node_index, primary_j_node_index,
@@ -546,7 +546,7 @@ end
 # Inlined version of the mortar flux computation on small elements for conservation fluxes
 @inline function calc_mortar_flux!(fstar,
                                    mesh::P4estMesh{3},
-                                   nonconservative_terms::Val{false}, equations,
+                                   nonconservative_terms::False, equations,
                                    surface_integral, dg::DG, cache,
                                    mortar_index, position_index, normal_direction,
                                    i_node_index, j_node_index)
@@ -565,7 +565,7 @@ end
 # with nonconservative terms
 @inline function calc_mortar_flux!(fstar,
                                    mesh::P4estMesh{3},
-                                   nonconservative_terms::Val{true}, equations,
+                                   nonconservative_terms::True, equations,
                                    surface_integral, dg::DG, cache,
                                    mortar_index, position_index, normal_direction,
                                    i_node_index, j_node_index)

--- a/src/solvers/dgsem_p4est/dg_3d_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_3d_parallel.jl
@@ -209,7 +209,7 @@ end
 # Inlined version of the interface flux computation for conservation laws
 @inline function calc_mpi_interface_flux!(surface_flux_values,
                                           mesh::P4estMesh{3},
-                                          nonconservative_terms::Val{false}, equations,
+                                          nonconservative_terms::False, equations,
                                           surface_integral, dg::DG, cache,
                                           interface_index, normal_direction,
                                           interface_i_node_index, interface_j_node_index, local_side,
@@ -392,7 +392,7 @@ end
 # Inlined version of the mortar flux computation on small elements for conservation laws
 @inline function calc_mpi_mortar_flux!(fstar,
                                        mesh::ParallelP4estMesh{3},
-                                       nonconservative_terms::Val{false}, equations,
+                                       nonconservative_terms::False, equations,
                                        surface_integral, dg::DG, cache,
                                        mortar_index, position_index, normal_direction,
                                        i_node_index, j_node_index)

--- a/src/solvers/dgsem_structured/dg_2d.jl
+++ b/src/solvers/dgsem_structured/dg_2d.jl
@@ -46,7 +46,7 @@ end
 
 @inline function weak_form_kernel!(du, u,
                                    element, mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
-                                   nonconservative_terms::Val{false}, equations,
+                                   nonconservative_terms::False, equations,
                                    dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
@@ -82,7 +82,7 @@ end
 
 @inline function split_form_kernel!(du, u,
                                     element, mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
-                                    nonconservative_terms::Val{false}, equations,
+                                    nonconservative_terms::False, equations,
                                     volume_flux, dg::DGSEM, cache, alpha=true)
   @unpack derivative_split = dg.basis
   @unpack contravariant_vectors = cache.elements
@@ -130,14 +130,14 @@ end
 
 @inline function split_form_kernel!(du, u,
                                     element, mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
-                                    nonconservative_terms::Val{true}, equations,
+                                    nonconservative_terms::True, equations,
                                     volume_flux, dg::DGSEM, cache, alpha=true)
   @unpack derivative_split = dg.basis
   @unpack contravariant_vectors = cache.elements
   symmetric_flux, nonconservative_flux = volume_flux
 
   # Apply the symmetric flux as usual
-  split_form_kernel!(du, u, element, mesh, Val(false), equations, symmetric_flux, dg, cache, alpha)
+  split_form_kernel!(du, u, element, mesh, False(), equations, symmetric_flux, dg, cache, alpha)
 
   # Calculate the remaining volume terms using the nonsymmetric generalized flux
   for j in eachnode(dg), i in eachnode(dg)
@@ -190,7 +190,7 @@ end
 # [arXiv: 2008.12044v2](https://arxiv.org/pdf/2008.12044)
 @inline function calcflux_fv!(fstar1_L, fstar1_R, fstar2_L, fstar2_R, u,
                               mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
-                              nonconservative_terms::Val{false}, equations,
+                              nonconservative_terms::False, equations,
                               volume_flux_fv, dg::DGSEM, element, cache)
   @unpack contravariant_vectors = cache.elements
   @unpack weights, derivative_matrix = dg.basis
@@ -252,7 +252,7 @@ end
 # Calculate the finite volume fluxes inside curvilinear elements (**with non-conservative terms**).
 @inline function calcflux_fv!(fstar1_L, fstar1_R, fstar2_L, fstar2_R, u::AbstractArray{<:Any,4},
                               mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
-                              nonconservative_terms::Val{true}, equations,
+                              nonconservative_terms::True, equations,
                               volume_flux_fv, dg::DGSEM, element, cache)
   @unpack contravariant_vectors = cache.elements
   @unpack weights, derivative_matrix = dg.basis
@@ -330,7 +330,7 @@ end
 
 function calc_interface_flux!(cache, u,
                               mesh::StructuredMesh{2},
-                              nonconservative_terms, # can be Val{true}/Val{false}
+                              nonconservative_terms, # can be True/False
                               equations, surface_integral, dg::DG)
   @unpack elements = cache
 
@@ -360,7 +360,7 @@ end
 @inline function calc_interface_flux!(surface_flux_values, left_element, right_element,
                                       orientation, u,
                                       mesh::StructuredMesh{2},
-                                      nonconservative_terms::Val{false}, equations,
+                                      nonconservative_terms::False, equations,
                                       surface_integral, dg::DG, cache)
   # This is slow for LSA, but for some reason faster for Euler (see #519)
   if left_element <= 0 # left_element = 0 at boundaries
@@ -415,9 +415,9 @@ end
 @inline function calc_interface_flux!(surface_flux_values, left_element, right_element,
                                       orientation, u,
                                       mesh::StructuredMesh{2},
-                                      nonconservative_terms::Val{true}, equations,
+                                      nonconservative_terms::True, equations,
                                       surface_integral, dg::DG, cache)
-  # See comment on `calc_interface_flux!` with `nonconservative_terms::Val{false}`
+  # See comment on `calc_interface_flux!` with `nonconservative_terms::False`
   if left_element <= 0 # left_element = 0 at boundaries
     return nothing
   end

--- a/src/solvers/dgsem_structured/dg_2d.jl
+++ b/src/solvers/dgsem_structured/dg_2d.jl
@@ -80,10 +80,10 @@ end
 end
 
 
-@inline function split_form_kernel!(du, u,
-                                    element, mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
-                                    nonconservative_terms::False, equations,
-                                    volume_flux, dg::DGSEM, cache, alpha=true)
+@inline function flux_differencing_kernel!(du, u,
+                                           element, mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
+                                           nonconservative_terms::False, equations,
+                                           volume_flux, dg::DGSEM, cache, alpha=true)
   @unpack derivative_split = dg.basis
   @unpack contravariant_vectors = cache.elements
 
@@ -128,16 +128,16 @@ end
   end
 end
 
-@inline function split_form_kernel!(du, u,
-                                    element, mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
-                                    nonconservative_terms::True, equations,
-                                    volume_flux, dg::DGSEM, cache, alpha=true)
+@inline function flux_differencing_kernel!(du, u,
+                                           element, mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
+                                           nonconservative_terms::True, equations,
+                                           volume_flux, dg::DGSEM, cache, alpha=true)
   @unpack derivative_split = dg.basis
   @unpack contravariant_vectors = cache.elements
   symmetric_flux, nonconservative_flux = volume_flux
 
   # Apply the symmetric flux as usual
-  split_form_kernel!(du, u, element, mesh, False(), equations, symmetric_flux, dg, cache, alpha)
+  flux_differencing_kernel!(du, u, element, mesh, False(), equations, symmetric_flux, dg, cache, alpha)
 
   # Calculate the remaining volume terms using the nonsymmetric generalized flux
   for j in eachnode(dg), i in eachnode(dg)

--- a/src/solvers/dgsem_structured/dg_2d_compressible_euler.jl
+++ b/src/solvers/dgsem_structured/dg_2d_compressible_euler.jl
@@ -21,7 +21,7 @@
 @inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
                                     element,
                                     mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
-                                    nonconservative_terms::Val{false},
+                                    nonconservative_terms::False,
                                     equations::CompressibleEulerEquations2D,
                                     volume_flux::typeof(flux_shima_etal_turbo),
                                     dg::DGSEM, cache, alpha)
@@ -223,7 +223,7 @@ end
 @inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
                                     element,
                                     mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
-                                    nonconservative_terms::Val{false},
+                                    nonconservative_terms::False,
                                     equations::CompressibleEulerEquations2D,
                                     volume_flux::typeof(flux_ranocha_turbo),
                                     dg::DGSEM, cache, alpha)

--- a/src/solvers/dgsem_structured/dg_2d_compressible_euler.jl
+++ b/src/solvers/dgsem_structured/dg_2d_compressible_euler.jl
@@ -18,13 +18,13 @@
 # We specialize on `PtrArray` since these will be returned by `Trixi.wrap_array`
 # if LoopVectorization.jl can handle the array types. This ensures that `@turbo`
 # works efficiently here.
-@inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
-                                    element,
-                                    mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
-                                    nonconservative_terms::False,
-                                    equations::CompressibleEulerEquations2D,
-                                    volume_flux::typeof(flux_shima_etal_turbo),
-                                    dg::DGSEM, cache, alpha)
+@inline function flux_differencing_kernel!(_du::PtrArray, u_cons::PtrArray,
+                                           element,
+                                           mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
+                                           nonconservative_terms::False,
+                                           equations::CompressibleEulerEquations2D,
+                                           volume_flux::typeof(flux_shima_etal_turbo),
+                                           dg::DGSEM, cache, alpha)
   @unpack derivative_split = dg.basis
   @unpack contravariant_vectors = cache.elements
 
@@ -220,13 +220,13 @@ end
 
 
 
-@inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
-                                    element,
-                                    mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
-                                    nonconservative_terms::False,
-                                    equations::CompressibleEulerEquations2D,
-                                    volume_flux::typeof(flux_ranocha_turbo),
-                                    dg::DGSEM, cache, alpha)
+@inline function flux_differencing_kernel!(_du::PtrArray, u_cons::PtrArray,
+                                           element,
+                                           mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2}},
+                                           nonconservative_terms::False,
+                                           equations::CompressibleEulerEquations2D,
+                                           volume_flux::typeof(flux_ranocha_turbo),
+                                           dg::DGSEM, cache, alpha)
   @unpack derivative_split = dg.basis
   @unpack contravariant_vectors = cache.elements
 

--- a/src/solvers/dgsem_structured/dg_3d.jl
+++ b/src/solvers/dgsem_structured/dg_3d.jl
@@ -46,7 +46,7 @@ end
 
 @inline function weak_form_kernel!(du, u,
                                    element, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
-                                   nonconservative_terms::Val{false}, equations,
+                                   nonconservative_terms::False, equations,
                                    dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
@@ -94,7 +94,7 @@ end
 # the physical fluxes in each Cartesian direction
 @inline function split_form_kernel!(du, u,
                                     element, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
-                                    nonconservative_terms::Val{false}, equations,
+                                    nonconservative_terms::False, equations,
                                     volume_flux, dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
@@ -161,14 +161,14 @@ end
 
 @inline function split_form_kernel!(du, u,
                                     element, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
-                                    nonconservative_terms::Val{true}, equations,
+                                    nonconservative_terms::True, equations,
                                     volume_flux, dg::DGSEM, cache, alpha=true)
   @unpack derivative_split = dg.basis
   @unpack contravariant_vectors = cache.elements
   symmetric_flux, nonconservative_flux = volume_flux
 
   # Apply the symmetric flux as usual
-  split_form_kernel!(du, u, element, mesh, Val(false), equations, symmetric_flux, dg, cache, alpha)
+  split_form_kernel!(du, u, element, mesh, False(), equations, symmetric_flux, dg, cache, alpha)
 
   # Calculate the remaining volume terms using the nonsymmetric generalized flux
   for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
@@ -234,7 +234,7 @@ end
 # "A provably entropy stable subcell shock capturing approach for high order split form DG for the compressible Euler equations"
 # [arXiv: 2008.12044v2](https://arxiv.org/pdf/2008.12044)
 @inline function calcflux_fv!(fstar1_L, fstar1_R, fstar2_L, fstar2_R, fstar3_L, fstar3_R, u,
-                              mesh::Union{StructuredMesh{3}, P4estMesh{3}}, nonconservative_terms::Val{false},
+                              mesh::Union{StructuredMesh{3}, P4estMesh{3}}, nonconservative_terms::False,
                               equations, volume_flux_fv, dg::DGSEM, element, cache)
   @unpack contravariant_vectors = cache.elements
   @unpack weights, derivative_matrix = dg.basis
@@ -318,7 +318,7 @@ end
 
 # # Calculate the finite volume fluxes inside curvilinear elements (**with non-conservative terms**).
 @inline function calcflux_fv!(fstar1_L, fstar1_R, fstar2_L, fstar2_R, fstar3_L, fstar3_R, u,
-                              mesh::Union{StructuredMesh{3}, P4estMesh{3}}, nonconservative_terms::Val{true},
+                              mesh::Union{StructuredMesh{3}, P4estMesh{3}}, nonconservative_terms::True,
                               equations, volume_flux_fv, dg::DGSEM, element, cache)
   @unpack contravariant_vectors = cache.elements
   @unpack weights, derivative_matrix = dg.basis
@@ -425,7 +425,7 @@ end
 
 
 function calc_interface_flux!(cache, u, mesh::StructuredMesh{3},
-                              nonconservative_terms, # can be Val{true}/Val{false}
+                              nonconservative_terms, # can be True/False
                               equations, surface_integral, dg::DG)
   @unpack elements = cache
 
@@ -462,7 +462,7 @@ end
 @inline function calc_interface_flux!(surface_flux_values, left_element, right_element,
                                       orientation, u,
                                       mesh::StructuredMesh{3},
-                                      nonconservative_terms::Val{false}, equations,
+                                      nonconservative_terms::False, equations,
                                       surface_integral, dg::DG, cache)
   # This is slow for LSA, but for some reason faster for Euler (see #519)
   if left_element <= 0 # left_element = 0 at boundaries
@@ -527,9 +527,9 @@ end
 @inline function calc_interface_flux!(surface_flux_values, left_element, right_element,
                                       orientation, u,
                                       mesh::StructuredMesh{3},
-                                      nonconservative_terms::Val{true}, equations,
+                                      nonconservative_terms::True, equations,
                                       surface_integral, dg::DG, cache)
-  # See comment on `calc_interface_flux!` with `nonconservative_terms::Val{false}`
+  # See comment on `calc_interface_flux!` with `nonconservative_terms::False`
   if left_element <= 0 # left_element = 0 at boundaries
     return surface_flux_values
   end

--- a/src/solvers/dgsem_structured/dg_3d.jl
+++ b/src/solvers/dgsem_structured/dg_3d.jl
@@ -92,10 +92,10 @@ end
 # flux differencing volume integral on curvilinear hexahedral elements. Averaging of the
 # mapping terms, stored in `contravariant_vectors`, is peeled apart from the evaluation of
 # the physical fluxes in each Cartesian direction
-@inline function split_form_kernel!(du, u,
-                                    element, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
-                                    nonconservative_terms::False, equations,
-                                    volume_flux, dg::DGSEM, cache, alpha=true)
+@inline function flux_differencing_kernel!(du, u,
+                                           element, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
+                                           nonconservative_terms::False, equations,
+                                           volume_flux, dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
   @unpack derivative_split = dg.basis
@@ -159,16 +159,16 @@ end
   end
 end
 
-@inline function split_form_kernel!(du, u,
-                                    element, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
-                                    nonconservative_terms::True, equations,
-                                    volume_flux, dg::DGSEM, cache, alpha=true)
+@inline function flux_differencing_kernel!(du, u,
+                                           element, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
+                                           nonconservative_terms::True, equations,
+                                           volume_flux, dg::DGSEM, cache, alpha=true)
   @unpack derivative_split = dg.basis
   @unpack contravariant_vectors = cache.elements
   symmetric_flux, nonconservative_flux = volume_flux
 
   # Apply the symmetric flux as usual
-  split_form_kernel!(du, u, element, mesh, False(), equations, symmetric_flux, dg, cache, alpha)
+  flux_differencing_kernel!(du, u, element, mesh, False(), equations, symmetric_flux, dg, cache, alpha)
 
   # Calculate the remaining volume terms using the nonsymmetric generalized flux
   for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)

--- a/src/solvers/dgsem_structured/dg_3d_compressible_euler.jl
+++ b/src/solvers/dgsem_structured/dg_3d_compressible_euler.jl
@@ -20,7 +20,7 @@
 # works efficiently here.
 @inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
                                     element, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
-                                    nonconservative_terms::Val{false},
+                                    nonconservative_terms::False,
                                     equations::CompressibleEulerEquations3D,
                                     volume_flux::typeof(flux_shima_etal_turbo),
                                     dg::DGSEM, cache, alpha)
@@ -334,7 +334,7 @@ end
 
 @inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
                                     element, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
-                                    nonconservative_terms::Val{false},
+                                    nonconservative_terms::False,
                                     equations::CompressibleEulerEquations3D,
                                     volume_flux::typeof(flux_ranocha_turbo),
                                     dg::DGSEM, cache, alpha)

--- a/src/solvers/dgsem_structured/dg_3d_compressible_euler.jl
+++ b/src/solvers/dgsem_structured/dg_3d_compressible_euler.jl
@@ -18,12 +18,12 @@
 # We specialize on `PtrArray` since these will be returned by `Trixi.wrap_array`
 # if LoopVectorization.jl can handle the array types. This ensures that `@turbo`
 # works efficiently here.
-@inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
-                                    element, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
-                                    nonconservative_terms::False,
-                                    equations::CompressibleEulerEquations3D,
-                                    volume_flux::typeof(flux_shima_etal_turbo),
-                                    dg::DGSEM, cache, alpha)
+@inline function flux_differencing_kernel!(_du::PtrArray, u_cons::PtrArray,
+                                           element, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
+                                           nonconservative_terms::False,
+                                           equations::CompressibleEulerEquations3D,
+                                           volume_flux::typeof(flux_shima_etal_turbo),
+                                           dg::DGSEM, cache, alpha)
   @unpack derivative_split = dg.basis
   @unpack contravariant_vectors = cache.elements
 
@@ -332,12 +332,12 @@ end
 
 
 
-@inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
-                                    element, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
-                                    nonconservative_terms::False,
-                                    equations::CompressibleEulerEquations3D,
-                                    volume_flux::typeof(flux_ranocha_turbo),
-                                    dg::DGSEM, cache, alpha)
+@inline function flux_differencing_kernel!(_du::PtrArray, u_cons::PtrArray,
+                                           element, mesh::Union{StructuredMesh{3}, P4estMesh{3}},
+                                           nonconservative_terms::False,
+                                           equations::CompressibleEulerEquations3D,
+                                           volume_flux::typeof(flux_ranocha_turbo),
+                                           dg::DGSEM, cache, alpha)
   @unpack derivative_split = dg.basis
   @unpack contravariant_vectors = cache.elements
 

--- a/src/solvers/dgsem_tree/dg_1d.jl
+++ b/src/solvers/dgsem_tree/dg_1d.jl
@@ -134,7 +134,7 @@ end
 
 @inline function weak_form_kernel!(du, u,
                                    element, mesh::Union{TreeMesh{1}, StructuredMesh{1}},
-                                   nonconservative_terms::Val{false}, equations,
+                                   nonconservative_terms::False, equations,
                                    dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
@@ -166,7 +166,7 @@ end
 
 @inline function split_form_kernel!(du, u,
                                     element, mesh::Union{TreeMesh{1}, StructuredMesh{1}},
-                                    nonconservative_terms::Val{false}, equations,
+                                    nonconservative_terms::False, equations,
                                     volume_flux, dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
@@ -193,7 +193,7 @@ end
 
 @inline function split_form_kernel!(du, u,
                                     element, mesh::Union{TreeMesh{1}, StructuredMesh{1}},
-                                    nonconservative_terms::Val{true}, equations,
+                                    nonconservative_terms::True, equations,
                                     volume_flux, dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
@@ -201,7 +201,7 @@ end
   symmetric_flux, nonconservative_flux = volume_flux
 
   # Apply the symmetric flux as usual
-  split_form_kernel!(du, u, element, mesh, Val(false), equations, symmetric_flux, dg, cache, alpha)
+  split_form_kernel!(du, u, element, mesh, False(), equations, symmetric_flux, dg, cache, alpha)
 
   # Calculate the remaining volume terms using the nonsymmetric generalized flux
   for i in eachnode(dg)
@@ -309,7 +309,7 @@ end
 
 @inline function calcflux_fv!(fstar1_L, fstar1_R, u::AbstractArray{<:Any,3},
                               mesh::Union{TreeMesh{1}, StructuredMesh{1}},
-                              nonconservative_terms::Val{false},
+                              nonconservative_terms::False,
                               equations, volume_flux_fv, dg::DGSEM, element, cache)
 
   fstar1_L[:, 1           ] .= zero(eltype(fstar1_L))
@@ -331,7 +331,7 @@ end
 
 @inline function calcflux_fv!(fstar1_L, fstar1_R, u::AbstractArray{<:Any,3},
                               mesh::TreeMesh{1},
-                              nonconservative_terms::Val{true},
+                              nonconservative_terms::True,
                               equations, volume_flux_fv, dg::DGSEM, element, cache)
   volume_flux, nonconservative_flux = volume_flux_fv
 
@@ -384,7 +384,7 @@ end
 
 function calc_interface_flux!(surface_flux_values,
                               mesh::TreeMesh{1},
-                              nonconservative_terms::Val{false}, equations,
+                              nonconservative_terms::False, equations,
                               surface_integral, dg::DG, cache)
   @unpack surface_flux = surface_integral
   @unpack u, neighbor_ids, orientations = cache.interfaces
@@ -413,7 +413,7 @@ end
 
 function calc_interface_flux!(surface_flux_values,
                               mesh::TreeMesh{1},
-                              nonconservative_terms::Val{true}, equations,
+                              nonconservative_terms::True, equations,
                               surface_integral, dg::DG, cache)
   surface_flux, nonconservative_flux = surface_integral.surface_flux
   @unpack u, neighbor_ids, orientations = cache.interfaces
@@ -503,7 +503,7 @@ end
 
 
 function calc_boundary_flux_by_direction!(surface_flux_values::AbstractArray{<:Any,3}, t,
-                                          boundary_condition, nonconservative_terms::Val{false}, equations,
+                                          boundary_condition, nonconservative_terms::False, equations,
                                           surface_integral, dg::DG, cache,
                                           direction, first_boundary, last_boundary)
 
@@ -535,7 +535,7 @@ function calc_boundary_flux_by_direction!(surface_flux_values::AbstractArray{<:A
 end
 
 function calc_boundary_flux_by_direction!(surface_flux_values::AbstractArray{<:Any,3}, t,
-                                          boundary_condition, nonconservative_terms::Val{true}, equations,
+                                          boundary_condition, nonconservative_terms::True, equations,
                                           surface_integral, dg::DG, cache,
                                           direction, first_boundary, last_boundary)
 

--- a/src/solvers/dgsem_tree/dg_1d.jl
+++ b/src/solvers/dgsem_tree/dg_1d.jl
@@ -159,15 +159,15 @@ function calc_volume_integral!(du, u,
                                volume_integral::VolumeIntegralFluxDifferencing,
                                dg::DGSEM, cache)
   @threaded for element in eachelement(dg, cache)
-    split_form_kernel!(du, u, element, mesh, nonconservative_terms, equations,
-                       volume_integral.volume_flux, dg, cache)
+    flux_differencing_kernel!(du, u, element, mesh, nonconservative_terms, equations,
+                              volume_integral.volume_flux, dg, cache)
   end
 end
 
-@inline function split_form_kernel!(du, u,
-                                    element, mesh::Union{TreeMesh{1}, StructuredMesh{1}},
-                                    nonconservative_terms::False, equations,
-                                    volume_flux, dg::DGSEM, cache, alpha=true)
+@inline function flux_differencing_kernel!(du, u,
+                                           element, mesh::Union{TreeMesh{1}, StructuredMesh{1}},
+                                           nonconservative_terms::False, equations,
+                                           volume_flux, dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
   @unpack derivative_split = dg.basis
@@ -191,17 +191,17 @@ end
   end
 end
 
-@inline function split_form_kernel!(du, u,
-                                    element, mesh::Union{TreeMesh{1}, StructuredMesh{1}},
-                                    nonconservative_terms::True, equations,
-                                    volume_flux, dg::DGSEM, cache, alpha=true)
+@inline function flux_differencing_kernel!(du, u,
+                                           element, mesh::Union{TreeMesh{1}, StructuredMesh{1}},
+                                           nonconservative_terms::True, equations,
+                                           volume_flux, dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
   @unpack derivative_split = dg.basis
   symmetric_flux, nonconservative_flux = volume_flux
 
   # Apply the symmetric flux as usual
-  split_form_kernel!(du, u, element, mesh, False(), equations, symmetric_flux, dg, cache, alpha)
+  flux_differencing_kernel!(du, u, element, mesh, False(), equations, symmetric_flux, dg, cache, alpha)
 
   # Calculate the remaining volume terms using the nonsymmetric generalized flux
   for i in eachnode(dg)
@@ -242,8 +242,8 @@ function calc_volume_integral!(du, u,
   # Loop over pure DG elements
   @trixi_timeit timer() "pure DG" @threaded for idx_element in eachindex(element_ids_dg)
     element = element_ids_dg[idx_element]
-    split_form_kernel!(du, u, element, mesh, nonconservative_terms, equations,
-                       volume_flux_dg, dg, cache)
+    flux_differencing_kernel!(du, u, element, mesh, nonconservative_terms, equations,
+                              volume_flux_dg, dg, cache)
   end
 
   # Loop over blended DG-FV elements
@@ -252,8 +252,8 @@ function calc_volume_integral!(du, u,
     alpha_element = alpha[element]
 
     # Calculate DG volume integral contribution
-    split_form_kernel!(du, u, element, mesh, nonconservative_terms, equations,
-                       volume_flux_dg, dg, cache, 1 - alpha_element)
+    flux_differencing_kernel!(du, u, element, mesh, nonconservative_terms, equations,
+                              volume_flux_dg, dg, cache, 1 - alpha_element)
 
     # Calculate FV volume integral contribution
     fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv,

--- a/src/solvers/dgsem_tree/dg_2d.jl
+++ b/src/solvers/dgsem_tree/dg_2d.jl
@@ -205,16 +205,16 @@ function calc_volume_integral!(du, u,
                                volume_integral::VolumeIntegralFluxDifferencing,
                                dg::DGSEM, cache)
   @threaded for element in eachelement(dg, cache)
-    split_form_kernel!(du, u, element, mesh,
-                       nonconservative_terms, equations,
-                       volume_integral.volume_flux, dg, cache)
+    flux_differencing_kernel!(du, u, element, mesh,
+                              nonconservative_terms, equations,
+                              volume_integral.volume_flux, dg, cache)
   end
 end
 
-@inline function split_form_kernel!(du, u,
-                                    element, mesh::TreeMesh{2},
-                                    nonconservative_terms::False, equations,
-                                    volume_flux, dg::DGSEM, cache, alpha=true)
+@inline function flux_differencing_kernel!(du, u,
+                                           element, mesh::TreeMesh{2},
+                                           nonconservative_terms::False, equations,
+                                           volume_flux, dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
   @unpack derivative_split = dg.basis
@@ -246,17 +246,17 @@ end
   end
 end
 
-@inline function split_form_kernel!(du, u,
-                                    element, mesh::TreeMesh{2},
-                                    nonconservative_terms::True, equations,
-                                    volume_flux, dg::DGSEM, cache, alpha=true)
+@inline function flux_differencing_kernel!(du, u,
+                                           element, mesh::TreeMesh{2},
+                                           nonconservative_terms::True, equations,
+                                           volume_flux, dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
   @unpack derivative_split = dg.basis
   symmetric_flux, nonconservative_flux = volume_flux
 
   # Apply the symmetric flux as usual
-  split_form_kernel!(du, u, element, mesh, False(), equations, symmetric_flux, dg, cache, alpha)
+  flux_differencing_kernel!(du, u, element, mesh, False(), equations, symmetric_flux, dg, cache, alpha)
 
   # Calculate the remaining volume terms using the nonsymmetric generalized flux
   for j in eachnode(dg), i in eachnode(dg)
@@ -304,9 +304,9 @@ function calc_volume_integral!(du, u,
   # Loop over pure DG elements
   @trixi_timeit timer() "pure DG" @threaded for idx_element in eachindex(element_ids_dg)
     element = element_ids_dg[idx_element]
-    split_form_kernel!(du, u, element, mesh,
-                       nonconservative_terms, equations,
-                       volume_flux_dg, dg, cache)
+    flux_differencing_kernel!(du, u, element, mesh,
+                              nonconservative_terms, equations,
+                              volume_flux_dg, dg, cache)
   end
 
   # Loop over blended DG-FV elements
@@ -315,9 +315,9 @@ function calc_volume_integral!(du, u,
     alpha_element = alpha[element]
 
     # Calculate DG volume integral contribution
-    split_form_kernel!(du, u, element, mesh,
-                       nonconservative_terms, equations,
-                       volume_flux_dg, dg, cache, 1 - alpha_element)
+    flux_differencing_kernel!(du, u, element, mesh,
+                              nonconservative_terms, equations,
+                              volume_flux_dg, dg, cache, 1 - alpha_element)
 
     # Calculate FV volume integral contribution
     fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv,

--- a/src/solvers/dgsem_tree/dg_2d.jl
+++ b/src/solvers/dgsem_tree/dg_2d.jl
@@ -171,7 +171,7 @@ end
 
 @inline function weak_form_kernel!(du, u,
                                    element, mesh::TreeMesh{2},
-                                   nonconservative_terms::Val{false}, equations,
+                                   nonconservative_terms::False, equations,
                                    dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
@@ -213,7 +213,7 @@ end
 
 @inline function split_form_kernel!(du, u,
                                     element, mesh::TreeMesh{2},
-                                    nonconservative_terms::Val{false}, equations,
+                                    nonconservative_terms::False, equations,
                                     volume_flux, dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
@@ -248,7 +248,7 @@ end
 
 @inline function split_form_kernel!(du, u,
                                     element, mesh::TreeMesh{2},
-                                    nonconservative_terms::Val{true}, equations,
+                                    nonconservative_terms::True, equations,
                                     volume_flux, dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
@@ -256,7 +256,7 @@ end
   symmetric_flux, nonconservative_flux = volume_flux
 
   # Apply the symmetric flux as usual
-  split_form_kernel!(du, u, element, mesh, Val(false), equations, symmetric_flux, dg, cache, alpha)
+  split_form_kernel!(du, u, element, mesh, False(), equations, symmetric_flux, dg, cache, alpha)
 
   # Calculate the remaining volume terms using the nonsymmetric generalized flux
   for j in eachnode(dg), i in eachnode(dg)
@@ -375,7 +375,7 @@ end
 
 
 #     calcflux_fv!(fstar1_L, fstar1_R, fstar2_L, fstar2_R, u_leftright,
-#                  nonconservative_terms::Val{false}, equations,
+#                  nonconservative_terms::False, equations,
 #                  volume_flux_fv, dg, element)
 #
 # Calculate the finite volume fluxes inside the elements (**without non-conservative terms**).
@@ -386,7 +386,7 @@ end
 # - `fstar2_L::AbstractArray{<:Real, 3}`
 # - `fstar2_R::AbstractArray{<:Real, 3}`
 @inline function calcflux_fv!(fstar1_L, fstar1_R, fstar2_L, fstar2_R, u::AbstractArray{<:Any,4},
-                              mesh::TreeMesh{2}, nonconservative_terms::Val{false}, equations,
+                              mesh::TreeMesh{2}, nonconservative_terms::False, equations,
                               volume_flux_fv, dg::DGSEM, element, cache)
 
   fstar1_L[:, 1,            :] .= zero(eltype(fstar1_L))
@@ -419,7 +419,7 @@ end
 end
 
 #     calcflux_fv!(fstar1_L, fstar1_R, fstar2_L, fstar2_R, u_leftright,
-#                  nonconservative_terms::Val{true}, equations,
+#                  nonconservative_terms::True, equations,
 #                  volume_flux_fv, dg, element)
 #
 # Calculate the finite volume fluxes inside the elements (**with non-conservative terms**).
@@ -431,7 +431,7 @@ end
 # - `fstar2_R::AbstractArray{<:Real, 3}`:
 # - `u_leftright::AbstractArray{<:Real, 4}`
 @inline function calcflux_fv!(fstar1_L, fstar1_R, fstar2_L, fstar2_R, u::AbstractArray{<:Any,4},
-                              mesh::TreeMesh{2}, nonconservative_terms::Val{true}, equations,
+                              mesh::TreeMesh{2}, nonconservative_terms::True, equations,
                               volume_flux_fv, dg::DGSEM, element, cache)
   volume_flux, nonconservative_flux = volume_flux_fv
 
@@ -519,7 +519,7 @@ end
 
 function calc_interface_flux!(surface_flux_values,
                               mesh::TreeMesh{2},
-                              nonconservative_terms::Val{false}, equations,
+                              nonconservative_terms::False, equations,
                               surface_integral, dg::DG, cache)
   @unpack surface_flux = surface_integral
   @unpack u, neighbor_ids, orientations = cache.interfaces
@@ -553,7 +553,7 @@ end
 
 function calc_interface_flux!(surface_flux_values,
                               mesh::TreeMesh{2},
-                              nonconservative_terms::Val{true}, equations,
+                              nonconservative_terms::True, equations,
                               surface_integral, dg::DG, cache)
   surface_flux, nonconservative_flux = surface_integral.surface_flux
   @unpack u, neighbor_ids, orientations = cache.interfaces
@@ -668,7 +668,7 @@ function calc_boundary_flux!(cache, t, boundary_conditions::NamedTuple,
 end
 
 function calc_boundary_flux_by_direction!(surface_flux_values::AbstractArray{<:Any,4}, t,
-                                          boundary_condition, nonconservative_terms::Val{false}, equations,
+                                          boundary_condition, nonconservative_terms::False, equations,
                                           surface_integral ,dg::DG, cache,
                                           direction, first_boundary, last_boundary)
   @unpack surface_flux = surface_integral
@@ -701,7 +701,7 @@ function calc_boundary_flux_by_direction!(surface_flux_values::AbstractArray{<:A
 end
 
 function calc_boundary_flux_by_direction!(surface_flux_values::AbstractArray{<:Any,4}, t,
-                                          boundary_condition, nonconservative_terms::Val{true}, equations,
+                                          boundary_condition, nonconservative_terms::True, equations,
                                           surface_integral ,dg::DG, cache,
                                           direction, first_boundary, last_boundary)
   surface_flux, nonconservative_flux = surface_integral.surface_flux
@@ -824,7 +824,7 @@ end
 
 function calc_mortar_flux!(surface_flux_values,
                            mesh::TreeMesh{2},
-                           nonconservative_terms::Val{false}, equations,
+                           nonconservative_terms::False, equations,
                            mortar_l2::LobattoLegendreMortarL2,
                            surface_integral, dg::DG, cache)
   @unpack surface_flux = surface_integral
@@ -851,7 +851,7 @@ end
 
 function calc_mortar_flux!(surface_flux_values,
                            mesh::TreeMesh{2},
-                           nonconservative_terms::Val{true}, equations,
+                           nonconservative_terms::True, equations,
                            mortar_l2::LobattoLegendreMortarL2,
                            surface_integral, dg::DG, cache)
   surface_flux, nonconservative_flux = surface_integral.surface_flux

--- a/src/solvers/dgsem_tree/dg_2d_compressible_euler.jl
+++ b/src/solvers/dgsem_tree/dg_2d_compressible_euler.jl
@@ -68,7 +68,7 @@ end # muladd
 # works efficiently here.
 @inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
                                     element, mesh::TreeMesh{2},
-                                    nonconservative_terms::Val{false},
+                                    nonconservative_terms::False,
                                     equations::CompressibleEulerEquations2D,
                                     volume_flux::typeof(flux_shima_etal_turbo),
                                     dg::DGSEM, cache, alpha)
@@ -230,7 +230,7 @@ end
 
 @inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
                                     element, mesh::TreeMesh{2},
-                                    nonconservative_terms::Val{false},
+                                    nonconservative_terms::False,
                                     equations::CompressibleEulerEquations2D,
                                     volume_flux::typeof(flux_ranocha_turbo),
                                     dg::DGSEM, cache, alpha)

--- a/src/solvers/dgsem_tree/dg_2d_compressible_euler.jl
+++ b/src/solvers/dgsem_tree/dg_2d_compressible_euler.jl
@@ -66,12 +66,12 @@ end # muladd
 # We specialize on `PtrArray` since these will be returned by `Trixi.wrap_array`
 # if LoopVectorization.jl can handle the array types. This ensures that `@turbo`
 # works efficiently here.
-@inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
-                                    element, mesh::TreeMesh{2},
-                                    nonconservative_terms::False,
-                                    equations::CompressibleEulerEquations2D,
-                                    volume_flux::typeof(flux_shima_etal_turbo),
-                                    dg::DGSEM, cache, alpha)
+@inline function flux_differencing_kernel!(_du::PtrArray, u_cons::PtrArray,
+                                           element, mesh::TreeMesh{2},
+                                           nonconservative_terms::False,
+                                           equations::CompressibleEulerEquations2D,
+                                           volume_flux::typeof(flux_shima_etal_turbo),
+                                           dg::DGSEM, cache, alpha)
   @unpack derivative_split = dg.basis
 
   # Create a temporary array that will be used to store the RHS with permuted
@@ -228,12 +228,12 @@ end
 
 
 
-@inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
-                                    element, mesh::TreeMesh{2},
-                                    nonconservative_terms::False,
-                                    equations::CompressibleEulerEquations2D,
-                                    volume_flux::typeof(flux_ranocha_turbo),
-                                    dg::DGSEM, cache, alpha)
+@inline function flux_differencing_kernel!(_du::PtrArray, u_cons::PtrArray,
+                                           element, mesh::TreeMesh{2},
+                                           nonconservative_terms::False,
+                                           equations::CompressibleEulerEquations2D,
+                                           volume_flux::typeof(flux_ranocha_turbo),
+                                           dg::DGSEM, cache, alpha)
   @unpack derivative_split = dg.basis
 
   # Create a temporary array that will be used to store the RHS with permuted

--- a/src/solvers/dgsem_tree/dg_2d_parallel.jl
+++ b/src/solvers/dgsem_tree/dg_2d_parallel.jl
@@ -681,7 +681,7 @@ end
 
 function calc_mpi_interface_flux!(surface_flux_values,
                                   mesh::ParallelTreeMesh{2},
-                                  nonconservative_terms::Val{false}, equations,
+                                  nonconservative_terms::False, equations,
                                   surface_integral, dg::DG, cache)
   @unpack surface_flux = surface_integral
   @unpack u, local_neighbor_ids, orientations, remote_sides = cache.mpi_interfaces
@@ -723,7 +723,7 @@ end
 
 function calc_mpi_mortar_flux!(surface_flux_values,
                                mesh::ParallelTreeMesh{2},
-                               nonconservative_terms::Val{false}, equations,
+                               nonconservative_terms::False, equations,
                                mortar_l2::LobattoLegendreMortarL2,
                                surface_integral, dg::DG, cache)
   @unpack surface_flux = surface_integral

--- a/src/solvers/dgsem_tree/dg_3d.jl
+++ b/src/solvers/dgsem_tree/dg_3d.jl
@@ -194,7 +194,7 @@ end
 
 @inline function weak_form_kernel!(du, u,
                                    element, mesh::TreeMesh{3},
-                                   nonconservative_terms::Val{false}, equations,
+                                   nonconservative_terms::False, equations,
                                    dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
@@ -237,7 +237,7 @@ end
 
 @inline function split_form_kernel!(du, u,
                                     element, mesh::TreeMesh{3},
-                                    nonconservative_terms::Val{false}, equations,
+                                    nonconservative_terms::False, equations,
                                     volume_flux, dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
@@ -280,7 +280,7 @@ end
 
 @inline function split_form_kernel!(du, u,
                                     element, mesh::TreeMesh{3},
-                                    nonconservative_terms::Val{true}, equations,
+                                    nonconservative_terms::True, equations,
                                     volume_flux, dg::DGSEM, cache, alpha=true)
   # true * [some floating point value] == [exactly the same floating point value]
   # This can (hopefully) be optimized away due to constant propagation.
@@ -288,7 +288,7 @@ end
   symmetric_flux, nonconservative_flux = volume_flux
 
   # Apply the symmetric flux as usual
-  split_form_kernel!(du, u, element, mesh, Val(false), equations, symmetric_flux, dg, cache, alpha)
+  split_form_kernel!(du, u, element, mesh, False(), equations, symmetric_flux, dg, cache, alpha)
 
   # Calculate the remaining volume terms using the nonsymmetric generalized flux
   for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
@@ -419,7 +419,7 @@ end
 
 # Calculate the finite volume fluxes inside the elements (**without non-conservative terms**).
 @inline function calcflux_fv!(fstar1_L, fstar1_R, fstar2_L, fstar2_R, fstar3_L, fstar3_R, u,
-                              mesh::TreeMesh{3}, nonconservative_terms::Val{false}, equations,
+                              mesh::TreeMesh{3}, nonconservative_terms::False, equations,
                               volume_flux_fv, dg::DGSEM, element, cache)
 
   fstar1_L[:, 1,            :, :] .= zero(eltype(fstar1_L))
@@ -467,7 +467,7 @@ end
 
 # Calculate the finite volume fluxes inside the elements (**without non-conservative terms**).
 @inline function calcflux_fv!(fstar1_L, fstar1_R, fstar2_L, fstar2_R, fstar3_L, fstar3_R, u,
-                              mesh::TreeMesh{3}, nonconservative_terms::Val{true}, equations,
+                              mesh::TreeMesh{3}, nonconservative_terms::True, equations,
                               volume_flux_fv, dg::DGSEM, element, cache)
   volume_flux, nonconservative_flux = volume_flux_fv
 
@@ -580,7 +580,7 @@ end
 
 function calc_interface_flux!(surface_flux_values,
                               mesh::TreeMesh{3},
-                              nonconservative_terms::Val{false}, equations,
+                              nonconservative_terms::False, equations,
                               surface_integral, dg::DG, cache)
   @unpack surface_flux = surface_integral
   @unpack u, neighbor_ids, orientations = cache.interfaces
@@ -613,7 +613,7 @@ end
 
 function calc_interface_flux!(surface_flux_values,
                               mesh::TreeMesh{3},
-                              nonconservative_terms::Val{true}, equations,
+                              nonconservative_terms::True, equations,
                               surface_integral, dg::DG, cache)
   surface_flux, nonconservative_flux = surface_integral.surface_flux
   @unpack u, neighbor_ids, orientations = cache.interfaces
@@ -909,7 +909,7 @@ end
 
 function calc_mortar_flux!(surface_flux_values,
                            mesh::TreeMesh{3},
-                           nonconservative_terms::Val{false}, equations,
+                           nonconservative_terms::False, equations,
                            mortar_l2::LobattoLegendreMortarL2,
                            surface_integral, dg::DG, cache)
   @unpack surface_flux = surface_integral
@@ -945,7 +945,7 @@ end
 
 function calc_mortar_flux!(surface_flux_values,
                            mesh::TreeMesh{3},
-                           nonconservative_terms::Val{true}, equations,
+                           nonconservative_terms::True, equations,
                            mortar_l2::LobattoLegendreMortarL2,
                            surface_integral, dg::DG, cache)
   surface_flux, nonconservative_flux = surface_integral.surface_flux

--- a/src/solvers/dgsem_tree/dg_3d_compressible_euler.jl
+++ b/src/solvers/dgsem_tree/dg_3d_compressible_euler.jl
@@ -19,7 +19,7 @@
 # works efficiently here.
 @inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
                                     element, mesh::TreeMesh{3},
-                                    nonconservative_terms::Val{false},
+                                    nonconservative_terms::False,
                                     equations::CompressibleEulerEquations3D,
                                     volume_flux::typeof(flux_shima_etal_turbo),
                                     dg::DGSEM, cache, alpha)
@@ -264,7 +264,7 @@ end
 
 @inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
                                     element, mesh::TreeMesh{3},
-                                    nonconservative_terms::Val{false},
+                                    nonconservative_terms::False,
                                     equations::CompressibleEulerEquations3D,
                                     volume_flux::typeof(flux_ranocha_turbo),
                                     dg::DGSEM, cache, alpha)

--- a/src/solvers/dgsem_tree/dg_3d_compressible_euler.jl
+++ b/src/solvers/dgsem_tree/dg_3d_compressible_euler.jl
@@ -17,12 +17,12 @@
 # We specialize on `PtrArray` since these will be returned by `Trixi.wrap_array`
 # if LoopVectorization.jl can handle the array types. This ensures that `@turbo`
 # works efficiently here.
-@inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
-                                    element, mesh::TreeMesh{3},
-                                    nonconservative_terms::False,
-                                    equations::CompressibleEulerEquations3D,
-                                    volume_flux::typeof(flux_shima_etal_turbo),
-                                    dg::DGSEM, cache, alpha)
+@inline function flux_differencing_kernel!(_du::PtrArray, u_cons::PtrArray,
+                                           element, mesh::TreeMesh{3},
+                                           nonconservative_terms::False,
+                                           equations::CompressibleEulerEquations3D,
+                                           volume_flux::typeof(flux_shima_etal_turbo),
+                                           dg::DGSEM, cache, alpha)
   @unpack derivative_split = dg.basis
 
   # Create a temporary array that will be used to store the RHS with permuted
@@ -262,12 +262,12 @@ end
 
 
 
-@inline function split_form_kernel!(_du::PtrArray, u_cons::PtrArray,
-                                    element, mesh::TreeMesh{3},
-                                    nonconservative_terms::False,
-                                    equations::CompressibleEulerEquations3D,
-                                    volume_flux::typeof(flux_ranocha_turbo),
-                                    dg::DGSEM, cache, alpha)
+@inline function flux_differencing_kernel!(_du::PtrArray, u_cons::PtrArray,
+                                           element, mesh::TreeMesh{3},
+                                           nonconservative_terms::False,
+                                           equations::CompressibleEulerEquations3D,
+                                           volume_flux::typeof(flux_ranocha_turbo),
+                                           dg::DGSEM, cache, alpha)
   @unpack derivative_split = dg.basis
 
   # Create a temporary array that will be used to store the RHS with permuted

--- a/src/solvers/dgsem_unstructured/containers_2d.jl
+++ b/src/solvers/dgsem_unstructured/containers_2d.jl
@@ -134,8 +134,13 @@ function init_interfaces(mesh::UnstructuredMesh2D, elements::UnstructuredElement
     mesh.n_interfaces, nvariables(elements), nnodes(elements))
 
   # extract and save the appropriate neighbour information from the mesh skeleton
-  init_interfaces!(interfaces, mesh.neighbour_information, mesh.boundary_names,
-                   mesh.n_elements, Val(isperiodic(mesh)))
+  if isperiodic(mesh)
+    init_interfaces!(interfaces, mesh.neighbour_information, mesh.boundary_names,
+                    mesh.n_elements, True())
+  else
+    init_interfaces!(interfaces, mesh.neighbour_information, mesh.boundary_names,
+                    mesh.n_elements, False())
+  end
 
   return interfaces
 end

--- a/src/solvers/dgsem_unstructured/containers_2d.jl
+++ b/src/solvers/dgsem_unstructured/containers_2d.jl
@@ -142,7 +142,7 @@ end
 
 
 function init_interfaces!(interfaces, edge_information, boundary_names, n_elements,
-                          periodic::Val{false})
+                          periodic::False)
 
   n_nodes = nnodes(interfaces)
   n_surfaces = size(edge_information, 2)
@@ -173,7 +173,7 @@ end
 
 
 function init_interfaces!(interfaces, edge_information, boundary_names, n_elements,
-                          periodic::Val{true})
+                          periodic::True)
 
   n_nodes = nnodes(interfaces)
   n_surfaces = size(edge_information, 2)

--- a/src/solvers/dgsem_unstructured/containers_2d.jl
+++ b/src/solvers/dgsem_unstructured/containers_2d.jl
@@ -136,10 +136,10 @@ function init_interfaces(mesh::UnstructuredMesh2D, elements::UnstructuredElement
   # extract and save the appropriate neighbour information from the mesh skeleton
   if isperiodic(mesh)
     init_interfaces!(interfaces, mesh.neighbour_information, mesh.boundary_names,
-                    mesh.n_elements, True())
+                     mesh.n_elements, True())
   else
     init_interfaces!(interfaces, mesh.neighbour_information, mesh.boundary_names,
-                    mesh.n_elements, False())
+                     mesh.n_elements, False())
   end
 
   return interfaces

--- a/src/solvers/dgsem_unstructured/dg_2d.jl
+++ b/src/solvers/dgsem_unstructured/dg_2d.jl
@@ -140,7 +140,7 @@ end
 # quadrilateral mesh
 function calc_interface_flux!(surface_flux_values,
                               mesh::UnstructuredMesh2D,
-                              nonconservative_terms::Val{false}, equations,
+                              nonconservative_terms::False, equations,
                               surface_integral, dg::DG, cache)
   @unpack surface_flux = surface_integral
   @unpack u, start_index, index_increment, element_ids, element_side_ids = cache.interfaces
@@ -193,7 +193,7 @@ end
 # on an unstructured quadrilateral mesh
 function calc_interface_flux!(surface_flux_values,
                               mesh::UnstructuredMesh2D,
-                              nonconservative_terms::Val{true}, equations,
+                              nonconservative_terms::True, equations,
                               surface_integral, dg::DG, cache)
   surface_flux, nonconservative_flux = surface_integral.surface_flux
   @unpack u, start_index, index_increment, element_ids, element_side_ids = cache.interfaces
@@ -371,7 +371,7 @@ end
 # boundary flux values are set according to a particular `boundary_condition` function
 @inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition,
                                      mesh::UnstructuredMesh2D,
-                                     nonconservative_terms::Val{false}, equations,
+                                     nonconservative_terms::False, equations,
                                      surface_integral, dg::DG, cache,
                                      node_index, side_index, element_index, boundary_index)
   @unpack normal_directions = cache.elements
@@ -403,7 +403,7 @@ end
 # `derivative_split` from `dg.basis` in [`split_form_kernel!`](@ref)
 @inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition,
                                      mesh::UnstructuredMesh2D,
-                                     nonconservative_terms::Val{true}, equations,
+                                     nonconservative_terms::True, equations,
                                      surface_integral, dg::DG, cache,
                                      node_index, side_index, element_index, boundary_index)
   surface_flux, nonconservative_flux = surface_integral.surface_flux

--- a/src/solvers/dgsem_unstructured/dg_2d.jl
+++ b/src/solvers/dgsem_unstructured/dg_2d.jl
@@ -400,7 +400,7 @@ end
 # are set according to a particular `boundary_condition` function
 # Note, it is necessary to set and add in the nonconservative values because
 # the upper left/lower right diagonal terms have been peeled off due to the use of
-# `derivative_split` from `dg.basis` in [`split_form_kernel!`](@ref)
+# `derivative_split` from `dg.basis` in [`flux_differencing_kernel!`](@ref)
 @inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition,
                                      mesh::UnstructuredMesh2D,
                                      nonconservative_terms::True, equations,

--- a/src/solvers/fdsbp_tree/fdsbp_1d.jl
+++ b/src/solvers/fdsbp_tree/fdsbp_1d.jl
@@ -42,7 +42,7 @@ end
 # 2D volume integral contributions for `VolumeIntegralStrongForm`
 function calc_volume_integral!(du, u,
                                mesh::TreeMesh{1},
-                               nonconservative_terms::Val{false}, equations,
+                               nonconservative_terms::False, equations,
                                volume_integral::VolumeIntegralStrongForm,
                                dg::FDSBP, cache)
   D = dg.basis # SBP derivative operator
@@ -88,7 +88,7 @@ end
 # of the flux splitting f^-.
 function calc_volume_integral!(du, u,
                                mesh::TreeMesh{1},
-                               nonconservative_terms::Val{false}, equations,
+                               nonconservative_terms::False, equations,
                                volume_integral::VolumeIntegralUpwind,
                                dg::FDSBP, cache)
   # Assume that
@@ -171,7 +171,7 @@ end
 # flux information at each side of an interface.
 function calc_interface_flux!(surface_flux_values,
                               mesh::TreeMesh{1},
-                              nonconservative_terms::Val{false}, equations,
+                              nonconservative_terms::False, equations,
                               surface_integral::SurfaceIntegralUpwind,
                               dg::FDSBP, cache)
   @unpack splitting = surface_integral

--- a/src/solvers/fdsbp_tree/fdsbp_2d.jl
+++ b/src/solvers/fdsbp_tree/fdsbp_2d.jl
@@ -42,7 +42,7 @@ end
 # 2D volume integral contributions for `VolumeIntegralStrongForm`
 function calc_volume_integral!(du, u,
                                mesh::TreeMesh{2},
-                               nonconservative_terms::Val{false}, equations,
+                               nonconservative_terms::False, equations,
                                volume_integral::VolumeIntegralStrongForm,
                                dg::FDSBP, cache)
   D = dg.basis # SBP derivative operator
@@ -97,7 +97,7 @@ end
 # of the flux splitting f^-.
 function calc_volume_integral!(du, u,
                                mesh::TreeMesh{2},
-                               nonconservative_terms::Val{false}, equations,
+                               nonconservative_terms::False, equations,
                                volume_integral::VolumeIntegralUpwind,
                                dg::FDSBP, cache)
   # Assume that
@@ -207,7 +207,7 @@ end
 # flux information at each side of an interface.
 function calc_interface_flux!(surface_flux_values,
                               mesh::TreeMesh{2},
-                              nonconservative_terms::Val{false}, equations,
+                              nonconservative_terms::False, equations,
                               surface_integral::SurfaceIntegralUpwind,
                               dg::FDSBP, cache)
   @unpack splitting = surface_integral

--- a/src/solvers/fdsbp_tree/fdsbp_3d.jl
+++ b/src/solvers/fdsbp_tree/fdsbp_3d.jl
@@ -42,7 +42,7 @@ end
 # 3D volume integral contributions for `VolumeIntegralStrongForm`
 function calc_volume_integral!(du, u,
                                mesh::TreeMesh{3},
-                               nonconservative_terms::Val{false}, equations,
+                               nonconservative_terms::False, equations,
                                volume_integral::VolumeIntegralStrongForm,
                                dg::FDSBP, cache)
   D = dg.basis # SBP derivative operator
@@ -104,7 +104,7 @@ end
 # of the flux splitting f^-.
 function calc_volume_integral!(du, u,
                                mesh::TreeMesh{3},
-                               nonconservative_terms::Val{false}, equations,
+                               nonconservative_terms::False, equations,
                                volume_integral::VolumeIntegralUpwind,
                                dg::FDSBP, cache)
   # Assume that
@@ -237,7 +237,7 @@ end
 # flux information at each side of an interface.
 function calc_interface_flux!(surface_flux_values,
                               mesh::TreeMesh{3},
-                              nonconservative_terms::Val{false}, equations,
+                              nonconservative_terms::False, equations,
                               surface_integral::SurfaceIntegralUpwind,
                               dg::FDSBP, cache)
   @unpack splitting = surface_integral

--- a/test/test_performance_specializations.jl
+++ b/test/test_performance_specializations.jl
@@ -28,7 +28,7 @@ isdir(outdir) && rm(outdir, recursive=true)
 
       # Call the optimized default version
       du .= 0
-      Trixi.split_form_kernel!(
+      Trixi.flux_differencing_kernel!(
         du, u, 1, semi.mesh,
         nonconservative_terms, semi.equations,
         semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
@@ -37,7 +37,7 @@ isdir(outdir) && rm(outdir, recursive=true)
       # Call the plain version - note the argument type `Function` of
       # `semi.solver.volume_integral.volume_flux`
       du .= 0
-      invoke(Trixi.split_form_kernel!,
+      invoke(Trixi.flux_differencing_kernel!,
         Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
         typeof(nonconservative_terms), typeof(semi.equations),
         Function, typeof(semi.solver), typeof(semi.cache), Bool},
@@ -67,7 +67,7 @@ isdir(outdir) && rm(outdir, recursive=true)
 
       # Call the optimized default version
       du .= 0
-      Trixi.split_form_kernel!(
+      Trixi.flux_differencing_kernel!(
         du, u, 1, semi.mesh,
         nonconservative_terms, semi.equations,
         semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
@@ -76,7 +76,7 @@ isdir(outdir) && rm(outdir, recursive=true)
       # Call the plain version - note the argument type `Function` of
       # `semi.solver.volume_integral.volume_flux`
       du .= 0
-      invoke(Trixi.split_form_kernel!,
+      invoke(Trixi.flux_differencing_kernel!,
         Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
         typeof(nonconservative_terms), typeof(semi.equations),
         Function, typeof(semi.solver), typeof(semi.cache), Bool},
@@ -106,7 +106,7 @@ isdir(outdir) && rm(outdir, recursive=true)
 
       # Call the optimized default version
       du .= 0
-      Trixi.split_form_kernel!(
+      Trixi.flux_differencing_kernel!(
         du, u, 1, semi.mesh,
         nonconservative_terms, semi.equations,
         semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
@@ -115,7 +115,7 @@ isdir(outdir) && rm(outdir, recursive=true)
       # Call the plain version - note the argument type `Function` of
       # `semi.solver.volume_integral.volume_flux`
       du .= 0
-      invoke(Trixi.split_form_kernel!,
+      invoke(Trixi.flux_differencing_kernel!,
         Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
         typeof(nonconservative_terms), typeof(semi.equations),
         Function, typeof(semi.solver), typeof(semi.cache), Bool},
@@ -145,7 +145,7 @@ isdir(outdir) && rm(outdir, recursive=true)
 
       # Call the optimized default version
       du .= 0
-      Trixi.split_form_kernel!(
+      Trixi.flux_differencing_kernel!(
         du, u, 1, semi.mesh,
         nonconservative_terms, semi.equations,
         semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
@@ -154,7 +154,7 @@ isdir(outdir) && rm(outdir, recursive=true)
       # Call the plain version - note the argument type `Function` of
       # `semi.solver.volume_integral.volume_flux`
       du .= 0
-      invoke(Trixi.split_form_kernel!,
+      invoke(Trixi.flux_differencing_kernel!,
         Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
         typeof(nonconservative_terms), typeof(semi.equations),
         Function, typeof(semi.solver), typeof(semi.cache), Bool},
@@ -184,7 +184,7 @@ isdir(outdir) && rm(outdir, recursive=true)
 
       # Call the optimized default version
       du .= 0
-      Trixi.split_form_kernel!(
+      Trixi.flux_differencing_kernel!(
         du, u, 1, semi.mesh,
         nonconservative_terms, semi.equations,
         semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
@@ -193,7 +193,7 @@ isdir(outdir) && rm(outdir, recursive=true)
       # Call the plain version - note the argument type `Function` of
       # `semi.solver.volume_integral.volume_flux`
       du .= 0
-      invoke(Trixi.split_form_kernel!,
+      invoke(Trixi.flux_differencing_kernel!,
         Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
         typeof(nonconservative_terms), typeof(semi.equations),
         Function, typeof(semi.solver), typeof(semi.cache), Bool},
@@ -223,7 +223,7 @@ isdir(outdir) && rm(outdir, recursive=true)
 
       # Call the optimized default version
       du .= 0
-      Trixi.split_form_kernel!(
+      Trixi.flux_differencing_kernel!(
         du, u, 1, semi.mesh,
         nonconservative_terms, semi.equations,
         semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
@@ -232,7 +232,7 @@ isdir(outdir) && rm(outdir, recursive=true)
       # Call the plain version - note the argument type `Function` of
       # `semi.solver.volume_integral.volume_flux`
       du .= 0
-      invoke(Trixi.split_form_kernel!,
+      invoke(Trixi.flux_differencing_kernel!,
         Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
         typeof(nonconservative_terms), typeof(semi.equations),
         Function, typeof(semi.solver), typeof(semi.cache), Bool},
@@ -262,7 +262,7 @@ isdir(outdir) && rm(outdir, recursive=true)
 
       # Call the optimized default version
       du .= 0
-      Trixi.split_form_kernel!(
+      Trixi.flux_differencing_kernel!(
         du, u, 1, semi.mesh,
         nonconservative_terms, semi.equations,
         semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
@@ -271,7 +271,7 @@ isdir(outdir) && rm(outdir, recursive=true)
       # Call the plain version - note the argument type `Function` of
       # `semi.solver.volume_integral.volume_flux`
       du .= 0
-      invoke(Trixi.split_form_kernel!,
+      invoke(Trixi.flux_differencing_kernel!,
         Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
         typeof(nonconservative_terms), typeof(semi.equations),
         Function, typeof(semi.solver), typeof(semi.cache), Bool},
@@ -301,7 +301,7 @@ isdir(outdir) && rm(outdir, recursive=true)
 
       # Call the optimized default version
       du .= 0
-      Trixi.split_form_kernel!(
+      Trixi.flux_differencing_kernel!(
         du, u, 1, semi.mesh,
         nonconservative_terms, semi.equations,
         semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
@@ -310,7 +310,7 @@ isdir(outdir) && rm(outdir, recursive=true)
       # Call the plain version - note the argument type `Function` of
       # `semi.solver.volume_integral.volume_flux`
       du .= 0
-      invoke(Trixi.split_form_kernel!,
+      invoke(Trixi.flux_differencing_kernel!,
         Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
         typeof(nonconservative_terms), typeof(semi.equations),
         Function, typeof(semi.solver), typeof(semi.cache), Bool},

--- a/test/test_tree_1d.jl
+++ b/test/test_tree_1d.jl
@@ -218,7 +218,7 @@ end
 
 
   # We use nonconservative terms
-  Trixi.have_nonconservative_terms(::NonconservativeLinearAdvectionEquation) = Val(true)
+  Trixi.have_nonconservative_terms(::NonconservativeLinearAdvectionEquation) = Trixi.True()
 
   function flux_nonconservative(u_mine, u_other, orientation,
                                 equations::NonconservativeLinearAdvectionEquation)


### PR DESCRIPTION
This includes a first set of breaking changes for Trixi.jl v0.5 described in https://github.com/trixi-framework/Trixi.jl/issues/938.

@jlchan Could you please check that I removed only the `DGMulti` code that you intended to be removed?

I will leave this in draft mode until we are ready for the breaking release of Trixi.jl. We also need to update the compat bounds of Trixi.jl at Trixi2Vtk.jl to create our documentation here.