### PR TITLE
Increase absolute tolerance to make CI pass with julia v1.9.3

### DIFF
--- a/test/test_tree_1d_shallowwater.jl
+++ b/test/test_tree_1d_shallowwater.jl
@@ -102,7 +102,8 @@ EXAMPLES_DIR = pkgdir(Trixi, "examples", "tree_1d_dgsem")
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_shallowwater_beach.jl"),
       l2   = [0.17979210479598923, 1.2377495706611434, 6.289818963361573e-8],
       linf = [0.845938394800688, 3.3740800777086575, 4.4541473087633676e-7],
-      tspan = (0.0, 0.05))
+      tspan = (0.0, 0.05),
+      atol = 3e-10) # see https://github.com/trixi-framework/Trixi.jl/issues/1617
   end
 
   @trixi_testset "elixir_shallowwater_parabolic_bowl.jl" begin

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -5,7 +5,7 @@ import Trixi
 # inside an elixir.
 """
     @test_trixi_include(elixir; l2=nothing, linf=nothing,
-                                atol=10*eps(), rtol=0.001,
+                                atol=500*eps(), rtol=sqrt(eps()),
                                 parameters...)
 
 Test Trixi by calling `trixi_include(elixir; parameters...)`.


### PR DESCRIPTION
With julia v1.9.3 one test fails due to different `l2` and `linf` errors, which is quite annoying. This PR simply increases the absolute tolerance as suggested by @ranocha in https://github.com/trixi-framework/Trixi.jl/issues/1617#issuecomment-1700482993. We need an absolute tolerance of `3e-10`, which IMHO is quite high... I've also noticed a mismatch in the docstring of `@test_trixi_include`.
Fixes #1617. 