### PR TITLE
Allow turning coarsening for `P4estMesh` on and off

### DIFF
--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -133,7 +133,7 @@ function initialize!(cb::DiscreteCallback{Condition,Affect!}, u, t, integrator) 
   if mesh isa P4estMesh
     if cb.affect!.p4est_partition_allow_for_coarsening != mesh.p4est_partition_allow_for_coarsening
       if mpi_isroot()
-        @info "The attribute p4est_partition_allow_for_coarsening from the mesh is changed."
+        @info "The attribute p4est_partition_allow_for_coarsening from the mesh is changed to `$(cb.affect!.p4est_partition_allow_for_coarsening)`."
       end
       mesh.p4est_partition_allow_for_coarsening = cb.affect!.p4est_partition_allow_for_coarsening
     end

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -134,7 +134,7 @@ function initialize!(cb::DiscreteCallback{Condition,Affect!}, u, t, integrator) 
     if cb.affect!.p4est_partition_allow_for_coarsening != mesh.p4est_partition_allow_for_coarsening
       mesh.p4est_partition_allow_for_coarsening = cb.affect!.p4est_partition_allow_for_coarsening
       if mpi_isroot()
-        @info "The attribute `p4est_partition_allow_for_coarsening` from the mesh was changed to `$(cb.affect!.p4est_partition_allow_for_coarsening)` by the `AMRCallback`."
+        @info "The mesh attribute `p4est_partition_allow_for_coarsening` was changed to `$(cb.affect!.p4est_partition_allow_for_coarsening)` by the `AMRCallback`."
       end
       partition!(mesh)
     end

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -131,11 +131,11 @@ function initialize!(cb::DiscreteCallback{Condition,Affect!}, u, t, integrator) 
   mesh, _, _, _ = mesh_equations_solver_cache(semi)
 
   if mesh isa P4estMesh
-    if p4est_partition_allow_for_coarsening != mesh.p4est_partition_allow_for_coarsening
+    if cb.affect!.p4est_partition_allow_for_coarsening != mesh.p4est_partition_allow_for_coarsening
       if mpi_isroot()
         @info "The attribute p4est_partition_allow_for_coarsening from the mesh is changed."
       end
-      mesh.p4est_partition_allow_for_coarsening = p4est_partition_allow_for_coarsening
+      mesh.p4est_partition_allow_for_coarsening = cb.affect!.p4est_partition_allow_for_coarsening
     end
   end
 

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -130,12 +130,13 @@ function initialize!(cb::DiscreteCallback{Condition,Affect!}, u, t, integrator) 
 
   mesh, _, _, _ = mesh_equations_solver_cache(semi)
 
-  if mesh isa P4estMesh
+  if mesh isa ParallelP4estMesh
     if cb.affect!.p4est_partition_allow_for_coarsening != mesh.p4est_partition_allow_for_coarsening
-      if mpi_isroot()
-        @info "The attribute p4est_partition_allow_for_coarsening from the mesh is changed to `$(cb.affect!.p4est_partition_allow_for_coarsening)`."
-      end
       mesh.p4est_partition_allow_for_coarsening = cb.affect!.p4est_partition_allow_for_coarsening
+      if mpi_isroot()
+        @info "The attribute `p4est_partition_allow_for_coarsening` from the mesh was changed to `$(cb.affect!.p4est_partition_allow_for_coarsening)` by the `AMRCallback`."
+      end
+      partition!(mesh)
     end
   end
 

--- a/src/meshes/mesh_io.jl
+++ b/src/meshes/mesh_io.jl
@@ -309,7 +309,7 @@ function load_mesh_serial(mesh_file::AbstractString; n_cells_max, RealT)
     p4est = load_p4est(p4est_file, Val(ndims))
 
     mesh = P4estMesh{ndims}(p4est, tree_node_coordinates,
-                            nodes, boundary_names, "", false)
+                            nodes, boundary_names, "", false, false)
   else
     error("Unknown mesh type!")
   end
