### PR TITLE
remove some minor allocations for threaded FDSBP

### DIFF
--- a/src/solvers/dgsem_unstructured/dg_2d.jl
+++ b/src/solvers/dgsem_unstructured/dg_2d.jl
@@ -280,26 +280,28 @@ function prolong2boundaries!(cache, u,
                              mesh::UnstructuredMesh2D,
                              equations, surface_integral, dg::DG)
     @unpack boundaries = cache
+    @unpack element_id, element_side_id = boundaries
+    boundaries_u = boundaries.u
 
     @threaded for boundary in eachboundary(dg, cache)
-        element = boundaries.element_id[boundary]
-        side = boundaries.element_side_id[boundary]
+        element = element_id[boundary]
+        side = element_side_id[boundary]
 
         if side == 1
             for l in eachnode(dg), v in eachvariable(equations)
-                boundaries.u[v, l, boundary] = u[v, l, 1, element]
+                boundaries_u[v, l, boundary] = u[v, l, 1, element]
             end
         elseif side == 2
             for l in eachnode(dg), v in eachvariable(equations)
-                boundaries.u[v, l, boundary] = u[v, nnodes(dg), l, element]
+                boundaries_u[v, l, boundary] = u[v, nnodes(dg), l, element]
             end
         elseif side == 3
             for l in eachnode(dg), v in eachvariable(equations)
-                boundaries.u[v, l, boundary] = u[v, l, nnodes(dg), element]
+                boundaries_u[v, l, boundary] = u[v, l, nnodes(dg), element]
             end
         else # side == 4
             for l in eachnode(dg), v in eachvariable(equations)
-                boundaries.u[v, l, boundary] = u[v, 1, l, element]
+                boundaries_u[v, l, boundary] = u[v, 1, l, element]
             end
         end
     end

--- a/src/solvers/dgsem_unstructured/dg_2d.jl
+++ b/src/solvers/dgsem_unstructured/dg_2d.jl
@@ -95,49 +95,51 @@ function prolong2interfaces!(cache, u,
                              mesh::UnstructuredMesh2D,
                              equations, surface_integral, dg::DG)
     @unpack interfaces = cache
+    @unpack element_ids, element_side_ids = interfaces
+    interfaces_u = interfaces.u
 
     @threaded for interface in eachinterface(dg, cache)
-        primary_element = interfaces.element_ids[1, interface]
-        secondary_element = interfaces.element_ids[2, interface]
+        primary_element = element_ids[1, interface]
+        secondary_element = element_ids[2, interface]
 
-        primary_side = interfaces.element_side_ids[1, interface]
-        secondary_side = interfaces.element_side_ids[2, interface]
+        primary_side = element_side_ids[1, interface]
+        secondary_side = element_side_ids[2, interface]
 
         if primary_side == 1
             for i in eachnode(dg), v in eachvariable(equations)
-                interfaces.u[1, v, i, interface] = u[v, i, 1, primary_element]
+                interfaces_u[1, v, i, interface] = u[v, i, 1, primary_element]
             end
         elseif primary_side == 2
             for i in eachnode(dg), v in eachvariable(equations)
-                interfaces.u[1, v, i, interface] = u[v, nnodes(dg), i, primary_element]
+                interfaces_u[1, v, i, interface] = u[v, nnodes(dg), i, primary_element]
             end
         elseif primary_side == 3
             for i in eachnode(dg), v in eachvariable(equations)
-                interfaces.u[1, v, i, interface] = u[v, i, nnodes(dg), primary_element]
+                interfaces_u[1, v, i, interface] = u[v, i, nnodes(dg), primary_element]
             end
         else # primary_side == 4
             for i in eachnode(dg), v in eachvariable(equations)
-                interfaces.u[1, v, i, interface] = u[v, 1, i, primary_element]
+                interfaces_u[1, v, i, interface] = u[v, 1, i, primary_element]
             end
         end
 
         if secondary_side == 1
             for i in eachnode(dg), v in eachvariable(equations)
-                interfaces.u[2, v, i, interface] = u[v, i, 1, secondary_element]
+                interfaces_u[2, v, i, interface] = u[v, i, 1, secondary_element]
             end
         elseif secondary_side == 2
             for i in eachnode(dg), v in eachvariable(equations)
-                interfaces.u[2, v, i, interface] = u[v, nnodes(dg), i,
+                interfaces_u[2, v, i, interface] = u[v, nnodes(dg), i,
                                                      secondary_element]
             end
         elseif secondary_side == 3
             for i in eachnode(dg), v in eachvariable(equations)
-                interfaces.u[2, v, i, interface] = u[v, i, nnodes(dg),
+                interfaces_u[2, v, i, interface] = u[v, i, nnodes(dg),
                                                      secondary_element]
             end
         else # secondary_side == 4
             for i in eachnode(dg), v in eachvariable(equations)
-                interfaces.u[2, v, i, interface] = u[v, 1, i, secondary_element]
+                interfaces_u[2, v, i, interface] = u[v, 1, i, secondary_element]
             end
         end
     end

--- a/src/solvers/fdsbp_unstructured/fdsbp_2d.jl
+++ b/src/solvers/fdsbp_unstructured/fdsbp_2d.jl
@@ -28,11 +28,11 @@ end
 # 2D volume integral contributions for `VolumeIntegralStrongForm`
 # OBS! This is the standard (not de-aliased) form of the volume integral.
 # So it is not provably stable for variable coefficients due to the the metric terms.
-@inline function calc_volume_integral!(du, u,
-                                       mesh::UnstructuredMesh2D,
-                                       nonconservative_terms::False, equations,
-                                       volume_integral::VolumeIntegralStrongForm,
-                                       dg::FDSBP, cache)
+function calc_volume_integral!(du, u,
+                               mesh::UnstructuredMesh2D,
+                               nonconservative_terms::False, equations,
+                               volume_integral::VolumeIntegralStrongForm,
+                               dg::FDSBP, cache)
     D = dg.basis # SBP derivative operator
     @unpack f_threaded = cache
     @unpack contravariant_vectors = cache.elements


### PR DESCRIPTION
I have observed some performance problems with FDSBP solvers and multiple threads on Julia 1.9. It seems to be okay again in Julia 1.10. So far, I haven't been able to figure out what exactly is wrong there. While debugging this stuff, I noticed a few minor performance improvements avoiding some allocations with multiple threads.