### PR TITLE
Use `pkgdir` instead of `pathof`

### DIFF
--- a/benchmark/run_benchmarks.jl
+++ b/benchmark/run_benchmarks.jl
@@ -7,7 +7,7 @@ let results = judge(Trixi,
             BenchmarkConfig(juliacmd=`$(Base.julia_cmd()) --check-bounds=no --threads=1`, id="main") # baseline
         )
 
-    export_markdown(joinpath(pathof(Trixi) |> dirname |> dirname, "benchmark", "results_$(gethostname())_threads1.md"), results)
+    export_markdown(joinpath(pkgdir(Trixi), "benchmark", "results_$(gethostname())_threads1.md"), results)
 end
 
 
@@ -16,5 +16,5 @@ let results = judge(Trixi,
             BenchmarkConfig(juliacmd=`$(Base.julia_cmd()) --check-bounds=no --threads=2`, id="main") # baseline
         )
 
-    export_markdown(joinpath(pathof(Trixi) |> dirname |> dirname, "benchmark", "results_$(gethostname())_threads2.md"), results)
+    export_markdown(joinpath(pkgdir(Trixi), "benchmark", "results_$(gethostname())_threads2.md"), results)
 end

--- a/benchmark/run_benchmarks.jl
+++ b/benchmark/run_benchmarks.jl
@@ -7,7 +7,7 @@ let results = judge(Trixi,
             BenchmarkConfig(juliacmd=`$(Base.julia_cmd()) --check-bounds=no --threads=1`, id="main") # baseline
         )
 
-    export_markdown(joinpath(pkgdir(Trixi), "benchmark", "results_$(gethostname())_threads1.md"), results)
+    export_markdown(pkgdir(Trixi, "benchmark", "results_$(gethostname())_threads1.md"), results)
 end
 
 
@@ -16,5 +16,5 @@ let results = judge(Trixi,
             BenchmarkConfig(juliacmd=`$(Base.julia_cmd()) --check-bounds=no --threads=2`, id="main") # baseline
         )
 
-    export_markdown(joinpath(pkgdir(Trixi), "benchmark", "results_$(gethostname())_threads2.md"), results)
+    export_markdown(pkgdir(Trixi, "benchmark", "results_$(gethostname())_threads2.md"), results)
 end

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -112,7 +112,7 @@ julia> using PkgBenchmark, Trixi
 
 julia> results = benchmarkpkg(Trixi, BenchmarkConfig(juliacmd=`$(Base.julia_cmd()) --check-bounds=no --threads=1`))
 
-julia> export_markdown(joinpath(pkgdir(Trixi), "benchmark", "single_benchmark.md"), results)
+julia> export_markdown(pkgdir(Trixi, "benchmark", "single_benchmark.md"), results)
 ```
 This will save a markdown file with a summary of the benchmark results similar to
 [this example](https://gist.github.com/ranocha/494fa2529e1e6703c17b08434c090980).
@@ -132,7 +132,7 @@ julia> results = judge(Trixi,
              BenchmarkConfig(juliacmd=`$(Base.julia_cmd()) --check-bounds=no --threads=1`, id="main") # baseline
        )
 
-julia> export_markdown(joinpath(pkgdir(Trixi), "benchmark", "results.md"), results)
+julia> export_markdown(pkgdir(Trixi, "benchmark", "results.md"), results)
 ```
 By default, the `target` is the current state of the repository. Remember that you
 need to be in a clean state (commit or stash your changes) to run this successfully.

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -112,7 +112,7 @@ julia> using PkgBenchmark, Trixi
 
 julia> results = benchmarkpkg(Trixi, BenchmarkConfig(juliacmd=`$(Base.julia_cmd()) --check-bounds=no --threads=1`))
 
