### PR TITLE
Enable L1 errors as `extra_analysis_errors`

### DIFF
--- a/examples/dgmulti_2d/elixir_navierstokes_convergence.jl
+++ b/examples/dgmulti_2d/elixir_navierstokes_convergence.jl
@@ -194,7 +194,7 @@ summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval=10)
 analysis_interval = 100
 analysis_callback = AnalysisCallback(semi, interval=analysis_interval, uEltype=real(dg))
-callbacks = CallbackSet(summary_callback, alive_callback)
+callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback)
 
 ###############################################################################
 # run the simulation

--- a/examples/dgmulti_2d/elixir_navierstokes_lid_driven_cavity.jl
+++ b/examples/dgmulti_2d/elixir_navierstokes_lid_driven_cavity.jl
@@ -62,7 +62,7 @@ summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval=10)
 analysis_interval = 100
 analysis_callback = AnalysisCallback(semi, interval=analysis_interval, uEltype=real(dg))
-callbacks = CallbackSet(summary_callback, alive_callback)
+callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback)
 
 ###############################################################################
 # run the simulation

--- a/examples/structured_2d_dgsem/elixir_advection_extended.jl
+++ b/examples/structured_2d_dgsem/elixir_advection_extended.jl
@@ -48,6 +48,7 @@ summary_callback = SummaryCallback()
 # The AnalysisCallback allows to analyse the solution in regular intervals and prints the results
 analysis_interval = 100
 analysis_callback = AnalysisCallback(semi, interval=analysis_interval,
+                                     extra_analysis_errors=(:l1_error,),
                                      extra_analysis_integrals=(entropy, energy_total))
 
 # The AliveCallback prints short status information in regular intervals

