### PR TITLE
Add NumFOCUS + ACTRIX to acknowledgments

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,13 +257,13 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 
 ## Acknowledgments
 <p align="center" style="font-size:0;"><!--
-  BMBF     --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120"><!--
-  DFG      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120"><!--
-  SRC      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120"><!--
-  ERC      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120"><!--
-  NSF      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120"><!--
-  DUBS     --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/c7f0ea4d-9865-40f4-b0bd-9f4709356f22" height="120"><!--
-  NumFOCUS --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120"><!--
+  BMBF     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120"><!--
+  DFG      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120"><!--
+  SRC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120"><!--
+  ERC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120"><!--
+  NSF      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120"><!--
+  DUBS     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937" height="120"><!--
+  NumFOCUS --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120"><!--
   -->
 </p>
 
@@ -295,5 +295,9 @@ This project has benefited from funding from the German
 through the project grant "Adaptive earth system modeling
 with significantly reduced computation time for exascale supercomputers
 (ADAPTEX)" (funding id: 16ME0668K).
+
+This project has benefited from funding by the
+[Daimler und Benz Stiftung](https://www.daimler-benz-stiftung.de) (Daimler and Benz Foundation)
+through grant no. 32-10/22.
 
 Trixi.jl is supported by [NumFOCUS](https://numfocus.org/) as an Affiliated Project.

--- a/README.md
+++ b/README.md
@@ -256,13 +256,15 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 
 
 ## Acknowledgments
-<p align="center" style="font-size:0;">
-     <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120px"><!--
-  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120px"><!--
-  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120px"><!--
-  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120px"><!--
-  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120px"><!--
-  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120px">
+<p align="center" style="font-size:0;"><!--
+  BMBF     --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120"><!--
+  DFG      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120"><!--
+  SRC      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120"><!--
+  ERC      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120"><!--
+  NSF      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120"><!--
+  DUBS     --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/c7f0ea4d-9865-40f4-b0bd-9f4709356f22" height="120"><!--
+  NumFOCUS --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120"><!--
+  -->
 </p>
 
 This project has benefited from funding by the [Deutsche

--- a/README.md
+++ b/README.md
@@ -256,16 +256,25 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 
 
 ## Acknowledgments
-<p align="center" style="font-size:0;"><!--
-  BMBF     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120"><!--
-  DFG      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120"><!--
-  SRC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120"><!--
-  ERC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120"><!--
-  NSF      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120"><!--
-  DUBS     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937" height="120"><!--
-  NumFOCUS --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120"><!--
-  -->
-</p>
+<div style="width: 100%; text-align: center; font-size: 0;">
+<!-- This style seems to work for both GitHub Flavored Markdown and Documenter.jl's raw HTML -->
+  <div><!--
+    BMBF     --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" style="height: 120px; width: auto"><!--
+    DFG      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" style="height: 120px; width: auto"><!--
+    SRC      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" style="height: 120px; width: auto"><!--
+    -->
+  </div>
+  <div><!--
+    ERC      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" style="height: 120px; width: auto"><!--
+    NSF      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/5325103c-ae81-4747-b87c-c6e4a1b1d7a8" style="height: 120px; width: auto"><!--
+    DUBS     --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937" style="height: 120px; width: auto"><!--
+    -->
+  </div>
+  <div><!--
+    NumFOCUS --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" style="height: 120px; width: auto"><!--
+    -->
+  </div>
+</div>
 
 This project has benefited from funding by the [Deutsche
 Forschungsgemeinschaft](https://www.dfg.de/) (DFG, German Research Foundation)

--- a/README.md
+++ b/README.md
@@ -256,25 +256,16 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 
 
 ## Acknowledgments
-<div style="width: 100%; text-align: center; font-size: 0;">
-<!-- This style seems to work for both GitHub Flavored Markdown and Documenter.jl's raw HTML -->
-  <div><!--
-    BMBF     --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" style="height: 120px; width: auto"><!--
-    DFG      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" style="height: 120px; width: auto"><!--
-    SRC      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" style="height: 120px; width: auto"><!--
-    -->
-  </div>
-  <div><!--
-    ERC      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" style="height: 120px; width: auto"><!--
-    NSF      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/5325103c-ae81-4747-b87c-c6e4a1b1d7a8" style="height: 120px; width: auto"><!--
-    DUBS     --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937" style="height: 120px; width: auto"><!--
-    -->
-  </div>
-  <div><!--
-    NumFOCUS --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" style="height: 120px; width: auto"><!--
-    -->
-  </div>
-</div>
+<p align="center" style="font-size:0;"><!--
+  BMBF     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120"><!--
+  DFG      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120"><!--
+  SRC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120"><!--
+  ERC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120"><!--
+  NSF      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/5325103c-ae81-4747-b87c-c6e4a1b1d7a8" height="120"><!--
+  DUBS     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937" height="120"><!--
+  NumFOCUS --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120"><!--
+  -->
+</p>
 
 This project has benefited from funding by the [Deutsche
 Forschungsgemeinschaft](https://www.dfg.de/) (DFG, German Research Foundation)

--- a/README.md
+++ b/README.md
@@ -257,12 +257,12 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 
 ## Acknowledgments
 <p align="center" style="font-size:0;">
-  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120px">
-  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120px">
-  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120px">
-  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120px">
-  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120px">
-  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120px">
+     <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120px"><!--
+  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120px"><!--
+  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120px"><!--
+  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120px"><!--
+  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120px"><!--
+  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120px">
 </p>
 
 This project has benefited from funding by the [Deutsche

--- a/README.md
+++ b/README.md
@@ -257,7 +257,12 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 
 ## Acknowledgments
 <p align="center">
-  <img align="middle" src="https://user-images.githubusercontent.com/3637659/233821022-84910be7-8649-4999-a0ff-22d5e20f0b90.jpg" width=auto/>
+  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120px">
+  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120px">
+  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120px">
+  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120px">
+  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120px">
+  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120px">
 </p>
 
 This project has benefited from funding by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation)
@@ -267,6 +272,9 @@ Dynamics-Geometry-Structure.
 This project has benefited from funding by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation)
 through the research unit FOR 5409 "Structure-Preserving Numerical Methods for Bulk- and
 Interface Coupling of Heterogeneous Models (SNuBIC)" (project number 463312734).
+
+This project has benefited from funding by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation)
+under grant no. 528753982.
 
 This project has benefited from funding from the European Research Council through the
 ERC Starting Grant "An Exascale aware and Un-crashable Space-Time-Adaptive
@@ -284,3 +292,5 @@ This project has benefited from funding from the German Federal Ministry of
 Education and Research through the project grant "Adaptive earth system modeling
 with significantly reduced computation time for exascale supercomputers
 (ADAPTEX)" (funding id: 16ME0668K).
+
+Trixi.jl is supported by NumFOCUS as an Affiliated Project.

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 
 
 ## Acknowledgments
-<p align="center">
+<p align="center" style="font-size:0;">
   <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120px">
   <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120px">
   <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120px">
@@ -265,32 +265,33 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
   <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120px">
 </p>
 
-This project has benefited from funding by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation)
-under Germany's Excellence Strategy EXC 2044-390685587, Mathematics Münster:
-Dynamics-Geometry-Structure.
+This project has benefited from funding by the [Deutsche
+Forschungsgemeinschaft](https://www.dfg.de/) (DFG, German Research Foundation)
+through the following grants:
+* Excellence Strategy EXC 2044-390685587, Mathematics Münster: Dynamics-Geometry-Structure.
+* Research unit FOR 5409 "Structure-Preserving Numerical Methods for Bulk- and
+  Interface Coupling of Heterogeneous Models (SNuBIC)" (project number 463312734).
+* Individual grant no. 528753982.
 
-This project has benefited from funding by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation)
-through the research unit FOR 5409 "Structure-Preserving Numerical Methods for Bulk- and
-Interface Coupling of Heterogeneous Models (SNuBIC)" (project number 463312734).
-
-This project has benefited from funding by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation)
-under grant no. 528753982.
-
-This project has benefited from funding from the European Research Council through the
+This project has benefited from funding from the [European Research Council](https://erc.europa.eu)
+through the
 ERC Starting Grant "An Exascale aware and Un-crashable Space-Time-Adaptive
 Discontinuous Spectral Element Solver for Non-Linear Conservation Laws" (Extreme),
 ERC grant agreement no. 714487.
 
-This project has benefited from funding from Vetenskapsrådet (VR, Swedish Research Council), Sweden
+This project has benefited from funding from [Vetenskapsrådet](https://www.vr.se)
+(VR, Swedish Research Council), Sweden
 through the VR Starting Grant "Shallow water flows including sediment transport and morphodynamics",
 VR grant agreement 2020-03642 VR.
 
-This project has benefited from funding from the United States National Science Foundation under awards
+This project has benefited from funding from the United States
+[National Science Foundation](https://www.nsf.gov/) (NSF) under awards
 DMS-1719818 and DMS-1943186.
 
-This project has benefited from funding from the German Federal Ministry of
-Education and Research through the project grant "Adaptive earth system modeling
+This project has benefited from funding from the German
+[Federal Ministry of Education and Research](https://www.bmbf.de) (BMBF)
+through the project grant "Adaptive earth system modeling
 with significantly reduced computation time for exascale supercomputers
 (ADAPTEX)" (funding id: 16ME0668K).
 
-Trixi.jl is supported by NumFOCUS as an Affiliated Project.
+Trixi.jl is supported by [NumFOCUS](https://numfocus.org/) as an Affiliated Project.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -399,6 +399,12 @@ through the project grant "Adaptive earth system modeling
 with significantly reduced computation time for exascale supercomputers
 (ADAPTEX)" (funding id: 16ME0668K).
 
+
+| ![BMBF](https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6) | ![DFG](https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e) | ![SRC](https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0) |
+| ![ERC](https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca) | ![NSF](https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125) | ![DUBS](https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937) |
+| | ![NumFOCUS](https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185) | |
+
+
 This project has benefited from funding by the
 [Daimler und Benz Stiftung](https://www.daimler-benz-stiftung.de) (Daimler and Benz Foundation)
 through grant no. 32-10/22.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -344,7 +344,16 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 
 ## Acknowledgments
 
-![funding-logo](https://user-images.githubusercontent.com/3637659/233821022-84910be7-8649-4999-a0ff-22d5e20f0b90.jpg)
+```@raw html
+<p align="center">
+  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120px">
+  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120px">
+  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120px">
+  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120px">
+  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120px">
+  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120px">
+</p>
+```
 
 This project has benefited from funding by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation)
 under Germany's Excellence Strategy EXC 2044-390685587, Mathematics Münster:
@@ -353,6 +362,9 @@ Dynamics-Geometry-Structure.
 This project has benefited from funding by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation)
 through the research unit FOR 5409 "Structure-Preserving Numerical Methods for Bulk- and
 Interface Coupling of Heterogeneous Models (SNuBIC)" (project number 463312734).
+
+This project has benefited from funding by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation)
+under grant no. 528753982.
 
 This project has benefited from funding from the European Research Council through the
 ERC Starting Grant "An Exascale aware and Un-crashable Space-Time-Adaptive
@@ -370,3 +382,5 @@ This project has benefited from funding from the German Federal Ministry of
 Education and Research through the project grant "Adaptive earth system modeling
 with significantly reduced computation time for exascale supercomputers
 (ADAPTEX)" (funding id: 16ME0668K).
+
+Trixi.jl is supported by NumFOCUS as an Affiliated Project.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -345,7 +345,7 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 ## Acknowledgments
 
 ```@raw html
-<p align="center">
+<p align="center" style="font-size:0;">
   <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120px">
   <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120px">
   <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120px">
@@ -355,32 +355,33 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 </p>
 ```
 
-This project has benefited from funding by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation)
-under Germany's Excellence Strategy EXC 2044-390685587, Mathematics Münster:
-Dynamics-Geometry-Structure.
+This project has benefited from funding by the [Deutsche
+Forschungsgemeinschaft](https://www.dfg.de/) (DFG, German Research Foundation)
+through the following grants:
+* Excellence Strategy EXC 2044-390685587, Mathematics Münster: Dynamics-Geometry-Structure.
+* Research unit FOR 5409 "Structure-Preserving Numerical Methods for Bulk- and
+  Interface Coupling of Heterogeneous Models (SNuBIC)" (project number 463312734).
+* Individual grant no. 528753982.
 
-This project has benefited from funding by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation)
-through the research unit FOR 5409 "Structure-Preserving Numerical Methods for Bulk- and
-Interface Coupling of Heterogeneous Models (SNuBIC)" (project number 463312734).
-
-This project has benefited from funding by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation)
-under grant no. 528753982.
-
-This project has benefited from funding from the European Research Council through the
+This project has benefited from funding from the [European Research Council](https://erc.europa.eu)
+through the
 ERC Starting Grant "An Exascale aware and Un-crashable Space-Time-Adaptive
 Discontinuous Spectral Element Solver for Non-Linear Conservation Laws" (Extreme),
 ERC grant agreement no. 714487.
 
-This project has benefited from funding from Vetenskapsrådet (VR, Swedish Research Council), Sweden
+This project has benefited from funding from [Vetenskapsrådet](https://www.vr.se)
+(VR, Swedish Research Council), Sweden
 through the VR Starting Grant "Shallow water flows including sediment transport and morphodynamics",
 VR grant agreement 2020-03642 VR.
 
-This project has benefited from funding from the United States National Science Foundation under awards
+This project has benefited from funding from the United States
+[National Science Foundation](https://www.nsf.gov/) (NSF) under awards
 DMS-1719818 and DMS-1943186.
 
-This project has benefited from funding from the German Federal Ministry of
-Education and Research through the project grant "Adaptive earth system modeling
+This project has benefited from funding from the German
+[Federal Ministry of Education and Research](https://www.bmbf.de) (BMBF)
+through the project grant "Adaptive earth system modeling
 with significantly reduced computation time for exascale supercomputers
 (ADAPTEX)" (funding id: 16ME0668K).
 
-Trixi.jl is supported by NumFOCUS as an Affiliated Project.
+Trixi.jl is supported by [NumFOCUS](https://numfocus.org/) as an Affiliated Project.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -341,33 +341,29 @@ To get in touch with the developers,
 [join us on Slack](https://join.slack.com/t/trixi-framework/shared_invite/zt-sgkc6ppw-6OXJqZAD5SPjBYqLd8MU~g)
 or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 
-```@raw html
-<p align="center" style="font-size:0;"><!--
-  BMBF     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120" style="display: inline;"><!--
-  DFG      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120" style="display: inline;"><!--
-  SRC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120" style="display: inline;"><!--
-  ERC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120" style="display: inline;"><!--
-  NSF      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120" style="display: inline;"><!--
-  DUBS     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937" height="120" style="display: inline;"><!--
-  NumFOCUS --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120" style="display: inline;"><!--
-  -->
-</p>
-```
-
 
 ## Acknowledgments
 
 ```@raw html
-<p align="center" style="font-size:0;"><!--
-  BMBF     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120"><!--
-  DFG      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120"><!--
-  SRC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120"><!--
-  ERC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120"><!--
-  NSF      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120"><!--
-  DUBS     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937" height="120"><!--
-  NumFOCUS --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120"><!--
-  -->
-</p>
+<div style="width: 100%; text-align: center; font-size: 0;">
+<!-- This style seems to work for both GitHub Flavored Markdown and Documenter.jl's raw HTML -->
+  <div><!--
+    BMBF     --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" style="height: 120px; width: auto"><!--
+    DFG      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" style="height: 120px; width: auto"><!--
+    SRC      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" style="height: 120px; width: auto"><!--
+    -->
+  </div>
+  <div><!--
+    ERC      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" style="height: 120px; width: auto"><!--
+    NSF      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/5325103c-ae81-4747-b87c-c6e4a1b1d7a8" style="height: 120px; width: auto"><!--
+    DUBS     --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937" style="height: 120px; width: auto"><!--
+    -->
+  </div>
+  <div><!--
+    NumFOCUS --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" style="height: 120px; width: auto"><!--
+    -->
+  </div>
+</div>
 ```
 
 This project has benefited from funding by the [Deutsche
@@ -399,54 +395,8 @@ through the project grant "Adaptive earth system modeling
 with significantly reduced computation time for exascale supercomputers
 (ADAPTEX)" (funding id: 16ME0668K).
 
-
-| Make | this | a table! |
-|--------|-------------|------------|
-| first | row | with text |
-| ![BMBF](https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6) | ![DFG](https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e) | ![SRC](https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0) |
-| ![ERC](https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca) | ![NSF](https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125) | ![DUBS](https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937) |
-| | ![NumFOCUS](https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185) | |
-
-
 This project has benefited from funding by the
 [Daimler und Benz Stiftung](https://www.daimler-benz-stiftung.de) (Daimler and Benz Foundation)
 through grant no. 32-10/22.
-```@raw html
-<p align="center" style="font-size:0;">
-  <table style="border-collapse: collapse; width: 100%">
-    <tr>
-      <td style="padding: 0; margin: 0; width: 33%">
-        <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120">
-      </td>
-      <td style="padding: 0; margin: 0; width: 33%">
-        <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120">
-      </td>
-      <td style="padding: 0; margin: 0; width: 33%">
-        <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120">
-      </td>
-    </tr>
-    <tr>
-      <td style="padding: 0; margin: 0; width: 33%">
-        <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120">
-      </td>
-      <td style="padding: 0; margin: 0; width: 33%">
-        <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120">
-      </td>
-      <td style="padding: 0; margin: 0; width: 33%">
-        <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937" height="120">
-      </td>
-    </tr>
-    <tr>
-      <td style="padding: 0; margin: 0; width: 33%">
-      </td>
-      <td style="padding: 0; margin: 0; width: 33%">
-        <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120">
-      </td>
-      <td style="padding: 0; margin: 0; width: 33%">
-      </td>
-    </tr>
-  </table>
-</p>
-```
 
 Trixi.jl is supported by [NumFOCUS](https://numfocus.org/) as an Affiliated Project.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -341,15 +341,32 @@ To get in touch with the developers,
 [join us on Slack](https://join.slack.com/t/trixi-framework/shared_invite/zt-sgkc6ppw-6OXJqZAD5SPjBYqLd8MU~g)
 or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 
+```@raw html
+<p align="center" style="font-size:0;"><!--
+  BMBF     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120" style="display: inline;"><!--
+  DFG      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120" style="display: inline;"><!--
+  SRC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120" style="display: inline;"><!--
+  ERC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120" style="display: inline;"><!--
+  NSF      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120" style="display: inline;"><!--
+  DUBS     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/c7f0ea4d-9865-40f4-b0bd-9f4709356f22" height="120" style="display: inline;"><!--
+  NumFOCUS --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120" style="display: inline;"><!--
+  -->
+</p>
+```
+
 
 ## Acknowledgments
 
 ```@raw html
-<p align="center" style="font-size:0;">
-     <!-- Unfortunately, Documenter does not support adding comments to remove
-     the line breaks, thus all images have to be on one line to be shown in
-     proper size and next to each other. -->
-     <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120px"><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120px"><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120px"><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120px"><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120px"><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120px">
+<p align="center" style="font-size:0;"><!--
+  BMBF     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120"><!--
+  DFG      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120"><!--
+  SRC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120"><!--
+  ERC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120"><!--
+  NSF      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120"><!--
+  DUBS     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/c7f0ea4d-9865-40f4-b0bd-9f4709356f22" height="120"><!--
+  NumFOCUS --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120"><!--
+  -->
 </p>
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -400,6 +400,9 @@ with significantly reduced computation time for exascale supercomputers
 (ADAPTEX)" (funding id: 16ME0668K).
 
 
+| Make | this | a table! |
+|--------|-------------|------------|
+| first | row | with text |
 | ![BMBF](https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6) | ![DFG](https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e) | ![SRC](https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0) |
 | ![ERC](https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca) | ![NSF](https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125) | ![DUBS](https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937) |
 | | ![NumFOCUS](https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185) | |
@@ -408,5 +411,42 @@ with significantly reduced computation time for exascale supercomputers
 This project has benefited from funding by the
 [Daimler und Benz Stiftung](https://www.daimler-benz-stiftung.de) (Daimler and Benz Foundation)
 through grant no. 32-10/22.
+```@raw html
+<p align="center" style="font-size:0;">
+  <table style="border-collapse: collapse; width: 100%">
+    <tr>
+      <td style="padding: 0; margin: 0; width: 33%">
+        <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120">
+      </td>
+      <td style="padding: 0; margin: 0; width: 33%">
+        <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120">
+      </td>
+      <td style="padding: 0; margin: 0; width: 33%">
+        <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120">
+      </td>
+    </tr>
+    <tr>
+      <td style="padding: 0; margin: 0; width: 33%">
+        <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120">
+      </td>
+      <td style="padding: 0; margin: 0; width: 33%">
+        <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120">
+      </td>
+      <td style="padding: 0; margin: 0; width: 33%">
+        <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937" height="120">
+      </td>
+    </tr>
+    <tr>
+      <td style="padding: 0; margin: 0; width: 33%">
+      </td>
+      <td style="padding: 0; margin: 0; width: 33%">
+        <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120">
+      </td>
+      <td style="padding: 0; margin: 0; width: 33%">
+      </td>
+    </tr>
+  </table>
+</p>
+```
 
 Trixi.jl is supported by [NumFOCUS](https://numfocus.org/) as an Affiliated Project.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -346,12 +346,10 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 
 ```@raw html
 <p align="center" style="font-size:0;">
-     <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120px"><!--
-  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120px"><!--
-  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120px"><!--
-  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120px"><!--
-  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120px"><!--
-  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120px">
+     <!-- Unfortunately, Documenter does not support adding comments to remove
+     the line breaks, thus all images have to be on one line to be shown in
+     proper size and next to each other. -->
+     <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120px"><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120px"><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120px"><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120px"><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120px"><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120px">
 </p>
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -346,7 +346,6 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 
 ```@raw html
 <div style="width: 100%; text-align: center; font-size: 0;">
-<!-- This style seems to work for both GitHub Flavored Markdown and Documenter.jl's raw HTML -->
   <div><!--
     BMBF     --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" style="height: 120px; width: auto"><!--
     DFG      --><img src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" style="height: 120px; width: auto"><!--

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -346,12 +346,12 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
 
 ```@raw html
 <p align="center" style="font-size:0;">
-  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120px">
-  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120px">
-  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120px">
-  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120px">
-  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120px">
-  <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120px">
+     <img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/f59af636-3098-4be6-bf80-c6be3f17cbc6" height="120px"><!--
+  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/e67b9ed3-7699-466a-bdaf-2ba070a29a8e" height="120px"><!--
+  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120px"><!--
+  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120px"><!--
+  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120px"><!--
+  --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120px">
 </p>
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -348,7 +348,7 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
   SRC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120" style="display: inline;"><!--
   ERC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120" style="display: inline;"><!--
   NSF      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120" style="display: inline;"><!--
-  DUBS     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/c7f0ea4d-9865-40f4-b0bd-9f4709356f22" height="120" style="display: inline;"><!--
+  DUBS     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937" height="120" style="display: inline;"><!--
   NumFOCUS --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120" style="display: inline;"><!--
   -->
 </p>
@@ -364,7 +364,7 @@ or [create an issue](https://github.com/trixi-framework/Trixi.jl/issues/new).
   SRC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/48f9da06-6f7a-4586-b23e-739bee3901c0" height="120"><!--
   ERC      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/9371e7e4-3491-4433-ac5f-b3bfb215f5ca" height="120"><!--
   NSF      --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/3d07b627-c602-483d-93c6-19ac88bba125" height="120"><!--
-  DUBS     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/c7f0ea4d-9865-40f4-b0bd-9f4709356f22" height="120"><!--
+  DUBS     --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/bb021e6e-42e6-4fe1-a414-c847402e1937" height="120"><!--
   NumFOCUS --><img align="middle" src="https://github.com/trixi-framework/Trixi.jl/assets/3637659/8496ac9e-b586-475f-adb7-69bcfc415185" height="120"><!--
   -->
 </p>
@@ -398,5 +398,9 @@ This project has benefited from funding from the German
 through the project grant "Adaptive earth system modeling
 with significantly reduced computation time for exascale supercomputers
 (ADAPTEX)" (funding id: 16ME0668K).
+
+This project has benefited from funding by the
+[Daimler und Benz Stiftung](https://www.daimler-benz-stiftung.de) (Daimler and Benz Foundation)
+through grant no. 32-10/22.
 
 Trixi.jl is supported by [NumFOCUS](https://numfocus.org/) as an Affiliated Project.


### PR DESCRIPTION
Besides adding the NumFOCUS logo and a corresponding statement, I made the following changes:
* Split funding logos into individual files again such that we can rearrange them and add/remove/replace them without going insane (also to allow better flow when viewing, eg, on mobile phones)
* Add ACTRIX funding and compress DFG funding statements
* Add links to funding agencies

See the changes live:
* [README.md](https://github.com/trixi-framework/Trixi.jl/tree/msl/add-numfocus#acknowledgments)
* [docs](https://trixi-framework.github.io/Trixi.jl/previews/PR1697/#Acknowledgments)