### PR TITLE
Split `misc_part3` into two CI jobs to speed up CI times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
           - paper_self_gravitating_gas_dynamics
           - misc_part1
           - misc_part2
-          - misc_part3
+          - performance_specializations_part1
+          - performance_specializations_part2
           - mpi
           - threaded
         include:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,8 +100,12 @@ const TRIXI_NTHREADS   = clamp(Sys.CPU_THREADS, 2, 3)
     include("test_special_elixirs.jl")
   end
 
-  @time if TRIXI_TEST == "all" || TRIXI_TEST == "misc_part3"
-    include("test_performance_specializations.jl")
+  @time if TRIXI_TEST == "all" || TRIXI_TEST == "performance_specializations_part1"
+    include("test_performance_specializations_2d.jl")
+  end
+
+  @time if TRIXI_TEST == "all" || TRIXI_TEST == "performance_specializations_part2"
+    include("test_performance_specializations_3d.jl")
   end
 
   @time if TRIXI_TEST == "all" || TRIXI_TEST == "paper_self_gravitating_gas_dynamics"

--- a/test/test_performance_specializations_2d.jl
+++ b/test/test_performance_specializations_2d.jl
@@ -1,4 +1,4 @@
-module TestPerformanceSpecializations
+module TestPerformanceSpecializations2D
 
 using Test
 using Trixi
@@ -10,7 +10,7 @@ outdir = "out"
 isdir(outdir) && rm(outdir, recursive=true)
 
 
