### PR TITLE
Add warning about polynomial degree 0

### DIFF
--- a/src/solvers/dgsem/basis_lobatto_legendre.jl
+++ b/src/solvers/dgsem/basis_lobatto_legendre.jl
@@ -12,6 +12,7 @@ Create a nodal Lobatto-Legendre basis for polynomials of degree `polydeg`.
 
 For the special case `polydeg=0` the DG method reduces to a finite volume method.
 Therefore, this function sets the center point of the cell as single node.
+This exceptional case is currently only supported for TreeMesh!
 """
 struct LobattoLegendreBasis{RealT <: Real, NNODES,
                             VectorT <: AbstractVector{RealT},


### PR DESCRIPTION
I was misled by a comment in basis_lobatto_legendre.jl, thinking `polydeg = 0` would be an exceptional but valid setting. It however only works with TreeMesh. See https://github.com/trixi-framework/Trixi.jl/pull/1489

So I extended the comment.

Would there be an easy way to catch such a setting early and warn users?