### PR TITLE
Fix formatter to older version

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -29,7 +29,7 @@ jobs:
         # TODO: Change the call below to
         #       format(".")
         run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter"))'
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.45"))'
           julia  -e 'using JuliaFormatter; format(["benchmark", "examples", "ext", "src", "test", "utils"])'
       - name: Format check
         run: |

--- a/utils/trixi-format-file.jl
+++ b/utils/trixi-format-file.jl
@@ -2,7 +2,7 @@
 
 using Pkg
 Pkg.activate(; temp = true, io = devnull)
-Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.45"); preserve = PRESERVE_ALL,
+Pkg.add(PackageSpec(name = "JuliaFormatter", version = "1.0.45"); preserve = PRESERVE_ALL,
         io = devnull)
 
 using JuliaFormatter: format_file

--- a/utils/trixi-format-file.jl
+++ b/utils/trixi-format-file.jl
@@ -2,7 +2,7 @@
 
 using Pkg
 Pkg.activate(; temp = true, io = devnull)
-Pkg.add("JuliaFormatter"; preserve = PRESERVE_ALL, io = devnull)
+Pkg.add("JuliaFormatter"; version="1.0.45", preserve = PRESERVE_ALL, io = devnull)
 
 using JuliaFormatter: format_file
 

--- a/utils/trixi-format-file.jl
+++ b/utils/trixi-format-file.jl
@@ -2,7 +2,8 @@
 
 using Pkg
 Pkg.activate(; temp = true, io = devnull)
-Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.45"); preserve = PRESERVE_ALL, io = devnull)
+Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.45"); preserve = PRESERVE_ALL,
+        io = devnull)
 
 using JuliaFormatter: format_file
 

--- a/utils/trixi-format-file.jl
+++ b/utils/trixi-format-file.jl
@@ -2,7 +2,7 @@
 
 using Pkg
 Pkg.activate(; temp = true, io = devnull)
-Pkg.add("JuliaFormatter"; version="1.0.45", preserve = PRESERVE_ALL, io = devnull)
+Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.45"); preserve = PRESERVE_ALL, io = devnull)
 
 using JuliaFormatter: format_file
 

--- a/utils/trixi-format.jl
+++ b/utils/trixi-format.jl
@@ -2,7 +2,7 @@
 
 using Pkg
 Pkg.activate(; temp = true, io = devnull)
-Pkg.add("JuliaFormatter"; version="1.0.45", preserve = PRESERVE_ALL, io = devnull)
+Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.45"); preserve = PRESERVE_ALL, io = devnull)
 
 using JuliaFormatter: format
 

--- a/utils/trixi-format.jl
+++ b/utils/trixi-format.jl
@@ -2,7 +2,8 @@
 
 using Pkg
 Pkg.activate(; temp = true, io = devnull)
-Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.45"); preserve = PRESERVE_ALL, io = devnull)
+Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.45"); preserve = PRESERVE_ALL,
+        io = devnull)
 
 using JuliaFormatter: format
 

--- a/utils/trixi-format.jl
+++ b/utils/trixi-format.jl
@@ -2,7 +2,7 @@
 
 using Pkg
 Pkg.activate(; temp = true, io = devnull)
-Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.45"); preserve = PRESERVE_ALL,
+Pkg.add(PackageSpec(name = "JuliaFormatter", version = "1.0.45"); preserve = PRESERVE_ALL,
         io = devnull)
 
 using JuliaFormatter: format

--- a/utils/trixi-format.jl
+++ b/utils/trixi-format.jl
@@ -2,7 +2,7 @@
 
 using Pkg
 Pkg.activate(; temp = true, io = devnull)
-Pkg.add("JuliaFormatter"; preserve = PRESERVE_ALL, io = devnull)
+Pkg.add("JuliaFormatter"; version="1.0.45", preserve = PRESERVE_ALL, io = devnull)
 
 using JuliaFormatter: format
 


### PR DESCRIPTION
As an alternative to https://github.com/trixi-framework/Trixi.jl/pull/1842, I fixed the version of JuliaFormatter to an older one.