### PR TITLE
Assure conservation for SSP scheme

### DIFF
--- a/src/time_integration/methods_SSP.jl
+++ b/src/time_integration/methods_SSP.jl
@@ -168,7 +168,8 @@ function solve!(integrator::SimpleIntegratorSSP)
             end
 
             # perform convex combination
-            @. integrator.u = (alg.a[stage] * integrator.r0 + alg.b[stage] * integrator.u) / alg.denom[stage]
+            @. integrator.u = (alg.a[stage] * integrator.r0 +
+                               alg.b[stage] * integrator.u) / alg.denom[stage]
         end
 
         integrator.iter += 1

--- a/src/time_integration/methods_SSP.jl
+++ b/src/time_integration/methods_SSP.jl
@@ -26,12 +26,14 @@ The third-order SSP Runge-Kutta method of Shu and Osher.
 struct SimpleSSPRK33{StageCallbacks} <: SimpleAlgorithmSSP
     a::SVector{3, Float64}
     b::SVector{3, Float64}
+    denom::SVector{3, Float64}
     c::SVector{3, Float64}
     stage_callbacks::StageCallbacks
 
     function SimpleSSPRK33(; stage_callbacks = ())
-        a = SVector(0.0, 3 / 4, 1 / 3)
-        b = SVector(1.0, 1 / 4, 2 / 3)
+        a = SVector(0.0, 3.0, 1.0) # a = a / denom
+        b = SVector(1.0, 1.0, 2.0) # b = b / denom
+        denom = SVector(1.0, 4.0, 3.0)
         c = SVector(0.0, 1.0, 1 / 2)
 
         # Butcher tableau
@@ -42,7 +44,7 @@ struct SimpleSSPRK33{StageCallbacks} <: SimpleAlgorithmSSP
         # --------------------
         #   b | 1/6  1/6  2/3
 
-        new{typeof(stage_callbacks)}(a, b, c, stage_callbacks)
+        new{typeof(stage_callbacks)}(a, b, denom, c, stage_callbacks)
     end
 end
 
@@ -166,7 +168,7 @@ function solve!(integrator::SimpleIntegratorSSP)
             end
 
             # perform convex combination
-            @. integrator.u = alg.a[stage] * integrator.r0 + alg.b[stage] * integrator.u
+            @. integrator.u = (alg.a[stage] * integrator.r0 + alg.b[stage] * integrator.u) / alg.denom[stage]
         end
 
         integrator.iter += 1

--- a/src/time_integration/methods_SSP.jl
+++ b/src/time_integration/methods_SSP.jl
@@ -24,16 +24,16 @@ The third-order SSP Runge-Kutta method of Shu and Osher.
     This is an experimental feature and may change in future releases.
 """
 struct SimpleSSPRK33{StageCallbacks} <: SimpleAlgorithmSSP
-    a::SVector{3, Float64}
-    b::SVector{3, Float64}
-    denom::SVector{3, Float64}
+    numerator_a::SVector{3, Float64}
+    numerator_b::SVector{3, Float64}
+    denominator::SVector{3, Float64}
     c::SVector{3, Float64}
     stage_callbacks::StageCallbacks
 
     function SimpleSSPRK33(; stage_callbacks = ())
-        a = SVector(0.0, 3.0, 1.0) # a = a / denom
-        b = SVector(1.0, 1.0, 2.0) # b = b / denom
-        denom = SVector(1.0, 4.0, 3.0)
+        numerator_a = SVector(0.0, 3.0, 1.0) # a = numerator_a / denominator
+        numerator_b = SVector(1.0, 1.0, 2.0) # b = numerator_b / denominator
+        denominator = SVector(1.0, 4.0, 3.0)
         c = SVector(0.0, 1.0, 1 / 2)
 
         # Butcher tableau
@@ -44,7 +44,8 @@ struct SimpleSSPRK33{StageCallbacks} <: SimpleAlgorithmSSP
         # --------------------
         #   b | 1/6  1/6  2/3
 
-        new{typeof(stage_callbacks)}(a, b, denom, c, stage_callbacks)
+        new{typeof(stage_callbacks)}(numerator_a, numerator_b, denominator, c,
+                                     stage_callbacks)
     end
 end
 
@@ -168,8 +169,9 @@ function solve!(integrator::SimpleIntegratorSSP)
             end
 
             # perform convex combination
-            @. integrator.u = (alg.a[stage] * integrator.r0 +
-                               alg.b[stage] * integrator.u) / alg.denom[stage]
+            @. integrator.u = (alg.numerator_a[stage] * integrator.r0 +
+                               alg.numerator_b[stage] * integrator.u) /
+                              alg.denominator[stage]
         end
 
         integrator.iter += 1


### PR DESCRIPTION
This PR corrects the implementation of the SSPRK33 method. It mimics the implementation of OrdinaryDiffEq.jl to guarantee conservation.

Before, the convex combination of the third stage of SSP33 looked like:
`@. integrator.u = 1/3 * integrator.r0 + 2/3 * integrator.u`
This led to problems with conservation in machine precision. The errors in conservation grow slightly over time:
![Screenshot from 2023-09-15 17-42-13](https://github.com/trixi-framework/Trixi.jl/assets/74359358/3ff68aab-3b1d-48ce-ab23-27fccf08ca0a)

Now, with using `@. integrator.u = (1 * integrator.r0 + 2 * integrator.u) / 3` the errors level off.
![Screenshot from 2023-09-15 18-03-39](https://github.com/trixi-framework/Trixi.jl/assets/74359358/eccafd40-be2a-4763-8eec-fd68670dc19a)

These are results of a blast wave simulation with 64x64 elements using positivity subcell limiting for density.