### PR TITLE
Fix some typos in docs

### DIFF
--- a/docs/src/github-git.md
+++ b/docs/src/github-git.md
@@ -112,7 +112,7 @@ branch, and the corresponding pull request will be updated automatically.
 Please note that a review has nothing to do with the lack of experience of the
 person developing changes: We try to review all code before it gets added to
 `main`, even from the most experienced developers. This is good practice and
-helps to keep the error rate low while ensuring the the code is developed in a
+helps to keep the error rate low while ensuring that the code is developed in a
 consistent fashion. Furthermore, do not take criticism of your code personally -
 we just try to keep Trixi.jl as accessible and easy to use for everyone.
 
@@ -121,7 +121,7 @@ Once your branch is reviewed and declared ready for merging by the reviewer,
 make sure that all the latest changes have been pushed. Then, one of the
 developers will merge your PR. If you are one of the developers, you can also go
 to the pull request page on GitHub and and click on **Merge pull request**.
-Voilá, you are done! Your branch will have been merged to
+Voilà, you are done! Your branch will have been merged to
 `main` and the source branch will have been deleted in the GitHub repository
 (if you are not working in your own fork).
 

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -213,7 +213,7 @@ might be provided by other packages such as [Polyester.jl](https://github.com/Ju
     This macro does not necessarily work for general `for` loops. For example,
     it does not necessarily support general iterables such as `eachline(filename)`.
 
-Some discussion can be found at [https://discourse.julialang.org/t/overhead-of-threads-threads/53964](53964https://discourse.julialang.org/t/overhead-of-threads-threads/53964)
+Some discussion can be found at [https://discourse.julialang.org/t/overhead-of-threads-threads/53964](https://discourse.julialang.org/t/overhead-of-threads-threads/53964)
 and [https://discourse.julialang.org/t/threads-threads-with-one-thread-how-to-remove-the-overhead/58435](https://discourse.julialang.org/t/threads-threads-with-one-thread-how-to-remove-the-overhead/58435).
 """
 macro threaded(expr)

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -132,7 +132,7 @@ end
     default_example()
 
 Return the path to an example elixir that can be used to quickly see Trixi.jl in action on a
-[`TreeMesh`]@(ref). See also [`examples_dir`](@ref) and [`get_examples`](@ref).
+[`TreeMesh`](@ref). See also [`examples_dir`](@ref) and [`get_examples`](@ref).
 """
 function default_example()
     joinpath(examples_dir(), "tree_2d_dgsem", "elixir_advection_basic.jl")
@@ -142,7 +142,7 @@ end
     default_example_unstructured()
 
 Return the path to an example elixir that can be used to quickly see Trixi.jl in action on an
-[`UnstructuredMesh2D`]@(ref). This simulation is run on the example curved, unstructured mesh
+[`UnstructuredMesh2D`](@ref). This simulation is run on the example curved, unstructured mesh
 given in the Trixi.jl documentation regarding unstructured meshes.
 """
 function default_example_unstructured()
@@ -155,7 +155,7 @@ end
 Return the default options for OrdinaryDiffEq's `solve`. Pass `ode_default_options()...` to `solve`
 to only return the solution at the final time and enable **MPI aware** error-based step size control,
 whenever MPI is used.
-For example, use `solve(ode, alg; ode_default_options()...)`
+For example, use `solve(ode, alg; ode_default_options()...)`.
 """
 function ode_default_options()
     if mpi_isparallel()
@@ -213,8 +213,8 @@ might be provided by other packages such as [Polyester.jl](https://github.com/Ju
     This macro does not necessarily work for general `for` loops. For example,
     it does not necessarily support general iterables such as `eachline(filename)`.
 
-Some discussion can be found at https://discourse.julialang.org/t/overhead-of-threads-threads/53964
-and https://discourse.julialang.org/t/threads-threads-with-one-thread-how-to-remove-the-overhead/58435.
+Some discussion can be found at [https://discourse.julialang.org/t/overhead-of-threads-threads/53964](53964https://discourse.julialang.org/t/overhead-of-threads-threads/53964)
+and [https://discourse.julialang.org/t/threads-threads-with-one-thread-how-to-remove-the-overhead/58435](https://discourse.julialang.org/t/threads-threads-with-one-thread-how-to-remove-the-overhead/58435).
 """
 macro threaded(expr)
     # Use `esc(quote ... end)` for nested macro calls as suggested in

--- a/src/auxiliary/math.jl
+++ b/src/auxiliary/math.jl
@@ -51,7 +51,7 @@ Given ε = 1.0e-4, we use the following algorithm.
 - Agner Fog.
   Lists of instruction latencies, throughputs and micro-operation breakdowns
   for Intel, AMD, and VIA CPUs.
-  https://www.agner.org/optimize/instruction_tables.pdf
+  [https://www.agner.org/optimize/instruction_tables.pdf](https://www.agner.org/optimize/instruction_tables.pdf)
 """
 @inline function ln_mean(x, y)
     epsilon_f2 = 1.0e-4
@@ -166,8 +166,10 @@ checks necessary in the presence of `NaN`s (or signed zeros).
 
 # Examples
 
+```jldoctest
 julia> max(2, 5, 1)
 5
+```
 """
 @inline max(args...) = @fastmath max(args...)
 
@@ -183,8 +185,10 @@ checks necessary in the presence of `NaN`s (or signed zeros).
 
 # Examples
 
+```jldoctest
 julia> min(2, 5, 1)
 1
+```
 """
 @inline min(args...) = @fastmath min(args...)
 

--- a/src/auxiliary/mpi.jl
+++ b/src/auxiliary/mpi.jl
@@ -72,7 +72,7 @@ You must pass this function as a keyword argument
 to OrdinaryDiffEq.jl's `solve` when using error-based step size control with MPI
 parallel execution of Trixi.jl.
 
-See the "Advanced Adaptive Stepsize Control" section of the [documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
+See the "Advanced Adaptive Stepsize Control" section of the [documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
 """
 ode_norm(u::Number, t) = @fastmath abs(u)
 function ode_norm(u::AbstractArray, t)
@@ -125,6 +125,6 @@ You should pass this function as a keyword argument
 to OrdinaryDiffEq.jl's  `solve` when using error-based step size control with MPI
 parallel execution of Trixi.jl.
 
-See the "Miscellaneous" section of the [documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
+See the "Miscellaneous" section of the [documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
 """
 ode_unstable_check(dt, u, semi, t) = isnan(dt)

--- a/src/equations/acoustic_perturbation_2d.jl
+++ b/src/equations/acoustic_perturbation_2d.jl
@@ -145,7 +145,7 @@ function initial_condition_convergence_test(x, t,
 end
 
 """
-  source_terms_convergence_test(u, x, t, equations::AcousticPerturbationEquations2D)
+    source_terms_convergence_test(u, x, t, equations::AcousticPerturbationEquations2D)
 
 Source terms used for convergence tests in combination with
 [`initial_condition_convergence_test`](@ref).

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -31,7 +31,7 @@ The compressible Euler equations
 ```
 for an ideal gas with ratio of specific heats `gamma`
 in two space dimensions.
-Here, ``\rho`` is the density, ``v_1``,`v_2` the velocities, ``e`` the specific total energy **rather than** specific internal energy, and
+Here, ``\rho`` is the density, ``v_1``, ``v_2`` the velocities, ``e`` the specific total energy **rather than** specific internal energy, and
 ```math
 p = (\gamma - 1) \left( \rho e - \frac{1}{2} \rho (v_1^2+v_2^2) \right)
 ```

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -36,7 +36,7 @@ The compressible Euler equations
 ```
 for an ideal gas with ratio of specific heats `gamma`
 in three space dimensions.
-Here, ``\rho`` is the density, ``v_1``,`v_2`, `v_3` the velocities, ``e`` the specific total energy **rather than** specific internal energy, and
+Here, ``\rho`` is the density, ``v_1``, ``v_2``, ``v_3`` the velocities, ``e`` the specific total energy **rather than** specific internal energy, and
 ```math
 p = (\gamma - 1) \left( \rho e - \frac{1}{2} \rho (v_1^2+v_2^2+v_3^2) \right)
 ```

--- a/src/equations/compressible_euler_multicomponent_1d.jl
+++ b/src/equations/compressible_euler_multicomponent_1d.jl
@@ -44,8 +44,8 @@ specific heat capacity at constant volume of component ``i``.
 In case of more than one component, the specific heat ratios `gammas` and the gas constants
 `gas_constants` should be passed as tuples, e.g., `gammas=(1.4, 1.667)`.
 
-The remaining variables like the specific heats at constant volume 'cv' or the specific heats at
-constant pressure 'cp' are then calculated considering a calorically perfect gas.
+The remaining variables like the specific heats at constant volume `cv` or the specific heats at
+constant pressure `cp` are then calculated considering a calorically perfect gas.
 """
 struct CompressibleEulerMulticomponentEquations1D{NVARS, NCOMP, RealT <: Real} <:
        AbstractCompressibleEulerMulticomponentEquations{1, NVARS, NCOMP}
@@ -247,8 +247,8 @@ end
 
 Entropy conserving two-point flux by
 - Ayoub Gouasmi, Karthik Duraisamy (2020)
-  "Formulation of Entropy-Stable schemes for the multicomponent compressible Euler equations""
-  arXiv:1904.00972v3 [math.NA] 4 Feb 2020
+  "Formulation of Entropy-Stable schemes for the multicomponent compressible Euler equations"
+  [arXiv:1904.00972v3](https://arxiv.org/abs/1904.00972) [math.NA] 4 Feb 2020
 """
 @inline function flux_chandrashekar(u_ll, u_rr, orientation::Integer,
                                     equations::CompressibleEulerMulticomponentEquations1D)

--- a/src/equations/compressible_euler_multicomponent_2d.jl
+++ b/src/equations/compressible_euler_multicomponent_2d.jl
@@ -48,8 +48,8 @@ specific heat capacity at constant volume of component ``i``.
 In case of more than one component, the specific heat ratios `gammas` and the gas constants
 `gas_constants` in [kJ/(kg*K)] should be passed as tuples, e.g., `gammas=(1.4, 1.667)`.
 
-The remaining variables like the specific heats at constant volume 'cv' or the specific heats at
-constant pressure 'cp' are then calculated considering a calorically perfect gas.
+The remaining variables like the specific heats at constant volume `cv` or the specific heats at
+constant pressure `cp` are then calculated considering a calorically perfect gas.
 """
 struct CompressibleEulerMulticomponentEquations2D{NVARS, NCOMP, RealT <: Real} <:
        AbstractCompressibleEulerMulticomponentEquations{2, NVARS, NCOMP}
@@ -275,8 +275,8 @@ end
 
 Adaption of the entropy conserving two-point flux by
 - Ayoub Gouasmi, Karthik Duraisamy (2020)
-  "Formulation of Entropy-Stable schemes for the multicomponent compressible Euler equations""
-  arXiv:1904.00972v3 [math.NA] 4 Feb 2020
+  "Formulation of Entropy-Stable schemes for the multicomponent compressible Euler equations"
+  [arXiv:1904.00972v3](https://arxiv.org/abs/1904.00972) [math.NA] 4 Feb 2020
 """
 @inline function flux_chandrashekar(u_ll, u_rr, orientation::Integer,
                                     equations::CompressibleEulerMulticomponentEquations2D)

--- a/src/equations/compressible_navier_stokes_2d.jl
+++ b/src/equations/compressible_navier_stokes_2d.jl
@@ -73,8 +73,8 @@ where
 w_2 = \frac{\rho v_1}{p},\, w_3 = \frac{\rho v_2}{p},\, w_4 = -\frac{\rho}{p}
 ```
 
-#!!! warning "Experimental code"
-#    This code is experimental and may be changed or removed in any future release.
+!!! warning "Experimental code"
+    This code is experimental and may be changed or removed in any future release.
 """
 struct CompressibleNavierStokesDiffusion2D{GradientVariables, RealT <: Real,
                                            E <: AbstractCompressibleEulerEquations{2}} <:
@@ -94,8 +94,8 @@ struct CompressibleNavierStokesDiffusion2D{GradientVariables, RealT <: Real,
 end
 
 """
-#!!! warning "Experimental code"
-#    This code is experimental and may be changed or removed in any future release.
+!!! warning "Experimental code"
+    This code is experimental and may be changed or removed in any future release.
 
 `GradientVariablesPrimitive` and `GradientVariablesEntropy` are gradient variable type parameters
 for `CompressibleNavierStokesDiffusion2D`. By default, the gradient variables are set to be

--- a/src/equations/compressible_navier_stokes_3d.jl
+++ b/src/equations/compressible_navier_stokes_3d.jl
@@ -73,8 +73,8 @@ where
 w_2 = \frac{\rho v_1}{p},\, w_3 = \frac{\rho v_2}{p},\, w_4 = \frac{\rho v_3}{p},\, w_5 = -\frac{\rho}{p}
 ```
 
-#!!! warning "Experimental code"
-#    This code is experimental and may be changed or removed in any future release.
+!!! warning "Experimental code"
+    This code is experimental and may be changed or removed in any future release.
 """
 struct CompressibleNavierStokesDiffusion3D{GradientVariables, RealT <: Real,
                                            E <: AbstractCompressibleEulerEquations{3}} <:

--- a/src/equations/hyperbolic_diffusion_2d.jl
+++ b/src/equations/hyperbolic_diffusion_2d.jl
@@ -10,7 +10,7 @@
 
 The linear hyperbolic diffusion equations in two space dimensions.
 A description of this system can be found in Sec. 2.5 of the book "I Do Like CFD, Too: Vol 1".
-The book is freely available at http://www.cfdbooks.com/ and further analysis can be found in
+The book is freely available at [http://www.cfdbooks.com/](http://www.cfdbooks.com/) and further analysis can be found in
 the paper by Nishikawa [DOI: 10.1016/j.jcp.2007.07.029](https://doi.org/10.1016/j.jcp.2007.07.029)
 """
 struct HyperbolicDiffusionEquations2D{RealT <: Real} <:

--- a/src/equations/hyperbolic_diffusion_3d.jl
+++ b/src/equations/hyperbolic_diffusion_3d.jl
@@ -10,7 +10,7 @@
 
 The linear hyperbolic diffusion equations in three space dimensions.
 A description of this system can be found in Sec. 2.5 of the book "I Do Like CFD, Too: Vol 1".
-The book is freely available at http://www.cfdbooks.com/ and further analysis can be found in
+The book is freely available at [http://www.cfdbooks.com/](http://www.cfdbooks.com/) and further analysis can be found in
 the paper by Nishikawa [DOI: 10.1016/j.jcp.2007.07.029](https://doi.org/10.1016/j.jcp.2007.07.029)
 """
 struct HyperbolicDiffusionEquations3D{RealT <: Real} <:

--- a/src/equations/ideal_glm_mhd_3d.jl
+++ b/src/equations/ideal_glm_mhd_3d.jl
@@ -41,7 +41,7 @@ end
 
 # Set initial conditions at physical location `x` for time `t`
 """
-initial_condition_constant(x, t, equations::IdealGlmMhdEquations3D)
+    initial_condition_constant(x, t, equations::IdealGlmMhdEquations3D)
 
 A constant initial condition to test free-stream preservation.
 """

--- a/src/equations/shallow_water_two_layer_1d.jl
+++ b/src/equations/shallow_water_two_layer_1d.jl
@@ -392,7 +392,7 @@ end
                            equations::ShallowWaterTwoLayerEquations1D)
 
 Entropy stable surface flux for the two-layer shallow water equations. Uses the entropy
-conservative flux_fjordholm_etal and adds a Lax-Friedrichs type dissipation dependent on the jump
+conservative [`flux_fjordholm_etal`](@ref) and adds a Lax-Friedrichs type dissipation dependent on the jump
 of entropy variables.
 
 Further details are available in the paper:

--- a/src/equations/shallow_water_two_layer_2d.jl
+++ b/src/equations/shallow_water_two_layer_2d.jl
@@ -695,8 +695,9 @@ end
 """
     flux_es_fjordholm_etal(u_ll, u_rr, orientation_or_normal_direction,
                            equations::ShallowWaterTwoLayerEquations1D)
+
 Entropy stable surface flux for the two-layer shallow water equations. Uses the entropy conservative 
-flux_fjordholm_etal and adds a Lax-Friedrichs type dissipation dependent on the jump of entropy
+[`flux_fjordholm_etal`](@ref) and adds a Lax-Friedrichs type dissipation dependent on the jump of entropy
 variables. 
 
 Further details are available in the paper:

--- a/src/meshes/structured_mesh.jl
+++ b/src/meshes/structured_mesh.jl
@@ -33,7 +33,7 @@ Create a StructuredMesh of the given size and shape that uses `RealT` as coordin
              the reference mesh to the physical domain.
              If no `mapping_as_string` is defined, this function must be defined with the name `mapping`
              to allow for restarts.
-             This will be changed in the future, see https://github.com/trixi-framework/Trixi.jl/issues/541.
+             This will be changed in the future, see [https://github.com/trixi-framework/Trixi.jl/issues/541](https://github.com/trixi-framework/Trixi.jl/issues/541).
 - `RealT::Type`: the type that should be used for coordinates.
 - `periodicity`: either a `Bool` deciding if all of the boundaries are periodic or an `NTuple{NDIMS, Bool}`
                  deciding for each dimension if the boundaries in this dimension are periodic.
@@ -41,7 +41,7 @@ Create a StructuredMesh of the given size and shape that uses `RealT` as coordin
 - `mapping_as_string::String`: the code that defines the `mapping`.
                                If `CodeTracking` can't find the function definition, it can be passed directly here.
                                The code string must define the mapping function with the name `mapping`.
-                               This will be changed in the future, see https://github.com/trixi-framework/Trixi.jl/issues/541.
+                               This will be changed in the future, see [https://github.com/trixi-framework/Trixi.jl/issues/541](https://github.com/trixi-framework/Trixi.jl/issues/541).
 """
 function StructuredMesh(cells_per_dimension, mapping; RealT = Float64,
                         periodicity = true, unsaved_changes = true,

--- a/src/solvers/dgmulti/types.jl
+++ b/src/solvers/dgmulti/types.jl
@@ -180,9 +180,9 @@ GeometricTermsType(mesh_type::Curved, element_type::AbstractElemShape) = NonAffi
 # other potential mesh types to add later: Polynomial{polydeg_geo}?
 
 """
-  DGMultiMesh(dg::DGMulti{NDIMS}, vertex_coordinates, EToV;
-              is_on_boundary=nothing,
-              periodicity=ntuple(_->false, NDIMS)) where {NDIMS}
+    DGMultiMesh(dg::DGMulti{NDIMS}, vertex_coordinates, EToV;
+                is_on_boundary=nothing,
+                periodicity=ntuple(_->false, NDIMS)) where {NDIMS}
 
 - `dg::DGMulti` contains information associated with to the reference element (e.g., quadrature,
   basis evaluation, differentiation, etc).

--- a/src/solvers/dgsem_tree/indicators.jl
+++ b/src/solvers/dgsem_tree/indicators.jl
@@ -159,7 +159,6 @@ and `basis` if this indicator should be used for shock capturing.
 - Löhner (1987)
   "An adaptive finite element scheme for transient problems in CFD"
   [doi: 10.1016/0045-7825(87)90098-3](https://doi.org/10.1016/0045-7825(87)90098-3)
-- http://flash.uchicago.edu/site/flashcode/user_support/flash4_ug_4p62/node59.html#SECTION05163100000000000000
 """
 struct IndicatorLöhner{RealT <: Real, Variable, Cache} <: AbstractIndicator
     f_wave::RealT # TODO: Taal documentation

--- a/src/solvers/dgsem_tree/indicators.jl
+++ b/src/solvers/dgsem_tree/indicators.jl
@@ -159,6 +159,7 @@ and `basis` if this indicator should be used for shock capturing.
 - Löhner (1987)
   "An adaptive finite element scheme for transient problems in CFD"
   [doi: 10.1016/0045-7825(87)90098-3](https://doi.org/10.1016/0045-7825(87)90098-3)
+- [https://flash.rochester.edu/site/flashcode/user_support/flash4_ug_4p62/node59.html#SECTION05163100000000000000](https://flash.rochester.edu/site/flashcode/user_support/flash4_ug_4p62/node59.html#SECTION05163100000000000000)
 """
 struct IndicatorLöhner{RealT <: Real, Variable, Cache} <: AbstractIndicator
     f_wave::RealT # TODO: Taal documentation


### PR DESCRIPTION
Just some typos and similar I found while browsing the docs, especially the Reference section.