-julia> export_markdown(joinpath(pathof(Trixi) |> dirname |> dirname, "benchmark", "single_benchmark.md"), results)
+julia> export_markdown(joinpath(pkgdir(Trixi), "benchmark", "single_benchmark.md"), results)
 ```
 This will save a markdown file with a summary of the benchmark results similar to
 [this example](https://gist.github.com/ranocha/494fa2529e1e6703c17b08434c090980).
@@ -132,7 +132,7 @@ julia> results = judge(Trixi,
              BenchmarkConfig(juliacmd=`$(Base.julia_cmd()) --check-bounds=no --threads=1`, id="main") # baseline
        )
 
-julia> export_markdown(joinpath(pathof(Trixi) |> dirname |> dirname, "benchmark", "results.md"), results)
+julia> export_markdown(joinpath(pkgdir(Trixi), "benchmark", "results.md"), results)
 ```
 By default, the `target` is the current state of the repository. Remember that you
 need to be in a clean state (commit or stash your changes) to run this successfully.

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -110,7 +110,7 @@ modified. To find out which files are available, use, e.g., `readdir`:
 readdir(examples_dir())
 ```
 """
-examples_dir() = joinpath(pkgdir(Trixi), "examples")
+examples_dir() = pkgdir(Trixi, "examples")
 
 
 """

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -110,7 +110,7 @@ modified. To find out which files are available, use, e.g., `readdir`:
 readdir(examples_dir())
 ```
 """
-examples_dir() = joinpath(pathof(Trixi) |> dirname |> dirname, "examples")
+examples_dir() = joinpath(pkgdir(Trixi), "examples")
 
 
 """

--- a/test/test_dgmulti_3d.jl
+++ b/test/test_dgmulti_3d.jl
@@ -5,7 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "dgmulti_3d")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "dgmulti_3d")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"

--- a/test/test_dgmulti_3d.jl
+++ b/test/test_dgmulti_3d.jl
@@ -5,7 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "dgmulti_3d")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "dgmulti_3d")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"

--- a/test/test_mpi_p4est_2d.jl
+++ b/test/test_mpi_p4est_2d.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-const EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "p4est_2d_dgsem")
+const EXAMPLES_DIR = pkgdir(Trixi, "examples", "p4est_2d_dgsem")
 
 @testset "P4estMesh MPI 2D" begin
 

--- a/test/test_mpi_p4est_2d.jl
+++ b/test/test_mpi_p4est_2d.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "p4est_2d_dgsem")
+const EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "p4est_2d_dgsem")
 
 @testset "P4estMesh MPI 2D" begin
 

--- a/test/test_mpi_p4est_3d.jl
+++ b/test/test_mpi_p4est_3d.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-const EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "p4est_3d_dgsem")
+const EXAMPLES_DIR = pkgdir(Trixi, "examples", "p4est_3d_dgsem")
 
 @testset "P4estMesh MPI 3D" begin
 

--- a/test/test_mpi_p4est_3d.jl
+++ b/test/test_mpi_p4est_3d.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "p4est_3d_dgsem")
+const EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "p4est_3d_dgsem")
 
 @testset "P4estMesh MPI 3D" begin
 

--- a/test/test_mpi_tree.jl
+++ b/test/test_mpi_tree.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-const EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
+const EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_2d_dgsem")
 
 # Needed to skip certain tests on Windows CI
 CI_ON_WINDOWS = (get(ENV, "GITHUB_ACTIONS", false) == "true") && Sys.iswindows()

--- a/test/test_mpi_tree.jl
+++ b/test/test_mpi_tree.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+const EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
 
 # Needed to skip certain tests on Windows CI
 CI_ON_WINDOWS = (get(ENV, "GITHUB_ACTIONS", false) == "true") && Sys.iswindows()

--- a/test/test_paper_self_gravitating_gas_dynamics.jl
+++ b/test/test_paper_self_gravitating_gas_dynamics.jl
@@ -10,7 +10,7 @@ outdir = "out"
 isdir(outdir) && rm(outdir, recursive=true)
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "paper_self_gravitating_gas_dynamics")
+const EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "paper_self_gravitating_gas_dynamics")
 
 # Numerical examples from the Euler-gravity paper
 @testset "paper_self_gravitating_gas_dynamics" begin

--- a/test/test_paper_self_gravitating_gas_dynamics.jl
+++ b/test/test_paper_self_gravitating_gas_dynamics.jl
@@ -9,8 +9,7 @@ include("test_trixi.jl")
 outdir = "out"
 isdir(outdir) && rm(outdir, recursive=true)
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-const EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "paper_self_gravitating_gas_dynamics")
+const EXAMPLES_DIR = pkgdir(Trixi, "examples", "paper_self_gravitating_gas_dynamics")
 
 # Numerical examples from the Euler-gravity paper
 @testset "paper_self_gravitating_gas_dynamics" begin

