### PR TITLE
Optimization of AMR with MPI in case of TreeMesh

### DIFF
--- a/src/meshes/abstract_tree.jl
+++ b/src/meshes/abstract_tree.jl
@@ -593,15 +593,16 @@ function coarsen!(t::AbstractTree, cell_ids::AbstractArray{Int})
     function recv_data_new(type,src, tag)
         local length=[0]
         local n_coarsened=[0]
-        MPI.Recv!(n_coarsened,src,tag,mpi_comm())
+        status=MPI.Status
+        MPI.Recv!(n_coarsened,mpi_comm(),status;source=src,tag=tag)
         n_coarsened=n_coarsened[1]
-        MPI.Recv!(length,src,tag,mpi_comm())
+        MPI.Recv!(length,mpi_comm(),status;source=src,tag=tag)
         length=length[1]
         local t=type(length)
         t.length=length
         local recv_buf=[t.parent_ids,t.child_ids,t.neighbor_ids,t.levels,t.coordinates,t.original_cell_ids,t.mpi_ranks]
         for i in 1:7
-            MPI.Recv!(recv_buf[i],src,tag,mpi_comm())
+            MPI.Recv!(recv_buf[i],mpi_comm(),status;source=src,tag=tag)
         end
         return t, n_coarsened
     end
@@ -609,13 +610,14 @@ function coarsen!(t::AbstractTree, cell_ids::AbstractArray{Int})
     function recv_inplace_new!(t,src, tag)
         local length=[0]
         local n_coarsened=[0]
-        MPI.Recv!(n_coarsened,src,tag,mpi_comm())
+        status=MPI.Status
+        MPI.Recv!(n_coarsened,mpi_comm(),status;source=src,tag=tag)
         n_coarsened=n_coarsened[1]
-        MPI.Recv!(length,src,tag,mpi_comm())
+        MPI.Recv!(length,mpi_comm(),status;source=src,tag=tag)
         t.length=length[1]
         local recv_buf=[t.parent_ids,t.child_ids,t.neighbor_ids,t.levels,t.coordinates,t.original_cell_ids,t.mpi_ranks]
         for i in 1:7
-            MPI.Recv!(recv_buf[i],src,tag,mpi_comm())
+            MPI.Recv!(recv_buf[i],mpi_comm(),status;source=src,tag=tag)
         end
         return n_coarsened
     end

--- a/src/meshes/abstract_tree.jl
+++ b/src/meshes/abstract_tree.jl
@@ -537,7 +537,8 @@ function coarsen!(t::AbstractTree, cell_ids::AbstractArray{Int})
     end
 
     function recv_data(type,src, tag)
-        recv,_=MPI.recv(src,tag,mpi_comm())
+        status=MPI.Status
+        recv,_=MPI.recv(mpi_comm(),status;source=src,tag=tag)
         length=recv[9]
         c=type(length)
         c.parent_ids[1:length]=recv[1]
@@ -557,7 +558,8 @@ function coarsen!(t::AbstractTree, cell_ids::AbstractArray{Int})
     end
   
     function recv_inplace!(t,src, tag)
-        recv,_=MPI.recv(src,tag,mpi_comm())
+        status=MPI.Status
+        recv,_=MPI.recv(mpi_comm(),status;source=src,tag=tag)
         length=recv[9]
         t.parent_ids[1:length]=recv[1]
         t.child_ids[:,1:length]=recv[2]

--- a/src/meshes/abstract_tree.jl
+++ b/src/meshes/abstract_tree.jl
@@ -505,7 +505,7 @@ function coarsen!(t::AbstractTree, cell_ids::AbstractArray{Int})
         return Int[]
     end
 
-    criterium=(length(cell_ids)>sqrt(t.length))
+    criterium=true # (length(cell_ids)>sqrt(t.length))
     if mpi_isparallel() && criterium
          cell_ids = cell_ids[t.mpi_ranks[cell_ids].==mpi_rank()]
     end


### PR DESCRIPTION
Now if an AMRCallback wants to refine/coarse a TreeMesh, every MPI process have to do all amount of work by itself.
I started optimization with coarsen. 
Idea is to distribute cells to coarsen between all MPI ranks (to the one to which it belongs).  And then to collect the TreeMeshes from all ranks to root and join them. After completing this job, the root sends it to all other processes.
https://github.com/trixi-framework/Trixi.jl/blob/9119f8dc43f8785f4b1c3a85c00727565844d215/src/meshes/abstract_tree.jl#L502

Hotspots of this algorithm are MPI communications, that synchronize processes, so some of them have to wait others. Also to transfer a whole TreeMesh takes time and memory. I'm still looking for a way to improve efficiency of MPI communications
Algorithm of uniting TreeMeshes looks like difficult due to the specific conversion of all ids, but seems to be quite fast. 

I'm not sure that it will work for all elixirs, but I didn't found such example yet.    
Of coarse, if this algorithm will make sense in terms of efficiency, I will re-write it in more easy-to-understand way. 