### PR TITLE
remove unused function `mpi_isparallel`

### DIFF
--- a/src/auxiliary/mpi.jl
+++ b/src/auxiliary/mpi.jl
@@ -45,18 +45,6 @@ const MPI_IS_ROOT = Ref(true)
 
 @inline mpi_isparallel() = MPI_IS_PARALLEL[]
 
-# This is not type-stable but that's okay since we want to get rid of it anyway
-# and it's not used in performance-critical parts. The alternative we used before,
-# calling something like `eval(:(mpi_parallel() = True()))` in `init_mpi()`,
-# causes invalidations and slows down the first call to Trixi.jl.
-function mpi_parallel()
-  if mpi_isparallel()
-    return True()
-  else
-    return False()
-  end
-end
-
 @inline mpi_isroot() = MPI_IS_ROOT[]
 
 @inline mpi_root() = 0


### PR DESCRIPTION
I had a look at coverage reports (since CI passes on `main` :partying_face:) and noticed that this function is never used.