### PR TITLE
fix `boundary_condition_do_nothing`

### DIFF
--- a/src/basic_types.jl
+++ b/src/basic_types.jl
@@ -73,7 +73,20 @@ Base.show(io::IO, ::BoundaryConditionPeriodic) = print(io, "boundary_condition_p
 
 struct BoundaryConditionDoNothing end
 
-@inline function (boundary_condition::BoundaryConditionDoNothing)(inner_flux_or_state, other_args...)
+# This version can be called by hyperbolic solvers on logically Cartesian meshes
+@inline function (::BoundaryConditionDoNothing)(
+    u_inner, orientation_or_normal_direction, direction::Integer, x, t, surface_flux, equations)
+  return flux(u_inner, orientation_or_normal_direction, equations)
+end
+
+# This version can be called by hyperbolic solvers on unstructured, curved meshes
+@inline function (::BoundaryConditionDoNothing)(
+    u_inner, outward_direction::AbstractVector, x, t, surface_flux, equations)
+  return flux(u_inner, outward_direction, equations)
+end
+
+# This version can be called by parabolic solvers
+@inline function (::BoundaryConditionDoNothing)(inner_flux_or_state, other_args...)
   return inner_flux_or_state
 end
     

--- a/test/test_parabolic_2d.jl
+++ b/test/test_parabolic_2d.jl
@@ -32,9 +32,9 @@ isdir(outdir) && rm(outdir, recursive=true)
     @test_nowarn_mod show(stdout, MIME"text/plain"(), semi)
     @test_nowarn_mod show(stdout, boundary_condition_do_nothing)
 
-    @test nvariables(semi)==nvariables(equations)
-    @test Base.ndims(semi)==Base.ndims(mesh)
-    @test Base.real(semi)==Base.real(dg)
+    @test nvariables(semi) == nvariables(equations)
+    @test Base.ndims(semi) == Base.ndims(mesh)
+    @test Base.real(semi) == Base.real(dg)
 
     ode = semidiscretize(semi, (0.0, 0.01))
     u0 = similar(ode.u0)

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -553,6 +553,24 @@ isdir(outdir) && rm(outdir, recursive=true)
     end
   end
 
+  @timed_testset "boundary_condition_do_nothing" begin
+    rho, v1, v2, p = 1.0, 0.1, 0.2, 0.3, 2.0
+
+    let equations = CompressibleEulerEquations2D(1.4)
+      u = prim2cons(SVector(rho, v1, v2, p), equations)
+      x = SVector(1.0, 2.0)
+      t = 0.5
+      surface_flux = flux_lax_friedrichs
+
+      outward_direction = SVector(0.2, -0.3)
+      @test flux(u, outward_direction, equations) ≈ boundary_condition_do_nothing(u, outward_direction, x, t, surface_flux, equations)
+
+      orientation = 2
+      direction = 4
+      @test flux(u, orientation, equations) ≈ boundary_condition_do_nothing(u, orientation, direction, x, t, surface_flux, equations)
+    end
+  end
+
   @timed_testset "TimeSeriesCallback" begin
     @test_nowarn_mod trixi_include(@__MODULE__,
                                      joinpath(examples_dir(), "tree_2d_dgsem", "elixir_acoustics_gaussian_source.jl"),


### PR DESCRIPTION
Fixes #1331

I can confirm that `examples/tree_2d_dgsem/elixir_euler_blast_wave.jl` runs with the change
```
shell> git diff
diff --git a/examples/tree_2d_dgsem/elixir_euler_blast_wave.jl b/examples/tree_2d_dgsem/elixir_euler_blast_wave.jl
index 0da18b712..fd997ce15 100644
--- a/examples/tree_2d_dgsem/elixir_euler_blast_wave.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_blast_wave.jl
@@ -52,10 +52,15 @@ coordinates_min = (-2.0, -2.0)
 coordinates_max = ( 2.0,  2.0)
 mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level=6,
-                n_cells_max=10_000)
+                n_cells_max=10_000, periodicity = false)
 
+boundary_conditions = ( x_pos = boundary_condition_do_nothing,
+                        x_neg = boundary_condition_do_nothing,
+                        y_pos = boundary_condition_do_nothing,
+                        y_neg = boundary_condition_do_nothing)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver;
+                                    boundary_conditions)
 
 
 ###############################################################################
```

(and also with Dirichlet BCs in y direction).

The problem was that the `boundary_condition_do_nothing` returned the first argument - which is the state, not the flux for hyperbolic equations. I guess this came from the parabolic setups we used - and didn't really matter for linear advection with velocity components unity...

@jlchan @andrewwinters5000 It would be nice if you could have a look at this.