### PR TITLE
Fix a type instability in parabolic solver for `DGMulti`

### DIFF
--- a/src/solvers/dgmulti/dg_parabolic.jl
+++ b/src/solvers/dgmulti/dg_parabolic.jl
@@ -213,14 +213,15 @@ function calc_single_boundary_flux!(flux_face_values, u_face_values, t,
   rd = dg.basis
   md = mesh.md
 
-  num_pts_per_face = rd.Nfq ÷ rd.Nfaces
+  num_faces = StartUpDG.num_faces(rd.element_type)
+  num_pts_per_face = rd.Nfq ÷ num_faces
   (; xyzf, nxyz) = md
   for f in mesh.boundary_faces[boundary_key]
     for i in Base.OneTo(num_pts_per_face)
 
       # reverse engineer element + face node indices (avoids reshaping arrays)
-      e = ((f-1) ÷ rd.Nfaces) + 1
-      fid = i + ((f-1) % rd.Nfaces) * num_pts_per_face
+      e = ((f-1) ÷ num_faces) + 1
+      fid = i + ((f-1) % num_faces) * num_pts_per_face
 
       face_normal = SVector{NDIMS}(getindex.(nxyz, fid, e))
       face_coordinates = SVector{NDIMS}(getindex.(xyzf, fid, e))


### PR DESCRIPTION
I found a type instability related to some overloaded `getproperty` calls to StartUpDG.jl. Removing it drops the allocations in `examples/dgmulti_2d/elixir_navierstokes_convergence.jl` for `rhs_parabolic!` from 
```julia
 parabolic rhs!             390    1.51s   57.2%  3.88ms    459MiB   87.2%  1.18MiB
```
to 
```julia
 parabolic rhs!             390    683ms   38.5%  1.75ms   82.1MiB   55.0%   216KiB
```
There are some other type instabilities, but they appear related to other dependencies.