@@ -398,7 +398,7 @@ function load_mesh_parallel(mesh_file::AbstractString; n_cells_max, RealT)
     p4est = load_p4est(p4est_file, Val(ndims_))
 
     mesh = P4estMesh{ndims_}(p4est, tree_node_coordinates,
-                            nodes, boundary_names, "", false)
+                            nodes, boundary_names, "", false, false)
   else
     error("Unknown mesh type!")
   end

--- a/src/meshes/mesh_io.jl
+++ b/src/meshes/mesh_io.jl
@@ -309,7 +309,7 @@ function load_mesh_serial(mesh_file::AbstractString; n_cells_max, RealT)
     p4est = load_p4est(p4est_file, Val(ndims))
 
     mesh = P4estMesh{ndims}(p4est, tree_node_coordinates,
-                            nodes, boundary_names, "", false, false)
+                            nodes, boundary_names, "", false, true)
   else
     error("Unknown mesh type!")
   end
@@ -398,7 +398,7 @@ function load_mesh_parallel(mesh_file::AbstractString; n_cells_max, RealT)
     p4est = load_p4est(p4est_file, Val(ndims_))
 
     mesh = P4estMesh{ndims_}(p4est, tree_node_coordinates,
-                            nodes, boundary_names, "", false, false)
+                            nodes, boundary_names, "", false, true)
   else
     error("Unknown mesh type!")
   end

--- a/src/meshes/p4est_mesh.jl
+++ b/src/meshes/p4est_mesh.jl
@@ -1444,7 +1444,7 @@ function balance!(mesh::P4estMesh{3}, init_fn=C_NULL)
   p8est_balance(mesh.p4est, P8EST_CONNECT_FACE, init_fn)
 end
 
-p4est_partition_allow_for_coarsening!(mesh::P4estMesh, p4est_partition_allow_for_coarsening) = mesh.p4est_partition_allow_for_coarsening = p4est_partition_allow_for_coarsening
+p4est_partition_allow_for_coarsening!(mesh::P4estMesh, new_value) = mesh.p4est_partition_allow_for_coarsening = new_value
 
 function partition!(mesh::P4estMesh{2}; weight_fn=C_NULL)
   p4est_partition(mesh.p4est, Int(mesh.p4est_partition_allow_for_coarsening), weight_fn)

--- a/src/meshes/p4est_mesh.jl
+++ b/src/meshes/p4est_mesh.jl
@@ -109,7 +109,7 @@ end
     P4estMesh(trees_per_dimension; polydeg,
               mapping=nothing, faces=nothing, coordinates_min=nothing, coordinates_max=nothing,
               RealT=Float64, initial_refinement_level=0, periodicity=true, unsaved_changes=true,
-              p4est_partition_allow_for_coarsening=false)
+              p4est_partition_allow_for_coarsening=true)
 
 Create a structured curved `P4estMesh` of the specified size.
 
