### PR TITLE
Fix bugs when run with MPI

### DIFF
--- a/src/auxiliary/mpi.jl
+++ b/src/auxiliary/mpi.jl
@@ -110,7 +110,9 @@ end
 # care of these situations when allowing to use `ode_norm` as default norm in
 # OrdinaryDiffEq.jl throughout all applications of Trixi.jl.
 recursive_sum_abs2(u::Number) = abs2(u)
-recursive_sum_abs2(u::AbstractArray) = sum(recursive_sum_abs2, u; init=zero(eltype(u)))
+# Use `mapreduce` instead of `sum` since `sum` from StaticArrays.jl does not
+# support the kwarg `init`
+recursive_sum_abs2(u::AbstractArray) = mapreduce(recursive_sum_abs2, +, u; init=zero(eltype(eltype(u))))
 
 recursive_length(u::Number) = length(u)
 recursive_length(u::AbstractArray{<:Number}) = length(u)

--- a/src/auxiliary/mpi.jl
+++ b/src/auxiliary/mpi.jl
@@ -110,7 +110,7 @@ end
 # care of these situations when allowing to use `ode_norm` as default norm in
 # OrdinaryDiffEq.jl throughout all applications of Trixi.jl.
 recursive_sum_abs2(u::Number) = abs2(u)
-recursive_sum_abs2(u::AbstractArray) = sum(recursive_sum_abs2, u)
+recursive_sum_abs2(u::AbstractArray) = sum(recursive_sum_abs2, u; init=0)
 
 recursive_length(u::Number) = length(u)
 recursive_length(u::AbstractArray{<:Number}) = length(u)

--- a/src/auxiliary/mpi.jl
+++ b/src/auxiliary/mpi.jl
@@ -110,7 +110,7 @@ end
 # care of these situations when allowing to use `ode_norm` as default norm in
 # OrdinaryDiffEq.jl throughout all applications of Trixi.jl.
 recursive_sum_abs2(u::Number) = abs2(u)
-recursive_sum_abs2(u::AbstractArray) = sum(recursive_sum_abs2, u; init=0)
+recursive_sum_abs2(u::AbstractArray) = sum(recursive_sum_abs2, u; init=zero(eltype(u)))
 
 recursive_length(u::Number) = length(u)
 recursive_length(u::AbstractArray{<:Number}) = length(u)

--- a/src/auxiliary/mpi.jl
+++ b/src/auxiliary/mpi.jl
@@ -112,6 +112,11 @@ end
 recursive_sum_abs2(u::Number) = abs2(u)
 # Use `mapreduce` instead of `sum` since `sum` from StaticArrays.jl does not
 # support the kwarg `init`
+# We need `init=zero(eltype(eltype(u))` below to deal with arrays of `SVector`s etc.
+# A better solution would be `recursive_unitless_bottom_eltype` from 
+# https://github.com/SciML/RecursiveArrayTools.jl
+# However, what you have is good enough for us for now, so we don't need this 
+# additional dependency at the moment.
 recursive_sum_abs2(u::AbstractArray) = mapreduce(recursive_sum_abs2, +, u; init=zero(eltype(eltype(u))))
 
 recursive_length(u::Number) = length(u)

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -450,15 +450,16 @@ function print_amr_information(callbacks, mesh::P4estMesh, solver, cache)
   # Check if there is at least one level with an element
   if isnothing(min_level_1) || isnothing(max_level_1)
     return nothing
-  else
-    min_level = min_level_1 - 1
-    max_level = max_level_1 - 1
-
-    for level = max_level:-1:min_level+1
-      mpi_println(" ├── level $level:    " * @sprintf("% 14d", elements_per_level[level + 1]))
-    end
-    mpi_println(" └── level $min_level:    " * @sprintf("% 14d", elements_per_level[min_level + 1]))
   end
+
+  min_level = min_level_1 - 1
+  max_level = max_level_1 - 1
+
+  for level = max_level:-1:min_level+1
+    mpi_println(" ├── level $level:    " * @sprintf("% 14d", elements_per_level[level + 1]))
+  end
+  mpi_println(" └── level $min_level:    " * @sprintf("% 14d", elements_per_level[min_level + 1]))
+
   return nothing
 end
 

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -444,6 +444,7 @@ function print_amr_information(callbacks, mesh::P4estMesh, solver, cache)
     elements_per_level .+= tree.quadrants_per_level
   end
 
+  # levels start at zero but Julia's standard indexing starts at 1
   min_level_1 = findfirst(i -> i > 0, elements_per_level)
   max_level_1 = findlast(i -> i > 0, elements_per_level)
 

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -444,14 +444,21 @@ function print_amr_information(callbacks, mesh::P4estMesh, solver, cache)
     elements_per_level .+= tree.quadrants_per_level
   end
 
-  min_level = findfirst(i -> i > 0, elements_per_level) - 1
-  max_level = findlast(i -> i > 0, elements_per_level) - 1
+  min_level_1 = findfirst(i -> i > 0, elements_per_level)
+  max_level_1 = findlast(i -> i > 0, elements_per_level)
 
-  for level = max_level:-1:min_level+1
-    mpi_println(" ├── level $level:    " * @sprintf("% 14d", elements_per_level[level + 1]))
+  # Check if there is at least one level with an element
+  if isnothing(min_level_1) || isnothing(max_level_1)
+    return nothing
+  else
+    min_level = min_level_1 - 1
+    max_level = max_level_1 - 1
+
+    for level = max_level:-1:min_level+1
+      mpi_println(" ├── level $level:    " * @sprintf("% 14d", elements_per_level[level + 1]))
+    end
+    mpi_println(" └── level $min_level:    " * @sprintf("% 14d", elements_per_level[min_level + 1]))
   end
-  mpi_println(" └── level $min_level:    " * @sprintf("% 14d", elements_per_level[min_level + 1]))
-
   return nothing
 end
 

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -59,7 +59,7 @@ macro test_trixi_include(elixir, args...)
     Trixi.mpi_isroot() && println("═"^100)
     Trixi.mpi_isroot() && println($elixir)
 
-    # if `maxiters` is set in tests, it is usually set to a small numer to
+    # if `maxiters` is set in tests, it is usually set to a small number to
     # run only a few steps - ignore possible warnings coming from that
     if any(==(:maxiters) ∘ first, $kwargs)
       additional_ignore_content = [
@@ -124,7 +124,7 @@ end
 
 
 # Modified version of `@test_nowarn` that prints the content of `stderr` when
-# it is not empty and ignnores module replacements.
+# it is not empty and ignores module replacements.
 macro test_nowarn_mod(expr, additional_ignore_content=String[])
   quote
     let fname = tempname()


### PR DESCRIPTION
Running `elixir_advection_amr_unstructured_flag.jl` with more than 24 MPI ranks gave an error in `analysis.jl`. Running the  "error-based step size control" test from `test_mpi_p4est_2d.jl` with more than 64 MPI ranks also gave an error. This PR should fix both.