### PR TITLE
Make CI fail if Codecov fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,8 @@ jobs:
           file: ./lcov.info
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: false
+          fail_ci_if_error: true
+          verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
       # The standard setup of Coveralls is just annoying for parallel builds, see, e.g.,
       # https://github.com/trixi-framework/Trixi.jl/issues/691


### PR DESCRIPTION
There were some problems, see https://github.com/trixi-framework/Trixi.jl/pull/1827#issuecomment-1926535167. Thus, I added the GitHub actions secret CODECOV_TOKEN to this repo.