@@ -155,7 +155,7 @@ Non-periodic boundaries will be called `:x_neg`, `:x_pos`, `:y_neg`, `:y_pos`, `
 function P4estMesh(trees_per_dimension; polydeg,
                    mapping=nothing, faces=nothing, coordinates_min=nothing, coordinates_max=nothing,
                    RealT=Float64, initial_refinement_level=0, periodicity=true, unsaved_changes=true,
-                   p4est_partition_allow_for_coarsening=false)
+                   p4est_partition_allow_for_coarsening=true)
 
   @assert (
     (coordinates_min === nothing) === (coordinates_max === nothing)
@@ -279,7 +279,7 @@ end
     P4estMesh{NDIMS}(meshfile::String;
                      mapping=nothing, polydeg=1, RealT=Float64,
                      initial_refinement_level=0, unsaved_changes=true,
-                     p4est_partition_allow_for_coarsening=false)
+                     p4est_partition_allow_for_coarsening=true)
 
 Main mesh constructor for the `P4estMesh` that imports an unstructured, conforming
 mesh from an Abaqus mesh file (`.inp`). Each element of the conforming mesh parsed
@@ -339,7 +339,7 @@ For example, if a two-dimensional base mesh contains 25 elements then setting
 function P4estMesh{NDIMS}(meshfile::String;
                           mapping=nothing, polydeg=1, RealT=Float64,
                           initial_refinement_level=0, unsaved_changes=true,
-                          p4est_partition_allow_for_coarsening=false) where NDIMS
+                          p4est_partition_allow_for_coarsening=true) where NDIMS
   # Prevent `p4est` from crashing Julia if the file doesn't exist
   @assert isfile(meshfile)
 
@@ -460,7 +460,7 @@ end
     P4estMeshCubedSphere(trees_per_face_dimension, layers, inner_radius, thickness;
                          polydeg, RealT=Float64,
                          initial_refinement_level=0, unsaved_changes=true,
-                         p4est_partition_allow_for_coarsening=false)
+                         p4est_partition_allow_for_coarsening=true)
 
 Build a "Cubed Sphere" mesh as `P4estMesh` with
 `6 * trees_per_face_dimension^2 * layers` trees.
@@ -487,7 +487,7 @@ The mesh will have two boundaries, `:inside` and `:outside`.
 function P4estMeshCubedSphere(trees_per_face_dimension, layers, inner_radius, thickness;
                               polydeg, RealT=Float64,
                               initial_refinement_level=0, unsaved_changes=true,
-                              p4est_partition_allow_for_coarsening=false)
+                              p4est_partition_allow_for_coarsening=true)
   connectivity = connectivity_cubed_sphere(trees_per_face_dimension, layers)
 
   n_trees = 6 * trees_per_face_dimension^2 * layers

--- a/src/meshes/p4est_mesh.jl
+++ b/src/meshes/p4est_mesh.jl
@@ -148,7 +148,8 @@ Non-periodic boundaries will be called `:x_neg`, `:x_pos`, `:y_neg`, `:y_pos`, `
 - `periodicity`: either a `Bool` deciding if all of the boundaries are periodic or an `NTuple{NDIMS, Bool}`
                  deciding for each dimension if the boundaries in this dimension are periodic.
 - `unsaved_changes::Bool`: if set to `true`, the mesh will be saved to a mesh file.
