### PR TITLE
Add `@autoinfiltrate` for simple, ad-hoc interactive debugging

### DIFF
--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -256,17 +256,13 @@ Breakpoints can be set by adding a line with the ```@infiltrate``` macro at the 
 in the code. Use [Revise](@ref interactive-use-of-julia) if you want to set and delete breakpoints
 in your package without having to restart Julia.
 
-!!! note
-    When running Julia inside a package environment, the ```@infiltrate``` macro only works if `Infiltrator`
-    has been added to the dependencies. Another work around when using Revise is to first load the
-    package and then add breakpoints with `Main.@infiltrate` to the code. If this is not
-    desired, the functional form
-    ```julia
-    if isdefined(Main, :Infiltrator)
-      Main.Infiltrator.infiltrate(@__MODULE__, Base.@locals, @__FILE__, @__LINE__)
-    end
-    ```
-    can be used to set breakpoints when working with Trixi.jl or other packages.
+!!! note "Use `@autoinfiltrate` when debugging Trixi.jl"
+    When running Julia inside a package environment, e.g., inside the source
+    code of Trixi.jl itself, the `@infiltrate` macro only works if
+    `Infiltrator` has been added to the package dependencies. To avoid this,
+    you can use the (non-exported) [`@autoinfiltrate`](@ref) macro
+    in Trixi.jl, which only requires Infiltrator.jl to be available in the
+    current environment stack and will auto-load it for you.
 
 Triggering the breakpoint starts a REPL session where it is possible to interact with the current
 local scope. Possible commands are:

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -327,7 +327,7 @@ macro autoinfiltrate(condition = true)
     :macrocall,
     Expr(:., i, QuoteNode(Symbol("@infiltrate"))),
     lnn,
-    condition
+    esc(condition)
   )
 end
 

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -1,13 +1,8 @@
-# By default, Julia/LLVM does not use fused multiply-add operations (FMAs).
-# Since these FMAs can increase the performance of many numerical algorithms,
-# we need to opt-in explicitly.
-# See https://ranocha.de/blog/Optimizing_EC_Trixi for further details.
-@muladd begin
-
+# The following statements below outside the `@muladd begin ... end` block, as otherwise
+# Revise.jl might be broken
 
 include("containers.jl")
 include("math.jl")
-
 
 # Enable debug timings `@trixi_timeit timer() "name" stuff...`.
 # This allows us to disable timings completely by executing
@@ -21,6 +16,13 @@ const main_timer = TimerOutput()
 
 # Always call timer() to hide implementation details
 timer() = main_timer
+
+
+# By default, Julia/LLVM does not use fused multiply-add operations (FMAs).
+# Since these FMAs can increase the performance of many numerical algorithms,
+# we need to opt-in explicitly.
+# See https://ranocha.de/blog/Optimizing_EC_Trixi for further details.
+@muladd begin
 
 
 """
@@ -276,6 +278,57 @@ macro trixi_timeit(timer_output, label, expr)
     end
     val
   end
+end
+
+
+"""
+    @autoinfiltrate
+    @autoinfiltrate condition::Bool
+
+Invoke the `@infiltrate` macro of the package Infiltrator.jl to create a breakpoint for ad-hoc
+interactive debugging in the REPL. If the optional argument `condition` is given, the breakpoint is
+only enabled if `condition` evaluates to `true`.
+
+As opposed to using `Infiltrator.@infiltrate` directly, this macro does not require Infiltrator.jl
+to be added as a dependency to Trixi.jl. As a bonus, the macro will also attempt to load the
+Infiltrator module if it has not yet been loaded manually.
+
+Note: For this macro to work, the Infiltrator.jl package needs to be installed in your current Julia
+environment stack.
+
+See also: [Infiltrator.jl](https://github.com/JuliaDebug/Infiltrator.jl)
+
+!!! warning "Internal use only"
+    Please note that this macro is intended for internal use only. It is *not* part of the public
+    API of Trixi.jl, and it thus can altered (or be removed) at any time without it being considered
+    a breaking change.
+"""
+macro autoinfiltrate(condition = true)
+  pkgid = Base.PkgId(Base.UUID("5903a43b-9cc3-4c30-8d17-598619ec4e9b"), "Infiltrator")
+  if !haskey(Base.loaded_modules, pkgid)
+    try
+      Base.eval(Main, :(using Infiltrator))
+    catch err
+      @error "Cannot load Infiltrator.jl. Make sure it is included in your environment stack."
+    end
+  end
+  i = get(Base.loaded_modules, pkgid, nothing)
+  lnn = LineNumberNode(__source__.line, __source__.file)
+
+  if i === nothing
+    return Expr(
+      :macrocall,
+      Symbol("@warn"),
+      lnn,
+      "Could not load Infiltrator.")
+  end
+
+  return Expr(
+    :macrocall,
+    Expr(:., i, QuoteNode(Symbol("@infiltrate"))),
+    lnn,
+    condition
+  )
 end
 
 


### PR DESCRIPTION
Based on https://github.com/JuliaDebug/Infiltrator.jl#auto-loading-infiltratorjl ([permalink](https://github.com/JuliaDebug/Infiltrator.jl/blob/6d83c8f6053f8c4acb4a1d860ab32b02d6b69e72/README.md?plain=1#L54-L89)).

Closes #1460.