### PR TITLE
fix docstring of `iplot`

### DIFF
--- a/src/visualization/recipes_makie.jl
+++ b/src/visualization/recipes_makie.jl
@@ -148,6 +148,7 @@ Keywords:
 !!! warning "Experimental implementation"
     This is an experimental feature and may change in future releases.
 """
+function iplot end
 
 # Enables `iplot(PlotData2D(sol))`.
 function iplot(pd::PlotData2DTriangulated;


### PR DESCRIPTION
The docstring did not have a connection to the function `iplot` before.