-- `p4est_partition_allow_for_coarsening::Bool`: allow the mesh to be coarsened when `p4est_partition` is called.
+- `p4est_partition_allow_for_coarsening::Bool`: modify the partition in `p4est_partition` such that more
+                                                aggressive coarsening is possible in parallel setups using MPI.
 """
 function P4estMesh(trees_per_dimension; polydeg,
                    mapping=nothing, faces=nothing, coordinates_min=nothing, coordinates_max=nothing,
@@ -330,7 +331,8 @@ For example, if a two-dimensional base mesh contains 25 elements then setting
 - `RealT::Type`: the type that should be used for coordinates.
 - `initial_refinement_level::Integer`: refine the mesh uniformly to this level before the simulation starts.
 - `unsaved_changes::Bool`: if set to `true`, the mesh will be saved to a mesh file.
-- `p4est_partition_allow_for_coarsening::Bool`: allow the mesh to be coarsened when `p4est_partition` is called.
+- `p4est_partition_allow_for_coarsening::Bool`: modify the partition in `p4est_partition` such that more
+                                                aggressive coarsening is possible in parallel setups using MPI.
 """
 function P4estMesh{NDIMS}(meshfile::String;
                           mapping=nothing, polydeg=1, RealT=Float64,
@@ -476,7 +478,8 @@ The mesh will have two boundaries, `:inside` and `:outside`.
 - `RealT::Type`: the type that should be used for coordinates.
 - `initial_refinement_level::Integer`: refine the mesh uniformly to this level before the simulation starts.
 - `unsaved_changes::Bool`: if set to `true`, the mesh will be saved to a mesh file.
-- `p4est_partition_allow_for_coarsening::Bool`: allow the mesh to be coarsened when `p4est_partition` is called.
+- `p4est_partition_allow_for_coarsening::Bool`: modify the partition in `p4est_partition` such that more
+                                                aggressive coarsening is possible in parallel setups using MPI.
 """
 function P4estMeshCubedSphere(trees_per_face_dimension, layers, inner_radius, thickness;
                               polydeg, RealT=Float64,

--- a/src/meshes/p4est_mesh.jl
+++ b/src/meshes/p4est_mesh.jl
@@ -22,9 +22,10 @@ mutable struct P4estMesh{NDIMS, RealT<:Real, IsParallel, P, Ghost, NDIMSP2, NNOD
   boundary_names        ::Array{Symbol, 2}      # [face direction, tree]
   current_filename      ::String
   unsaved_changes       ::Bool
+  p4est_partition_allow_for_coarsening::Bool
 
   function P4estMesh{NDIMS}(p4est, tree_node_coordinates, nodes, boundary_names,
-                            current_filename, unsaved_changes) where NDIMS
+                            current_filename, unsaved_changes, p4est_partition_allow_for_coarsening) where NDIMS
     if NDIMS == 2
       @assert p4est isa Ptr{p4est_t}
     elseif NDIMS == 3
@@ -43,7 +44,8 @@ mutable struct P4estMesh{NDIMS, RealT<:Real, IsParallel, P, Ghost, NDIMSP2, NNOD
     ghost = ghost_new_p4est(p4est)
 
     mesh = new{NDIMS, eltype(tree_node_coordinates), typeof(is_parallel), typeof(p4est), typeof(ghost), NDIMS+2, length(nodes)}(
-      p4est, is_parallel, ghost, tree_node_coordinates, nodes, boundary_names, current_filename, unsaved_changes)
+      p4est, is_parallel, ghost, tree_node_coordinates, nodes, boundary_names, current_filename, unsaved_changes,
+      p4est_partition_allow_for_coarsening)
 
     # Destroy `p4est` structs when the mesh is garbage collected
     finalizer(destroy_mesh, mesh)
@@ -106,7 +108,8 @@ end
 """
     P4estMesh(trees_per_dimension; polydeg,
               mapping=nothing, faces=nothing, coordinates_min=nothing, coordinates_max=nothing,
-              RealT=Float64, initial_refinement_level=0, periodicity=true, unsaved_changes=true)
+              RealT=Float64, initial_refinement_level=0, periodicity=true, unsaved_changes=true,
+              p4est_partition_allow_for_coarsening=false)
 
 Create a structured curved `P4estMesh` of the specified size.
 