--- a/test/test_special_elixirs.jl
+++ b/test/test_special_elixirs.jl
@@ -12,8 +12,7 @@ include("test_trixi.jl")
 outdir = "out"
 isdir(outdir) && rm(outdir, recursive=true)
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-const EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples")
+const EXAMPLES_DIR = pkgdir(Trixi, "examples")
 
 cmd = string(Base.julia_cmd())
 coverage = occursin("--code-coverage", cmd) && !occursin("--code-coverage=none", cmd)

--- a/test/test_special_elixirs.jl
+++ b/test/test_special_elixirs.jl
@@ -13,7 +13,7 @@ outdir = "out"
 isdir(outdir) && rm(outdir, recursive=true)
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-const EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples")
+const EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples")
 
 cmd = string(Base.julia_cmd())
 coverage = occursin("--code-coverage", cmd) && !occursin("--code-coverage=none", cmd)

--- a/test/test_structured_1d.jl
+++ b/test/test_structured_1d.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "structured_1d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "structured_1d_dgsem")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"

--- a/test/test_structured_1d.jl
+++ b/test/test_structured_1d.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "structured_1d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "structured_1d_dgsem")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"

--- a/test/test_structured_2d.jl
+++ b/test/test_structured_2d.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "structured_2d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "structured_2d_dgsem")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"

--- a/test/test_structured_2d.jl
+++ b/test/test_structured_2d.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "structured_2d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "structured_2d_dgsem")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"

--- a/test/test_structured_3d.jl
+++ b/test/test_structured_3d.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "structured_3d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "structured_3d_dgsem")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"

--- a/test/test_structured_3d.jl
+++ b/test/test_structured_3d.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "structured_3d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "structured_3d_dgsem")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"

--- a/test/test_tree_1d.jl
+++ b/test/test_tree_1d.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_1d_dgsem")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"

--- a/test/test_tree_1d.jl
+++ b/test/test_tree_1d.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"

--- a/test/test_tree_1d_advection.jl
+++ b/test/test_tree_1d_advection.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_1d_dgsem")
 
 @testset "Linear scalar advection" begin
   @trixi_testset "elixir_advection_basic.jl" begin

--- a/test/test_tree_1d_advection.jl
+++ b/test/test_tree_1d_advection.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
 
 @testset "Linear scalar advection" begin
   @trixi_testset "elixir_advection_basic.jl" begin

--- a/test/test_tree_1d_burgers.jl
+++ b/test/test_tree_1d_burgers.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_1d_dgsem")
 
 @testset "Inviscid Burgers" begin
   @trixi_testset "elixir_burgers_basic.jl" begin

--- a/test/test_tree_1d_burgers.jl
+++ b/test/test_tree_1d_burgers.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
 
 @testset "Inviscid Burgers" begin
   @trixi_testset "elixir_burgers_basic.jl" begin

--- a/test/test_tree_1d_euler.jl
+++ b/test/test_tree_1d_euler.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
 
 @testset "Compressible Euler" begin
   @trixi_testset "elixir_euler_source_terms.jl" begin

--- a/test/test_tree_1d_euler.jl
+++ b/test/test_tree_1d_euler.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_1d_dgsem")
 
 @testset "Compressible Euler" begin
   @trixi_testset "elixir_euler_source_terms.jl" begin

--- a/test/test_tree_1d_eulergravity.jl
+++ b/test/test_tree_1d_eulergravity.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_1d_dgsem")
 
 @testset "Compressible Euler with self-gravity" begin
   @trixi_testset "elixir_eulergravity_convergence.jl" begin

--- a/test/test_tree_1d_eulergravity.jl
+++ b/test/test_tree_1d_eulergravity.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
 
 @testset "Compressible Euler with self-gravity" begin
   @trixi_testset "elixir_eulergravity_convergence.jl" begin

--- a/test/test_tree_1d_eulermulti.jl
+++ b/test/test_tree_1d_eulermulti.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
 
 @testset "Compressible Euler Multicomponent" begin
 

--- a/test/test_tree_1d_eulermulti.jl
+++ b/test/test_tree_1d_eulermulti.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_1d_dgsem")
 
 @testset "Compressible Euler Multicomponent" begin
 

