### PR TITLE
Mean value in Zhang-Shu limiter on curved meshes

### DIFF
--- a/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
@@ -6,7 +6,7 @@
 #! format: noindent
 
 function limiter_zhang_shu!(u, threshold::Real, variable,
-                            mesh::AbstractMesh{2}, equations, dg::DGSEM, cache)
+                            mesh::TreeMesh{2}, equations, dg::DGSEM, cache)
     @unpack weights = dg.basis
 
     @threaded for element in eachelement(dg, cache)
@@ -28,6 +28,50 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
         end
         # note that the reference element is [-1,1]^ndims(dg), thus the weights sum to 2
         u_mean = u_mean / 2^ndims(mesh)
+
+        # We compute the value directly with the mean values, as we assume that
+        # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
+        value_mean = variable(u_mean, equations)
+        theta = (value_mean - threshold) / (value_mean - value_min)
+        for j in eachnode(dg), i in eachnode(dg)
+            u_node = get_node_vars(u, equations, dg, i, j, element)
+            set_node_vars!(u, theta * u_node + (1 - theta) * u_mean,
+                           equations, dg, i, j, element)
+        end
+    end
+
+    return nothing
+end
+
+function limiter_zhang_shu!(u, threshold::Real, variable,
+                            mesh::Union{StructuredMesh{2}, StructuredMeshView{2},
+                                        UnstructuredMesh2D, P4estMesh{2},
+                                        T8codeMesh{2}},
+                            equations, dg::DGSEM, cache)
+    @unpack weights = dg.basis
+
+    @threaded for element in eachelement(dg, cache)
+        # determine minimum value
+        value_min = typemax(eltype(u))
+        for j in eachnode(dg), i in eachnode(dg)
+            u_node = get_node_vars(u, equations, dg, i, j, element)
+            value_min = min(value_min, variable(u_node, equations))
+        end
+
+        # detect if limiting is necessary
+        value_min < threshold || continue
+
+        # compute mean value
+        u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
+        total_volume = zero(real(mesh))
+        for j in eachnode(dg), i in eachnode(dg)
+            jacobian_node = abs(inv(cache.elements.inverse_jacobian[i, j, element]))
+            u_node = get_node_vars(u, equations, dg, i, j, element)
+            u_mean += u_node * weights[i] * weights[j] * jacobian_node
+            total_volume += weights[i] * weights[j] * jacobian_node
+        end
+        # normalize with the total volume
+        u_mean = u_mean / total_volume
 
         # We compute the value directly with the mean values, as we assume that
         # Jensen's inequality holds (e.g. pressure for compressible Euler equations).

--- a/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
@@ -7,6 +7,9 @@
 
 function limiter_zhang_shu!(u, threshold::Real, variable,
                             mesh::AbstractMesh{2}, equations, dg::DGSEM, cache)
+    @unpack weights = dg.basis
+    @unpack inverse_jacobian = cache.elements
+
     @threaded for element in eachelement(dg, cache)
         # determine minimum value
         value_min = typemax(eltype(u))
@@ -19,7 +22,17 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
         value_min < threshold || continue
 
         # compute mean value
-        u_mean = mean_value_element(u, element, mesh, equations, dg, cache)
+        u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
+        total_volume = zero(eltype(u))
+        for j in eachnode(dg), i in eachnode(dg)
+            volume_jacobian = abs(inv(get_inverse_jacobian(inverse_jacobian, mesh,
+                                                           element, i, j)))
+            u_node = get_node_vars(u, equations, dg, i, j, element)
+            u_mean += u_node * weights[i] * weights[j] * volume_jacobian
+            total_volume += weights[i] * weights[j] * volume_jacobian
+        end
+        # normalize with the total volume
+        u_mean = u_mean / total_volume
 
         # We compute the value directly with the mean values, as we assume that
         # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
@@ -33,39 +46,5 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
     end
 
     return nothing
