### PR TITLE
Adding an error message for TreeMesh3D with MPI

### DIFF
--- a/src/meshes/tree_mesh.jl
+++ b/src/meshes/tree_mesh.jl
@@ -111,6 +111,10 @@ function TreeMesh(coordinates_min::NTuple{NDIMS,Real}, coordinates_max::NTuple{N
 
   # TODO: MPI, create nice interface for a parallel tree/mesh
   if mpi_isparallel()
+    if mpi_isroot() && NDIMS == 3
+      println(stderr, "ERROR: TreeMesh3D does not support parallel execution with MPI")
+      MPI.Abort(mpi_comm(), 1)
+    end
     TreeType = ParallelTree{NDIMS}
   else
     TreeType = SerialTree{NDIMS}


### PR DESCRIPTION
I added easy understandable error message in case of execution an elixir using TreeMesh3D with MPI. See #1488 
Test: 
```
mpiexec() do cmd
	run(`$cmd -n 3 $(Base.julia_cmd()) --threads=1 --project=Trixi.jl.my/run -e 'using Trixi; trixi_include(joinpath(examples_dir(), "tree_3d_dgsem","elixir_advection_basic.jl"))'`)
end
```
Now it gives an Error at stage of creating TreeMesh:
```
ERROR: TreeMesh3D does not support parallel execution with MPI

job aborted:
[ranks] message

[0] application aborted
aborting MPI_COMM_WORLD (comm=0x44000000), error 1, comm rank 0
```
Before changes was long and not really helpful report:
```
LoadError: type NamedTuple has no field mpi_cache
Stacktrace:
  [1] getproperty
    @ .\Base.jl:38 [inlined]
  [2] nelementsglobal
    @ D:\work\Trixi.jl.my\src\solvers\dg.jl:444 [inlined]
  [3] ndofsglobal
    @ D:\work\Trixi.jl.my\src\solvers\dg.jl:387 [inlined]
....
```