### PR TITLE
Make error norm calculation optional

### DIFF
--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -377,8 +377,14 @@ function (analysis_callback::AnalysisCallback)(io, du, u, u_ode, t, semi)
         println()
     end
 
-    # Calculate L2/Linf errors, which are also returned
-    l2_error, linf_error = calc_error_norms(u_ode, t, analyzer, semi, cache_analysis)
+    if :l2_error in analysis_errors || :linf_error in analysis_errors
+        # Calculate L2/Linf errors, which are also returned
+        l2_error, linf_error = calc_error_norms(u_ode, t, analyzer, semi,
+                                                cache_analysis)
+    else # Need something to be returned
+        l2_error = nothing
+        linf_error = nothing
+    end
 
     if mpi_isroot()
         # L2 error


### PR DESCRIPTION
The calculation of the error norms is for non MPI runs (i.e., thread-parallel applications) are not parallelized and can thus consume a tremendous fraction of computation time for large 2D, 3D systems.
While one might be interested in quantities computed by the `analysis_callback` such as the integrals of internal and kinetic energy, seldom $L^2$ and $L^\infty$ errors are for practical applications of interest.