### PR TITLE
Davis wave speed estimate for shallow water equations

### DIFF
--- a/src/equations/shallow_water_1d.jl
+++ b/src/equations/shallow_water_1d.jl
@@ -653,7 +653,7 @@ end
     c_rr = sqrt(equations.gravity * h_rr)
 
     λ_min = min(v_ll - c_ll, v_rr - c_rr)
-    λ_max = max(v_rr + c_rr, v_rr + c_rr)
+    λ_max = max(v_ll + c_ll, v_rr + c_rr)
 
     return λ_min, λ_max
 end


### PR DESCRIPTION
There are two different things I noticed related to the Davis wave speed estimate for the shallow water equations that were introduced in #1561. First, I think there is a typo for the one-dimensional SWE. The second one is a question. The PR #1561 introduced `min_max_speed_davis` and #1501 introduced `min_max_speed_chen_noelle`  for the SWE, which are basically the same functions (in 1d and in 2d) except that `min_max_speed_chen_noelle` also has `zero(eltype(u_ll))` in the `min` and `max`. Is this known and is it intended to have (almost) the same function twice or does it suffice to keep just one? If both are necessary maybe a comment would be helpful for people looking at the source and wonder about these two functions.

cc @DanielDoehring 