### PR TITLE
Add documentation of distribution of cells for `P4estMesh` with MPI

### DIFF
--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -147,4 +147,4 @@ ranks, this has the consequence that sibling cells (i.e., child cells with the s
 are kept on the same MPI rank to be able to coarsen them easily. This might cause an unbalanced
 distribution of cells on different ranks. For 2D meshes, this also means that *initially* each rank will
 at least own 4 cells, and for 3D meshes, *initially* each rank will at least own 8 cells.
-
+See [issue #1329](https://github.com/trixi-framework/Trixi.jl/issues/1329).

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -139,3 +139,8 @@ begin
 end
 ```
 
+
+## Distribution of cells on multiple MPI ranks in [`P4estMesh`](@ref)
+
+The [`P4estMesh`](@ref) allows coarsening the mesh by default. When Trixi is parallelized with multiple MPI ranks this has the consequence that families of cells are kept on the same MPI rank to be able to coarsen them easily. This might cause an unbalanced distribution of cells on different ranks. For 2D meshes this also means that each rank will at least own 4 cells and for 3D meshes each rank will at least own 8 cells.
+

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -142,5 +142,9 @@ end
 
 ## MPI ranks are assigned zero cells in [`P4estMesh`](@ref) even though there are enough cells
 
-The [`P4estMesh`](@ref) allows coarsening the mesh by default. When Trixi is parallelized with multiple MPI ranks this has the consequence that families of cells are kept on the same MPI rank to be able to coarsen them easily. This might cause an unbalanced distribution of cells on different ranks. For 2D meshes this also means that each rank will at least own 4 cells and for 3D meshes each rank will at least own 8 cells.
+The [`P4estMesh`](@ref) allows one to coarsen the mesh by default. When Trixi is parallelized with multiple MPI
+ranks, this has the consequence that sibling cells (i.e., child cells with the same parent cell)
+are kept on the same MPI rank to be able to coarsen them easily. This might cause an unbalanced
+distribution of cells on different ranks. For 2D meshes, this also means that *initially* each rank will
+at least own 4 cells, and for 3D meshes, *initially* each rank will at least own 8 cells.
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -140,7 +140,7 @@ end
 ```
 
 
-## Distribution of cells on multiple MPI ranks in [`P4estMesh`](@ref)
+## MPI ranks are assigned zero cells in [`P4estMesh`](@ref) even though there are enough cells
 
 The [`P4estMesh`](@ref) allows coarsening the mesh by default. When Trixi is parallelized with multiple MPI ranks this has the consequence that families of cells are kept on the same MPI rank to be able to coarsen them easily. This might cause an unbalanced distribution of cells on different ranks. For 2D meshes this also means that each rank will at least own 4 cells and for 3D meshes each rank will at least own 8 cells.
 


### PR DESCRIPTION
This briefly documents the behavior of the `P4estMesh` when multiple MPI ranks are used, as discussed in #1329.