### PR TITLE
hotfix destats -> stats deprecation

### DIFF
--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -155,6 +155,10 @@ macro test_nowarn_mod(expr, additional_ignore_content=String[])
           r"┌ Warning: `parse\(::Type, ::Coloarant\)` is deprecated.+\n│.+\n│.+\n└ @ Plots.+\n",
           # TODO: Silence warning introduced by Flux v0.13.13. Should be properly fixed.
           r"┌ Warning: Layer with Float32 parameters got Float64 input.+\n│.+\n│.+\n│.+\n└ @ Flux.+\n",
+          # TODO: Silence warning from deprecation destats -> stats. Should be fixed in
+          #       https://github.com/trixi-framework/Trixi.jl/pull/1372
+          r"┌ Warning: `destats` kwarg has been deprecated in favor of `stats`.+\n│.+\n└ @.1\n",
+          r"┌ Warning: `sol.destats` is deprecated. Use `sol.stats` instead.+\n│.+\n└ @.+\n",
         ]
         append!(ignore_content, $additional_ignore_content)
         for pattern in ignore_content

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -157,7 +157,7 @@ macro test_nowarn_mod(expr, additional_ignore_content=String[])
           r"┌ Warning: Layer with Float32 parameters got Float64 input.+\n│.+\n│.+\n│.+\n└ @ Flux.+\n",
           # TODO: Silence warning from deprecation destats -> stats. Should be fixed in
           #       https://github.com/trixi-framework/Trixi.jl/pull/1372
-          r"┌ Warning: `destats` kwarg has been deprecated in favor of `stats`.+\n│.+\n└ @.1\n",
+          r"┌ Warning: `destats` kwarg has been deprecated in favor of `stats`\n│.+\n└ @.+\n",
           r"┌ Warning: `sol.destats` is deprecated. Use `sol.stats` instead.+\n│.+\n└ @.+\n",
         ]
         append!(ignore_content, $additional_ignore_content)


### PR DESCRIPTION
The proper fix #1372 requires updates of upstream dependencies. This just silences the deprecation warning for now.