--- a/test/test_tree_1d_fdsbp.jl
+++ b/test/test_tree_1d_fdsbp.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1d_fdsbp")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_fdsbp")
 
 @testset "Inviscid Burgers" begin
   @trixi_testset "elixir_burgers_basic.jl" begin

--- a/test/test_tree_1d_fdsbp.jl
+++ b/test/test_tree_1d_fdsbp.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_fdsbp")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_1d_fdsbp")
 
 @testset "Inviscid Burgers" begin
   @trixi_testset "elixir_burgers_basic.jl" begin

--- a/test/test_tree_1d_hypdiff.jl
+++ b/test/test_tree_1d_hypdiff.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
 
 @testset "Hyperbolic diffusion" begin
 

--- a/test/test_tree_1d_hypdiff.jl
+++ b/test/test_tree_1d_hypdiff.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_1d_dgsem")
 
 @testset "Hyperbolic diffusion" begin
 

--- a/test/test_tree_1d_mhd.jl
+++ b/test/test_tree_1d_mhd.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
 
 @testset "MHD" begin
 

--- a/test/test_tree_1d_mhd.jl
+++ b/test/test_tree_1d_mhd.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_1d_dgsem")
 
 @testset "MHD" begin
 

--- a/test/test_tree_1d_mhdmulti.jl
+++ b/test/test_tree_1d_mhdmulti.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_1d_dgsem")
 
 @testset "MHD Multicomponent" begin
 

--- a/test/test_tree_1d_mhdmulti.jl
+++ b/test/test_tree_1d_mhdmulti.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
 
 @testset "MHD Multicomponent" begin
 

--- a/test/test_tree_1d_shallowwater.jl
+++ b/test/test_tree_1d_shallowwater.jl
@@ -5,7 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_1d_dgsem")
 
 @testset "Shallow Water" begin
   @trixi_testset "elixir_shallowwater_ec.jl" begin

--- a/test/test_tree_1d_shallowwater.jl
+++ b/test/test_tree_1d_shallowwater.jl
@@ -5,7 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
 
 @testset "Shallow Water" begin
   @trixi_testset "elixir_shallowwater_ec.jl" begin

--- a/test/test_tree_1d_shallowwater_twolayer.jl
+++ b/test/test_tree_1d_shallowwater_twolayer.jl
@@ -5,7 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
 
 @testset "Shallow Water Two layer" begin
   @trixi_testset "elixir_shallowwater_twolayer_convergence.jl" begin
@@ -20,7 +20,7 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1
   @trixi_testset "elixir_shallowwater_twolayer_convergence.jl with flux_es_fjordholm_etal" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_shallowwater_twolayer_convergence.jl"),
     l2    = [0.0027681377074701345, 0.0018007543202559165, 0.0028036917433720576,
-             0.0013980358596935737, 0.0004744186597732706], 
+             0.0013980358596935737, 0.0004744186597732706],
     linf  = [0.005699303919826093, 0.006432952918256296, 0.0058507082844360125, 0.002717615543961216,
              0.0008992474511784199],
     surface_flux=(flux_es_fjordholm_etal, flux_nonconservative_fjordholm_etal),
@@ -38,8 +38,8 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_1
 
   @trixi_testset "elixir_shallowwater_twolayer_dam_break.jl with flux_lax_friedrichs" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_shallowwater_twolayer_dam_break.jl"),
-    l2    = [0.35490827242437256, 1.6715402155795918, 0.6960264969949427, 
-             0.9351481433409805, 0.7938172946965545], 
+    l2    = [0.35490827242437256, 1.6715402155795918, 0.6960264969949427,
+             0.9351481433409805, 0.7938172946965545],
     linf  = [0.6417127471419837, 1.9742107034120873, 1.135774587483082, 1.236125279347084, 1.1],
     surface_flux = (flux_lax_friedrichs, flux_nonconservative_fjordholm_etal),
     tspan = (0.0, 0.25))

--- a/test/test_tree_1d_shallowwater_twolayer.jl
+++ b/test/test_tree_1d_shallowwater_twolayer.jl
@@ -5,7 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_1d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_1d_dgsem")
 
 @testset "Shallow Water Two layer" begin
   @trixi_testset "elixir_shallowwater_twolayer_convergence.jl" begin

--- a/test/test_tree_2d_acoustics.jl
+++ b/test/test_tree_2d_acoustics.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
 
 @testset "Acoustic Perturbation" begin
   @trixi_testset "elixir_acoustics_convergence.jl" begin

