### PR TITLE
Increase type stab, avoid allocs

### DIFF
--- a/src/solvers/dgsem_unstructured/dg_2d.jl
+++ b/src/solvers/dgsem_unstructured/dg_2d.jl
@@ -313,7 +313,7 @@ function calc_boundary_flux!(cache, t, boundary_condition::BoundaryConditionPeri
 end
 
 # Function barrier for type stability
-function calc_boundary_flux!(cache, t, boundary_conditions,
+function calc_boundary_flux!(cache, t, boundary_conditions::UnstructuredSortedBoundaryTypes,
                              mesh::Union{UnstructuredMesh2D, P4estMesh, T8codeMesh},
                              equations, surface_integral, dg::DG)
     @unpack boundary_condition_types, boundary_indices = boundary_conditions
@@ -357,9 +357,9 @@ function calc_boundary_flux_by_type!(cache, t, BCs::Tuple{}, BC_indices::Tuple{}
     nothing
 end
 
-function calc_boundary_flux!(cache, t, boundary_condition, boundary_indexing,
+function calc_boundary_flux!(cache, t, boundary_condition::BC, boundary_indexing,
                              mesh::UnstructuredMesh2D, equations,
-                             surface_integral, dg::DG)
+                             surface_integral, dg::DG) where {BC}
     @unpack surface_flux_values = cache.elements
     @unpack element_id, element_side_id = cache.boundaries
 
@@ -383,12 +383,12 @@ end
 
 # inlined version of the boundary flux calculation along a physical interface where the
 # boundary flux values are set according to a particular `boundary_condition` function
-@inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition,
+@inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition::BC,
                                      mesh::UnstructuredMesh2D,
                                      nonconservative_terms::False, equations,
                                      surface_integral, dg::DG, cache,
                                      node_index, side_index, element_index,
-                                     boundary_index)
+                                     boundary_index) where{BC}
     @unpack normal_directions = cache.elements
     @unpack u, node_coordinates = cache.boundaries
     @unpack surface_flux = surface_integral
@@ -417,12 +417,12 @@ end
 # Note, it is necessary to set and add in the nonconservative values because
 # the upper left/lower right diagonal terms have been peeled off due to the use of
 # `derivative_split` from `dg.basis` in [`flux_differencing_kernel!`](@ref)
-@inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition,
+@inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition::BC,
                                      mesh::UnstructuredMesh2D,
                                      nonconservative_terms::True, equations,
                                      surface_integral, dg::DG, cache,
                                      node_index, side_index, element_index,
-                                     boundary_index)
+                                     boundary_index) where {BC}
     surface_flux, nonconservative_flux = surface_integral.surface_flux
     @unpack normal_directions = cache.elements
     @unpack u, node_coordinates = cache.boundaries

--- a/src/solvers/dgsem_unstructured/dg_2d.jl
+++ b/src/solvers/dgsem_unstructured/dg_2d.jl
@@ -313,7 +313,8 @@ function calc_boundary_flux!(cache, t, boundary_condition::BoundaryConditionPeri
 end
 
 # Function barrier for type stability
-function calc_boundary_flux!(cache, t, boundary_conditions::UnstructuredSortedBoundaryTypes,
+function calc_boundary_flux!(cache, t,
+                             boundary_conditions::UnstructuredSortedBoundaryTypes,
                              mesh::Union{UnstructuredMesh2D, P4estMesh, T8codeMesh},
                              equations, surface_integral, dg::DG)
     @unpack boundary_condition_types, boundary_indices = boundary_conditions
@@ -388,7 +389,7 @@ end
                                      nonconservative_terms::False, equations,
                                      surface_integral, dg::DG, cache,
                                      node_index, side_index, element_index,
-                                     boundary_index) where{BC}
+                                     boundary_index) where {BC}
     @unpack normal_directions = cache.elements
     @unpack u, node_coordinates = cache.boundaries
     @unpack surface_flux = surface_integral

