### PR TITLE
Don't export `TrixiBase`

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -70,7 +70,8 @@ using Triangulate: Triangulate, TriangulateIO, triangulate
 export TriangulateIO # for type parameter in DGMultiMesh
 using TriplotBase: TriplotBase
 using TriplotRecipes: DGTriPseudocolor
-@reexport using TrixiBase: TrixiBase, trixi_include
+@reexport using TrixiBase: trixi_include
+using TrixiBase: TrixiBase
 @reexport using SimpleUnPack: @unpack
 using SimpleUnPack: @pack!
 using DataStructures: BinaryHeap, FasterForward, extract_all!


### PR DESCRIPTION
> Sorry, I know I'm a little late to the party, but why do we export `TrixiBase`? Wouldn't it suffice to just export `trixi_include`?

_Originally posted by @sloede in https://github.com/trixi-framework/Trixi.jl/pull/1832#discussion_r1490556823_
            