-end
-
-function calc_element_mean_value(u, element, mesh::TreeMesh{2}, equations, dg::DGSEM,
-                                 cache)
-    @unpack weights = dg.basis
-
-    u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
-    for j in eachnode(dg), i in eachnode(dg)
-        u_node = get_node_vars(u, equations, dg, i, j, element)
-        u_mean += u_node * weights[i] * weights[j]
-    end
-
-    # note that the reference element is [-1,1]^ndims(dg), thus the weights sum to 2
-    return u_mean / 2^ndims(mesh)
-end
-
-function calc_element_mean_value(u, element,
-                                 mesh::Union{StructuredMesh{2}, StructuredMeshView{2},
-                                             UnstructuredMesh2D, P4estMesh{2},
-                                             T8codeMesh{2}},
-                                 equations, dg::DGSEM, cache)
-    @unpack weights = dg.basis
-
-    u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
-    total_volume = zero(real(mesh))
-    for j in eachnode(dg), i in eachnode(dg)
-        volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, element]))
-        u_node = get_node_vars(u, equations, dg, i, j, element)
-        u_mean += u_node * weights[i] * weights[j] * volume_jacobian
-        total_volume += weights[i] * weights[j] * volume_jacobian
-    end
-
-    # normalize with the total volume
-    return u_mean / total_volume
 end
 end # @muladd

--- a/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
@@ -26,7 +26,7 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
         total_volume = zero(eltype(u))
         for j in eachnode(dg), i in eachnode(dg)
             volume_jacobian = abs(inv(get_inverse_jacobian(inverse_jacobian, mesh,
-                                                           element, i, j)))
+                                                           i, j, element)))
             u_node = get_node_vars(u, equations, dg, i, j, element)
             u_mean += u_node * weights[i] * weights[j] * volume_jacobian
             total_volume += weights[i] * weights[j] * volume_jacobian

--- a/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
@@ -26,7 +26,7 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
         total_volume = zero(eltype(u))
         for j in eachnode(dg), i in eachnode(dg)
             volume_jacobian = abs(inv(get_inverse_jacobian(inverse_jacobian, mesh,
-                                                           i, j, element)))
+                                                           element, i, j)))
             u_node = get_node_vars(u, equations, dg, i, j, element)
             u_mean += u_node * weights[i] * weights[j] * volume_jacobian
             total_volume += weights[i] * weights[j] * volume_jacobian

--- a/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
@@ -35,7 +35,8 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
     return nothing
 end
 
-function calc_element_mean_value(u, element, mesh::TreeMesh{2}, equations, dg::DGSEM, cache)
+function calc_element_mean_value(u, element, mesh::TreeMesh{2}, equations, dg::DGSEM,
+                                 cache)
     @unpack weights = dg.basis
 
     u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
@@ -52,7 +53,7 @@ function calc_element_mean_value(u, element,
                                  mesh::Union{StructuredMesh{2}, StructuredMeshView{2},
                                              UnstructuredMesh2D, P4estMesh{2},
                                              T8codeMesh{2}},
-                                  equations, dg::DGSEM, cache)
+                                 equations, dg::DGSEM, cache)
     @unpack weights = dg.basis
 
     u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))

--- a/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
@@ -7,8 +7,6 @@
 
 function limiter_zhang_shu!(u, threshold::Real, variable,
                             mesh::AbstractMesh{2}, equations, dg::DGSEM, cache)
-    @unpack weights = dg.basis
-
     @threaded for element in eachelement(dg, cache)
         # determine minimum value
         value_min = typemax(eltype(u))
@@ -21,16 +19,7 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
         value_min < threshold || continue
 
         # compute mean value
-        u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
-        total_volume = zero(eltype(u))
-        for j in eachnode(dg), i in eachnode(dg)
-            volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, element]))
-            u_node = get_node_vars(u, equations, dg, i, j, element)
-            u_mean += u_node * weights[i] * weights[j] * volume_jacobian
-            total_volume += weights[i] * weights[j] * volume_jacobian
-        end
-        # normalize with the total volume
-        u_mean = u_mean / total_volume
+        u_mean = mean_value_element(u, element, mesh, equations, dg, cache)
 
         # We compute the value directly with the mean values, as we assume that
         # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
@@ -44,5 +33,38 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
     end
 
     return nothing
