### PR TITLE
test threaded time integration

### DIFF
--- a/examples/dgmulti_2d/elixir_euler_curved.jl
+++ b/examples/dgmulti_2d/elixir_euler_curved.jl
@@ -42,7 +42,8 @@ callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback)
 ###############################################################################
 # run the simulation
 
-sol = solve(ode, RDPK3SpFSAL49(); abstol=1.0e-6, reltol=1.0e-6,
+alg = RDPK3SpFSAL49()
+sol = solve(ode, alg; abstol=1.0e-6, reltol=1.0e-6,
             ode_default_options()..., callback=callbacks);
 
 summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/elixir_advection_diffusion.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_diffusion.jl
@@ -75,8 +75,9 @@ callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback)
 # run the simulation
 
 # OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
+alg = RDPK3SpFSAL49()
 time_int_tol = 1.0e-11
-sol = solve(ode, RDPK3SpFSAL49(); abstol=time_int_tol, reltol=time_int_tol,
+sol = solve(ode, alg; abstol=time_int_tol, reltol=time_int_tol,
             ode_default_options()..., callback=callbacks)
 
 # Print the timer summary

--- a/examples/tree_2d_dgsem/elixir_advection_restart.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_restart.jl
@@ -26,7 +26,8 @@ ode = semidiscretize(semi, tspan, restart_filename);
 # Do not overwrite the initial snapshot written by elixir_advection_extended.jl.
 save_solution.condition.save_initial_solution = false
 
-integrator = init(ode, CarpenterKennedy2N54(williamson_condition=false),
+alg = CarpenterKennedy2N54(williamson_condition=false)
+integrator = init(ode, alg,
                   dt=dt, # solve needs some value here but it will be overwritten by the stepsize_callback
                   save_everystep=false, callback=callbacks)
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -24,9 +24,9 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [preferences.OrdinaryDiffEq]
 PrecompileAutoSpecialize = false
 PrecompileAutoSwitch = false
-PrecompileDefaultSpecialize = true
+PrecompileDefaultSpecialize = false
 PrecompileFunctionWrapperSpecialize = false
-PrecompileLowStorage = true
+PrecompileLowStorage = false
 PrecompileNoSpecialize = false
-PrecompileNonStiff = true
+PrecompileNonStiff = false
 PrecompileStiff = false

--- a/test/test_threaded.jl
+++ b/test/test_threaded.jl
@@ -127,7 +127,8 @@ Trixi.mpi_isroot() && isdir(outdir) && rm(outdir, recursive=true)
 
     @trixi_testset "elixir_euler_curved.jl with threaded time integration" begin
       @test_broken false
-      # TODO: This is cirrently broken and needs to be fixed upstream
+      # TODO: This is currently broken and needs to be fixed upstream
+      #       See https://github.com/JuliaSIMD/StrideArrays.jl/issues/77
       # @test_trixi_include(joinpath(examples_dir(), "dgmulti_2d", "elixir_euler_curved.jl"),
       #   alg = RDPK3SpFSAL49(thread = OrdinaryDiffEq.True()),
       #   l2 = [1.720476068165337e-5, 1.592168205710526e-5, 1.592168205812963e-5, 4.894094865697305e-5],

--- a/test/test_threaded.jl
+++ b/test/test_threaded.jl
@@ -18,6 +18,14 @@ Trixi.mpi_isroot() && isdir(outdir) && rm(outdir, recursive=true)
         linf = [6.314906965243505e-5])
     end
 
+    @trixi_testset "elixir_advection_restart.jl with threaded time integration" begin
+      @test_trixi_include(joinpath(examples_dir(), "tree_2d_dgsem", "elixir_advection_restart.jl"),
+        alg = CarpenterKennedy2N54(williamson_condition = false, thread = OrdinaryDiffEq.True()),
+        # Expected errors are exactly the same as in the serial test!
+        l2   = [7.81674284320524e-6],
+        linf = [6.314906965243505e-5])
+    end
+
     @trixi_testset "elixir_advection_amr_refine_twice.jl" begin
       @test_trixi_include(joinpath(examples_dir(), "tree_2d_dgsem", "elixir_advection_amr_refine_twice.jl"),
         l2   = [0.00020547512522578292],
@@ -41,6 +49,15 @@ Trixi.mpi_isroot() && isdir(outdir) && rm(outdir, recursive=true)
       @test_trixi_include(joinpath(examples_dir(), "tree_2d_dgsem", "elixir_euler_ec.jl"),
         l2   = [0.061751715597716854, 0.05018223615408711, 0.05018989446443463, 0.225871559730513],
         linf = [0.29347582879608825, 0.31081249232844693, 0.3107380389947736, 1.0540358049885143])
+    end
+
+    @trixi_testset "elixir_advection_diffusion.jl" begin
+      @test_trixi_include(joinpath(examples_dir(), "tree_2d_dgsem", "elixir_advection_diffusion.jl"),
+        initial_refinement_level = 2, tspan = (0.0, 0.4), polydeg = 5,
+        alg = RDPK3SpFSAL49(thread = OrdinaryDiffEq.True()),
+        l2 = [4.0915532997994255e-6],
+        linf = [2.3040850347877395e-5]
+      )
     end
   end
 
@@ -106,6 +123,16 @@ Trixi.mpi_isroot() && isdir(outdir) && rm(outdir, recursive=true)
         l2 = [0.006400337855843578, 0.005303799804137764, 0.005303799804119745, 0.013204169007030144],
         linf = [0.03798302318566282, 0.05321027922532284, 0.05321027922605448, 0.13392025411839015],
       )
+    end
+
+    @trixi_testset "elixir_euler_curved.jl with threaded time integration" begin
+      @test_broken false
+      # TODO: This is cirrently broken and needs to be fixed upstream
+      # @test_trixi_include(joinpath(examples_dir(), "dgmulti_2d", "elixir_euler_curved.jl"),
+      #   alg = RDPK3SpFSAL49(thread = OrdinaryDiffEq.True()),
+      #   l2 = [1.720476068165337e-5, 1.592168205710526e-5, 1.592168205812963e-5, 4.894094865697305e-5],
+      #   linf = [0.00010525416930584619, 0.00010003778091061122, 0.00010003778085621029, 0.00036426282101720275]
+      # )
     end
 
     @trixi_testset "elixir_euler_triangulate_pkg_mesh.jl" begin


### PR DESCRIPTION
I added some tests with threaded time intergation so that we can catch issues such as #1577 and https://github.com/SciML/OrdinaryDiffEq.jl/issues/1989 in our CI pipeline.

I also reduced the precompilation workload of OrdinaryDiffEq.jl for CI tests to make it less expensive. We don't use all of the methods that are precompiled with the old settings, so it doesn't really help to compile them all.

There is currently an issue with threaded time integration and arrays of `SVector`s used by the flux differencing `DGMulti` solver that I will report upstream.
Edit: See https://github.com/JuliaSIMD/StrideArrays.jl/issues/77

@trixi-framework/developers Anybody up for a review?