--- a/src/callbacks_step/analysis_dg2d.jl
+++ b/src/callbacks_step/analysis_dg2d.jl
@@ -61,6 +61,7 @@ function calc_error_norms(func, u, t, analyzer,
   # Set up data structures
   l2_error   = zero(func(get_node_vars(u, equations, dg, 1, 1, 1), equations))
   linf_error = copy(l2_error)
+  l1_error   = copy(l2_error)
 
   # Iterate over all elements for error calculations
   # Accumulate L2 error on the element first so that the order of summation is the
@@ -68,8 +69,9 @@ function calc_error_norms(func, u, t, analyzer,
   # development and debugging (see
   # https://github.com/trixi-framework/Trixi.jl/pull/850#pullrequestreview-757463943 for details).
   for element in eachelement(dg, cache)
-    # Set up data structures for local element L2 error
+    # Set up data structures for local element L2/L1 error
     l2_error_local = zero(l2_error)
+    l1_error_local = zero(l1_error)
 
     # Interpolate solution and node locations to analysis nodes
     multiply_dimensionwise!(u_local, vandermonde, view(u,                :, :, :, element), u_tmp1)
@@ -81,17 +83,21 @@ function calc_error_norms(func, u, t, analyzer,
     for j in eachnode(analyzer), i in eachnode(analyzer)
       u_exact = initial_condition(get_node_coords(x_local, equations, dg, i, j), t, equations)
       diff = func(u_exact, equations) - func(get_node_vars(u_local, equations, dg, i, j), equations)
+
       l2_error_local += diff.^2 * (weights[i] * weights[j] * volume_jacobian_)
-      linf_error = @. max(linf_error, abs(diff))
+      linf_error      = @. max(linf_error, abs(diff))
+      l1_error_local += abs.(diff) * (weights[i] * weights[j] * volume_jacobian_)
     end
     l2_error += l2_error_local
+    l1_error += l1_error_local
   end
 
-  # For L2 error, divide by total volume
+  # For L2/L1 error, divide by total volume
   total_volume_ = total_volume(mesh)
-  l2_error = @. sqrt(l2_error / total_volume_)
+  l2_error  = @. sqrt(l2_error / total_volume_)
+  l1_error /= total_volume_
 
-  return l2_error, linf_error
+  return l2_error, linf_error, l1_error
 end
 
 
@@ -105,6 +111,7 @@ function calc_error_norms(func, u, t, analyzer,
   # Set up data structures
   l2_error   = zero(func(get_node_vars(u, equations, dg, 1, 1, 1), equations))
   linf_error = copy(l2_error)
+  l1_error   = copy(l2_error)
   total_volume = zero(real(mesh))
 
   # Iterate over all elements for error calculations
@@ -120,16 +127,20 @@ function calc_error_norms(func, u, t, analyzer,
     for j in eachnode(analyzer), i in eachnode(analyzer)
       u_exact = initial_condition(get_node_coords(x_local, equations, dg, i, j), t, equations)
       diff = func(u_exact, equations) - func(get_node_vars(u_local, equations, dg, i, j), equations)
+
       l2_error += diff.^2 * (weights[i] * weights[j] * jacobian_local[i, j])
       linf_error = @. max(linf_error, abs(diff))
+      l1_error += abs.(diff) * (weights[i] * weights[j] * jacobian_local[i, j])
+
       total_volume += weights[i] * weights[j] * jacobian_local[i, j]
     end
   end
 
-  # For L2 error, divide by total volume
-  l2_error = @. sqrt(l2_error / total_volume)
+  # For L2/L1 error, divide by total volume
+  l2_error  = @. sqrt(l2_error / total_volume)
+  l1_error /= total_volume
 
-  return l2_error, linf_error
+  return l2_error, linf_error, l1_error
 end
 
 

--- a/src/callbacks_step/analysis_dg2d_parallel.jl
+++ b/src/callbacks_step/analysis_dg2d_parallel.jl
@@ -75,7 +75,7 @@ function calc_error_norms_per_element(func, u, t, analyzer,
   T = typeof(zero(func(get_node_vars(u, equations, dg, 1, 1, 1), equations)))
   l2_errors   = zeros(T, nelements(dg, cache))
   linf_errors = copy(l2_errors)
-  l1_errors   = copy(l1_errors)
+  l1_errors   = copy(l2_errors)
 
   # Iterate over all elements for error calculations
   for element in eachelement(dg, cache)
@@ -110,7 +110,7 @@ function calc_error_norms(func, u, t, analyzer,
   # Set up data structures
   l2_error   = zero(func(get_node_vars(u, equations, dg, 1, 1, 1), equations))
   linf_error = copy(l2_error)
-  l2_error   = copy(l2_error)
+  l1_error   = copy(l2_error)
   volume = zero(real(mesh))
 
   # Iterate over all elements for error calculations

--- a/src/callbacks_step/analysis_dg2d_parallel.jl
+++ b/src/callbacks_step/analysis_dg2d_parallel.jl
@@ -58,7 +58,7 @@ function calc_error_norms(func, u, t, analyzer,
   else
     l2_error   = convert(eltype(l2_errors), NaN * zero(eltype(l2_errors)))
     linf_error = convert(eltype(linf_errors), NaN * zero(eltype(linf_errors)))
-    l1_error   = convert(eltype(l2_errors), NaN * zero(eltype(l2_errors)))
+    l1_error   = convert(eltype(l2_errors), NaN * zero(eltype(l1_errors)))
   end
 
   return l2_error, linf_error, l1_error

--- a/src/callbacks_step/analysis_dg2d_parallel.jl
+++ b/src/callbacks_step/analysis_dg2d_parallel.jl
@@ -8,9 +8,9 @@
 function calc_error_norms(func, u, t, analyzer,
                           mesh::ParallelTreeMesh{2}, equations, initial_condition,
                           dg::DGSEM, cache, cache_analysis)
-  l2_errors, linf_errors = calc_error_norms_per_element(func, u, t, analyzer,
-                                                        mesh, equations, initial_condition,
-                                                        dg, cache, cache_analysis)
+  l2_errors, linf_errors, l1_errors = calc_error_norms_per_element(func, u, t, analyzer,
+                                                                   mesh, equations, initial_condition,
+                                                                   dg, cache, cache_analysis)
 
   # Collect local error norms for each element on root process. That way, when aggregating the L2
   # errors, the order of summation is the same as in the serial case to ensure exact equality.
@@ -18,17 +18,21 @@ function calc_error_norms(func, u, t, analyzer,
   # https://github.com/trixi-framework/Trixi.jl/pull/850#pullrequestreview-757463943 for details).
   # Note that this approach does not scale.
   if mpi_isroot()
-    global_l2_errors = zeros(eltype(l2_errors), cache.mpi_cache.n_elements_global)
+    global_l2_errors   = zeros(eltype(l2_errors), cache.mpi_cache.n_elements_global)
     global_linf_errors = similar(global_l2_errors)
+    global_l1_errors   = similar(global_l2_errors)
 
     n_elements_by_rank = parent(cache.mpi_cache.n_elements_by_rank) # convert OffsetArray to Array
-    l2_buf = MPI.VBuffer(global_l2_errors, n_elements_by_rank)
+    l2_buf   = MPI.VBuffer(global_l2_errors, n_elements_by_rank)
     linf_buf = MPI.VBuffer(global_linf_errors, n_elements_by_rank)
+    l1_buf   = MPI.VBuffer(global_l1_errors, n_elements_by_rank)
     MPI.Gatherv!(l2_errors, l2_buf, mpi_root(), mpi_comm())
     MPI.Gatherv!(linf_errors, linf_buf, mpi_root(), mpi_comm())
+    MPI.Gatherv!(l1_errors, l1_buf, mpi_root(), mpi_comm())
   else
     MPI.Gatherv!(l2_errors, nothing, mpi_root(), mpi_comm())
     MPI.Gatherv!(linf_errors, nothing, mpi_root(), mpi_comm())
+    MPI.Gatherv!(l1_errors, nothing, mpi_root(), mpi_comm())
   end
 
   # Aggregate element error norms on root process
@@ -39,17 +43,25 @@ function calc_error_norms(func, u, t, analyzer,
     for error in global_l2_errors
       l2_error += error
     end
+
     linf_error = reduce((x, y) -> max.(x, y), global_linf_errors)
 
-    # For L2 error, divide by total volume
+    l1_error = zero(eltype(global_l1_errors))
+    for error in global_l1_errors
+      l1_error += error
+    end
+
+    # For L2/L1 error, divide by total volume
     total_volume_ = total_volume(mesh)
-    l2_error = @. sqrt(l2_error / total_volume_)
+    l2_error  = @. sqrt(l2_error / total_volume_)
+    l1_error /= total_volume_
   else
-    l2_error = convert(eltype(l2_errors), NaN * zero(eltype(l2_errors)))
+    l2_error   = convert(eltype(l2_errors), NaN * zero(eltype(l2_errors)))
     linf_error = convert(eltype(linf_errors), NaN * zero(eltype(linf_errors)))
+    l1_error   = convert(eltype(l2_errors), NaN * zero(eltype(l2_errors)))
   end
 
-  return l2_error, linf_error
+  return l2_error, linf_error, l1_error
 end
 
 function calc_error_norms_per_element(func, u, t, analyzer,
@@ -61,8 +73,9 @@ function calc_error_norms_per_element(func, u, t, analyzer,
 
   # Set up data structures
   T = typeof(zero(func(get_node_vars(u, equations, dg, 1, 1, 1), equations)))
-  l2_errors = zeros(T, nelements(dg, cache))
+  l2_errors   = zeros(T, nelements(dg, cache))
   linf_errors = copy(l2_errors)
+  l1_errors   = copy(l1_errors)
 
   # Iterate over all elements for error calculations
   for element in eachelement(dg, cache)
@@ -76,12 +89,14 @@ function calc_error_norms_per_element(func, u, t, analyzer,
     for j in eachnode(analyzer), i in eachnode(analyzer)
       u_exact = initial_condition(get_node_coords(x_local, equations, dg, i, j), t, equations)
       diff = func(u_exact, equations) - func(get_node_vars(u_local, equations, dg, i, j), equations)
-      l2_errors[element] += diff.^2 * (weights[i] * weights[j] * volume_jacobian_)
+
+      l2_errors[element]  += diff.^2 * (weights[i] * weights[j] * volume_jacobian_)
       linf_errors[element] = @. max(linf_errors[element], abs(diff))
+      l1_errors[element]  += abs.(diff) * (weights[i] * weights[j] * volume_jacobian_)
     end
   end
 
-  return l2_errors, linf_errors
+  return l2_errors, linf_errors, l1_errors
 end
 
 
@@ -95,6 +110,7 @@ function calc_error_norms(func, u, t, analyzer,
   # Set up data structures
   l2_error   = zero(func(get_node_vars(u, equations, dg, 1, 1, 1), equations))
   linf_error = copy(l2_error)
+  l2_error   = copy(l2_error)
   volume = zero(real(mesh))
 
   # Iterate over all elements for error calculations
@@ -110,8 +126,11 @@ function calc_error_norms(func, u, t, analyzer,
     for j in eachnode(analyzer), i in eachnode(analyzer)
       u_exact = initial_condition(get_node_coords(x_local, equations, dg, i, j), t, equations)
       diff = func(u_exact, equations) - func(get_node_vars(u_local, equations, dg, i, j), equations)
-      l2_error += diff.^2 * (weights[i] * weights[j] * jacobian_local[i, j])
+
+      l2_error  += diff.^2 * (weights[i] * weights[j] * jacobian_local[i, j])
       linf_error = @. max(linf_error, abs(diff))
+      l1_error  += abs.(diff) * (weights[i] * weights[j] * jacobian_local[i, j])
+
       volume += weights[i] * weights[j] * jacobian_local[i, j]
     end
   end
@@ -119,20 +138,24 @@ function calc_error_norms(func, u, t, analyzer,
   # Accumulate local results on root process
   global_l2_error = Vector(l2_error)
   global_linf_error = Vector(linf_error)
+  global_l1_error = Vector(l1_error)
   MPI.Reduce!(global_l2_error, +, mpi_root(), mpi_comm())
   MPI.Reduce!(global_linf_error, max, mpi_root(), mpi_comm())
   total_volume = MPI.Reduce(volume, +, mpi_root(), mpi_comm())
   if mpi_isroot()
     l2_error   = convert(typeof(l2_error),   global_l2_error)
     linf_error = convert(typeof(linf_error), global_linf_error)
-    # For L2 error, divide by total volume
-    l2_error = @. sqrt(l2_error / total_volume)
+    l1_error   = convert(typeof(l1_error),   global_l1_error)
+    # For L2/L1 error, divide by total volume
+    l2_error  = @. sqrt(l2_error / total_volume)
+    l1_error /= total_volume
   else
     l2_error   = convert(typeof(l2_error),   NaN * global_l2_error)
     linf_error = convert(typeof(linf_error), NaN * global_linf_error)
+    l1_error   = convert(typeof(l1_error),   NaN * global_l1_error)
   end
 
-  return l2_error, linf_error
+  return l2_error, linf_error, l1_error
 end
 
 

--- a/src/callbacks_step/analysis_dg3d.jl
+++ b/src/callbacks_step/analysis_dg3d.jl
@@ -71,6 +71,7 @@ function calc_error_norms(func, u, t, analyzer,
   # Set up data structures
   l2_error   = zero(func(get_node_vars(u, equations, dg, 1, 1, 1, 1), equations))
   linf_error = copy(l2_error)
+  l1_error   = copy(l2_error)
 
   # Iterate over all elements for error calculations
   for element in eachelement(dg, cache)
@@ -84,16 +85,19 @@ function calc_error_norms(func, u, t, analyzer,
     for k in eachnode(analyzer), j in eachnode(analyzer), i in eachnode(analyzer)
       u_exact = initial_condition(get_node_coords(x_local, equations, dg, i, j, k), t, equations)
       diff = func(u_exact, equations) - func(get_node_vars(u_local, equations, dg, i, j, k), equations)
-      l2_error += diff.^2 * (weights[i] * weights[j] * weights[k] * volume_jacobian_)
+
+      l2_error  += diff.^2 * (weights[i] * weights[j] * weights[k] * volume_jacobian_)
       linf_error = @. max(linf_error, abs(diff))
+      l1_error  += abs.(diff) * (weights[i] * weights[j] * weights[k] * volume_jacobian_)
     end
   end
 
-  # For L2 error, divide by total volume
+  # For L2/L1 error, divide by total volume
   total_volume_ = total_volume(mesh)
-  l2_error = @. sqrt(l2_error / total_volume_)
+  l2_error  = @. sqrt(l2_error / total_volume_)
+  l1_error /= total_volume_
 
-  return l2_error, linf_error
+  return l2_error, linf_error, l1_error
 end
 
 
@@ -108,6 +112,7 @@ function calc_error_norms(func, u, t, analyzer,
   # Set up data structures
   l2_error   = zero(func(get_node_vars(u, equations, dg, 1, 1, 1, 1), equations))
   linf_error = copy(l2_error)
+  l1_error   = copy(l2_error)
   total_volume = zero(real(mesh))
 
   # Iterate over all elements for error calculations
@@ -123,16 +128,20 @@ function calc_error_norms(func, u, t, analyzer,
     for k in eachnode(analyzer), j in eachnode(analyzer), i in eachnode(analyzer)
       u_exact = initial_condition(get_node_coords(x_local, equations, dg, i, j, k), t, equations)
       diff = func(u_exact, equations) - func(get_node_vars(u_local, equations, dg, i, j, k), equations)
-      l2_error += diff.^2 * (weights[i] * weights[j] * weights[k] * jacobian_local[i, j, k])
+
+      l2_error  += diff.^2 * (weights[i] * weights[j] * weights[k] * jacobian_local[i, j, k])
       linf_error = @. max(linf_error, abs(diff))
+      l1_error  += abs.(diff) * (weights[i] * weights[j] * weights[k] * jacobian_local[i, j, k])
+
       total_volume += weights[i] * weights[j] * weights[k] * jacobian_local[i, j, k]
     end
   end
 
-  # For L2 error, divide by total volume
-  l2_error = @. sqrt(l2_error / total_volume)
+  # For L2/L1 error, divide by total volume
+  l2_error  = @. sqrt(l2_error / total_volume)
+  l1_error /= total_volume
 
-  return l2_error, linf_error
+  return l2_error, linf_error, l1_error
 end
 
 

--- a/src/solvers/fdsbp_tree/fdsbp_1d.jl
+++ b/src/solvers/fdsbp_tree/fdsbp_1d.jl
@@ -276,6 +276,7 @@ function calc_error_norms(func, u, t, analyzer,
   # Set up data structures
   l2_error   = zero(func(get_node_vars(u, equations, dg, 1, 1), equations))
   linf_error = copy(l2_error)
+  l1_error   = copy(l2_error)
 
   # Iterate over all elements for error calculations
   for element in eachelement(dg, cache)
@@ -287,16 +288,19 @@ function calc_error_norms(func, u, t, analyzer,
         get_node_coords(node_coordinates, equations, dg, i, element), t, equations)
       diff = func(u_exact, equations) - func(
         get_node_vars(u, equations, dg, i, element), equations)
-      l2_error += diff.^2 * (weights[i] * volume_jacobian_)
+
+      l2_error  += diff.^2 * (weights[i] * volume_jacobian_)
       linf_error = @. max(linf_error, abs(diff))
+      l1_error  += abs.(diff) * (weights[i] * volume_jacobian_)
     end
   end
 
-  # For L2 error, divide by total volume
+  # For L2/L1 error, divide by total volume
   total_volume_ = total_volume(mesh)
-  l2_error = @. sqrt(l2_error / total_volume_)
+  l2_error  = @. sqrt(l2_error / total_volume_)
+  l1_error /= total_volume_
 
-  return l2_error, linf_error
+  return l2_error, linf_error, l1_error
 end
 
 

--- a/src/solvers/fdsbp_tree/fdsbp_2d.jl
+++ b/src/solvers/fdsbp_tree/fdsbp_2d.jl
@@ -331,6 +331,7 @@ function calc_error_norms(func, u, t, analyzer,
   # Set up data structures
   l2_error   = zero(func(get_node_vars(u, equations, dg, 1, 1, 1), equations))
   linf_error = copy(l2_error)
+  l1_error   = copy(l2_error)
 
   # Iterate over all elements for error calculations
   for element in eachelement(dg, cache)
@@ -342,16 +343,19 @@ function calc_error_norms(func, u, t, analyzer,
         get_node_coords(node_coordinates, equations, dg, i, j, element), t, equations)
       diff = func(u_exact, equations) - func(
         get_node_vars(u, equations, dg, i, j, element), equations)
-      l2_error += diff.^2 * (weights[i] * weights[j] * volume_jacobian_)
+
+      l2_error  += diff.^2 * (weights[i] * weights[j] * volume_jacobian_)
       linf_error = @. max(linf_error, abs(diff))
+      l1_error  += abs.(diff) * (weights[i] * weights[j] * volume_jacobian_)
     end
   end
 
-  # For L2 error, divide by total volume
+  # For L2/L1 error, divide by total volume
   total_volume_ = total_volume(mesh)
-  l2_error = @. sqrt(l2_error / total_volume_)
+  l2_error  = @. sqrt(l2_error / total_volume_)
+  l1_error /= total_volume_
 
-  return l2_error, linf_error
+  return l2_error, linf_error, l1_error
 end
 
 

--- a/src/solvers/fdsbp_tree/fdsbp_3d.jl
+++ b/src/solvers/fdsbp_tree/fdsbp_3d.jl
@@ -377,6 +377,7 @@ function calc_error_norms(func, u, t, analyzer,
   # Set up data structures
   l2_error   = zero(func(get_node_vars(u, equations, dg, 1, 1, 1, 1), equations))
   linf_error = copy(l2_error)
+  l1_error   = copy(l2_error)
 
   # Iterate over all elements for error calculations
   for element in eachelement(dg, cache)
@@ -388,16 +389,19 @@ function calc_error_norms(func, u, t, analyzer,
         get_node_coords(node_coordinates, equations, dg, i, j, k, element), t, equations)
       diff = func(u_exact, equations) - func(
         get_node_vars(u, equations, dg, i, j, k, element), equations)
-      l2_error += diff.^2 * (weights[i] * weights[j] * weights[k] * volume_jacobian_)
+
+      l2_error  += diff.^2 * (weights[i] * weights[j] * weights[k] * volume_jacobian_)
       linf_error = @. max(linf_error, abs(diff))
+      l1_error  += abs.(diff) * (weights[i] * weights[j] * weights[k] * volume_jacobian_)
     end
   end
 
-  # For L2 error, divide by total volume
+  # For L2/L1 error, divide by total volume
   total_volume_ = total_volume(mesh)
-  l2_error = @. sqrt(l2_error / total_volume_)
+  l2_error  = @. sqrt(l2_error / total_volume_)
+  l1_error /= total_volume_
 
-  return l2_error, linf_error
+  return l2_error, linf_error, l1_error
 end
 
 


### PR DESCRIPTION
For (scalar) hyperbolic PDEs $L^1$ is the [natural error norm](https://link.springer.com/chapter/10.1007/978-3-642-04048-1_6) around which the theory has evolved. 
I adapted the code for the $L^2$ errors such that now also $L^1$ errors are computed analogously.
These are accessible via `extra_analysis_errors = (:l1_error, l1_error_primitive,)`, i.e., they are not yet default.

Tested with:

DGSEM:

Structured 1D: advection_basic (l1_error)
Structured 2D: advection_extended (l1_error)
Structured 3D: euler_sedov (l1_error, l1_error_primitive)

Tree 1D: burgers_shock (l1_error)
Tree 2D: euler_blob_amr (l1_error, l1_error_primitive)
Tree 3D: mhd_alfven_wave (l1_error, l1_error_primitive)

DGMULTI:

1D: advection_gauss_sbp (l1_error)
2D: shallowwater_source_terms (l1_error, l1_error_primitive)
3D: navierstokes_convergence (l1_error, l1_error_primitive)

FDSBP:

Tree 1D: euler_densitiy_wave (l1_error, l1_error_primitive)
Tree 2D: lbm_coutte (l1_error)
Tree 3D: euler_taylor_green_vortex