+end
+
+function calc_element_mean_value(u, element, mesh::TreeMesh{2}, equations, dg::DGSEM, cache)
+    @unpack weights = dg.basis
+
+    u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
+    for j in eachnode(dg), i in eachnode(dg)
+        u_node = get_node_vars(u, equations, dg, i, j, element)
+        u_mean += u_node * weights[i] * weights[j]
+    end
+
+    # note that the reference element is [-1,1]^ndims(dg), thus the weights sum to 2
+    return u_mean / 2^ndims(mesh)
+end
+
+function calc_element_mean_value(u, element,
+                                 mesh::Union{StructuredMesh{2}, StructuredMeshView{2},
+                                             UnstructuredMesh2D, P4estMesh{2},
+                                             T8codeMesh{2}},
+                                  equations, dg::DGSEM, cache)
+    @unpack weights = dg.basis
+
+    u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
+    total_volume = zero(real(mesh))
+    for j in eachnode(dg), i in eachnode(dg)
+        volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, element]))
+        u_node = get_node_vars(u, equations, dg, i, j, element)
+        u_mean += u_node * weights[i] * weights[j] * volume_jacobian
+        total_volume += weights[i] * weights[j] * volume_jacobian
+    end
+
+    # normalize with the total volume
+    return u_mean / total_volume
 end
 end # @muladd

--- a/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
@@ -6,9 +6,7 @@
 #! format: noindent
 
 function limiter_zhang_shu!(u, threshold::Real, variable,
-                            mesh::TreeMesh{2}, equations, dg::DGSEM, cache)
-    @unpack weights = dg.basis
-
+                            mesh::AbstractMesh{2}, equations, dg::DGSEM, cache)
     @threaded for element in eachelement(dg, cache)
         # determine minimum value
         value_min = typemax(eltype(u))
@@ -21,13 +19,7 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
         value_min < threshold || continue
 
         # compute mean value
-        u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
-        for j in eachnode(dg), i in eachnode(dg)
-            u_node = get_node_vars(u, equations, dg, i, j, element)
-            u_mean += u_node * weights[i] * weights[j]
-        end
-        # note that the reference element is [-1,1]^ndims(dg), thus the weights sum to 2
-        u_mean = u_mean / 2^ndims(mesh)
+        u_mean = mean_value_element(u, element, mesh, equations, dg, cache)
 
         # We compute the value directly with the mean values, as we assume that
         # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
@@ -43,47 +35,36 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
     return nothing
 end
 
-function limiter_zhang_shu!(u, threshold::Real, variable,
+function mean_value_element(u, element, mesh::TreeMesh{2}, equations, dg::DGSEM, cache)
+    @unpack weights = dg.basis
+
+    u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
+    for j in eachnode(dg), i in eachnode(dg)
+        u_node = get_node_vars(u, equations, dg, i, j, element)
+        u_mean += u_node * weights[i] * weights[j]
+    end
+
+    # note that the reference element is [-1,1]^ndims(dg), thus the weights sum to 2
+    return u_mean / 2^ndims(mesh)
+end
+
+function mean_value_element(u, element,
                             mesh::Union{StructuredMesh{2}, StructuredMeshView{2},
                                         UnstructuredMesh2D, P4estMesh{2},
                                         T8codeMesh{2}},
                             equations, dg::DGSEM, cache)
     @unpack weights = dg.basis
 
-    @threaded for element in eachelement(dg, cache)
-        # determine minimum value
-        value_min = typemax(eltype(u))
-        for j in eachnode(dg), i in eachnode(dg)
-            u_node = get_node_vars(u, equations, dg, i, j, element)
-            value_min = min(value_min, variable(u_node, equations))
-        end
-
-        # detect if limiting is necessary
-        value_min < threshold || continue
-
-        # compute mean value
-        u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
-        total_volume = zero(real(mesh))
-        for j in eachnode(dg), i in eachnode(dg)
-            jacobian_node = abs(inv(cache.elements.inverse_jacobian[i, j, element]))
-            u_node = get_node_vars(u, equations, dg, i, j, element)
-            u_mean += u_node * weights[i] * weights[j] * jacobian_node
-            total_volume += weights[i] * weights[j] * jacobian_node
-        end
-        # normalize with the total volume
-        u_mean = u_mean / total_volume
-
-        # We compute the value directly with the mean values, as we assume that
-        # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
-        value_mean = variable(u_mean, equations)
-        theta = (value_mean - threshold) / (value_mean - value_min)
-        for j in eachnode(dg), i in eachnode(dg)
-            u_node = get_node_vars(u, equations, dg, i, j, element)
-            set_node_vars!(u, theta * u_node + (1 - theta) * u_mean,
-                           equations, dg, i, j, element)
-        end
+    u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
+    total_volume = zero(real(mesh))
+    for j in eachnode(dg), i in eachnode(dg)
+        jacobian_node = abs(inv(cache.elements.inverse_jacobian[i, j, element]))
+        u_node = get_node_vars(u, equations, dg, i, j, element)
+        u_mean += u_node * weights[i] * weights[j] * jacobian_node
+        total_volume += weights[i] * weights[j] * jacobian_node
     end
 
-    return nothing
+    # normalize with the total volume
+    return u_mean / total_volume
 end
 end # @muladd

--- a/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
@@ -19,7 +19,7 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
         value_min < threshold || continue
 
         # compute mean value
-        u_mean = mean_value_element(u, element, mesh, equations, dg, cache)
+        u_mean = calc_element_mean_value(u, element, mesh, equations, dg, cache)
 
         # We compute the value directly with the mean values, as we assume that
         # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
@@ -35,7 +35,8 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
     return nothing
 end
 
-function mean_value_element(u, element, mesh::TreeMesh{2}, equations, dg::DGSEM, cache)
+function calc_element_mean_value(u, element, mesh::TreeMesh{2}, equations, dg::DGSEM,
+                                 cache)
     @unpack weights = dg.basis
 
     u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
@@ -48,11 +49,11 @@ function mean_value_element(u, element, mesh::TreeMesh{2}, equations, dg::DGSEM,
     return u_mean / 2^ndims(mesh)
 end
 
-function mean_value_element(u, element,
-                            mesh::Union{StructuredMesh{2}, StructuredMeshView{2},
-                                        UnstructuredMesh2D, P4estMesh{2},
-                                        T8codeMesh{2}},
-                            equations, dg::DGSEM, cache)
+function calc_element_mean_value(u, element,
+                                 mesh::Union{StructuredMesh{2}, StructuredMeshView{2},
+                                             UnstructuredMesh2D, P4estMesh{2},
+                                             T8codeMesh{2}},
+                                 equations, dg::DGSEM, cache)
     @unpack weights = dg.basis
 
     u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))

