### PR TITLE
fix docstring of `boundary_condition_do_nothing`

### DIFF
--- a/src/basic_types.jl
+++ b/src/basic_types.jl
@@ -62,7 +62,7 @@ abstract type AdaptorL2{RealT<:Real} <: AdaptorAMR{RealT} end
 struct BoundaryConditionPeriodic end
 
 """
-    boundary_condition_periodic = BoundaryConditionPeriodic()
+    boundary_condition_periodic = Trixi.BoundaryConditionPeriodic()
 
 A singleton struct indicating periodic boundary conditions.
 """
@@ -70,17 +70,18 @@ const boundary_condition_periodic = BoundaryConditionPeriodic()
 
 Base.show(io::IO, ::BoundaryConditionPeriodic) = print(io, "boundary_condition_periodic")
 
-"""
-    boundary_condition_do_nothing = BoundaryConditionDoNothing()
 
-Imposing no boundary condition just evaluates the flux at the inner state.
-"""
 struct BoundaryConditionDoNothing end
 
 @inline function (boundary_condition::BoundaryConditionDoNothing)(inner_flux_or_state, other_args...)
   return inner_flux_or_state
 end
+    
+"""
+    boundary_condition_do_nothing = Trixi.BoundaryConditionDoNothing()
 
+Imposing no boundary condition just evaluates the flux at the inner state.
+"""
 const boundary_condition_do_nothing = BoundaryConditionDoNothing()
 
 Base.show(io::IO, ::BoundaryConditionDoNothing) = print(io, "boundary_condition_do_nothing")


### PR DESCRIPTION
I found this when looking at #1331 - we didn`t have a docstring for the exported name `boundary_condition_do_nothing` but only for the un-exported struct `BoundaryConditionDoNothing`. I changed that, mimicking what we do for periodic BCs.