### PR TITLE
Hotfix issues coming from Flux v0.13.13

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -14,7 +14,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 BSON = "0.3.3"
 CairoMakie = "0.6, 0.7, 0.8, 0.9, 0.10"
-Flux = "0.13 - 0.13.12"
+Flux = "0.13 - 0.13.12" # TODO: Return to "0.13" once https://github.com/FluxML/Flux.jl/issues/2204 is resolved
 ForwardDiff = "0.10"
 MPI = "0.20"
 OrdinaryDiffEq = "5.65, 6"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -14,7 +14,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 BSON = "0.3.3"
 CairoMakie = "0.6, 0.7, 0.8, 0.9, 0.10"
-Flux = "0.13"
+Flux = "0.13 - 0.13.12"
 ForwardDiff = "0.10"
 MPI = "0.20"
 OrdinaryDiffEq = "5.65, 6"

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -153,6 +153,8 @@ macro test_nowarn_mod(expr, additional_ignore_content=String[])
           "WARNING: importing deprecated binding Colors.RGB4 into PlotUtils.\n",
           r"┌ Warning: Keyword argument letter not supported with Plots.+\n└ @ Plots.+\n",
           r"┌ Warning: `parse\(::Type, ::Coloarant\)` is deprecated.+\n│.+\n│.+\n└ @ Plots.+\n",
+          # TODO: Silence warning introduced by Flux v0.13.13. Should be properly fixed.
+          r"┌ Warning: Layer with Float32 parameters got Float64 input.+\n│.+\n│.+\n│.+\n└ @ Flux.+\n",
         ]
         append!(ignore_content, $additional_ignore_content)
         for pattern in ignore_content


### PR DESCRIPTION
This should hotfix the missing `flatten` in Flux.jl, see https://github.com/FluxML/Flux.jl/issues/2204. Once a new release of Flux has been tagged that does not create the issue, we return the compat to its previous value.

Furthermore, it silences a warning that is produced by non-optimal data types (this will be necessary also with Flux v0.13.13).