### PR TITLE
Print info on potential wait time in `trixi_include` only in serial runs

### DIFF
--- a/src/auxiliary/special_elixirs.jl
+++ b/src/auxiliary/special_elixirs.jl
@@ -35,7 +35,10 @@ julia> redirect_stdout(devnull) do
 ```
 """
 function trixi_include(mod::Module, elixir::AbstractString; kwargs...)
-  @info "You just called `trixi_include`. Julia may now compile the code, please be patient."
+  # Print information on possible wait time only in non-parallel case
+  if !mpi_isparallel()
+    @info "You just called `trixi_include`. Julia may now compile the code, please be patient."
+  end
   Base.include(ex -> replace_assignments(insert_maxiters(ex); kwargs...), mod, elixir)
 end
 

--- a/src/auxiliary/special_elixirs.jl
+++ b/src/auxiliary/special_elixirs.jl
@@ -35,7 +35,7 @@ julia> redirect_stdout(devnull) do
 ```
 """
 function trixi_include(mod::Module, elixir::AbstractString; kwargs...)
-  # Print information on possible wait time only in non-parallel case
+  # Print information on potential wait time only in non-parallel case
   if !mpi_isparallel()
     @info "You just called `trixi_include`. Julia may now compile the code, please be patient."
   end


### PR DESCRIPTION
I just created a couple of output files with hundreds of these info messages on JURECA 😅