### PR TITLE
Avoid allocations in `boundary flux` for parabolic RHS

### DIFF
--- a/examples/tree_2d_dgsem/elixir_navierstokes_convergence.jl
+++ b/examples/tree_2d_dgsem/elixir_navierstokes_convergence.jl
@@ -170,8 +170,10 @@ end
 initial_condition = initial_condition_navier_stokes_convergence_test
 
 # BC types
-velocity_bc_top_bottom = NoSlip((x, t, equations) -> SVector(initial_condition_navier_stokes_convergence_test(x, t, equations)[2], 
-                                                             initial_condition_navier_stokes_convergence_test(x, t, equations)[3]))
+velocity_bc_top_bottom = NoSlip() do x, t, equations
+    u = initial_condition_navier_stokes_convergence_test(x, t, equations)
+    return SVector(u[2], u[3])
+end
 heat_bc_top_bottom = Adiabatic((x, t, equations) -> 0.0)
 boundary_condition_top_bottom = BoundaryConditionNavierStokesWall(velocity_bc_top_bottom, heat_bc_top_bottom)
 

--- a/examples/tree_2d_dgsem/elixir_navierstokes_convergence.jl
+++ b/examples/tree_2d_dgsem/elixir_navierstokes_convergence.jl
@@ -170,7 +170,8 @@ end
 initial_condition = initial_condition_navier_stokes_convergence_test
 
 # BC types
-velocity_bc_top_bottom = NoSlip((x, t, equations) -> initial_condition_navier_stokes_convergence_test(x, t, equations)[2:3])
+velocity_bc_top_bottom = NoSlip((x, t, equations) -> SVector(initial_condition_navier_stokes_convergence_test(x, t, equations)[2], 
+                                                             initial_condition_navier_stokes_convergence_test(x, t, equations)[3]))
 heat_bc_top_bottom = Adiabatic((x, t, equations) -> 0.0)
 boundary_condition_top_bottom = BoundaryConditionNavierStokesWall(velocity_bc_top_bottom, heat_bc_top_bottom)
 

--- a/examples/tree_2d_dgsem/elixir_navierstokes_shear_layer.jl
+++ b/examples/tree_2d_dgsem/elixir_navierstokes_shear_layer.jl
@@ -14,14 +14,16 @@ equations_parabolic = CompressibleNavierStokesDiffusion2D(equations, mu=mu(),
                                                           Prandtl=prandtl_number())
 
 function initial_condition_shear_layer(x, t, equations::CompressibleEulerEquations2D)
+  # Shear layer parameters
   k = 80
   delta = 0.05
   u0 = 1.0
+  
   Ms = 0.1 # maximum Mach number
 
   rho = 1.0
-  v1  = x[2] <= 0.5 ? u0*tanh(k*(x[2]*0.5 - 0.25)) : tanh(k*(0.75 -x[2]*0.5))
-  v2  = u0*delta * sin(2*pi*(x[1]*0.5 + 0.25))
+  v1  = x[2] <= 0.5 ? u0 * tanh(k*(x[2]*0.5 - 0.25)) : u0 * tanh(k*(0.75 -x[2]*0.5))
+  v2  = u0 * delta * sin(2*pi*(x[1]*0.5 + 0.25))
   p   = (u0 / Ms)^2 * rho / equations.gamma # scaling to get Ms
 
   return prim2cons(SVector(rho, v1, v2, p), equations)

--- a/examples/tree_3d_dgsem/elixir_navierstokes_convergence.jl
+++ b/examples/tree_3d_dgsem/elixir_navierstokes_convergence.jl
@@ -220,7 +220,10 @@ end
 initial_condition = initial_condition_navier_stokes_convergence_test
 
 # BC types
-velocity_bc_top_bottom = NoSlip((x, t, equations) -> initial_condition_navier_stokes_convergence_test(x, t, equations)[2:4])
+velocity_bc_top_bottom = NoSlip((x, t, equations) -> SVector(initial_condition_navier_stokes_convergence_test(x, t, equations)[2], 
+                                                             initial_condition_navier_stokes_convergence_test(x, t, equations)[3],
+                                                             initial_condition_navier_stokes_convergence_test(x, t, equations)[4])
+                                                             )
 heat_bc_top_bottom = Adiabatic((x, t, equations) -> 0.0)
 boundary_condition_top_bottom = BoundaryConditionNavierStokesWall(velocity_bc_top_bottom, heat_bc_top_bottom)
 

--- a/examples/tree_3d_dgsem/elixir_navierstokes_convergence.jl
+++ b/examples/tree_3d_dgsem/elixir_navierstokes_convergence.jl
@@ -220,10 +220,10 @@ end
 initial_condition = initial_condition_navier_stokes_convergence_test
 
 # BC types
