### PR TITLE
run only threaded tests by default

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,11 @@
 using Test
 using MPI: mpiexec
 
-# run tests on Travis CI in parallel
-const TRIXI_TEST = get(ENV, "TRIXI_TEST", "all")
+# We run tests in parallel with CI jobs setting the `TRIXI_TEST` environment
+# variable to determine the subset of tests to execute.
+# By default, we just run the threaded tests since they are relatively cheap
+# and test a good amount of different functionality.
+const TRIXI_TEST = get(ENV, "TRIXI_TEST", "threaded")
 const TRIXI_MPI_NPROCS = clamp(Sys.CPU_THREADS, 2, 3)
 const TRIXI_NTHREADS = clamp(Sys.CPU_THREADS, 2, 3)
 


### PR DESCRIPTION
The motivation for this is stated in #1564:

> Right now, we try to run all tests when the environment variable `TRIXI_TEST` is not set. This takes quite a lot of time and makes it unusable in most cases. I think nobody really wants to do this.
> 
> It also means that Trixi.jl is basically ignored by Julia's PkgEval, e.g. it's in "Test log exceeded the size limit (36 packages)" in the latest run https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_date/2023-07/11/report.html due to an internal Julia error (in the development version) - otherwise, it would have exceeded the time limit.
> 
> I think it would be nice if we modified the settings such that only some cheap tests are executed when calling `Pkg.runtests("Trixi")` by default - maybe the threaded ones?

Closes #1564