--- a/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg2d.jl
@@ -22,7 +22,7 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
 
         # compute mean value
         u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
-        total_volume = zero(real(mesh))
+        total_volume = zero(eltype(u))
         for j in eachnode(dg), i in eachnode(dg)
             volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, element]))
             u_node = get_node_vars(u, equations, dg, i, j, element)

--- a/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
@@ -6,9 +6,7 @@
 #! format: noindent
 
 function limiter_zhang_shu!(u, threshold::Real, variable,
-                            mesh::TreeMesh{3}, equations, dg::DGSEM, cache)
-    @unpack weights = dg.basis
-
+                            mesh::AbstractMesh{3}, equations, dg::DGSEM, cache)
     @threaded for element in eachelement(dg, cache)
         # determine minimum value
         value_min = typemax(eltype(u))
@@ -21,13 +19,7 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
         value_min < threshold || continue
 
         # compute mean value
-        u_mean = zero(get_node_vars(u, equations, dg, 1, 1, 1, element))
-        for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-            u_node = get_node_vars(u, equations, dg, i, j, k, element)
-            u_mean += u_node * weights[i] * weights[j] * weights[k]
-        end
-        # note that the reference element is [-1,1]^ndims(dg), thus the weights sum to 2
-        u_mean = u_mean / 2^ndims(mesh)
+        u_mean = calc_element_mean_value(u, element, mesh, equations, dg, cache)
 
         # We compute the value directly with the mean values, as we assume that
         # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
@@ -43,45 +35,34 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
     return nothing
 end
 
-function limiter_zhang_shu!(u, threshold::Real, variable,
-                            mesh::Union{StructuredMesh{3}, P4estMesh{3}, T8codeMesh{3}},
-                            equations, dg::DGSEM, cache)
+function calc_element_mean_value(u, element, mesh::TreeMesh{3}, equations, dg::DGSEM,
+                                 cache)
     @unpack weights = dg.basis
 