@@ -145,10 +148,12 @@ Non-periodic boundaries will be called `:x_neg`, `:x_pos`, `:y_neg`, `:y_pos`, `
 - `periodicity`: either a `Bool` deciding if all of the boundaries are periodic or an `NTuple{NDIMS, Bool}`
                  deciding for each dimension if the boundaries in this dimension are periodic.
 - `unsaved_changes::Bool`: if set to `true`, the mesh will be saved to a mesh file.
+- `p4est_partition_allow_for_coarsening::Bool`: allow the mesh to be coarsened when `p4est_partition` is called.
 """
 function P4estMesh(trees_per_dimension; polydeg,
                    mapping=nothing, faces=nothing, coordinates_min=nothing, coordinates_max=nothing,
-                   RealT=Float64, initial_refinement_level=0, periodicity=true, unsaved_changes=true)
+                   RealT=Float64, initial_refinement_level=0, periodicity=true, unsaved_changes=true,
+                   p4est_partition_allow_for_coarsening=false)
 
   @assert (
     (coordinates_min === nothing) === (coordinates_max === nothing)
@@ -198,7 +203,8 @@ function P4estMesh(trees_per_dimension; polydeg,
   structured_boundary_names!(boundary_names, trees_per_dimension, periodicity)
 
   return P4estMesh{NDIMS}(p4est, tree_node_coordinates, nodes,
-                          boundary_names, "", unsaved_changes)
+                          boundary_names, "", unsaved_changes,
+                          p4est_partition_allow_for_coarsening)
 end
 
 # 2D version
@@ -270,7 +276,8 @@ end
 """
     P4estMesh{NDIMS}(meshfile::String;
                      mapping=nothing, polydeg=1, RealT=Float64,
-                     initial_refinement_level=0, unsaved_changes=true)
+                     initial_refinement_level=0, unsaved_changes=true,
+                     p4est_partition_allow_for_coarsening=false)
 
 Main mesh constructor for the `P4estMesh` that imports an unstructured, conforming
 mesh from an Abaqus mesh file (`.inp`). Each element of the conforming mesh parsed
@@ -323,10 +330,12 @@ For example, if a two-dimensional base mesh contains 25 elements then setting
 - `RealT::Type`: the type that should be used for coordinates.
 - `initial_refinement_level::Integer`: refine the mesh uniformly to this level before the simulation starts.
 - `unsaved_changes::Bool`: if set to `true`, the mesh will be saved to a mesh file.
+- `p4est_partition_allow_for_coarsening::Bool`: allow the mesh to be coarsened when `p4est_partition` is called.
 """
 function P4estMesh{NDIMS}(meshfile::String;
                           mapping=nothing, polydeg=1, RealT=Float64,
-                          initial_refinement_level=0, unsaved_changes=true) where NDIMS
+                          initial_refinement_level=0, unsaved_changes=true,
+                          p4est_partition_allow_for_coarsening=false) where NDIMS
   # Prevent `p4est` from crashing Julia if the file doesn't exist
   @assert isfile(meshfile)
 
@@ -349,7 +358,8 @@ function P4estMesh{NDIMS}(meshfile::String;
   end
 
   return P4estMesh{NDIMS}(p4est, tree_node_coordinates, nodes,
-                          boundary_names, "", unsaved_changes)
+                          boundary_names, "", unsaved_changes,
+                          p4est_partition_allow_for_coarsening)
 end
 
 
@@ -445,7 +455,8 @@ end
 """
     P4estMeshCubedSphere(trees_per_face_dimension, layers, inner_radius, thickness;
                          polydeg, RealT=Float64,
-                         initial_refinement_level=0, unsaved_changes=true)
+                         initial_refinement_level=0, unsaved_changes=true,
+                         p4est_partition_allow_for_coarsening=false)
 
 Build a "Cubed Sphere" mesh as `P4estMesh` with
 `6 * trees_per_face_dimension^2 * layers` trees.
@@ -465,10 +476,12 @@ The mesh will have two boundaries, `:inside` and `:outside`.
 - `RealT::Type`: the type that should be used for coordinates.
 - `initial_refinement_level::Integer`: refine the mesh uniformly to this level before the simulation starts.
 - `unsaved_changes::Bool`: if set to `true`, the mesh will be saved to a mesh file.
+- `p4est_partition_allow_for_coarsening::Bool`: allow the mesh to be coarsened when `p4est_partition` is called.
 """
 function P4estMeshCubedSphere(trees_per_face_dimension, layers, inner_radius, thickness;
                               polydeg, RealT=Float64,
-                              initial_refinement_level=0, unsaved_changes=true)
+                              initial_refinement_level=0, unsaved_changes=true,
+                              p4est_partition_allow_for_coarsening=false)
   connectivity = connectivity_cubed_sphere(trees_per_face_dimension, layers)
 
   n_trees = 6 * trees_per_face_dimension^2 * layers
@@ -489,7 +502,8 @@ function P4estMeshCubedSphere(trees_per_face_dimension, layers, inner_radius, th
   boundary_names[6, :] .= Symbol("outside")
 
   return P4estMesh{3}(p4est, tree_node_coordinates, nodes,
-                      boundary_names, "", unsaved_changes)
+                      boundary_names, "", unsaved_changes,
+                      p4est_partition_allow_for_coarsening)
 end
 
 
@@ -1427,13 +1441,14 @@ function balance!(mesh::P4estMesh{3}, init_fn=C_NULL)
   p8est_balance(mesh.p4est, P8EST_CONNECT_FACE, init_fn)
 end
 
+p4est_partition_allow_for_coarsening!(mesh::P4estMesh, p4est_partition_allow_for_coarsening) = mesh.p4est_partition_allow_for_coarsening = p4est_partition_allow_for_coarsening
 
-function partition!(mesh::P4estMesh{2}; allow_coarsening=true, weight_fn=C_NULL)
-  p4est_partition(mesh.p4est, Int(allow_coarsening), weight_fn)
+function partition!(mesh::P4estMesh{2}; weight_fn=C_NULL)
+  p4est_partition(mesh.p4est, Int(mesh.p4est_partition_allow_for_coarsening), weight_fn)
 end
 
-function partition!(mesh::P4estMesh{3}; allow_coarsening=true, weight_fn=C_NULL)
-  p8est_partition(mesh.p4est, Int(allow_coarsening), weight_fn)
+function partition!(mesh::P4estMesh{3}; weight_fn=C_NULL)
+  p8est_partition(mesh.p4est, Int(mesh.p4est_partition_allow_for_coarsening), weight_fn)
 end
 
 

--- a/src/meshes/p4est_mesh.jl
+++ b/src/meshes/p4est_mesh.jl
@@ -1447,12 +1447,6 @@ function balance!(mesh::P4estMesh{3}, init_fn=C_NULL)
   p8est_balance(mesh.p4est, P8EST_CONNECT_FACE, init_fn)
 end
 
-"""
-    p4est_partition_allow_for_coarsening!(mesh::P4estMesh, new_value::Bool)
-Set the parameter `p4est_partition_allow_for_coarsening` of the `mesh` to the `new_value`.
-"""
-p4est_partition_allow_for_coarsening!(mesh::P4estMesh, new_value) = mesh.p4est_partition_allow_for_coarsening = new_value
-
 function partition!(mesh::P4estMesh{2}; weight_fn=C_NULL)
   p4est_partition(mesh.p4est, Int(mesh.p4est_partition_allow_for_coarsening), weight_fn)
 end

--- a/src/meshes/p4est_mesh.jl
+++ b/src/meshes/p4est_mesh.jl
@@ -148,8 +148,9 @@ Non-periodic boundaries will be called `:x_neg`, `:x_pos`, `:y_neg`, `:y_pos`, `
 - `periodicity`: either a `Bool` deciding if all of the boundaries are periodic or an `NTuple{NDIMS, Bool}`
                  deciding for each dimension if the boundaries in this dimension are periodic.
 - `unsaved_changes::Bool`: if set to `true`, the mesh will be saved to a mesh file.
