### PR TITLE
Enable MPI coverage with Linux and reduce heap size hint

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,10 +28,10 @@ const TRIXI_NTHREADS = clamp(Sys.CPU_THREADS, 2, 3)
         cmd = string(Base.julia_cmd())
         coverage = occursin("--code-coverage", cmd) &&
                    !occursin("--code-coverage=none", cmd)
-        if !(coverage && Sys.iswindows()) && !(coverage && Sys.islinux())
+        if !(coverage && Sys.iswindows())
             # We provide a `--heap-size-hint` to avoid/reduce out-of-memory errors during CI testing
             mpiexec() do cmd
-                run(`$cmd -n $TRIXI_MPI_NPROCS $(Base.julia_cmd()) --threads=1 --check-bounds=yes --heap-size-hint=1G $(abspath("test_mpi.jl"))`)
+                run(`$cmd -n $TRIXI_MPI_NPROCS $(Base.julia_cmd()) --threads=1 --check-bounds=yes --heap-size-hint=0.5G $(abspath("test_mpi.jl"))`)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,6 @@ const TRIXI_NTHREADS = clamp(Sys.CPU_THREADS, 2, 3)
                    !occursin("--code-coverage=none", cmd)
         if !(coverage && Sys.iswindows()) && !(coverage && Sys.isapple())
             # We provide a `--heap-size-hint` to avoid/reduce out-of-memory errors during CI testing
-            # TODO: remove this line
             mpiexec() do cmd
                 run(`$cmd -n $TRIXI_MPI_NPROCS $(Base.julia_cmd()) --threads=1 --check-bounds=yes --heap-size-hint=0.5G $(abspath("test_mpi.jl"))`)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ const TRIXI_NTHREADS = clamp(Sys.CPU_THREADS, 2, 3)
         cmd = string(Base.julia_cmd())
         coverage = occursin("--code-coverage", cmd) &&
                    !occursin("--code-coverage=none", cmd)
-        if !(coverage && Sys.iswindows()) || !(coverage && Sys.isapple())
+        if !(coverage && Sys.iswindows()) && !(coverage && Sys.isapple())
             # We provide a `--heap-size-hint` to avoid/reduce out-of-memory errors during CI testing
             # TODO: remove this line
             mpiexec() do cmd

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,7 @@ const TRIXI_NTHREADS = clamp(Sys.CPU_THREADS, 2, 3)
                    !occursin("--code-coverage=none", cmd)
         if !(coverage && Sys.iswindows())
             # We provide a `--heap-size-hint` to avoid/reduce out-of-memory errors during CI testing
+            # TODO: remove this line
             mpiexec() do cmd
                 run(`$cmd -n $TRIXI_MPI_NPROCS $(Base.julia_cmd()) --threads=1 --check-bounds=yes --heap-size-hint=0.5G $(abspath("test_mpi.jl"))`)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ const TRIXI_NTHREADS = clamp(Sys.CPU_THREADS, 2, 3)
         cmd = string(Base.julia_cmd())
         coverage = occursin("--code-coverage", cmd) &&
                    !occursin("--code-coverage=none", cmd)
-        if !(coverage && Sys.iswindows())
+        if !(coverage && Sys.iswindows()) || !(coverage && Sys.isapple())
             # We provide a `--heap-size-hint` to avoid/reduce out-of-memory errors during CI testing
             # TODO: remove this line
             mpiexec() do cmd


### PR DESCRIPTION
Experimenting with different settings to avoid #1590


The following runs are with MPI coverage on both Linux and macOS:
- First run: Ubuntu works, macOS fails
- Second run: Ubuntu works, macOS works
- Third run: Ubuntu works, macOS works
- Fourth run: Ubuntu works, macOS fails

The following runs are with MPI coverage only on Linux, not on macOS:
- First run: Ubuntu works, macOS works (Windows fails :cry: )
- Second run: Ubuntu works, macOS works (Windows works :slightly_smiling_face: )

### Result

I adapted the MPI coverage code so that only Linux runs MPI coverage tests. Based on the results above, it looks like thi avoids the stochastic failures on macOS with MPI.