### PR TITLE
hotfix: restrict DiffEqBase.jl to let CI pass

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -54,6 +54,7 @@ TrixiMakieExt = "Makie"
 CodeTracking = "1.0.5"
 ConstructionBase = "1.3"
 DataStructures = "0.18.15"
+DiffEqBase = "6 - 6.143"
 DiffEqCallbacks = "2.25"
 EllipsisNotation = "1.0"
 FillArrays = "0.13.2, 1"
@@ -94,4 +95,5 @@ TriplotRecipes = "0.1"
 julia = "1.8"
 
 [extras]
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.6.6-pre"
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
@@ -95,5 +96,4 @@ TriplotRecipes = "0.1"
 julia = "1.8"
 
 [extras]
-DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -15,7 +14,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.8"
 CairoMakie = "0.6, 0.7, 0.8, 0.9, 0.10"
-DiffEqBase = "6 - 6.143"
 Downloads = "1"
 ForwardDiff = "0.10"
 LinearAlgebra = "1"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -14,6 +15,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.8"
 CairoMakie = "0.6, 0.7, 0.8, 0.9, 0.10"
+DiffEqBase = "6 - 6.143"
 Downloads = "1"
 ForwardDiff = "0.10"
 LinearAlgebra = "1"


### PR DESCRIPTION
Closes #1784 

A better fix would be #1785 but there seems to be something missing for it right now...