-velocity_bc_top_bottom = NoSlip((x, t, equations) -> SVector(initial_condition_navier_stokes_convergence_test(x, t, equations)[2], 
-                                                             initial_condition_navier_stokes_convergence_test(x, t, equations)[3],
-                                                             initial_condition_navier_stokes_convergence_test(x, t, equations)[4])
-                                                             )
+velocity_bc_top_bottom = NoSlip() do x, t, equations
+    u = initial_condition_navier_stokes_convergence_test(x, t, equations)
+    return  SVector(u[2], u[3], u[4])
+end
 heat_bc_top_bottom = Adiabatic((x, t, equations) -> 0.0)
 boundary_condition_top_bottom = BoundaryConditionNavierStokesWall(velocity_bc_top_bottom, heat_bc_top_bottom)
 

--- a/src/solvers/dgsem_p4est/dg_3d_parabolic.jl
+++ b/src/solvers/dgsem_p4est/dg_3d_parabolic.jl
@@ -563,60 +563,6 @@ function prolong2boundaries!(cache_parabolic, flux_viscous,
     return nothing
 end
 
-# # Function barrier for type stability
-# !!! TODO: Figure out why this cannot removed eventhough it exists in the dg_2d_parabolic.jl file
-function calc_boundary_flux_gradients!(cache, t, boundary_conditions, mesh::P4estMesh,
-                                       equations, surface_integral, dg::DG)
-    (; boundary_condition_types, boundary_indices) = boundary_conditions
-
-    calc_boundary_flux_by_type!(cache, t, boundary_condition_types, boundary_indices,
-                                Gradient(), mesh, equations, surface_integral, dg)
-    return nothing
-end
-
-function calc_boundary_flux_divergence!(cache, t, boundary_conditions, mesh::P4estMesh,
-                                        equations, surface_integral, dg::DG)
-    (; boundary_condition_types, boundary_indices) = boundary_conditions
-
-    calc_boundary_flux_by_type!(cache, t, boundary_condition_types, boundary_indices,
-                                Divergence(), mesh, equations, surface_integral, dg)
-    return nothing
-end
-
-# Iterate over tuples of boundary condition types and associated indices
-# in a type-stable way using "lispy tuple programming".
-function calc_boundary_flux_by_type!(cache, t, BCs::NTuple{N, Any},
-                                     BC_indices::NTuple{N, Vector{Int}},
-                                     operator_type,
-                                     mesh::P4estMesh,
-                                     equations, surface_integral, dg::DG) where {N}
-    # Extract the boundary condition type and index vector
-    boundary_condition = first(BCs)
-    boundary_condition_indices = first(BC_indices)
-    # Extract the remaining types and indices to be processed later
-    remaining_boundary_conditions = Base.tail(BCs)
-    remaining_boundary_condition_indices = Base.tail(BC_indices)
-
-    # process the first boundary condition type
-    calc_boundary_flux!(cache, t, boundary_condition, boundary_condition_indices,
-                        operator_type, mesh, equations, surface_integral, dg)
-
-    # recursively call this method with the unprocessed boundary types
-    calc_boundary_flux_by_type!(cache, t, remaining_boundary_conditions,
-                                remaining_boundary_condition_indices,
-                                operator_type,
-                                mesh, equations, surface_integral, dg)
-
-    return nothing
-end
-
-# terminate the type-stable iteration over tuples
-function calc_boundary_flux_by_type!(cache, t, BCs::Tuple{}, BC_indices::Tuple{},
-                                     operator_type, mesh::P4estMesh, equations,
-                                     surface_integral, dg::DG)
-    nothing
-end
-
 function calc_boundary_flux!(cache, t,
                              boundary_condition_parabolic, # works with Dict types
                              boundary_condition_indices,

--- a/src/solvers/dgsem_p4est/dg_3d_parabolic.jl
+++ b/src/solvers/dgsem_p4est/dg_3d_parabolic.jl
@@ -563,6 +563,60 @@ function prolong2boundaries!(cache_parabolic, flux_viscous,
     return nothing
 end
 
+# # Function barrier for type stability
+# !!! TODO: Figure out why this cannot removed eventhough it exists in the dg_2d_parabolic.jl file
+function calc_boundary_flux_gradients!(cache, t, boundary_conditions, mesh::P4estMesh,
+                                       equations, surface_integral, dg::DG)
+    (; boundary_condition_types, boundary_indices) = boundary_conditions
+
+    calc_boundary_flux_by_type!(cache, t, boundary_condition_types, boundary_indices,
+                                Gradient(), mesh, equations, surface_integral, dg)
+    return nothing
+end
+
+function calc_boundary_flux_divergence!(cache, t, boundary_conditions, mesh::P4estMesh,
+                                        equations, surface_integral, dg::DG)
+    (; boundary_condition_types, boundary_indices) = boundary_conditions
+
+    calc_boundary_flux_by_type!(cache, t, boundary_condition_types, boundary_indices,
+                                Divergence(), mesh, equations, surface_integral, dg)
+    return nothing
+end
+
+# Iterate over tuples of boundary condition types and associated indices
+# in a type-stable way using "lispy tuple programming".
+function calc_boundary_flux_by_type!(cache, t, BCs::NTuple{N, Any},
+                                     BC_indices::NTuple{N, Vector{Int}},
+                                     operator_type,
+                                     mesh::P4estMesh,
+                                     equations, surface_integral, dg::DG) where {N}
+    # Extract the boundary condition type and index vector
+    boundary_condition = first(BCs)
+    boundary_condition_indices = first(BC_indices)
+    # Extract the remaining types and indices to be processed later
+    remaining_boundary_conditions = Base.tail(BCs)
+    remaining_boundary_condition_indices = Base.tail(BC_indices)
+
+    # process the first boundary condition type
+    calc_boundary_flux!(cache, t, boundary_condition, boundary_condition_indices,
+                        operator_type, mesh, equations, surface_integral, dg)
+
+    # recursively call this method with the unprocessed boundary types
+    calc_boundary_flux_by_type!(cache, t, remaining_boundary_conditions,
+                                remaining_boundary_condition_indices,
+                                operator_type,
+                                mesh, equations, surface_integral, dg)
+
+    return nothing
+end
+
+# terminate the type-stable iteration over tuples
+function calc_boundary_flux_by_type!(cache, t, BCs::Tuple{}, BC_indices::Tuple{},
+                                     operator_type, mesh::P4estMesh, equations,
+                                     surface_integral, dg::DG)
+    nothing
+end
+
 function calc_boundary_flux!(cache, t,
                              boundary_condition_parabolic, # works with Dict types
                              boundary_condition_indices,

--- a/src/solvers/dgsem_tree/containers_2d.jl
+++ b/src/solvers/dgsem_tree/containers_2d.jl
@@ -764,10 +764,10 @@ end
 
 # Container data structure (structure-of-arrays style) for DG MPI interfaces
 mutable struct MPIInterfaceContainer2D{uEltype <: Real} <: AbstractContainer
-    u::Array{uEltype, 4}           # [leftright, variables, i, interfaces]
+    u::Array{uEltype, 4}            # [leftright, variables, i, interfaces]
     local_neighbor_ids::Vector{Int} # [interfaces]
-    orientations::Vector{Int}      # [interfaces]
-    remote_sides::Vector{Int}      # [interfaces]
+    orientations::Vector{Int}       # [interfaces]
+    remote_sides::Vector{Int}       # [interfaces]
     # internal `resize!`able storage
     _u::Vector{uEltype}
 end

--- a/src/solvers/dgsem_tree/containers_3d.jl
+++ b/src/solvers/dgsem_tree/containers_3d.jl
@@ -520,14 +520,14 @@ end
 # Left and right are used *both* for the numbering of the mortar faces *and* for the position of the
 # elements with respect to the axis orthogonal to the mortar.
 mutable struct L2MortarContainer3D{uEltype <: Real} <: AbstractContainer
-    u_upper_left::Array{uEltype, 5} # [leftright, variables, i, j, mortars]
+    u_upper_left::Array{uEltype, 5}  # [leftright, variables, i, j, mortars]
     u_upper_right::Array{uEltype, 5} # [leftright, variables, i, j, mortars]
-    u_lower_left::Array{uEltype, 5} # [leftright, variables, i, j, mortars]
+    u_lower_left::Array{uEltype, 5}  # [leftright, variables, i, j, mortars]
     u_lower_right::Array{uEltype, 5} # [leftright, variables, i, j, mortars]
-    neighbor_ids::Array{Int, 2}     # [position, mortars]
+    neighbor_ids::Array{Int, 2}      # [position, mortars]
     # Large sides: left -> 1, right -> 2
     large_sides::Vector{Int}  # [mortars]
-    orientations::Vector{Int}  # [mortars]
+    orientations::Vector{Int} # [mortars]
     # internal `resize!`able storage
     _u_upper_left::Vector{uEltype}
     _u_upper_right::Vector{uEltype}


### PR DESCRIPTION
The previous implementation caused allocations due to the slicing.