### PR TITLE
disable `interface_checks` of OrdinaryDiffEq.jl

### DIFF
--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -160,9 +160,9 @@ For example, use `solve(ode, alg; ode_default_options()...)`.
 function ode_default_options()
     if mpi_isparallel()
         return (; save_everystep = false, internalnorm = ode_norm,
-                unstable_check = ode_unstable_check)
+                unstable_check = ode_unstable_check, interface_checks = false)
     else
-        return (; save_everystep = false)
+        return (; save_everystep = false, interface_checks = false)
     end
 end
 


### PR DESCRIPTION
As discussed in the meeting today. Xref https://github.com/SciML/SciMLBase.jl/pull/561/files

This is just a hotfix and should be fixed properly.

Edit: Looks like the keyword is not implemented right now. 
Xref https://github.com/SciML/DiffEqBase.jl/issues/980