### PR TITLE
Extra instructions for docs build on a fork

### DIFF
--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -311,7 +311,8 @@ possible to step into further calls or access other function scopes.
 
 You can build the documentation of Trixi.jl locally by running
 ```bash
-julia --project=docs -e 'using Pkg; Pkg.instantiate(); include("docs/make.jl")'
+julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+julia --project=docs --color=yes docs/make.jl
 ```
 from the Trixi.jl main directory. Then, you can look at the html files generated in
 `docs/build`.
@@ -319,13 +320,7 @@ For PRs triggered from branches inside the Trixi.jl main repository previews of
 the new documentation are generated at `https://trixi-framework.github.io/Trixi.jl/previews/PRXXX`,
 where `XXX` is the number of the PR.
 This does not work for PRs from forks for security reasons (since anyone could otherwise push
-arbitrary stuff to the Trixi website, including malicious code). In order to build the documentation
-locally for PRs from forks you can use the following commands that mimic what is done by the CI
-```bash
-julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-julia --project=docs --color=yes docs/make.jl
-```
-where, again, the html files are found in the `docs/build` folder.
+arbitrary stuff to the Trixi website, including malicious code).
 
 
 

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -229,20 +229,20 @@ mode [julia-emacs](https://github.com/JuliaEditorSupport/julia-emacs).
 
 
 ## Debugging
-Julia offers several options for debugging. A classical debugger is available with the 
-[Debugger.jl](https://github.com/JuliaDebug/Debugger.jl) package or in the 
-[Julia extension for VS Code](https://www.julia-vscode.org/docs/stable/userguide/debugging/). 
-However, it can be quite slow and, at the time of writing (January 2023), currently does not work 
-properly with Trixi. The [Infiltrator.jl](https://github.com/JuliaDebug/Infiltrator.jl) package on 
-the other hand does not offer all features of a full debugger, but is a fast and simple tool that 
+Julia offers several options for debugging. A classical debugger is available with the
+[Debugger.jl](https://github.com/JuliaDebug/Debugger.jl) package or in the
+[Julia extension for VS Code](https://www.julia-vscode.org/docs/stable/userguide/debugging/).
+However, it can be quite slow and, at the time of writing (January 2023), currently does not work
+properly with Trixi. The [Infiltrator.jl](https://github.com/JuliaDebug/Infiltrator.jl) package on
+the other hand does not offer all features of a full debugger, but is a fast and simple tool that
 allows users to set breakpoints to open a local REPL session and access the call stack and variables.
 
 ### Infiltrator
-The Infiltrator package provides fast, interactive breakpoints using the ```@infiltrate``` command, 
-which drops the user into a local REPL session. From there, it is possible to access local variables, 
+The Infiltrator package provides fast, interactive breakpoints using the ```@infiltrate``` command,
+which drops the user into a local REPL session. From there, it is possible to access local variables,
 see the call stack, and execute statements.
 
-The package can be installed in the Julia REPL by executing 
+The package can be installed in the Julia REPL by executing
 ```julia-repl
 (@v1.8) pkg> add Infiltrator
 ```
@@ -252,14 +252,14 @@ To load the package in the Julia REPL execute
 julia> using Infiltrator
 ```
 
-Breakpoints can be set by adding a line with the ```@infiltrate``` macro at the respective position 
-in the code. Use [Revise](@ref interactive-use-of-julia) if you want to set and delete breakpoints 
-in your package without having to restart Julia. 
+Breakpoints can be set by adding a line with the ```@infiltrate``` macro at the respective position
+in the code. Use [Revise](@ref interactive-use-of-julia) if you want to set and delete breakpoints
+in your package without having to restart Julia.
 
-!!! note 
-    When running Julia inside a package environment, the ```@infiltrate``` macro only works if `Infiltrator` 
+!!! note
+    When running Julia inside a package environment, the ```@infiltrate``` macro only works if `Infiltrator`
     has been added to the dependencies. Another work around when using Revise is to first load the
-    package and then add breakpoints with `Main.@infiltrate` to the code. If this is not 
+    package and then add breakpoints with `Main.@infiltrate` to the code. If this is not
     desired, the functional form
     ```julia
     if isdefined(Main, :Infiltrator)
@@ -268,20 +268,20 @@ in your package without having to restart Julia.
     ```
     can be used to set breakpoints when working with Trixi or other packages.
 
-Triggering the breakpoint starts a REPL session where it is possible to interact with the current 
+Triggering the breakpoint starts a REPL session where it is possible to interact with the current
 local scope. Possible commands are:
 - ```@locals```: Print the local variables.
-- ```@exfiltrate```: Save the local variables to a global storage, which can be accessed with 
+- ```@exfiltrate```: Save the local variables to a global storage, which can be accessed with
   the ```safehouse``` variable outside the Infiltrator session.
 - ```@trace```: Print the current stack trace.
 - Execute other arbitrary statements
 - ```?```: Print a help list with all options
 
 To finish a debugging session, either use ```@continue``` to continue and eventually stop at the
-next breakpoint or ```@exit``` to skip further breakpoints. After the code has finished, local 
+next breakpoint or ```@exit``` to skip further breakpoints. After the code has finished, local
 variables saved with ```@exfiltrate``` can be accessed in the REPL using the ```safehouse``` variable.
 
-Limitations of using Infiltrator.jl are that local variables cannot be changed, and that it is not 
+Limitations of using Infiltrator.jl are that local variables cannot be changed, and that it is not
 possible to step into further calls or access other function scopes.
 
 
@@ -319,7 +319,13 @@ For PRs triggered from branches inside the Trixi.jl main repository previews of
 the new documentation are generated at `https://trixi-framework.github.io/Trixi.jl/previews/PRXXX`,
 where `XXX` is the number of the PR.
 This does not work for PRs from forks for security reasons (since anyone could otherwise push
-arbitrary stuff to the Trixi website, including malicious code).
+arbitrary stuff to the Trixi website, including malicious code). In order to build the documentation
+locally for PRs from forks you can use the following commands that mimic what is done by the CI
+```bash
+julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+julia --project=docs --color=yes docs/make.jl
+```
+where, again, the html files are found in the `docs/build` folder.
 
 
 


### PR DESCRIPTION
This adds some extra instructions and explanation for those who want to build the docs locally on a fork for which a github preview of the docs is unavailable. Closes #1351 