--- a/src/solvers/dgsem_unstructured/dg_2d.jl
+++ b/src/solvers/dgsem_unstructured/dg_2d.jl
@@ -313,8 +313,7 @@ function calc_boundary_flux!(cache, t, boundary_condition::BoundaryConditionPeri
 end
 
 # Function barrier for type stability
-function calc_boundary_flux!(cache, t,
-                             boundary_conditions::UnstructuredSortedBoundaryTypes,
+function calc_boundary_flux!(cache, t, boundary_conditions,
                              mesh::Union{UnstructuredMesh2D, P4estMesh, T8codeMesh},
                              equations, surface_integral, dg::DG)
     @unpack boundary_condition_types, boundary_indices = boundary_conditions
@@ -384,12 +383,12 @@ end
 
 # inlined version of the boundary flux calculation along a physical interface where the
 # boundary flux values are set according to a particular `boundary_condition` function
-@inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition::BC,
+@inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition,
                                      mesh::UnstructuredMesh2D,
                                      nonconservative_terms::False, equations,
                                      surface_integral, dg::DG, cache,
                                      node_index, side_index, element_index,
-                                     boundary_index) where {BC}
+                                     boundary_index)
     @unpack normal_directions = cache.elements
     @unpack u, node_coordinates = cache.boundaries
     @unpack surface_flux = surface_integral
@@ -418,12 +417,12 @@ end
 # Note, it is necessary to set and add in the nonconservative values because
 # the upper left/lower right diagonal terms have been peeled off due to the use of
 # `derivative_split` from `dg.basis` in [`flux_differencing_kernel!`](@ref)
-@inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition::BC,
+@inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition,
                                      mesh::UnstructuredMesh2D,
                                      nonconservative_terms::True, equations,
                                      surface_integral, dg::DG, cache,
                                      node_index, side_index, element_index,
-                                     boundary_index) where {BC}
+                                     boundary_index)
     surface_flux, nonconservative_flux = surface_integral.surface_flux
     @unpack normal_directions = cache.elements
     @unpack u, node_coordinates = cache.boundaries

