### PR TITLE
Change parabolic `apply_jacobian!` to `apply_jacobian_parabolic!`

### DIFF
--- a/src/solvers/dgsem_tree/dg_1d_parabolic.jl
+++ b/src/solvers/dgsem_tree/dg_1d_parabolic.jl
@@ -73,7 +73,7 @@ function rhs_parabolic!(du, u, t, mesh::TreeMesh{1}, equations_parabolic::Abstra
     du, u, mesh, equations_parabolic, dg.surface_integral, dg, cache_parabolic)
 
   # Apply Jacobian from mapping to reference element
-  @trixi_timeit timer() "Jacobian" apply_jacobian!(
+  @trixi_timeit timer() "Jacobian" apply_jacobian_parabolic!(
     du, mesh, equations_parabolic, dg, cache_parabolic)
 
   return nothing
@@ -483,7 +483,7 @@ end
 # This is because the parabolic fluxes are assumed to be of the form
 #   `du/dt + df/dx = dg/dx + source(x,t)`,
 # where f(u) is the inviscid flux and g(u) is the viscous flux.
-function apply_jacobian!(du, mesh::TreeMesh{1},
+function apply_jacobian_parabolic!(du, mesh::TreeMesh{1},
                          equations::AbstractEquationsParabolic, dg::DG, cache)
 
   @threaded for element in eachelement(dg, cache)

--- a/src/solvers/dgsem_tree/dg_1d_parabolic.jl
+++ b/src/solvers/dgsem_tree/dg_1d_parabolic.jl
@@ -444,7 +444,7 @@ function calc_gradient!(gradients, u_transformed, t,
 
   # Apply Jacobian from mapping to reference element
   @trixi_timeit timer() "Jacobian" begin
-    apply_jacobian!(gradients, mesh, equations_parabolic, dg, cache_parabolic)
+    apply_jacobian_parabolic!(gradients, mesh, equations_parabolic, dg, cache_parabolic)
   end
 
   return nothing

--- a/src/solvers/dgsem_tree/dg_1d_parabolic.jl
+++ b/src/solvers/dgsem_tree/dg_1d_parabolic.jl
@@ -484,7 +484,7 @@ end
 #   `du/dt + df/dx = dg/dx + source(x,t)`,
 # where f(u) is the inviscid flux and g(u) is the viscous flux.
 function apply_jacobian_parabolic!(du, mesh::TreeMesh{1},
-                         equations::AbstractEquationsParabolic, dg::DG, cache)
+                                   equations::AbstractEquationsParabolic, dg::DG, cache)
 
   @threaded for element in eachelement(dg, cache)
     factor = cache.elements.inverse_jacobian[element]

--- a/src/solvers/dgsem_tree/dg_2d_parabolic.jl
+++ b/src/solvers/dgsem_tree/dg_2d_parabolic.jl
@@ -76,7 +76,7 @@ function rhs_parabolic!(du, u, t, mesh::TreeMesh{2}, equations_parabolic::Abstra
     du, u, mesh, equations_parabolic, dg.surface_integral, dg, cache_parabolic)
 
   # Apply Jacobian from mapping to reference element
-  @trixi_timeit timer() "Jacobian" apply_jacobian!(
+  @trixi_timeit timer() "Jacobian" apply_jacobian_parabolic!(
     du, mesh, equations_parabolic, dg, cache_parabolic)
 
   return nothing
@@ -540,8 +540,8 @@ function calc_gradient!(gradients, u_transformed, t,
 
   # Apply Jacobian from mapping to reference element
   @trixi_timeit timer() "Jacobian" begin
-    apply_jacobian!(gradients_x, mesh, equations_parabolic, dg, cache_parabolic)
-    apply_jacobian!(gradients_y, mesh, equations_parabolic, dg, cache_parabolic)
+    apply_jacobian_parabolic!(gradients_x, mesh, equations_parabolic, dg, cache_parabolic)
+    apply_jacobian_parabolic!(gradients_y, mesh, equations_parabolic, dg, cache_parabolic)
   end
 
   return nothing
@@ -586,8 +586,8 @@ end
 # This is because the parabolic fluxes are assumed to be of the form
 #   `du/dt + df/dx = dg/dx + source(x,t)`,
 # where f(u) is the inviscid flux and g(u) is the viscous flux.
-function apply_jacobian!(du, mesh::TreeMesh{2},
-                         equations::AbstractEquationsParabolic, dg::DG, cache)
+function apply_jacobian_parabolic!(du, mesh::TreeMesh{2},
+                                   equations::AbstractEquationsParabolic, dg::DG, cache)
 
   @threaded for element in eachelement(dg, cache)
     factor = cache.elements.inverse_jacobian[element]

--- a/src/solvers/dgsem_tree/dg_3d_parabolic.jl
+++ b/src/solvers/dgsem_tree/dg_3d_parabolic.jl
@@ -76,7 +76,7 @@ function rhs_parabolic!(du, u, t, mesh::TreeMesh{3}, equations_parabolic::Abstra
     du, u, mesh, equations_parabolic, dg.surface_integral, dg, cache_parabolic)
 
   # Apply Jacobian from mapping to reference element
-  @trixi_timeit timer() "Jacobian" apply_jacobian!(
+  @trixi_timeit timer() "Jacobian" apply_jacobian_parabolic!(
     du, mesh, equations_parabolic, dg, cache_parabolic)
 
   return nothing
@@ -601,9 +601,9 @@ function calc_gradient!(gradients, u_transformed, t,
 
   # Apply Jacobian from mapping to reference element
   @trixi_timeit timer() "Jacobian" begin
-    apply_jacobian!(gradients_x, mesh, equations_parabolic, dg, cache_parabolic)
-    apply_jacobian!(gradients_y, mesh, equations_parabolic, dg, cache_parabolic)
-    apply_jacobian!(gradients_z, mesh, equations_parabolic, dg, cache_parabolic)
+    apply_jacobian_parabolic!(gradients_x, mesh, equations_parabolic, dg, cache_parabolic)
+    apply_jacobian_parabolic!(gradients_y, mesh, equations_parabolic, dg, cache_parabolic)
+    apply_jacobian_parabolic!(gradients_z, mesh, equations_parabolic, dg, cache_parabolic)
   end
 
   return nothing
@@ -648,8 +648,8 @@ end
 # This is because the parabolic fluxes are assumed to be of the form
 #   `du/dt + df/dx = dg/dx + source(x,t)`,
 # where f(u) is the inviscid flux and g(u) is the viscous flux.
-function apply_jacobian!(du, mesh::TreeMesh{3},
-                         equations::AbstractEquationsParabolic, dg::DG, cache)
+function apply_jacobian_parabolic!(du, mesh::TreeMesh{3},
+                                   equations::AbstractEquationsParabolic, dg::DG, cache)
 
   @threaded for element in eachelement(dg, cache)
     factor = cache.elements.inverse_jacobian[element]


### PR DESCRIPTION
This PR is intended to reduce the size of #1490. 

The motivation is because editing the signature of `apply_jacobian!` https://github.com/trixi-framework/Trixi.jl/blob/f6c5bcebbe963a23cb388f83b1c7e369a3bb2c1b/src/solvers/dgsem_tree/dg_2d_parabolic.jl#LL589C1-L590C79 
```julia
function apply_jacobian!(du, mesh::TreeMesh{2},
                         equations::AbstractEquationsParabolic, dg::DG, cache)
```
to 
```julia
function apply_jacobian!(du, mesh::Union{TreeMesh{2}, P4estMesh{2}}, 
                         equations::AbstractEquationsParabolic, dg::DG, cache)
```
creates a type ambiguity with https://github.com/trixi-framework/Trixi.jl/blob/f6c5bcebbe963a23cb388f83b1c7e369a3bb2c1b/src/solvers/dgsem_structured/dg_2d.jl#L545-L547

Moreover, this makes it clearer that applying the Jacobian for parabolic equations is different from applying the Jacobian for hyperbolic equations (there is no sign flip for parabolic).