-    @threaded for element in eachelement(dg, cache)
-        # determine minimum value
-        value_min = typemax(eltype(u))
-        for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-            u_node = get_node_vars(u, equations, dg, i, j, k, element)
-            value_min = min(value_min, variable(u_node, equations))
-        end
-
-        # detect if limiting is necessary
-        value_min < threshold || continue
-
-        # compute mean value
-        u_mean = zero(get_node_vars(u, equations, dg, 1, 1, 1, element))
-        total_volume = zero(real(mesh))
-        for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-            jacobian_node = abs(inv(cache.elements.inverse_jacobian[i, j, k, element]))
-            u_node = get_node_vars(u, equations, dg, i, j, k, element)
-            u_mean += u_node * weights[i] * weights[j] * weights[k] * jacobian_node
-            total_volume += weights[i] * weights[j] * weights[k] * jacobian_node
-        end
-        # normalize with the total volume
-        u_mean = u_mean / total_volume
-
-        # We compute the value directly with the mean values, as we assume that
-        # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
-        value_mean = variable(u_mean, equations)
-        theta = (value_mean - threshold) / (value_mean - value_min)
-        for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-            u_node = get_node_vars(u, equations, dg, i, j, k, element)
-            set_node_vars!(u, theta * u_node + (1 - theta) * u_mean,
-                           equations, dg, i, j, k, element)
-        end
+    u_mean = zero(get_node_vars(u, equations, dg, 1, 1, 1, element))
+    for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
+        u_node = get_node_vars(u, equations, dg, i, j, k, element)
+        u_mean += u_node * weights[i] * weights[j] * weights[k]
     end
+    # note that the reference element is [-1,1]^ndims(dg), thus the weights sum to 2
+    return u_mean / 2^ndims(mesh)
+end
 
-    return nothing
+function calc_element_mean_value(u, element,
+                                 mesh::Union{StructuredMesh{3}, P4estMesh{3},
+                                             T8codeMesh{3}},
+                                 equations, dg::DGSEM, cache)
+    @unpack weights = dg.basis
+
+    u_mean = zero(get_node_vars(u, equations, dg, 1, 1, 1, element))
+    total_volume = zero(real(mesh))
+    for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
+        jacobian_node = abs(inv(cache.elements.inverse_jacobian[i, j, k, element]))
+        u_node = get_node_vars(u, equations, dg, i, j, k, element)
+        u_mean += u_node * weights[i] * weights[j] * weights[k] * jacobian_node
+        total_volume += weights[i] * weights[j] * weights[k] * jacobian_node
+    end
+    # normalize with the total volume
+    return u_mean / total_volume
 end
 end # @muladd

--- a/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
@@ -7,8 +7,6 @@
 
 function limiter_zhang_shu!(u, threshold::Real, variable,
                             mesh::AbstractMesh{3}, equations, dg::DGSEM, cache)
-    @unpack weights = dg.basis
-
     @threaded for element in eachelement(dg, cache)
         # determine minimum value
         value_min = typemax(eltype(u))
@@ -21,16 +19,7 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
         value_min < threshold || continue
 
         # compute mean value
-        u_mean = zero(get_node_vars(u, equations, dg, 1, 1, 1, element))
-        total_volume = zero(eltype(u))
-        for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-            volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, k, element]))
-            u_node = get_node_vars(u, equations, dg, i, j, k, element)
-            u_mean += u_node * weights[i] * weights[j] * weights[k] * volume_jacobian
-            total_volume += weights[i] * weights[j] * weights[k] * volume_jacobian
-        end
-        # normalize with the total volume
-        u_mean = u_mean / total_volume
+        u_mean = calc_element_mean_value(u, element, mesh, equations, dg, cache)
 
         # We compute the value directly with the mean values, as we assume that
         # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
@@ -44,5 +33,36 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
     end
 
     return nothing
