### PR TITLE
Fix broken ref in documentation

### DIFF
--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -260,7 +260,7 @@ in your package without having to restart Julia.
     When running Julia inside a package environment, e.g., inside the source
     code of Trixi.jl itself, the `@infiltrate` macro only works if
     `Infiltrator` has been added to the package dependencies. To avoid this,
-    you can use the (non-exported) [`@autoinfiltrate`](@ref) macro
+    you can use the (non-exported) `@autoinfiltrate` macro
     in Trixi.jl, which only requires Infiltrator.jl to be available in the
     current environment stack and will auto-load it for you.
 


### PR DESCRIPTION
Fixes #1468.

I couldn't figure out what was wrong with the original ref. It turns out, other macro refs (I tested, e.g., `@threaded`) fail with the same error message, thus I'm wondering if this is a Documenter.jl issue. I do not have time to investigate this right now, though.