### PR TITLE
Extend documentation of `tmpi`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Trixi"
 uuid = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 authors = ["Michael Schlottke-Lakemper <m.schlottke-lakemper@hlrs.de>", "Gregor Gassner <ggassner@uni-koeln.de>", "Hendrik Ranocha <mail@ranocha.de>", "Andrew R. Winters <andrew.ross.winters@liu.se>", "Jesse Chan <jesse.chan@rice.edu>"]
-version = "0.5.9"
+version = "0.5.10-pre"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/docs/src/parallelization.md
+++ b/docs/src/parallelization.md
@@ -113,11 +113,15 @@ To start Trixi in parallel with MPI, there are three options:
    documentation for `tmux`
    [available](https://github.com/tmux/tmux/wiki/Getting-Started) and once you
    get the hang of it, developing Trixi in parallel becomes much smoother this
-   way.
+   way. Some helpful commands are the following. To close a single pane you can press `Ctrl+b`
+   and then `x` followed by `y` to confirm. To quit the whole session you press `Ctrl+b` followed
+   by `:kill-session`. Often, you like to scroll up. You can do that by pressing `Ctrl+b` and then `[`,
+   which allows you to use the arrow keys to scroll up and down. To leave the scroll mode you press `q`.
+   Switching between panes can be done by `Ctrl+b` followed by `o`.
    As of March 2022, newer versions of tmpi also support mpich, which is the default
    backend of MPI.jl (via MPICH_Jll.jl). To use this setup, you need to install
    `mpiexecjl` as described in the 
-   [documentation of MPI.jl](https://juliaparallel.github.io/MPI.jl/latest/configuration/#Julia-wrapper-for-mpiexec)
+   [documentation of MPI.jl](https://docs.juliahub.com/MPI/nO0XF/0.16.0/configuration/)
    and make it available as `mpirun`, e.g., via a symlink of the form
    ```bash
    ln -s ~/.julia/bin/mpiexecjl /somewhere/in/your/path/mpirun

--- a/docs/src/parallelization.md
+++ b/docs/src/parallelization.md
@@ -115,7 +115,7 @@ To start Trixi in parallel with MPI, there are three options:
    get the hang of it, developing Trixi in parallel becomes much smoother this
    way. Some helpful commands are the following. To close a single pane you can press `Ctrl+b`
    and then `x` followed by `y` to confirm. To quit the whole session you press `Ctrl+b` followed
-   by `:kill-session`. Often, you like to scroll up. You can do that by pressing `Ctrl+b` and then `[`,
+   by `:kill-session`. Often you would like to scroll up. You can do that by pressing `Ctrl+b` and then `[`,
    which allows you to use the arrow keys to scroll up and down. To leave the scroll mode you press `q`.
    Switching between panes can be done by `Ctrl+b` followed by `o`.
    As of March 2022, newer versions of tmpi also support mpich, which is the default

--- a/docs/src/parallelization.md
+++ b/docs/src/parallelization.md
@@ -121,7 +121,7 @@ To start Trixi in parallel with MPI, there are three options:
    As of March 2022, newer versions of tmpi also support mpich, which is the default
    backend of MPI.jl (via MPICH_Jll.jl). To use this setup, you need to install
    `mpiexecjl` as described in the 
-   [documentation of MPI.jl](https://docs.juliahub.com/MPI/nO0XF/0.16.0/configuration/)
+   [documentation of MPI.jl](https://docs.juliahub.com/MPI/nO0XF/0.16.0/configuration/#Julia-wrapper-for-mpiexec)
    and make it available as `mpirun`, e.g., via a symlink of the form
    ```bash
    ln -s ~/.julia/bin/mpiexecjl /somewhere/in/your/path/mpirun

--- a/docs/src/parallelization.md
+++ b/docs/src/parallelization.md
@@ -121,7 +121,7 @@ To start Trixi in parallel with MPI, there are three options:
    As of March 2022, newer versions of tmpi also support mpich, which is the default
    backend of MPI.jl (via MPICH_Jll.jl). To use this setup, you need to install
    `mpiexecjl` as described in the 
-   [documentation of MPI.jl](https://docs.juliahub.com/MPI/nO0XF/0.16.0/configuration/#Julia-wrapper-for-mpiexec)
+   [documentation of MPI.jl](https://juliaparallel.org/MPI.jl/v0.20/usage/#Julia-wrapper-for-mpiexec)
    and make it available as `mpirun`, e.g., via a symlink of the form
    ```bash
    ln -s ~/.julia/bin/mpiexecjl /somewhere/in/your/path/mpirun


### PR DESCRIPTION
I added some useful commands of `tmux` to the documentation of `tmpi`. Additionally, I updated the link to the documentation of MPI.jl for the installation of `mpiexecjl` since it is not part of the old link anymore.