+end
+
+function calc_element_mean_value(u, element, mesh::TreeMesh{3}, equations, dg::DGSEM,
+                                 cache)
+    @unpack weights = dg.basis
+
+    u_mean = zero(get_node_vars(u, equations, dg, 1, 1, 1, element))
+    for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
+        u_node = get_node_vars(u, equations, dg, i, j, k, element)
+        u_mean += u_node * weights[i] * weights[j] * weights[k]
+    end
+    # note that the reference element is [-1,1]^ndims(dg), thus the weights sum to 2
+    return u_mean / 2^ndims(mesh)
+end
+
+function calc_element_mean_value(u, element,
+                                 mesh::Union{StructuredMesh{3}, P4estMesh{3},
+                                             T8codeMesh{3}},
+                                 equations, dg::DGSEM, cache)
+    @unpack weights = dg.basis
+
+    u_mean = zero(get_node_vars(u, equations, dg, 1, 1, 1, element))
+    total_volume = zero(real(mesh))
+    for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
+        volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, k, element]))
+        u_node = get_node_vars(u, equations, dg, i, j, k, element)
+        u_mean += u_node * weights[i] * weights[j] * weights[k] * volume_jacobian
+        total_volume += weights[i] * weights[j] * weights[k] * volume_jacobian
+    end
+    # normalize with the total volume
+    return u_mean / total_volume
 end
 end # @muladd

--- a/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
@@ -26,7 +26,7 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
         total_volume = zero(eltype(u))
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
             volume_jacobian = abs(inv(get_inverse_jacobian(inverse_jacobian, mesh,
-                                                           i, j, k, element)))
+                                                           element, i, j, k)))
             u_node = get_node_vars(u, equations, dg, i, j, k, element)
             u_mean += u_node * weights[i] * weights[j] * weights[k] * volume_jacobian
             total_volume += weights[i] * weights[j] * weights[k] * volume_jacobian

--- a/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
@@ -6,7 +6,7 @@
 #! format: noindent
 
 function limiter_zhang_shu!(u, threshold::Real, variable,
-                            mesh::AbstractMesh{3}, equations, dg::DGSEM, cache)
+                            mesh::TreeMesh{3}, equations, dg::DGSEM, cache)
     @unpack weights = dg.basis
 
     @threaded for element in eachelement(dg, cache)
@@ -28,6 +28,48 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
         end
         # note that the reference element is [-1,1]^ndims(dg), thus the weights sum to 2
         u_mean = u_mean / 2^ndims(mesh)
+
+        # We compute the value directly with the mean values, as we assume that
+        # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
+        value_mean = variable(u_mean, equations)
+        theta = (value_mean - threshold) / (value_mean - value_min)
+        for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
+            u_node = get_node_vars(u, equations, dg, i, j, k, element)
+            set_node_vars!(u, theta * u_node + (1 - theta) * u_mean,
+                           equations, dg, i, j, k, element)
+        end
+    end
+
+    return nothing
+end
+
+function limiter_zhang_shu!(u, threshold::Real, variable,
+                            mesh::Union{StructuredMesh{3}, P4estMesh{3}, T8codeMesh{3}},
+                            equations, dg::DGSEM, cache)
+    @unpack weights = dg.basis
+
+    @threaded for element in eachelement(dg, cache)
+        # determine minimum value
+        value_min = typemax(eltype(u))
+        for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
+            u_node = get_node_vars(u, equations, dg, i, j, k, element)
+            value_min = min(value_min, variable(u_node, equations))
+        end
+
+        # detect if limiting is necessary
+        value_min < threshold || continue
+
+        # compute mean value
+        u_mean = zero(get_node_vars(u, equations, dg, 1, 1, 1, element))
+        total_volume = zero(real(mesh))
+        for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
+            jacobian_node = abs(inv(cache.elements.inverse_jacobian[i, j, k, element]))
+            u_node = get_node_vars(u, equations, dg, i, j, k, element)
+            u_mean += u_node * weights[i] * weights[j] * weights[k] * jacobian_node
+            total_volume += weights[i] * weights[j] * weights[k] * jacobian_node
+        end
+        # normalize with the total volume
+        u_mean = u_mean / total_volume
 
         # We compute the value directly with the mean values, as we assume that
         # Jensen's inequality holds (e.g. pressure for compressible Euler equations).

--- a/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
@@ -7,6 +7,8 @@
 
 function limiter_zhang_shu!(u, threshold::Real, variable,
                             mesh::AbstractMesh{3}, equations, dg::DGSEM, cache)
+    @unpack weights = dg.basis
+
     @threaded for element in eachelement(dg, cache)
         # determine minimum value
         value_min = typemax(eltype(u))
@@ -19,7 +21,16 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
         value_min < threshold || continue
 
         # compute mean value