-- `p4est_partition_allow_for_coarsening::Bool`: modify the partition in `p4est_partition` such that more
-                                                aggressive coarsening is possible in parallel setups using MPI.
+- `p4est_partition_allow_for_coarsening::Bool`: Must be `true` when using AMR to make mesh adaptivity
+                                                independent of domain partitioning. Should be `false` for static meshes
+                                                to permit more fine-grained partitioning.
 """
 function P4estMesh(trees_per_dimension; polydeg,
                    mapping=nothing, faces=nothing, coordinates_min=nothing, coordinates_max=nothing,
@@ -331,8 +332,9 @@ For example, if a two-dimensional base mesh contains 25 elements then setting
 - `RealT::Type`: the type that should be used for coordinates.
 - `initial_refinement_level::Integer`: refine the mesh uniformly to this level before the simulation starts.
 - `unsaved_changes::Bool`: if set to `true`, the mesh will be saved to a mesh file.
-- `p4est_partition_allow_for_coarsening::Bool`: modify the partition in `p4est_partition` such that more
-                                                aggressive coarsening is possible in parallel setups using MPI.
+- `p4est_partition_allow_for_coarsening::Bool`: Must be `true` when using AMR to make mesh adaptivity
+                                                independent of domain partitioning. Should be `false` for static meshes
+                                                to permit more fine-grained partitioning.
 """
 function P4estMesh{NDIMS}(meshfile::String;
                           mapping=nothing, polydeg=1, RealT=Float64,
@@ -478,8 +480,9 @@ The mesh will have two boundaries, `:inside` and `:outside`.
 - `RealT::Type`: the type that should be used for coordinates.
 - `initial_refinement_level::Integer`: refine the mesh uniformly to this level before the simulation starts.
 - `unsaved_changes::Bool`: if set to `true`, the mesh will be saved to a mesh file.
-- `p4est_partition_allow_for_coarsening::Bool`: modify the partition in `p4est_partition` such that more
-                                                aggressive coarsening is possible in parallel setups using MPI.
+- `p4est_partition_allow_for_coarsening::Bool`: Must be `true` when using AMR to make mesh adaptivity
+                                                independent of domain partitioning. Should be `false` for static meshes
+                                                to permit more fine-grained partitioning.
 """
 function P4estMeshCubedSphere(trees_per_face_dimension, layers, inner_radius, thickness;
                               polydeg, RealT=Float64,

--- a/src/meshes/p4est_mesh.jl
+++ b/src/meshes/p4est_mesh.jl
@@ -1444,6 +1444,10 @@ function balance!(mesh::P4estMesh{3}, init_fn=C_NULL)
   p8est_balance(mesh.p4est, P8EST_CONNECT_FACE, init_fn)
 end
 
+"""
+    p4est_partition_allow_for_coarsening!(mesh::P4estMesh, new_value::Bool)
+Set the parameter `p4est_partition_allow_for_coarsening` of the `mesh` to the `new_value`.
+"""
 p4est_partition_allow_for_coarsening!(mesh::P4estMesh, new_value) = mesh.p4est_partition_allow_for_coarsening = new_value
 
 function partition!(mesh::P4estMesh{2}; weight_fn=C_NULL)

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -148,8 +148,8 @@ macro test_nowarn_mod(expr, additional_ignore_content=String[])
           # We also ignore our own compilation messages
           "[ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.\n",
           # Ignore info about overriding attribute from P4estMesh inside AMRCallback
-          "[ Info: The attribute p4est_partition_allow_for_coarsening from the mesh is changed to `true`.\n",
-          "[ Info: The attribute p4est_partition_allow_for_coarsening from the mesh is changed to `false`.\n",
+          "[ Info: The attribute `p4est_partition_allow_for_coarsening` from the mesh was changed to `true` by the `AMRCallback`.\n",
+          "[ Info: The attribute `p4est_partition_allow_for_coarsening` from the mesh was changed to `false by the `AMRCallback`.\n",
           # TODO: Upstream (PlotUtils). This should be removed again once the
           #       deprecated stuff is fixed upstream.
           "WARNING: importing deprecated binding Colors.RGB1 into PlotUtils.\n",

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -148,8 +148,8 @@ macro test_nowarn_mod(expr, additional_ignore_content=String[])
           # We also ignore our own compilation messages
           "[ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.\n",
           # Ignore info about overriding attribute from P4estMesh inside AMRCallback
-          "[ Info: The attribute `p4est_partition_allow_for_coarsening` from the mesh was changed to `true` by the `AMRCallback`.\n",
-          "[ Info: The attribute `p4est_partition_allow_for_coarsening` from the mesh was changed to `false by the `AMRCallback`.\n",
+          "[ Info: The mesh attribute `p4est_partition_allow_for_coarsening` was changed to `true` by the `AMRCallback`.\n",
+          "[ Info: The mesh attribute `p4est_partition_allow_for_coarsening` was changed to `false by the `AMRCallback`.\n",
           # TODO: Upstream (PlotUtils). This should be removed again once the
           #       deprecated stuff is fixed upstream.
           "WARNING: importing deprecated binding Colors.RGB1 into PlotUtils.\n",

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -147,6 +147,8 @@ macro test_nowarn_mod(expr, additional_ignore_content=String[])
           r"┌ Info:   Steady state tolerance reached\n│   steady_state_callback .+\n└   t = .+\n",
           # We also ignore our own compilation messages
           "[ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.\n",
+          # Ignore info about overriding attribute from P4estMesh inside AMRCallback
+          "[ Info: The attribute p4est_partition_allow_for_coarsening from the mesh is changed.\n",
           # TODO: Upstream (PlotUtils). This should be removed again once the
           #       deprecated stuff is fixed upstream.
           "WARNING: importing deprecated binding Colors.RGB1 into PlotUtils.\n",

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -148,7 +148,8 @@ macro test_nowarn_mod(expr, additional_ignore_content=String[])
           # We also ignore our own compilation messages
           "[ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.\n",
           # Ignore info about overriding attribute from P4estMesh inside AMRCallback
-          "[ Info: The attribute p4est_partition_allow_for_coarsening from the mesh is changed.\n",
+          "[ Info: The attribute p4est_partition_allow_for_coarsening from the mesh is changed to `true`.\n",
+          "[ Info: The attribute p4est_partition_allow_for_coarsening from the mesh is changed to `false`.\n",
           # TODO: Upstream (PlotUtils). This should be removed again once the
           #       deprecated stuff is fixed upstream.
           "WARNING: importing deprecated binding Colors.RGB1 into PlotUtils.\n",

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -147,9 +147,6 @@ macro test_nowarn_mod(expr, additional_ignore_content=String[])
           r"┌ Info:   Steady state tolerance reached\n│   steady_state_callback .+\n└   t = .+\n",
           # We also ignore our own compilation messages
           "[ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.\n",
-          # Ignore info about overriding attribute from P4estMesh inside AMRCallback
-          "[ Info: The mesh attribute `p4est_partition_allow_for_coarsening` was changed to `true` by the `AMRCallback`.\n",
-          "[ Info: The mesh attribute `p4est_partition_allow_for_coarsening` was changed to `false by the `AMRCallback`.\n",
           # TODO: Upstream (PlotUtils). This should be removed again once the
           #       deprecated stuff is fixed upstream.
           "WARNING: importing deprecated binding Colors.RGB1 into PlotUtils.\n",


### PR DESCRIPTION
This adds a new attribute `p4est_partition_allow_coarsening` to the `P4estMesh` that allows the user to enable and disable coarsening, see #1339. In agreement with @ranocha I changed the name of the attribute since `override_mesh_partition`, the suggestion of @lchristm, doesn't really make clear what is changed by the value. WIth `p4est_partition_allow_coarsening` it is clear that an attribute of the `p4est` is changed, also when it is used in the `AMRCallback` and that is used inside `partition`. Feel free to suggest different (maybe shorter?) names. Note also the additional changes in [src/meshes/mesh_io.jl](https://github.com/trixi-framework/Trixi.jl/compare/main...JoshuaLampert:Trixi.jl:p4est-allow-coarsening?expand=1#diff-255cc23d36b6b8dc92defee112a2086aa30f553034a5f6b4ab45c819845ed804) and [test/test_trixi.jl](https://github.com/trixi-framework/Trixi.jl/compare/main...JoshuaLampert:Trixi.jl:p4est-allow-coarsening?expand=1#diff-57294bc80feea88f5712e89ebe10219b5867895c83f66952141a18f75393a476).