### PR TITLE
Add Trixi2Vtk.jl to downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -60,6 +60,7 @@ jobs:
         arch:
           - x64
         package:
+          - Trixi2Vtk.jl
           - TrixiShallowWater.jl
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Requires https://github.com/trixi-framework/Trixi2Vtk.jl/pull/79 to be merged first + a subsequent run of this PR to make sure that everything works as expected.