-        u_mean = calc_element_mean_value(u, element, mesh, equations, dg, cache)
+        u_mean = zero(get_node_vars(u, equations, dg, 1, 1, 1, element))
+        total_volume = zero(real(mesh))
+        for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
+            volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, k, element]))
+            u_node = get_node_vars(u, equations, dg, i, j, k, element)
+            u_mean += u_node * weights[i] * weights[j] * weights[k] * volume_jacobian
+            total_volume += weights[i] * weights[j] * weights[k] * volume_jacobian
+        end
+        # normalize with the total volume
+        u_mean = u_mean / total_volume
 
         # We compute the value directly with the mean values, as we assume that
         # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
@@ -33,36 +44,5 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
     end
 
     return nothing
-end
-
-function calc_element_mean_value(u, element, mesh::TreeMesh{3}, equations, dg::DGSEM,
-                                 cache)
-    @unpack weights = dg.basis
-
-    u_mean = zero(get_node_vars(u, equations, dg, 1, 1, 1, element))
-    for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-        u_node = get_node_vars(u, equations, dg, i, j, k, element)
-        u_mean += u_node * weights[i] * weights[j] * weights[k]
-    end
-    # note that the reference element is [-1,1]^ndims(dg), thus the weights sum to 2
-    return u_mean / 2^ndims(mesh)
-end
-
-function calc_element_mean_value(u, element,
-                                 mesh::Union{StructuredMesh{3}, P4estMesh{3},
-                                             T8codeMesh{3}},
-                                 equations, dg::DGSEM, cache)
-    @unpack weights = dg.basis
-
-    u_mean = zero(get_node_vars(u, equations, dg, 1, 1, 1, element))
-    total_volume = zero(real(mesh))
-    for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-        jacobian_node = abs(inv(cache.elements.inverse_jacobian[i, j, k, element]))
-        u_node = get_node_vars(u, equations, dg, i, j, k, element)
-        u_mean += u_node * weights[i] * weights[j] * weights[k] * jacobian_node
-        total_volume += weights[i] * weights[j] * weights[k] * jacobian_node
-    end
-    # normalize with the total volume
-    return u_mean / total_volume
 end
 end # @muladd

--- a/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
@@ -22,7 +22,7 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
 
         # compute mean value
         u_mean = zero(get_node_vars(u, equations, dg, 1, 1, 1, element))
-        total_volume = zero(real(mesh))
+        total_volume = zero(eltype(u))
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
             volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, k, element]))
             u_node = get_node_vars(u, equations, dg, i, j, k, element)

--- a/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
+++ b/src/callbacks_stage/positivity_zhang_shu_dg3d.jl
@@ -26,7 +26,7 @@ function limiter_zhang_shu!(u, threshold::Real, variable,
         total_volume = zero(eltype(u))
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
             volume_jacobian = abs(inv(get_inverse_jacobian(inverse_jacobian, mesh,
-                                                           element, i, j, k)))
+                                                           i, j, k, element)))
             u_node = get_node_vars(u, equations, dg, i, j, k, element)
             u_mean += u_node * weights[i] * weights[j] * weights[k] * volume_jacobian
             total_volume += weights[i] * weights[j] * weights[k] * volume_jacobian

--- a/src/solvers/dgsem_structured/dg.jl
+++ b/src/solvers/dgsem_structured/dg.jl
@@ -80,7 +80,7 @@ end
                                       mesh::Union{StructuredMesh, StructuredMeshView,
                                                   UnstructuredMesh2D, P4estMesh,
                                                   T8codeMesh},
-                                      element, indices...)
+                                      indices..., element)
     return inverse_jacobian[indices..., element]
 end
 

--- a/src/solvers/dgsem_structured/dg.jl
+++ b/src/solvers/dgsem_structured/dg.jl
@@ -80,8 +80,8 @@ end
                                       mesh::Union{StructuredMesh, StructuredMeshView,
                                                   UnstructuredMesh2D, P4estMesh,
                                                   T8codeMesh},
-                                      element, indices...)
-    return inverse_jacobian[indices..., element]
+                                      indices...)
+    return inverse_jacobian[indices...]
 end
 
 include("containers.jl")

--- a/src/solvers/dgsem_structured/dg.jl
+++ b/src/solvers/dgsem_structured/dg.jl
@@ -76,6 +76,14 @@ end
     end
 end
 