--- a/src/time_integration/methods_SSP.jl
+++ b/src/time_integration/methods_SSP.jl
@@ -24,14 +24,16 @@ The third-order SSP Runge-Kutta method of Shu and Osher.
     This is an experimental feature and may change in future releases.
 """
 struct SimpleSSPRK33{StageCallbacks} <: SimpleAlgorithmSSP
-    a::SVector{3, Float64}
-    b::SVector{3, Float64}
+    numerator_a::SVector{3, Float64}
+    numerator_b::SVector{3, Float64}
+    denominator::SVector{3, Float64}
     c::SVector{3, Float64}
     stage_callbacks::StageCallbacks
 
     function SimpleSSPRK33(; stage_callbacks = ())
-        a = SVector(0.0, 3 / 4, 1 / 3)
-        b = SVector(1.0, 1 / 4, 2 / 3)
+        numerator_a = SVector(0.0, 3.0, 1.0) # a = numerator_a / denominator
+        numerator_b = SVector(1.0, 1.0, 2.0) # b = numerator_b / denominator
+        denominator = SVector(1.0, 4.0, 3.0)
         c = SVector(0.0, 1.0, 1 / 2)
 
         # Butcher tableau
@@ -42,7 +44,8 @@ struct SimpleSSPRK33{StageCallbacks} <: SimpleAlgorithmSSP
         # --------------------
         #   b | 1/6  1/6  2/3
 
-        new{typeof(stage_callbacks)}(a, b, c, stage_callbacks)
+        new{typeof(stage_callbacks)}(numerator_a, numerator_b, denominator, c,
+                                     stage_callbacks)
     end
 end
 
@@ -166,7 +169,9 @@ function solve!(integrator::SimpleIntegratorSSP)
             end
 
             # perform convex combination
-            @. integrator.u = alg.a[stage] * integrator.r0 + alg.b[stage] * integrator.u
+            @. integrator.u = (alg.numerator_a[stage] * integrator.r0 +
+                               alg.numerator_b[stage] * integrator.u) /
+                              alg.denominator[stage]
         end
 
         integrator.iter += 1

--- a/test/test_threaded.jl
+++ b/test/test_threaded.jl
@@ -312,11 +312,7 @@ Trixi.mpi_isroot() && isdir(outdir) && rm(outdir, recursive=true)
         t = sol.t[end]
         u_ode = sol.u[end]
         du_ode = similar(u_ode)
-        if (Threads.nthreads() < 2) || (VERSION < v"1.9")
-          @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 5000
-        else
-          @test_broken (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 5000
-        end
+        @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 5000
       end
     end
 


### PR DESCRIPTION
Similar to  #1635 and the corresponding fix #1636 I noticed in recent test runs (e.g. https://github.com/trixi-framework/Trixi.jl/actions/runs/6219235479/job/16876951926?pr=1629#step:7:4212) allocations in `calc_boundary_flux!`. 

For https://github.com/trixi-framework/Trixi.jl/blob/main/examples/unstructured_2d_dgsem/elixir_acoustics_gauss_wall.jl I get for the current version on main 

```
 ────────────────────────────────────────────────────────────────────────────────────
              Trixi.jl                      Time                    Allocations      
                                   ───────────────────────   ────────────────────────
         Tot / % measured:              9.93s /  77.7%           3.68GiB /  99.5%    

 Section                   ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────────────────────
 rhs!                       13.2k    7.28s   94.4%   552μs   3.61GiB   98.7%   287KiB
   volume integral          13.2k    2.88s   37.4%   219μs     0.00B    0.0%    0.00B
   interface flux           13.2k    1.14s   14.8%  86.3μs     0.00B    0.0%    0.00B
   boundary flux            13.2k    1.11s   14.4%  84.3μs   3.61GiB   98.7%   287KiB
   prolong2interfaces       13.2k    758ms    9.8%  57.5μs     0.00B    0.0%    0.00B
   surface integral         13.2k    716ms    9.3%  54.3μs     0.00B    0.0%    0.00B
   Jacobian                 13.2k    369ms    4.8%  28.0μs     0.00B    0.0%    0.00B
   reset ∂u/∂t              13.2k    227ms    2.9%  17.2μs     0.00B    0.0%    0.00B
   prolong2boundaries       13.2k   53.5ms    0.7%  4.06μs     0.00B    0.0%    0.00B
   ~rhs!~                   13.2k   18.5ms    0.2%  1.40μs   6.61KiB    0.0%    0.51B
   source terms             13.2k    204μs    0.0%  15.4ns     0.00B    0.0%    0.00B
 I/O                           32    298ms    3.9%  9.31ms   37.8MiB    1.0%  1.18MiB
   save solution               31    191ms    2.5%  6.17ms   37.6MiB    1.0%  1.21MiB
   ~I/O~                       32    107ms    1.4%  3.33ms    249KiB    0.0%  7.77KiB
   get element variables       31   41.0μs    0.0%  1.32μs   6.78KiB    0.0%     224B
   save mesh                   31   10.8μs    0.0%   347ns     0.00B    0.0%    0.00B
 analyze solution              16    135ms    1.7%  8.42ms   10.9MiB    0.3%   695KiB
 ────────────────────────────────────────────────────────────────────────────────────
```

With the proposed changes

```
 ────────────────────────────────────────────────────────────────────────────────────
              Trixi.jl                      Time                    Allocations      
                                   ───────────────────────   ────────────────────────
         Tot / % measured:              8.93s /  76.7%           61.1MiB /  72.1%    

 Section                   ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────────────────────
 rhs!                       13.2k    6.42s   93.6%   486μs   6.61KiB    0.0%    0.51B
   volume integral          13.2k    2.91s   42.5%   221μs     0.00B    0.0%    0.00B
   interface flux           13.2k    1.15s   16.8%  87.3μs     0.00B    0.0%    0.00B
   prolong2interfaces       13.2k    770ms   11.2%  58.4μs     0.00B    0.0%    0.00B
   surface integral         13.2k    708ms   10.3%  53.7μs     0.00B    0.0%    0.00B
   Jacobian                 13.2k    356ms    5.2%  27.0μs     0.00B    0.0%    0.00B
   reset ∂u/∂t              13.2k    228ms    3.3%  17.3μs     0.00B    0.0%    0.00B
   boundary flux            13.2k    217ms    3.2%  16.5μs     0.00B    0.0%    0.00B
   prolong2boundaries       13.2k   55.3ms    0.8%  4.20μs     0.00B    0.0%    0.00B
   ~rhs!~                   13.2k   18.6ms    0.3%  1.41μs   6.61KiB    0.0%    0.51B
   source terms             13.2k    282μs    0.0%  21.4ns     0.00B    0.0%    0.00B
 I/O                           32    294ms    4.3%  9.18ms   37.8MiB   85.8%  1.18MiB
   save solution               31    178ms    2.6%  5.76ms   37.6MiB   85.3%  1.21MiB
   ~I/O~                       32    115ms    1.7%  3.60ms    249KiB    0.6%  7.77KiB
   get element variables       31   40.3μs    0.0%  1.30μs   6.78KiB    0.0%     224B
   save mesh                   31   11.9μs    0.0%   385ns     0.00B    0.0%    0.00B
 analyze solution              16    145ms    2.1%  9.06ms   6.24MiB   14.2%   400KiB
 ────────────────────────────────────────────────────────────────────────────────────
```

