### PR TITLE
use julia-actions/cache also for Documenter

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           version: '1.9'
           show-versioninfo: true
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
         env:
           PYTHON: ""


### PR DESCRIPTION
It looks like caching provides a really nice speedup for our usual CI runs (see https://github.com/trixi-framework/Trixi.jl/pull/1781#issuecomment-1887011213). Let's see whether we can get something similar for building the docs.

Edit: Yes, it works and reduces installation time from roughly 10 minutes (https://github.com/trixi-framework/Trixi.jl/actions/runs/7491114374/job/20391555439) to 3 minutes (https://github.com/trixi-framework/Trixi.jl/actions/runs/7498922391/job/20414820484?pr=1802)