### PR TITLE
Extra Analysis Callback: Total Variation 

### DIFF
--- a/src/semidiscretization/semidiscretization.jl
+++ b/src/semidiscretization/semidiscretization.jl
@@ -46,10 +46,20 @@ function integrate(func::Func, u_ode, semi::AbstractSemidiscretization; normaliz
   integrate(func, u, mesh, equations, solver, cache, normalize=normalize)
 end
 
-function integrate(u, semi::AbstractSemidiscretization; normalize=true)
-  integrate(cons2cons, u, semi; normalize=normalize)
+function integrate(u_ode, semi::AbstractSemidiscretization; normalize=true)
+  integrate(cons2cons, u_ode, semi; normalize=normalize)
 end
 
+function integrate_element(func::Func, u_ode, element, semi::AbstractSemidiscretization; normalize=true) where {Func}
+  mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
+
+  u = wrap_array(u_ode, mesh, equations, solver, cache)
+  integrate_element(func, u, element, mesh, equations, solver, cache, normalize=normalize)
+end
+
+function integrate_element(u_ode, element, semi::AbstractSemidiscretization; normalize=true)
+  integrate_element(cons2cons, u_ode, element, semi; normalize=normalize)
+end
 
 """
     calc_error_norms([func=(u_node,equations)->u_node,] u_ode, t, analyzer, semi::AbstractSemidiscretization, cache_analysis)


### PR DESCRIPTION
One thing I missed is the option to compute the total variation
$$|| U ||_{\text{TV}} = \sum_i  | U _{i+1} - U_i |$$
semi-norm.

I gave this a start by implementing a total variation extra analysis callback for scalar equations on periodic meshes.
The extension to systems of equations should be straightforward once one has agreed on a definition - a possible choice is given by equation (3.6) [here](https://www.ams.org/journals/mcom/1987-49-179/S0025-5718-1987-0890257-7/).
