### PR TITLE
Remove duplicate entry from NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,6 @@ for human readability.
 ## Changes in the v0.7 lifecycle
 
 #### Added
-- Implementation of `TimeSeriesCallback` for curvilinear meshes on `UnstructuredMesh2D`.
 - Implementation of `TimeSeriesCallback` for curvilinear meshes on `UnstructuredMesh2D` and extension
   to 1D and 3D on `TreeMesh`.
 - Implementation of 1D Linearized Euler Equations.


### PR DESCRIPTION
The `TimeSeriesCallback` news item was listed twice, so one has been removed.