### PR TITLE
format with new version of JuliaFormatter

### DIFF
--- a/src/semidiscretization/semidiscretization_euler_acoustics.jl
+++ b/src/semidiscretization/semidiscretization_euler_acoustics.jl
@@ -51,11 +51,11 @@ function SemidiscretizationEulerAcoustics(semi_acoustics::SemiAcoustics,
                                           semi_euler::SemiEuler;
                                           source_region = x -> true,
                                           weights = x -> 1.0) where
-    {Mesh,
-     SemiAcoustics <:
-     SemidiscretizationHyperbolic{Mesh, <:AbstractAcousticPerturbationEquations},
-     SemiEuler <:
-     SemidiscretizationHyperbolic{Mesh, <:AbstractCompressibleEulerEquations}}
+        {Mesh,
+         SemiAcoustics <:
+         SemidiscretizationHyperbolic{Mesh, <:AbstractAcousticPerturbationEquations},
+         SemiEuler <:
+         SemidiscretizationHyperbolic{Mesh, <:AbstractCompressibleEulerEquations}}
     cache = create_cache(SemidiscretizationEulerAcoustics, source_region, weights,
                          mesh_equations_solver_cache(semi_acoustics)...)
 

--- a/src/semidiscretization/semidiscretization_euler_gravity.jl
+++ b/src/semidiscretization/semidiscretization_euler_gravity.jl
@@ -117,11 +117,11 @@ Construct a semidiscretization of the compressible Euler equations with self-gra
 function SemidiscretizationEulerGravity(semi_euler::SemiEuler,
                                         semi_gravity::SemiGravity,
                                         parameters) where
-    {Mesh,
-     SemiEuler <:
-     SemidiscretizationHyperbolic{Mesh, <:AbstractCompressibleEulerEquations},
-     SemiGravity <:
-     SemidiscretizationHyperbolic{Mesh, <:AbstractHyperbolicDiffusionEquations}}
+        {Mesh,
+         SemiEuler <:
+         SemidiscretizationHyperbolic{Mesh, <:AbstractCompressibleEulerEquations},
+         SemiGravity <:
+         SemidiscretizationHyperbolic{Mesh, <:AbstractHyperbolicDiffusionEquations}}
     u_ode = compute_coefficients(zero(real(semi_gravity)), semi_gravity)
     du_ode = similar(u_ode)
     u_tmp1_ode = similar(u_ode)


### PR DESCRIPTION
JuliaFormatter released a new version changing the SciML style again. Thus, we have to re-format our code to let the corresponding CI job pass.