### PR TITLE
throw better error message with MPI for TreeMesh1D

### DIFF
--- a/src/meshes/tree_mesh.jl
+++ b/src/meshes/tree_mesh.jl
@@ -125,9 +125,9 @@ function TreeMesh(coordinates_min::NTuple{NDIMS, Real},
 
     # TODO: MPI, create nice interface for a parallel tree/mesh
     if mpi_isparallel()
-        if mpi_isroot() && NDIMS == 3
+        if mpi_isroot() && NDIMS != 2
             println(stderr,
-                    "ERROR: TreeMesh3D does not support parallel execution with MPI")
+                    "ERROR: The TreeMesh supports parallel execution with MPI only in 2 dimensions")
             MPI.Abort(mpi_comm(), 1)
         end
         TreeType = ParallelTree{NDIMS}


### PR DESCRIPTION
Fixes #1567

```bash
Trixi$ mpirun -n 2 julia --project=run -e 'using Trixi; trixi_include("examples/tree_1d_dgsem/elixir_advection_basic.jl")'
ERROR: The TreeMesh supports parallel execution with MPI only in 2 dimensions
application called MPI_Abort(MPI_COMM_WORLD, 1) - process 0

$ mpirun -n 2 julia --project=run -e 'using Trixi; trixi_include("examples/tree_3d_dgsem/elixir_advection_basic.jl")'
ERROR: The TreeMesh supports parallel execution with MPI only in 2 dimensions
```