### PR TITLE
Fix the wet/dry test for SWE

### DIFF
--- a/test/test_tree_1d_shallowwater.jl
+++ b/test/test_tree_1d_shallowwater.jl
@@ -111,7 +111,7 @@ end
                         ],
                         tspan=(0.0, 0.25),
                         # Soften the tolerance as test results vary between different CPUs
-                        atol = 1000*eps())
+                        atol=1000 * eps())
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     let

--- a/test/test_tree_1d_shallowwater.jl
+++ b/test/test_tree_1d_shallowwater.jl
@@ -109,7 +109,9 @@ end
                             2.2447689894899726e-13,
                             1.9999999999999714,
                         ],
-                        tspan=(0.0, 0.25))
+                        tspan=(0.0, 0.25),
+                        # Soften the tolerance as test results vary between different CPUs
+                        atol = 1000*eps())
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     let


### PR DESCRIPTION
The goal of this PR is to fix the  failing tests for the **elixir_shallowwater_well_balanced_wet_dry.jl**.

This test was observed to fail for CI runs on _Intel Xeon Platinum_ CPUs. The L_inf error in this test seems to be highly sensitive to the specific CPU used in the run. In a sample of CI runs the following errors have been observed:
- _Intel Xeon Platinum_: ~8.3339e-14
- _Intel Xeon E_: ~1.2044e-13
- _AMD EPYC_: ~1.2155e-13

As the differences are negligible and seem to depend only on the specific CPU, this PR adjusts the absolute tolerance of this test from `atol=500*eps() `to `atol=1000*eps()` such that the test passes on the _Intel Xeon Platinum_ CPUs.
