### PR TITLE
Fix mapping string in `StructuredMesh`

### DIFF
--- a/src/meshes/mesh_io.jl
+++ b/src/meshes/mesh_io.jl
@@ -263,32 +263,27 @@ function load_mesh_serial(mesh_file::AbstractString; n_cells_max, RealT)
         size = Tuple(size_)
 
         # TODO: `@eval` is evil
-        # A temporary workaround to evaluate the code that defines the domain mapping in a local scope.
-        # This prevents errors when multiple restart elixirs are executed in one session, where one
-        # defines `mapping` as a variable, while the other defines it as a function.
         #
         # This should be replaced with something more robust and secure,
         # see https://github.com/trixi-framework/Trixi.jl/issues/541).
-        expr = Meta.parseall(mapping_as_string)
-        if expr.head == :toplevel
-            expr.head = :block
-        end
-
         if ndims == 1
-            mapping = @eval function (xi)
-                $expr
+            mapping = eval(Meta.parse("""function (xi)
+                $mapping_as_string
                 mapping(xi)
             end
+            """))
         elseif ndims == 2
-            mapping = @eval function (xi, eta)
-                $expr
+            mapping = eval(Meta.parse("""function (xi, eta)
+                $mapping_as_string
                 mapping(xi, eta)
             end
+            """))
         else # ndims == 3
-            mapping = @eval function (xi, eta, zeta)
-                $expr
+            mapping = eval(Meta.parse("""function (xi, eta, zeta)
+                $mapping_as_string
                 mapping(xi, eta, zeta)
             end
+            """))
         end
 
         mesh = StructuredMesh(size, mapping; RealT = RealT, unsaved_changes = false,

--- a/src/meshes/mesh_io.jl
+++ b/src/meshes/mesh_io.jl
@@ -269,7 +269,7 @@ function load_mesh_serial(mesh_file::AbstractString; n_cells_max, RealT)
         #
         # This should be replaced with something more robust and secure,
         # see https://github.com/trixi-framework/Trixi.jl/issues/541).
-        expr = Meta.parse(mapping_as_string)
+        expr = Meta.parseall(mapping_as_string)
         if expr.head == :toplevel
             expr.head = :block
         end

--- a/src/meshes/structured_mesh.jl
+++ b/src/meshes/structured_mesh.jl
@@ -102,7 +102,11 @@ function StructuredMesh(cells_per_dimension, faces::Tuple; RealT = Float64,
 
     # Include faces definition in `mapping_as_string` to allow for evaluation
     # without knowing the face functions
-    mapping_as_string = "$faces_definition\nfaces = $(string(faces))\nmapping = transfinite_mapping(faces)"
+    mapping_as_string = """
+        $faces_definition
+        faces = $(string(faces))
+        mapping = transfinite_mapping(faces)
+        """
 
     return StructuredMesh(cells_per_dimension, mapping; RealT = RealT,
                           periodicity = periodicity,
@@ -123,13 +127,14 @@ Create a StructuredMesh that represents a uncurved structured mesh with a rectan
 """
 function StructuredMesh(cells_per_dimension, coordinates_min, coordinates_max;
                         periodicity = true)
-    NDIMS = length(cells_per_dimension)
     RealT = promote_type(eltype(coordinates_min), eltype(coordinates_max))
 
     mapping = coordinates2mapping(coordinates_min, coordinates_max)
-    mapping_as_string = "coordinates_min = $coordinates_min; " *
-                        "coordinates_max = $coordinates_max; " *
-                        "mapping = coordinates2mapping(coordinates_min, coordinates_max)"
+    mapping_as_string = """
+        coordinates_min = $coordinates_min
+        coordinates_max = $coordinates_max
+        mapping = coordinates2mapping(coordinates_min, coordinates_max)
+        """
     return StructuredMesh(cells_per_dimension, mapping; RealT = RealT,
                           periodicity = periodicity,
                           mapping_as_string = mapping_as_string)

--- a/src/meshes/structured_mesh.jl
+++ b/src/meshes/structured_mesh.jl
@@ -96,13 +96,13 @@ function StructuredMesh(cells_per_dimension, faces::Tuple; RealT = Float64,
 
     # Collect definitions of face functions in one string (separated by semicolons)
     face2substring(face) = code_string(face, ntuple(_ -> Float64, NDIMS - 1))
-    join_semicolon(strings) = join(strings, "; ")
+    join_newline(strings) = join(strings, "\n")
 
-    faces_definition = faces .|> face2substring .|> string |> join_semicolon
+    faces_definition = faces .|> face2substring .|> string |> join_newline
 
     # Include faces definition in `mapping_as_string` to allow for evaluation
     # without knowing the face functions
-    mapping_as_string = "$faces_definition; faces = $(string(faces)); mapping = transfinite_mapping(faces)"
+    mapping_as_string = "$faces_definition\nfaces = $(string(faces))\nmapping = transfinite_mapping(faces)"
 
     return StructuredMesh(cells_per_dimension, mapping; RealT = RealT,
                           periodicity = periodicity,


### PR DESCRIPTION
This is a quick fix to allow mapping definitions with inline comments like this:
```julia
f1(x) = SVector(0.0, x) # some comment
f2(x) = SVector(1.0, x) # some comment
f3(eta) = SVector(x, 0.0) # some comment
f4(eta) = SVector(x, 1.0) # some comment
```
It still doesn't work when external variables are used in the face definitions, like
```julia
a = 0.0
f1(x) = SVector(a, x)
```
And the whole eval thing is still not nice, but for that we have #541.