### PR TITLE
Fix calcuation of `n_elements` in resizing limiter-specific containers

### DIFF
--- a/src/time_integration/methods_SSP.jl
+++ b/src/time_integration/methods_SSP.jl
@@ -226,7 +226,9 @@ function Base.resize!(integrator::SimpleIntegratorSSP, new_size)
     resize!(integrator.r0, new_size)
 
     # Resize container
-    resize!(integrator.p, new_size)
+    # new_size = n_variables * n_nodes^n_dims * n_elements
+    n_elements = nelements(integrator.p.solver, integrator.p.cache)
+    resize!(integrator.p, n_elements)
 end
 
 function Base.resize!(semi::AbstractSemidiscretization, new_size)


### PR DESCRIPTION
This fixes an error in the resizing of limiter-specific containers. Before, `length(u_ode)` was used for the new number of elements, although `length(u_ode) = n_variables * n_nodes^n_dims * n_elements`.
So, now it is possible to use AMR and initially nonconforming meshes for subcell limiting.

Nevertheless, **respecting the bounds is not guaranteed for subcell IDP limiting at non-conforming subcell interfaces**. Therefore, hanging nodes and mortars are ignored in the limiting process right now. However, often the simulation is still running nearly as good and with less computing effort.
