### PR TITLE
Help user when trying to run functions from not-yet-loaded extension

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -253,6 +253,8 @@ function __init__()
 
   init_p4est()
 
+  register_error_hints()
+
   # Enable features that depend on the availability of the Plots package
   @require Plots="91a5bcdd-55d7-5caf-9e0b-520d859cae80" begin
     using .Plots: Plots

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -332,4 +332,29 @@ macro autoinfiltrate(condition = true)
 end
 
 
+# Use the *experimental* feature in `Base` to add error hints for specific errors. We use it to
+# warn users in case they try to execute functions that are extended in package extensions which
+# have not yet been loaded.
+#
+# Reference: https://docs.julialang.org/en/v1/base/base/#Base.Experimental.register_error_hint
+function register_error_hints()
+  # We follow the advice in the docs and gracefully exit without doing anything if the experimental
+  # features gets silently removed.
+  if !isdefined(Base.Experimental, :register_error_hint)
+    return nothing
+  end
+
+  Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
+    if exc.f in [iplot, iplot!] && isempty(methods(exc.f))
+      print(io, "\n$(exc.f) has no methods yet. It is part of a plotting extension of Trixi.jl " *
+                "that relies on Makie being loaded.\n" *
+                "To activate the extension, execute `using Makie`, `using CairoMakie`, " *
+                "`using GLMakie`, or load any other package that also uses Makie.")
+    end
+  end
+
+  return nothing
+end
+
+
 end # @muladd


### PR DESCRIPTION
Currently, we export `iplot` and `iplot!` as functions without methods by default, while meaningful methods are only added once a user also loads `Makie`. If someone tries to use any of these functions without `Makie `being loaded, they get a non-informative method error since no method exists (yet). This PR uses `Base.register_error_hint` to give users a clue why their call is failing and what to do to remedy it.

On `main`:
```julia
julia> using Trixi

julia> iplot(nothing)
ERROR: MethodError: no method matching iplot(::Nothing)
```

With this PR:
```julia
julia> using Trixi

julia> iplot(nothing)
ERROR: MethodError: no method matching iplot(::Nothing)
iplot has no methods yet. It is part of a plotting extension of Trixi.jl that relies on Makie being loaded.
To activate the extension, execute `using Makie`, `using CairoMakie`, `using GLMakie`, or load any other package that also uses Makie.
```

Inspired by https://github.com/jkrumbiegel/MakiePkgExtTest/blob/3fcb019c7c520aafe03fefdd52223d33923ffa52/SomePackage/src/SomePackage.jl#L27-L34. Thanks to @jkrumbiegel for providing the nice example 🙏