### PR TITLE
precompile tweaks

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -272,15 +272,17 @@ function __init__()
   #       https://github.com/JuliaLang/julia/issues/32552
   #       https://github.com/JuliaLang/julia/issues/41740
   # See also https://discourse.julialang.org/t/performance-depends-dramatically-on-compilation-order/58425
-  let
-    for T in (Float32, Float64)
-      u_mortars_2d = zeros(T, 2, 2, 2, 2, 2)
-      u_view_2d = view(u_mortars_2d, 1, :, 1, :, 1)
-      LoopVectorization.axes(u_view_2d)
+  if VERSION < v"1.9.0"
+    let
+      for T in (Float32, Float64)
+        u_mortars_2d = zeros(T, 2, 2, 2, 2, 2)
+        u_view_2d = view(u_mortars_2d, 1, :, 1, :, 1)
+        LoopVectorization.axes(u_view_2d)
 
-      u_mortars_3d = zeros(T, 2, 2, 2, 2, 2, 2)
-      u_view_3d = view(u_mortars_3d, 1, :, 1, :, :, 1)
-      LoopVectorization.axes(u_view_3d)
+        u_mortars_3d = zeros(T, 2, 2, 2, 2, 2, 2)
+        u_view_3d = view(u_mortars_3d, 1, :, 1, :, :, 1)
+        LoopVectorization.axes(u_view_3d)
+      end
     end
   end
 end

--- a/src/auxiliary/precompile.jl
+++ b/src/auxiliary/precompile.jl
@@ -460,6 +460,9 @@ function _precompile_manual_()
     @assert Base.precompile(Tuple{typeof(trixi_include),String})
   end
 
+  @assert Base.precompile(Tuple{typeof(init_mpi)})
+  @assert Base.precompile(Tuple{typeof(init_p4est)})
+
   # The following precompile statements do not seem to be taken
   # # `multiply_dimensionwise!` as used in the analysis callback
   # for RealT in (Float64,)


### PR DESCRIPTION
I added precompile statements for `init_mpi` and `init_p4est`. I also checked that the hacky workaround to compile stuff in `__init__` is not required in Julia v1.9.0 anymore - removing it reduces the loading time of Trixi.jl reported by `@time_imports` by roughly 30% (note that this is only the loading time taken by Trixi.jl itself, not its dependencies)