### PR TITLE
Deprecate some `DGMultiMesh` constructors 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,7 +58,7 @@ for human readability.
   argument now comes first.
 - The undocumented and unused
   `DGMultiMesh(triangulateIO, rd::RefElemData{2, Tri}, boundary_dict::Dict{Symbol, Int})`
-  constructor was removed.
+  constructor was deprecated.
 
 #### Removed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -58,7 +58,7 @@ for human readability.
   argument now comes first.
 - The undocumented and unused
   `DGMultiMesh(triangulateIO, rd::RefElemData{2, Tri}, boundary_dict::Dict{Symbol, Int})`
-  constructor was deprecated.
+  constructor was removed.
 
 #### Removed
 

--- a/docs/literate/src/files/DGMulti_1.jl
+++ b/docs/literate/src/files/DGMulti_1.jl
@@ -168,7 +168,7 @@ meshIO = StartUpDG.triangulate_domain(StartUpDG.RectangularDomainWithHole());
 
 # The pre-defined Triangulate geometry in StartUpDG has integer boundary tags. With [`DGMultiMesh`](@ref)
 # we assign boundary faces based on these integer boundary tags and create a mesh compatible with Trixi.jl.
-mesh = DGMultiMesh(meshIO, dg, Dict(:outer_boundary=>1, :inner_boundary=>2))
+mesh = DGMultiMesh(dg, meshIO, Dict(:outer_boundary=>1, :inner_boundary=>2))
 #-
 boundary_condition_convergence_test = BoundaryConditionDirichlet(initial_condition)
 boundary_conditions = (; :outer_boundary => boundary_condition_convergence_test,

--- a/src/solvers/dgmulti/types.jl
+++ b/src/solvers/dgmulti/types.jl
@@ -434,7 +434,3 @@ function LinearAlgebra.mul!(b_in, A_kronecker::SimpleKronecker{3}, x_in)
 end
 end # @muladd
 
-# TODO: deprecations introduced in Trixi.jl v0.6
-@deprecate DGMultiMesh(dg::DGMulti{NDIMS}; cells_per_dimension, kwargs...) where {NDIMS} DGMultiMesh(dg,
-                                                                                                     cells_per_dimension;
-                                                                                                     kwargs...)

--- a/src/solvers/dgmulti/types.jl
+++ b/src/solvers/dgmulti/types.jl
@@ -433,4 +433,3 @@ function LinearAlgebra.mul!(b_in, A_kronecker::SimpleKronecker{3}, x_in)
     return nothing
 end
 end # @muladd
-

--- a/src/solvers/dgmulti/types.jl
+++ b/src/solvers/dgmulti/types.jl
@@ -438,10 +438,3 @@ end # @muladd
 @deprecate DGMultiMesh(dg::DGMulti{NDIMS}; cells_per_dimension, kwargs...) where {NDIMS} DGMultiMesh(dg,
                                                                                                      cells_per_dimension;
                                                                                                      kwargs...)
-
-# TODO: deprecations introduced in Trixi.jl v0.5
-@deprecate DGMultiMesh(vertex_coordinates, EToV, dg::DGMulti{NDIMS};
-                       kwargs...) where {NDIMS} DGMultiMesh(dg, vertex_coordinates, EToV;
-                                                            kwargs...)
-@deprecate DGMultiMesh(triangulateIO, dg::DGMulti{2, Tri}, boundary_dict::Dict{Symbol, Int};
-                       kwargs...) DGMultiMesh(dg, triangulateIO, boundary_dict; kwargs...)


### PR DESCRIPTION
One deprecated `DGMultiMesh` constructor remains:
```julia
# TODO: deprecations introduced in Trixi.jl v0.6
@deprecate DGMultiMesh(dg::DGMulti{NDIMS}; cells_per_dimension, kwargs...) where {NDIMS} DGMultiMesh(dg,
                                                                                                     cells_per_dimension;
                                                                                                     kwargs...)
```
However, since this was deprecated in the v0.5 lifecycle, I didn't remove it. Should it be removed, or should we leave this until v0.7?