--- a/test/test_tree_2d_acoustics.jl
+++ b/test/test_tree_2d_acoustics.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_2d_dgsem")
 
 @testset "Acoustic Perturbation" begin
   @trixi_testset "elixir_acoustics_convergence.jl" begin

--- a/test/test_tree_2d_advection.jl
+++ b/test/test_tree_2d_advection.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_2d_dgsem")
 
 @testset "Linear scalar advection" begin
   @trixi_testset "elixir_advection_basic.jl" begin

--- a/test/test_tree_2d_advection.jl
+++ b/test/test_tree_2d_advection.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
 
 @testset "Linear scalar advection" begin
   @trixi_testset "elixir_advection_basic.jl" begin

--- a/test/test_tree_2d_euler.jl
+++ b/test/test_tree_2d_euler.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
 
 @testset "Compressible Euler" begin
   @trixi_testset "elixir_euler_source_terms.jl" begin

--- a/test/test_tree_2d_euler.jl
+++ b/test/test_tree_2d_euler.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_2d_dgsem")
 
 @testset "Compressible Euler" begin
   @trixi_testset "elixir_euler_source_terms.jl" begin

--- a/test/test_tree_2d_eulermulti.jl
+++ b/test/test_tree_2d_eulermulti.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
 
 @testset "Compressible Euler Multicomponent" begin
   # NOTE: Some of the L2/Linf errors are comparably large. This is due to the fact that some of the

--- a/test/test_tree_2d_eulermulti.jl
+++ b/test/test_tree_2d_eulermulti.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_2d_dgsem")
 
 @testset "Compressible Euler Multicomponent" begin
   # NOTE: Some of the L2/Linf errors are comparably large. This is due to the fact that some of the

--- a/test/test_tree_2d_fdsbp.jl
+++ b/test/test_tree_2d_fdsbp.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_fdsbp")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_fdsbp")
 
 @testset "Linear scalar advection" begin
   @trixi_testset "elixir_advection_extended.jl" begin

--- a/test/test_tree_2d_fdsbp.jl
+++ b/test/test_tree_2d_fdsbp.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_fdsbp")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_2d_fdsbp")
 
 @testset "Linear scalar advection" begin
   @trixi_testset "elixir_advection_extended.jl" begin

--- a/test/test_tree_2d_hypdiff.jl
+++ b/test/test_tree_2d_hypdiff.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_2d_dgsem")
 
 @testset "Hyperbolic diffusion" begin
   @trixi_testset "elixir_hypdiff_lax_friedrichs.jl" begin

--- a/test/test_tree_2d_hypdiff.jl
+++ b/test/test_tree_2d_hypdiff.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
 
 @testset "Hyperbolic diffusion" begin
   @trixi_testset "elixir_hypdiff_lax_friedrichs.jl" begin

--- a/test/test_tree_2d_lbm.jl
+++ b/test/test_tree_2d_lbm.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_2d_dgsem")
 
 @testset "Lattice-Boltzmann" begin
   @trixi_testset "elixir_lbm_constant.jl" begin

--- a/test/test_tree_2d_lbm.jl
+++ b/test/test_tree_2d_lbm.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
 
 @testset "Lattice-Boltzmann" begin
   @trixi_testset "elixir_lbm_constant.jl" begin

--- a/test/test_tree_2d_linearizedeuler.jl
+++ b/test/test_tree_2d_linearizedeuler.jl
@@ -4,8 +4,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_2d_dgsem")
 
 @testset "Linearized Euler Equations 2D" begin
   @trixi_testset "elixir_linearizedeuler_convergence.jl" begin

--- a/test/test_tree_2d_linearizedeuler.jl
+++ b/test/test_tree_2d_linearizedeuler.jl
@@ -5,7 +5,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
 
 @testset "Linearized Euler Equations 2D" begin
   @trixi_testset "elixir_linearizedeuler_convergence.jl" begin

--- a/test/test_tree_2d_mhd.jl
+++ b/test/test_tree_2d_mhd.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
 
 @testset "MHD" begin
   @trixi_testset "elixir_mhd_alfven_wave.jl" begin

--- a/test/test_tree_2d_mhd.jl
+++ b/test/test_tree_2d_mhd.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_2d_dgsem")
 
 @testset "MHD" begin
   @trixi_testset "elixir_mhd_alfven_wave.jl" begin