-@testset "Performance specializations" begin
+@testset "Performance specializations 2D" begin
   @timed_testset "TreeMesh2D, flux_shima_etal_turbo" begin
     trixi_include(@__MODULE__,
       joinpath(examples_dir(), "tree_2d_dgsem", "elixir_euler_ec.jl"),
@@ -162,162 +162,6 @@ isdir(outdir) && rm(outdir, recursive=true)
         nonconservative_terms, semi.equations,
         semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
       du_baseline = du[:, :, :, 1]
-
-      @test du_specialized ≈ du_baseline
-    end
-  end
-
-  @timed_testset "TreeMesh3D, flux_shima_etal_turbo" begin
-    trixi_include(@__MODULE__,
-      joinpath(examples_dir(), "tree_3d_dgsem", "elixir_euler_ec.jl"),
-      initial_refinement_level=0, tspan=(0.0, 0.0), polydeg=3,
-      volume_flux=flux_shima_etal_turbo, surface_flux=flux_shima_etal_turbo)
-    u_ode = copy(sol.u[end])
-    du_ode = zero(u_ode)
-
-    # Preserve original memory since it will be `unsafe_wrap`ped and might
-    # thus otherwise be garbage collected
-    GC.@preserve u_ode du_ode begin
-      u = Trixi.wrap_array(u_ode, semi)
-      du = Trixi.wrap_array(du_ode, semi)
-      nonconservative_terms = Trixi.have_nonconservative_terms(semi.equations)
-
-      # Call the optimized default version
-      du .= 0
-      Trixi.flux_differencing_kernel!(
-        du, u, 1, semi.mesh,
-        nonconservative_terms, semi.equations,
-        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
-      du_specialized = du[:, :, :, :, 1]
-
-      # Call the plain version - note the argument type `Function` of
-      # `semi.solver.volume_integral.volume_flux`
-      du .= 0
-      invoke(Trixi.flux_differencing_kernel!,
-        Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
-        typeof(nonconservative_terms), typeof(semi.equations),
-        Function, typeof(semi.solver), typeof(semi.cache), Bool},
-        du, u, 1, semi.mesh,
-        nonconservative_terms, semi.equations,
-        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
-      du_baseline = du[:, :, :, :, 1]
-
-      @test du_specialized ≈ du_baseline
-    end
-  end
-
-  @timed_testset "TreeMesh3D, flux_ranocha_turbo" begin
-    trixi_include(@__MODULE__,
-      joinpath(examples_dir(), "tree_3d_dgsem", "elixir_euler_ec.jl"),
-      initial_refinement_level=0, tspan=(0.0, 0.0), polydeg=3,
-      volume_flux=flux_ranocha_turbo, surface_flux=flux_ranocha_turbo)
-    u_ode = copy(sol.u[end])
-    du_ode = zero(u_ode)
-
-    # Preserve original memory since it will be `unsafe_wrap`ped and might
-    # thus otherwise be garbage collected
-    GC.@preserve u_ode du_ode begin
-      u = Trixi.wrap_array(u_ode, semi)
-      du = Trixi.wrap_array(du_ode, semi)
-      nonconservative_terms = Trixi.have_nonconservative_terms(semi.equations)
-
-      # Call the optimized default version
-      du .= 0
-      Trixi.flux_differencing_kernel!(
-        du, u, 1, semi.mesh,
-        nonconservative_terms, semi.equations,
-        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
-      du_specialized = du[:, :, :, :, 1]
-
-      # Call the plain version - note the argument type `Function` of
-      # `semi.solver.volume_integral.volume_flux`
-      du .= 0
-      invoke(Trixi.flux_differencing_kernel!,
-        Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
-        typeof(nonconservative_terms), typeof(semi.equations),
-        Function, typeof(semi.solver), typeof(semi.cache), Bool},
-        du, u, 1, semi.mesh,
-        nonconservative_terms, semi.equations,
-        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
-      du_baseline = du[:, :, :, :, 1]
-
-      @test du_specialized ≈ du_baseline
-    end
-  end
-
-  @timed_testset "StructuredMesh3D, flux_shima_etal_turbo" begin
-    trixi_include(@__MODULE__,
-      joinpath(examples_dir(), "structured_3d_dgsem", "elixir_euler_ec.jl"),
-      cells_per_dimension=(1, 1, 1), tspan=(0.0, 0.0), polydeg=3,
-      volume_flux=flux_shima_etal_turbo, surface_flux=flux_shima_etal_turbo)
-    u_ode = copy(sol.u[end])
-    du_ode = zero(u_ode)
-
-    # Preserve original memory since it will be `unsafe_wrap`ped and might
-    # thus otherwise be garbage collected
-    GC.@preserve u_ode du_ode begin
-      u = Trixi.wrap_array(u_ode, semi)
-      du = Trixi.wrap_array(du_ode, semi)
-      nonconservative_terms = Trixi.have_nonconservative_terms(semi.equations)
-
-      # Call the optimized default version
-      du .= 0
-      Trixi.flux_differencing_kernel!(
-        du, u, 1, semi.mesh,
-        nonconservative_terms, semi.equations,
-        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
-      du_specialized = du[:, :, :, :, 1]
-
-      # Call the plain version - note the argument type `Function` of
-      # `semi.solver.volume_integral.volume_flux`
-      du .= 0
-      invoke(Trixi.flux_differencing_kernel!,
-        Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
-        typeof(nonconservative_terms), typeof(semi.equations),
-        Function, typeof(semi.solver), typeof(semi.cache), Bool},
-        du, u, 1, semi.mesh,
-        nonconservative_terms, semi.equations,
-        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
-      du_baseline = du[:, :, :, :, 1]
-
-      @test du_specialized ≈ du_baseline
-    end
-  end
-
-  @timed_testset "StructuredMesh3D, flux_ranocha_turbo" begin
-    trixi_include(@__MODULE__,
-      joinpath(examples_dir(), "structured_3d_dgsem", "elixir_euler_ec.jl"),
-      cells_per_dimension=(1, 1, 1), tspan=(0.0, 0.0), polydeg=3,
-      volume_flux=flux_ranocha_turbo, surface_flux=flux_ranocha_turbo)
-    u_ode = copy(sol.u[end])
-    du_ode = zero(u_ode)
-
-    # Preserve original memory since it will be `unsafe_wrap`ped and might
-    # thus otherwise be garbage collected
-    GC.@preserve u_ode du_ode begin
-      u = Trixi.wrap_array(u_ode, semi)
-      du = Trixi.wrap_array(du_ode, semi)
-      nonconservative_terms = Trixi.have_nonconservative_terms(semi.equations)
-
-      # Call the optimized default version
-      du .= 0
-      Trixi.flux_differencing_kernel!(
-        du, u, 1, semi.mesh,
-        nonconservative_terms, semi.equations,
-        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
-      du_specialized = du[:, :, :, :, 1]
-
-      # Call the plain version - note the argument type `Function` of
-      # `semi.solver.volume_integral.volume_flux`
-      du .= 0
-      invoke(Trixi.flux_differencing_kernel!,
-        Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
-        typeof(nonconservative_terms), typeof(semi.equations),
-        Function, typeof(semi.solver), typeof(semi.cache), Bool},
-        du, u, 1, semi.mesh,
-        nonconservative_terms, semi.equations,
-        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
-      du_baseline = du[:, :, :, :, 1]
 
       @test du_specialized ≈ du_baseline
     end

--- a/test/test_performance_specializations_3d.jl
+++ b/test/test_performance_specializations_3d.jl
@@ -1,0 +1,175 @@
+module TestPerformanceSpecializations3D
+
+using Test
+using Trixi
+
+include("test_trixi.jl")
+
+# Start with a clean environment: remove Trixi.jl output directory if it exists
+outdir = "out"
+isdir(outdir) && rm(outdir, recursive=true)
+
+
+@testset "Performance specializations 3D" begin
+  @timed_testset "TreeMesh3D, flux_shima_etal_turbo" begin
+    trixi_include(@__MODULE__,
+      joinpath(examples_dir(), "tree_3d_dgsem", "elixir_euler_ec.jl"),
+      initial_refinement_level=0, tspan=(0.0, 0.0), polydeg=3,
+      volume_flux=flux_shima_etal_turbo, surface_flux=flux_shima_etal_turbo)
+    u_ode = copy(sol.u[end])
+    du_ode = zero(u_ode)
+
+    # Preserve original memory since it will be `unsafe_wrap`ped and might
+    # thus otherwise be garbage collected
+    GC.@preserve u_ode du_ode begin
+      u = Trixi.wrap_array(u_ode, semi)
+      du = Trixi.wrap_array(du_ode, semi)
+      nonconservative_terms = Trixi.have_nonconservative_terms(semi.equations)
+
+      # Call the optimized default version
+      du .= 0
+      Trixi.flux_differencing_kernel!(
+        du, u, 1, semi.mesh,
+        nonconservative_terms, semi.equations,
+        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
+      du_specialized = du[:, :, :, :, 1]
+
+      # Call the plain version - note the argument type `Function` of
+      # `semi.solver.volume_integral.volume_flux`
+      du .= 0
+      invoke(Trixi.flux_differencing_kernel!,
+        Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
+        typeof(nonconservative_terms), typeof(semi.equations),
+        Function, typeof(semi.solver), typeof(semi.cache), Bool},
+        du, u, 1, semi.mesh,
+        nonconservative_terms, semi.equations,
+        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
+      du_baseline = du[:, :, :, :, 1]
+
+      @test du_specialized ≈ du_baseline
+    end
+  end
+
+  @timed_testset "TreeMesh3D, flux_ranocha_turbo" begin
+    trixi_include(@__MODULE__,
+      joinpath(examples_dir(), "tree_3d_dgsem", "elixir_euler_ec.jl"),
+      initial_refinement_level=0, tspan=(0.0, 0.0), polydeg=3,
+      volume_flux=flux_ranocha_turbo, surface_flux=flux_ranocha_turbo)
+    u_ode = copy(sol.u[end])
+    du_ode = zero(u_ode)
+
+    # Preserve original memory since it will be `unsafe_wrap`ped and might
+    # thus otherwise be garbage collected
+    GC.@preserve u_ode du_ode begin
+      u = Trixi.wrap_array(u_ode, semi)
+      du = Trixi.wrap_array(du_ode, semi)
+      nonconservative_terms = Trixi.have_nonconservative_terms(semi.equations)
+
+      # Call the optimized default version
+      du .= 0
+      Trixi.flux_differencing_kernel!(
+        du, u, 1, semi.mesh,
+        nonconservative_terms, semi.equations,
+        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
+      du_specialized = du[:, :, :, :, 1]
+
+      # Call the plain version - note the argument type `Function` of
+      # `semi.solver.volume_integral.volume_flux`
+      du .= 0
+      invoke(Trixi.flux_differencing_kernel!,
+        Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
+        typeof(nonconservative_terms), typeof(semi.equations),
+        Function, typeof(semi.solver), typeof(semi.cache), Bool},
+        du, u, 1, semi.mesh,
+        nonconservative_terms, semi.equations,
+        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
+      du_baseline = du[:, :, :, :, 1]
+
+      @test du_specialized ≈ du_baseline
+    end
+  end
+
+  @timed_testset "StructuredMesh3D, flux_shima_etal_turbo" begin
+    trixi_include(@__MODULE__,
+      joinpath(examples_dir(), "structured_3d_dgsem", "elixir_euler_ec.jl"),
+      cells_per_dimension=(1, 1, 1), tspan=(0.0, 0.0), polydeg=3,
+      volume_flux=flux_shima_etal_turbo, surface_flux=flux_shima_etal_turbo)
+    u_ode = copy(sol.u[end])
+    du_ode = zero(u_ode)
+
+    # Preserve original memory since it will be `unsafe_wrap`ped and might
+    # thus otherwise be garbage collected
+    GC.@preserve u_ode du_ode begin
+      u = Trixi.wrap_array(u_ode, semi)
+      du = Trixi.wrap_array(du_ode, semi)
+      nonconservative_terms = Trixi.have_nonconservative_terms(semi.equations)
+
+      # Call the optimized default version
+      du .= 0
+      Trixi.flux_differencing_kernel!(
+        du, u, 1, semi.mesh,
+        nonconservative_terms, semi.equations,
+        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
+      du_specialized = du[:, :, :, :, 1]
+
+      # Call the plain version - note the argument type `Function` of
+      # `semi.solver.volume_integral.volume_flux`
+      du .= 0
+      invoke(Trixi.flux_differencing_kernel!,
+        Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
+        typeof(nonconservative_terms), typeof(semi.equations),
+        Function, typeof(semi.solver), typeof(semi.cache), Bool},
+        du, u, 1, semi.mesh,
+        nonconservative_terms, semi.equations,
+        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
+      du_baseline = du[:, :, :, :, 1]
+
+      @test du_specialized ≈ du_baseline
+    end
+  end
+
+  @timed_testset "StructuredMesh3D, flux_ranocha_turbo" begin
+    trixi_include(@__MODULE__,
+      joinpath(examples_dir(), "structured_3d_dgsem", "elixir_euler_ec.jl"),
+      cells_per_dimension=(1, 1, 1), tspan=(0.0, 0.0), polydeg=3,
+      volume_flux=flux_ranocha_turbo, surface_flux=flux_ranocha_turbo)
+    u_ode = copy(sol.u[end])
+    du_ode = zero(u_ode)
+
+    # Preserve original memory since it will be `unsafe_wrap`ped and might
+    # thus otherwise be garbage collected
+    GC.@preserve u_ode du_ode begin
+      u = Trixi.wrap_array(u_ode, semi)
+      du = Trixi.wrap_array(du_ode, semi)
+      nonconservative_terms = Trixi.have_nonconservative_terms(semi.equations)
+
+      # Call the optimized default version
+      du .= 0
+      Trixi.flux_differencing_kernel!(
+        du, u, 1, semi.mesh,
+        nonconservative_terms, semi.equations,
+        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
+      du_specialized = du[:, :, :, :, 1]
+
+      # Call the plain version - note the argument type `Function` of
+      # `semi.solver.volume_integral.volume_flux`
+      du .= 0
+      invoke(Trixi.flux_differencing_kernel!,
+        Tuple{typeof(du), typeof(u), Integer, typeof(semi.mesh),
+        typeof(nonconservative_terms), typeof(semi.equations),
+        Function, typeof(semi.solver), typeof(semi.cache), Bool},
+        du, u, 1, semi.mesh,
+        nonconservative_terms, semi.equations,
+        semi.solver.volume_integral.volume_flux, semi.solver, semi.cache, true)
+      du_baseline = du[:, :, :, :, 1]
+
+      @test du_specialized ≈ du_baseline
+    end
+  end
+end
+
+
+# Clean up afterwards: delete Trixi.jl output directory
+@test_nowarn rm(outdir, recursive=true)
+
+end #module


### PR DESCRIPTION
Fixes #1413.

Once merged, we should adapt the [branch protection rules for `main`](https://github.com/trixi-framework/Trixi.jl/settings/branch_protection_rules/17269475) to reflect the new job names.