+@inline function get_inverse_jacobian(inverse_jacobian,
+                                      mesh::Union{StructuredMesh, StructuredMeshView,
+                                                  UnstructuredMesh2D, P4estMesh,
+                                                  T8codeMesh},
+                                      element, indices...)
+    return inverse_jacobian[indices..., element]
+end
+
 include("containers.jl")
 include("dg_1d.jl")
 include("dg_2d.jl")

--- a/src/solvers/dgsem_structured/dg.jl
+++ b/src/solvers/dgsem_structured/dg.jl
@@ -80,7 +80,7 @@ end
                                       mesh::Union{StructuredMesh, StructuredMeshView,
                                                   UnstructuredMesh2D, P4estMesh,
                                                   T8codeMesh},
-                                      indices..., element)
+                                      element, indices...)
     return inverse_jacobian[indices..., element]
 end
 

--- a/src/solvers/dgsem_tree/dg.jl
+++ b/src/solvers/dgsem_tree/dg.jl
@@ -43,7 +43,7 @@ function volume_jacobian(element, mesh::TreeMesh, cache)
 end
 
 @inline function get_inverse_jacobian(inverse_jacobian, mesh::TreeMesh,
-                                      indices..., element)
+                                      element, indices...)
     return inverse_jacobian[element]
 end
 

--- a/src/solvers/dgsem_tree/dg.jl
+++ b/src/solvers/dgsem_tree/dg.jl
@@ -42,6 +42,11 @@ function volume_jacobian(element, mesh::TreeMesh, cache)
     return inv(cache.elements.inverse_jacobian[element])^ndims(mesh)
 end
 
+@inline function get_inverse_jacobian(inverse_jacobian, mesh::TreeMesh,
+                                      element, indices...)
+    return inverse_jacobian[element]
+end
+
 # Indicators used for shock-capturing and AMR
 include("indicators.jl")
 include("indicators_1d.jl")

--- a/src/solvers/dgsem_tree/dg.jl
+++ b/src/solvers/dgsem_tree/dg.jl
@@ -44,7 +44,8 @@ end
 
 @inline function get_inverse_jacobian(inverse_jacobian, mesh::TreeMesh,
                                       indices...)
-    return inverse_jacobian[last(indices)]
+    element = last(indices)
+    return inverse_jacobian[element]
 end
 
 # Indicators used for shock-capturing and AMR

--- a/src/solvers/dgsem_tree/dg.jl
+++ b/src/solvers/dgsem_tree/dg.jl
@@ -43,7 +43,7 @@ function volume_jacobian(element, mesh::TreeMesh, cache)
 end
 
 @inline function get_inverse_jacobian(inverse_jacobian, mesh::TreeMesh,
-                                      element, indices...)
+                                      indices..., element)
     return inverse_jacobian[element]
 end
 

--- a/src/solvers/dgsem_tree/dg.jl
+++ b/src/solvers/dgsem_tree/dg.jl
@@ -44,7 +44,7 @@ end
 
 @inline function get_inverse_jacobian(inverse_jacobian, mesh::TreeMesh,
                                       indices...)
-    return inverse_jacobian[last(indices...)]
+    return inverse_jacobian[last(indices)]
 end
 
 # Indicators used for shock-capturing and AMR

--- a/src/solvers/dgsem_tree/dg.jl
+++ b/src/solvers/dgsem_tree/dg.jl
@@ -43,8 +43,8 @@ function volume_jacobian(element, mesh::TreeMesh, cache)
 end
 
 @inline function get_inverse_jacobian(inverse_jacobian, mesh::TreeMesh,
-                                      element, indices...)
-    return inverse_jacobian[element]
+                                      indices...)
+    return inverse_jacobian[last(indices...)]
 end
 
 # Indicators used for shock-capturing and AMR


### PR DESCRIPTION
This is a bug fix where all mesh types other than `TreeMesh` should compute the solution mean value `u_mean` including the element Jacobians. If this is not done, it is possible to lose conservation. Typically, the values from `extra_analysis_errors = (:conservation_error,)` in the `AnalysisCallback` should stay between `1e-13` to `1e-15`. However, when one computes the incorrect value for `u_mean` on a curved mesh these conservation errors *might* increase to something between `1e-4` to `1e-8` (depending on the setup, how often the limiter is called, and how "warped" the mesh elements are).