### PR TITLE
fix docstring of `trixi_include`

### DIFF
--- a/src/auxiliary/special_elixirs.jl
+++ b/src/auxiliary/special_elixirs.jl
@@ -20,7 +20,8 @@ providing examples with sensible default values for users.
 
 Before replacing assignments in `elixir`, the keyword argument `maxiters` is inserted
 into calls to `solve` and `Trixi.solve` with it's default value used in the SciML ecosystem
-for ODEs, see the "Miscellaneous" section of the [documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
+for ODEs, see the "Miscellaneous" section of the 
+[documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
 
 # Examples
 


### PR DESCRIPTION
Before:
```julia
julia> using Trixi

help?> trixi_include
search: trixi_include

  trixi_include([mod::Module=Main,] elixir::AbstractString; kwargs...)

  include the file elixir and evaluate its content in the global scope of module mod. You can override specific
  assignments in elixir by supplying keyword arguments. It's basic purpose is to make it easier to modify some
  parameters while running Trixi from the REPL. Additionally, this is used in tests to reduce the computational
  burden for CI while still providing examples with sensible default values for users.

  Before replacing assignments in elixir, the keyword argument maxiters is inserted into calls to solve and
  Trixi.solve with it's default value used in the SciML ecosystem for ODEs, see
  https://diffeq.sciml.ai/stable/basics/commonsolveropts/#Miscellaneous.

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> redirect_stdout(devnull) do
           trixi_include(@__MODULE__, joinpath(examples_dir(), "tree_1d_dgsem", "elixir_advection_extended.jl"),
                         tspan=(0.0, 0.1))
           sol.t[end]
         end
  [ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.
  0.1
```

After:
```julia
julia> using Trixi

help?> trixi_include
search: trixi_include

  trixi_include([mod::Module=Main,] elixir::AbstractString; kwargs...)

  include the file elixir and evaluate its content in the global scope of module mod. You can override specific
  assignments in elixir by supplying keyword arguments. It's basic purpose is to make it easier to modify some
  parameters while running Trixi.jl from the REPL. Additionally, this is used in tests to reduce the
  computational burden for CI while still providing examples with sensible default values for users.

  Before replacing assignments in elixir, the keyword argument maxiters is inserted into calls to solve and
  Trixi.solve with it's default value used in the SciML ecosystem for ODEs, see the "Miscellaneous" section of
  the documentation (https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> redirect_stdout(devnull) do
           trixi_include(@__MODULE__, joinpath(examples_dir(), "tree_1d_dgsem", "elixir_advection_extended.jl"),
                         tspan=(0.0, 0.1))
           sol.t[end]
         end
  [ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.
  0.1
```

Note the wrong link in the old version.