--- a/test/test_tree_2d_mhdmulti.jl
+++ b/test/test_tree_2d_mhdmulti.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_2d_dgsem")
 
 @testset "MHD Multicomponent" begin
 

--- a/test/test_tree_2d_mhdmulti.jl
+++ b/test/test_tree_2d_mhdmulti.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
 
 @testset "MHD Multicomponent" begin
 

--- a/test/test_tree_2d_part1.jl
+++ b/test/test_tree_2d_part1.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"

--- a/test/test_tree_2d_part1.jl
+++ b/test/test_tree_2d_part1.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_2d_dgsem")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"

--- a/test/test_tree_3d_advection.jl
+++ b/test/test_tree_3d_advection.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_3d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_3d_dgsem")
 
 @testset "Linear scalar advection" begin
   @trixi_testset "elixir_advection_basic.jl" begin
@@ -48,7 +48,7 @@ EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_3
       l2   = [0.001810141301577316],
       linf = [0.017848192256602058])
 
-    # Ensure that we do not have excessive memory allocations 
+    # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     let
       t = sol.t[end]

--- a/test/test_tree_3d_advection.jl
+++ b/test/test_tree_3d_advection.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_3d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_3d_dgsem")
 
 @testset "Linear scalar advection" begin
   @trixi_testset "elixir_advection_basic.jl" begin

--- a/test/test_tree_3d_euler.jl
+++ b/test/test_tree_3d_euler.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_3d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_3d_dgsem")
 
 @testset "Compressible Euler" begin
   @trixi_testset "elixir_euler_source_terms.jl" begin

--- a/test/test_tree_3d_euler.jl
+++ b/test/test_tree_3d_euler.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_3d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_3d_dgsem")
 
 @testset "Compressible Euler" begin
   @trixi_testset "elixir_euler_source_terms.jl" begin

--- a/test/test_tree_3d_eulergravity.jl
+++ b/test/test_tree_3d_eulergravity.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_3d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_3d_dgsem")
 
 @testset "Compressible Euler with self-gravity" begin
   @trixi_testset "elixir_eulergravity_convergence.jl" begin

--- a/test/test_tree_3d_eulergravity.jl
+++ b/test/test_tree_3d_eulergravity.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_3d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_3d_dgsem")
 
 @testset "Compressible Euler with self-gravity" begin
   @trixi_testset "elixir_eulergravity_convergence.jl" begin

--- a/test/test_tree_3d_fdsbp.jl
+++ b/test/test_tree_3d_fdsbp.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_3d_fdsbp")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_3d_fdsbp")
 
 @testset "Compressible Euler" begin
   @trixi_testset "elixir_euler_convergence.jl" begin

--- a/test/test_tree_3d_fdsbp.jl
+++ b/test/test_tree_3d_fdsbp.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_3d_fdsbp")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_3d_fdsbp")
 
 @testset "Compressible Euler" begin
   @trixi_testset "elixir_euler_convergence.jl" begin

--- a/test/test_tree_3d_hypdiff.jl
+++ b/test/test_tree_3d_hypdiff.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_3d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_3d_dgsem")
 
 @testset "Hyperbolic diffusion" begin
   @trixi_testset "elixir_hypdiff_lax_friedrichs.jl" begin

--- a/test/test_tree_3d_hypdiff.jl
+++ b/test/test_tree_3d_hypdiff.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_3d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_3d_dgsem")
 
 @testset "Hyperbolic diffusion" begin
   @trixi_testset "elixir_hypdiff_lax_friedrichs.jl" begin

--- a/test/test_tree_3d_lbm.jl
+++ b/test/test_tree_3d_lbm.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_3d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_3d_dgsem")
 
 @testset "Lattice-Boltzmann" begin
   @trixi_testset "elixir_lbm_constant.jl" begin

--- a/test/test_tree_3d_lbm.jl
+++ b/test/test_tree_3d_lbm.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_3d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_3d_dgsem")
 
 @testset "Lattice-Boltzmann" begin
   @trixi_testset "elixir_lbm_constant.jl" begin

--- a/test/test_tree_3d_mhd.jl
+++ b/test/test_tree_3d_mhd.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_3d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_3d_dgsem")
 
 @testset "MHD" begin
   @trixi_testset "elixir_mhd_ec.jl" begin

