### PR TITLE
Fix link to download notebook badge in documentation

### DIFF
--- a/docs/literate/make.jl
+++ b/docs/literate/make.jl
@@ -11,16 +11,16 @@ function create_files(title, file, repo_src, pages_dir, notebooks_dir; folder=""
 
     binder_logo   = "https://mybinder.org/badge_logo.svg"
     nbviewer_logo = "https://github.com/trixi-framework/Trixi.jl/assets/74359358/fb572b02-9329-48c1-8f19-9140f5dcd4be"
-    download_logo = "https://github.com/trixi-framework/Trixi.jl/assets/74359358/5364d4b9-6db5-4b54-92f9-95319a8b469c"
+    raw_notebook_logo = "https://github.com/trixi-framework/Trixi.jl/assets/74359358/5e7c2f38-28b5-4dde-a6b6-50829615d24d"
 
     notebook_path = "tutorials/notebooks/$notebook_filename"
     binder_url   = "https://mybinder.org/v2/gh/trixi-framework/Trixi.jl/tutorial_notebooks?filepath=$notebook_path"
     nbviewer_url = "https://nbviewer.jupyter.org/github/trixi-framework/Trixi.jl/blob/tutorial_notebooks/$notebook_path"
-    download_url = "https://raw.githubusercontent.com/trixi-framework/Trixi.jl/tutorial_notebooks/$notebook_path"
+    raw_notebook_url = "https://raw.githubusercontent.com/trixi-framework/Trixi.jl/tutorial_notebooks/$notebook_path"
 
     binder_badge   = "# [![]($binder_logo)]($binder_url)"
     nbviewer_badge = "# [![]($nbviewer_logo)]($nbviewer_url)"
-    download_badge = "# [![]($download_logo)]($download_url)"
+    raw_notebook_badge = "# [![]($raw_notebook_logo)]($raw_notebook_url)"
 
     # Generate notebook file
     function preprocess_notebook(content)
@@ -32,7 +32,7 @@ function create_files(title, file, repo_src, pages_dir, notebooks_dir; folder=""
 
     # Generate markdown file
     function preprocess_docs(content)
-        return string("# # [$title](@id $(splitext(file)[1]))\n $binder_badge\n $nbviewer_badge\n $download_badge\n\n", content)
+        return string("# # [$title](@id $(splitext(file)[1]))\n $binder_badge\n $nbviewer_badge\n $raw_notebook_badge\n\n", content)
     end
     Literate.markdown(joinpath(repo_src, folder, file), joinpath(pages_dir, folder); preprocess=preprocess_docs,)
 end

--- a/docs/literate/make.jl
+++ b/docs/literate/make.jl
@@ -45,7 +45,6 @@ function create_tutorials(files)
     notebooks_dir   = joinpath(pages_dir, "notebooks")
 
     Sys.rm(pages_dir;       recursive=true, force=true)
-
     Sys.rm("out"; recursive=true, force=true)
 
     # Run tests on all tutorial files

--- a/docs/literate/make.jl
+++ b/docs/literate/make.jl
@@ -10,8 +10,8 @@ function create_files(title, file, repo_src, pages_dir, notebooks_dir; folder=""
     end
 
     binder_logo   = "https://mybinder.org/badge_logo.svg"
-    nbviewer_logo = "https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg"
-    download_logo = "https://camo.githubusercontent.com/aea75103f6d9f690a19cb0e17c06f984ab0f472d9e6fe4eadaa0cc438ba88ada/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f646f776e6c6f61642d6e6f7465626f6f6b2d627269676874677265656e"
+    nbviewer_logo = "https://github.com/trixi-framework/Trixi.jl/assets/74359358/fb572b02-9329-48c1-8f19-9140f5dcd4be"
+    download_logo = "https://github.com/trixi-framework/Trixi.jl/assets/74359358/5364d4b9-6db5-4b54-92f9-95319a8b469c"
 
     notebook_path = "tutorials/notebooks/$notebook_filename"
     binder_url   = "https://mybinder.org/v2/gh/trixi-framework/Trixi.jl/tutorial_notebooks?filepath=$notebook_path"
@@ -45,6 +45,7 @@ function create_tutorials(files)
     notebooks_dir   = joinpath(pages_dir, "notebooks")
 
     Sys.rm(pages_dir;       recursive=true, force=true)
+
     Sys.rm("out"; recursive=true, force=true)
 
     # Run tests on all tutorial files

--- a/docs/literate/make.jl
+++ b/docs/literate/make.jl
@@ -10,8 +10,8 @@ function create_files(title, file, repo_src, pages_dir, notebooks_dir; folder=""
     end
 
     binder_logo   = "https://mybinder.org/badge_logo.svg"
-    nbviewer_logo = "https://github.com/trixi-framework/Trixi.jl/assets/74359358/fb572b02-9329-48c1-8f19-9140f5dcd4be"
-    raw_notebook_logo = "https://github.com/trixi-framework/Trixi.jl/assets/74359358/5e7c2f38-28b5-4dde-a6b6-50829615d24d"
+    nbviewer_logo = "https://img.shields.io/badge/render-nbviewer-f37726"
+    raw_notebook_logo = "https://img.shields.io/badge/raw-notebook-4cc61e"
 
     notebook_path = "tutorials/notebooks/$notebook_filename"
     binder_url   = "https://mybinder.org/v2/gh/trixi-framework/Trixi.jl/tutorial_notebooks?filepath=$notebook_path"

--- a/docs/literate/src/files/index.jl
+++ b/docs/literate/src/files/index.jl
@@ -5,9 +5,9 @@
 
 # Right now, you are using the classic documentation. The corresponding interactive notebooks can
 # be opened in [Binder](https://mybinder.org/) and viewed in [nbviewer](https://nbviewer.jupyter.org/)
-# via the icons ![](https://mybinder.org/badge_logo.svg) and ![](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)
+# via the icons ![](https://mybinder.org/badge_logo.svg) and ![](https://img.shields.io/badge/render-nbviewer-f37726)
 # in the respective tutorial.
-# You can download the raw notebooks from GitHub via ![](https://camo.githubusercontent.com/aea75103f6d9f690a19cb0e17c06f984ab0f472d9e6fe4eadaa0cc438ba88ada/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f646f776e6c6f61642d6e6f7465626f6f6b2d627269676874677265656e).
+# You can also open the raw notebook files via ![](https://img.shields.io/badge/raw-notebook-4cc61e).
 
 # **Note:** To improve responsiveness via caching, the notebooks are updated only once a week. They are only
 # available for the latest stable release of Trixi.jl at the time of caching.


### PR DESCRIPTION
The old link to the download badge doesn't work anymore. This PR replaces the link with a new self-generated one.
To prevent this from happening in the future for the link to the nbviewer badge, I updated it as well.

New badges are created directly with https://shields.io/:
https://img.shields.io/badge/render-nbviewer-f37726
https://img.shields.io/badge/raw-notebook-4cc61e
