### PR TITLE
reset threads also when initializing the summary callback

### DIFF
--- a/src/callbacks_step/summary.jl
+++ b/src/callbacks_step/summary.jl
@@ -15,10 +15,12 @@ Create and return a callback that prints a human-readable summary of the simulat
 beginning of a simulation and then resets the timer. When the returned callback is executed
 directly, the current timer values are shown.
 """
-function SummaryCallback()
+function SummaryCallback(reset_threads = true)
+    initialize(cb, u, t, integrator) = initialize_summary_callback(cb, u, t, integrator;
+                                                                   reset_threads)
     DiscreteCallback(summary_callback, summary_callback,
                      save_positions = (false, false),
-                     initialize = initialize_summary_callback)
+                     initialize = initialize)
 end
 
 function Base.show(io::IO, cb::DiscreteCallback{<:Any, <:typeof(summary_callback)})
@@ -139,7 +141,15 @@ end
 
 # Print information about the current simulation setup
 # Note: This is called *after* all initialization is done, but *before* the first time step
-function initialize_summary_callback(cb::DiscreteCallback, u, t, integrator)
+function initialize_summary_callback(cb::DiscreteCallback, u, t, integrator;
+                                     reset_threads = true)
+    # Optionally reset Polyester.jl threads. See
+    # https://github.com/trixi-framework/Trixi.jl/issues/1583
+    # https://github.com/JuliaSIMD/Polyester.jl/issues/30
+    if reset_threads
+        Polyester.reset_threads!()
+    end
+
     mpi_isroot() || return nothing
 
     print_startup_message()

--- a/src/callbacks_step/summary.jl
+++ b/src/callbacks_step/summary.jl
@@ -16,8 +16,10 @@ beginning of a simulation and then resets the timer. When the returned callback 
 directly, the current timer values are shown.
 """
 function SummaryCallback(reset_threads = true)
-    initialize(cb, u, t, integrator) = initialize_summary_callback(cb, u, t, integrator;
-                                                                   reset_threads)
+    function initialize(cb, u, t, integrator)
+        initialize_summary_callback(cb, u, t, integrator;
+                                    reset_threads)
+    end
     DiscreteCallback(summary_callback, summary_callback,
                      save_positions = (false, false),
                      initialize = initialize)


### PR DESCRIPTION
I added the option to reset the threads from Polyester.jl in also in the summary callback. The idea is that this supports another development workflow where we just modify the RHS implementation and call solve again without re-ccreating the ODE.

See also #1584, #1583

The same comment as in 036eaed82b92be9376c5b610d8d40eddf45ca1fa applies: However, I did not document it in the docstring since we have not documented that we use Polyester.jl threads in general - and the resetting is specific to Polyester.jl. I was not sure whether we still would like to keep the option to change the threading backend any time - although I do not see a good reason why we should do so.