### PR TITLE
Check MPI CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,41 +59,41 @@ jobs:
         arch:
           - x64
         trixi_test:
-          - tree_part1
-          - tree_part2
-          - tree_part3
-          - tree_part4
-          - tree_part5
-          - tree_part6
-          - structured
-          - p4est_part1
-          - p4est_part2
-          - unstructured_dgmulti
-          - parabolic
-          - paper_self_gravitating_gas_dynamics
-          - misc_part1
-          - misc_part2
-          - performance_specializations_part1
-          - performance_specializations_part2
+          # - tree_part1
+          # - tree_part2
+          # - tree_part3
+          # - tree_part4
+          # - tree_part5
+          # - tree_part6
+          # - structured
+          # - p4est_part1
+          # - p4est_part2
+          # - unstructured_dgmulti
+          # - parabolic
+          # - paper_self_gravitating_gas_dynamics
+          # - misc_part1
+          # - misc_part2
+          # - performance_specializations_part1
+          # - performance_specializations_part2
           - mpi
-          - threaded
+          # - threaded
         include:
           - version: '1.8'
             os: macOS-latest
             arch: x64
             trixi_test: mpi
-          - version: '1.8'
-            os: macOS-latest
-            arch: x64
-            trixi_test: threaded
+          # - version: '1.8'
+          #   os: macOS-latest
+          #   arch: x64
+          #   trixi_test: threaded
           - version: '1.8'
             os: windows-latest
             arch: x64
             trixi_test: mpi
-          - version: '1.8'
-            os: windows-latest
-            arch: x64
-            trixi_test: threaded
+          # - version: '1.8'
+          #   os: windows-latest
+          #   arch: x64
+          #   trixi_test: threaded
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -1,6 +1,6 @@
 """
     Trixi
-
+ 
 **Trixi.jl** is a numerical simulation framework for hyperbolic conservation
 laws. A key objective for the framework is to be useful to both scientists
 and students. Therefore, next to having an extensible design with a fast


### PR DESCRIPTION
The first commit uses MPI.jl v0.20.8 and fails with
```
[ Info: Testset elixir_advection_restart.jl finished in 2.992906955 seconds.
WARNING: replacing module TrixiTestModule.
════════════════════════════════════════════════════════════════════════════════════════════════════
/home/runner/work/Trixi.jl/Trixi.jl/examples/p4est_3d_dgsem/elixir_advection_cubed_sphere.jl

signal (15): Terminated
in expression starting at /home/runner/work/Trixi.jl/Trixi.jl/test/runtests.jl:9

signal (15): Terminated
in expression starting at /home/runner/work/_actions/julia-actions/julia-runtest/v1/test_harness.jl:7
epoll_wait at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
epoll_wait at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)

===================================================================================
=   BAD TERMINATION OF ONE OF YOUR APPLICATION PROCESSES
=   PID 3335 RUNNING AT fv-az444-724
=   EXIT CODE: 9
=   CLEANING UP REMAINING PROCESSES
=   YOU CAN IGNORE THE BELOW CLEANUP MESSAGES
===================================================================================
YOUR APPLICATION TERMINATED WITH THE EXIT STRING: Killed (signal 9)
This typically refers to a problem with your application.
Please see the FAQ page for debugging suggestions
Error: The operation was canceled.
```
https://github.com/trixi-framework/Trixi.jl/actions/runs/4966630518/jobs/8888172828?pr=1461#step:7:10165