### PR TITLE
import `compute_coefficients` from SummationByPartsOperators.jl

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -69,6 +69,7 @@ using SummationByPartsOperators: AbstractDerivativeOperator,
   AbstractNonperiodicDerivativeOperator, DerivativeOperator,
   AbstractPeriodicDerivativeOperator, PeriodicDerivativeOperator, grid
 import SummationByPartsOperators: integrate, semidiscretize,
+                                  compute_coefficients, compute_coefficients!,
                                   left_boundary_weight, right_boundary_weight
 @reexport using SummationByPartsOperators:
   SummationByPartsOperators, derivative_operator, periodic_derivative_operator,


### PR DESCRIPTION
I wrote the interface of `compute_coefficients` in Trixi.jl based on my earlier work in SummationByPartsOperators.jl. I just realized that we should `import` it to use the same function to avoid conflicts when `using SummationByPartsOperators`.

Right now, tests fail due to
>   LoadError: Failed to precompile OrdinaryDiffEq [1dea7af3-3e70-54e6-95c3-0bf5283fa5ed]