### PR TITLE
Fix tests related to `StartUpDG.inverse_trace_constant` warnings

### DIFF
--- a/src/solvers/dgmulti/flux_differencing_gauss_sbp.jl
+++ b/src/solvers/dgmulti/flux_differencing_gauss_sbp.jl
@@ -316,7 +316,7 @@ end
 # in StartUpDG.jl, which have explicit formulas. These inverse trace constants are used in
 # CFL-based control of the time-step size.
 import StartUpDG: inverse_trace_constant
-inverse_trace_constant(rd::RefElemData{2, Quad, <:GaussSBP}) = (rd.N+1) * (rd.N + 2)
+inverse_trace_constant(rd::RefElemData{2, Quad, <:GaussSBP}) = (rd.N + 1) * (rd.N + 2)
 inverse_trace_constant(rd::RefElemData{3, Hex, <:GaussSBP}) = 3 * (rd.N + 1) * (rd.N + 2) / 2
 
 function DGMulti(element_type::Line,

--- a/src/solvers/dgmulti/flux_differencing_gauss_sbp.jl
+++ b/src/solvers/dgmulti/flux_differencing_gauss_sbp.jl
@@ -311,6 +311,14 @@ end
   end
 end
 
+# Since GaussSBP uses Gauss quadrature which is exact for polynomials of degree N, the
+# inverse trace constants for GaussSBP are identical to polynomial inverse trace constants
+# in StartUpDG.jl, which have explicit formulas. These inverse trace constants are used in
+# CFL-based control of the time-step size.
+import StartUpDG: inverse_trace_constant
+inverse_trace_constant(rd::RefElemData{2, Quad, <:GaussSBP}) = (rd.N+1) * (rd.N + 2)
+inverse_trace_constant(rd::RefElemData{3, Hex, <:GaussSBP}) = 3 * (rd.N + 1) * (rd.N + 2) / 2
+
 function DGMulti(element_type::Line,
                  approximation_type::GaussSBP,
                  volume_integral, surface_integral;


### PR DESCRIPTION
I added a warning for `StartUpDG.inverse_trace_constants`, which appears to have broken several Trixi tests. These should be fixed by v0.14.9 of StartUpDG.jl (https://github.com/JuliaRegistries/General/pull/74443) and this PR.