--- a/test/test_tree_3d_mhd.jl
+++ b/test/test_tree_3d_mhd.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_3d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_3d_dgsem")
 
 @testset "MHD" begin
   @trixi_testset "elixir_mhd_ec.jl" begin

--- a/test/test_unstructured_2d.jl
+++ b/test/test_unstructured_2d.jl
@@ -5,8 +5,7 @@ using Trixi
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "unstructured_2d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "unstructured_2d_dgsem")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"

--- a/test/test_unstructured_2d.jl
+++ b/test/test_unstructured_2d.jl
@@ -6,7 +6,7 @@ using Trixi
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "unstructured_2d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "unstructured_2d_dgsem")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"
@@ -160,7 +160,7 @@ isdir(outdir) && rm(outdir, recursive=true)
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_shallowwater_twolayer_convergence.jl"),
       l2    = [0.0007953969898161991, 0.00882074628714633, 0.0024322572528892934,
                0.0007597425017400447, 0.004501238950166439, 0.0015784803573661104,
-               6.849532064729749e-6], 
+               6.849532064729749e-6],
       linf  = [0.00592559068081977, 0.08072451118697077, 0.0344854497419107, 0.005892196680485795,
                0.04262651217675306, 0.014006223513881366, 2.5829318284764646e-5],
       tspan = (0.0, 0.25))
@@ -168,8 +168,8 @@ isdir(outdir) && rm(outdir, recursive=true)
 
   @trixi_testset "elixir_shallowwater_twolayer_well_balanced.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_shallowwater_twolayer_well_balanced.jl"),
-      l2    = [4.706532184998499e-16, 1.1215950712872183e-15, 6.7822712922421565e-16, 
-               0.002192812926266047, 5.506855295923691e-15, 3.3105180099689275e-15, 
+      l2    = [4.706532184998499e-16, 1.1215950712872183e-15, 6.7822712922421565e-16,
+               0.002192812926266047, 5.506855295923691e-15, 3.3105180099689275e-15,
                0.0021928129262660085],
       linf  = [4.468647674116255e-15, 1.3607872120431166e-14, 9.557155049520056e-15,
                0.024280130945632084, 6.68910907640583e-14, 4.7000983997100496e-14,
@@ -179,7 +179,7 @@ isdir(outdir) && rm(outdir, recursive=true)
 
   @trixi_testset "elixir_shallowwater_twolayer_dam_break.jl with flux_lax_friedrichs" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_shallowwater_twolayer_dam_break.jl"),
-      l2    = [0.012471300561905669, 0.012363413819726868, 0.0009541478004413331, 
+      l2    = [0.012471300561905669, 0.012363413819726868, 0.0009541478004413331,
                0.09120260327331643, 0.015269590815749993, 0.0012064657396853422,
                0.09991983966647647],
       linf  = [0.04497814714937959, 0.03286959000796511, 0.010746094385294369,

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -12,7 +12,7 @@ using CairoMakie
 include("test_trixi.jl")
 
 # pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pathof(Trixi) |> dirname |> dirname, "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -11,8 +11,7 @@ using CairoMakie
 
 include("test_trixi.jl")
 
-# pathof(Trixi) returns /path/to/Trixi.jl/src/Trixi.jl, dirname gives the parent directory
-EXAMPLES_DIR = joinpath(pkgdir(Trixi), "examples", "tree_2d_dgsem")
+EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_2d_dgsem")
 
 # Start with a clean environment: remove Trixi.jl output directory if it exists
 outdir = "out"


### PR DESCRIPTION
I just came across `pkgdir` and thought it would be nice to simplify this pattern we used quite a lot:

```julia
help?> pkgdir
search: pkgdir

  pkgdir(m::Module[, paths::String...])

  Return the root directory of the package that imported module m, or nothing if m was not imported from a
  package. Optionally further path component strings can be provided to construct a path within the package
  root.

  To get the root directory of the package that imported the current module the form pkgdir(@__MODULE__) can be
  used.

  julia> pkgdir(Foo)
  "/path/to/Foo.jl"
  
  julia> pkgdir(Foo, "src", "file.jl")
  "/path/to/Foo.jl/src/file.jl"

  │ Julia 1.7
  │
  │  The optional argument paths requires at least Julia 1.7.

```