### PR TITLE
Remove `interfaces` and `boundaries` from `cache_parabolic`

### DIFF
--- a/src/callbacks_step/amr_dg1d.jl
+++ b/src/callbacks_step/amr_dg1d.jl
@@ -89,9 +89,11 @@ function refine!(u_ode::AbstractVector, adaptor, mesh::TreeMesh{1},
     reinitialize_containers!(mesh, equations, dg, cache_parabolic)
 
     # Sanity check
-    @unpack interfaces = cache_parabolic
+    #@unpack interfaces = cache_parabolic
+    (; interfaces) = cache
     if isperiodic(mesh.tree)
-        @assert ninterfaces(interfaces)==1 * nelements(dg, cache_parabolic) ("For 1D and periodic domains, the number of interfaces must be the same as the number of elements")
+        #@assert ninterfaces(interfaces)==1 * nelements(dg, cache_parabolic) ("For 1D and periodic domains, the number of interfaces must be the same as the number of elements")
+        @assert ninterfaces(interfaces)==1 * nelements(dg, cache) ("For 1D and periodic domains, the number of interfaces must be the same as the number of elements")
     end
 
     return nothing


### PR DESCRIPTION
Addresses step 3 of https://github.com/trixi-framework/Trixi.jl/issues/1674