### PR TITLE
fix typos in FDSBP elixir comments

### DIFF
--- a/examples/tree_2d_fdsbp/elixir_euler_convergence.jl
+++ b/examples/tree_2d_fdsbp/elixir_euler_convergence.jl
@@ -5,7 +5,8 @@ using OrdinaryDiffEq
 using Trixi
 
 ###############################################################################
-# semidiscretization of the linear advection equation
+# semidiscretization of the compressible Euler equations
+
 equations = CompressibleEulerEquations2D(1.4)
 
 initial_condition = initial_condition_convergence_test

--- a/examples/tree_2d_fdsbp/elixir_euler_kelvin_helmholtz_instability.jl
+++ b/examples/tree_2d_fdsbp/elixir_euler_kelvin_helmholtz_instability.jl
@@ -5,7 +5,8 @@ using OrdinaryDiffEq
 using Trixi
 
 ###############################################################################
-# semidiscretization of the linear advection equation
+# semidiscretization of the compressible Euler equations
+
 equations = CompressibleEulerEquations2D(1.4)
 
 function initial_condition_kelvin_helmholtz_instability(x, t, equations::CompressibleEulerEquations2D)

--- a/examples/tree_2d_fdsbp/elixir_euler_vortex.jl
+++ b/examples/tree_2d_fdsbp/elixir_euler_vortex.jl
@@ -5,7 +5,8 @@ using OrdinaryDiffEq
 using Trixi
 
 ###############################################################################
-# semidiscretization of the linear advection equation
+# semidiscretization of the compressible Euler equations
+
 equations = CompressibleEulerEquations2D(1.4)
 
 """

--- a/examples/tree_3d_fdsbp/elixir_euler_convergence.jl
+++ b/examples/tree_3d_fdsbp/elixir_euler_convergence.jl
@@ -6,7 +6,6 @@ using Trixi
 
 ###############################################################################
 # semidiscretization of the compressible Euler equations
-
 equations = CompressibleEulerEquations3D(1.4)
 
 initial_condition = initial_condition_convergence_test


### PR DESCRIPTION
I fixed some typos in the comments of some FDSBP elixirs and adapted the whitespace for consistency with other elixirs.