### PR TITLE
Clean up callback conditions

### DIFF
--- a/src/callbacks_step/alive.jl
+++ b/src/callbacks_step/alive.jl
@@ -67,8 +67,7 @@ function (alive_callback::AliveCallback)(u, t, integrator)
     #    (total #steps)       (#accepted steps)
     # We need to check the number of accepted steps since callbacks are not
     # activated after a rejected step.
-    return alive_interval > 0 && ((integrator.stats.naccept % alive_interval == 0 &&
-             !(integrator.stats.naccept == 0 && integrator.iter > 0) &&
+    return alive_interval > 0 && ((integrator.stats.naccept % alive_interval == 0  &&
              (analysis_interval == 0 ||
               integrator.stats.naccept % analysis_interval != 0)) ||
             isfinished(integrator))

--- a/src/callbacks_step/alive.jl
+++ b/src/callbacks_step/alive.jl
@@ -67,7 +67,7 @@ function (alive_callback::AliveCallback)(u, t, integrator)
     #    (total #steps)       (#accepted steps)
     # We need to check the number of accepted steps since callbacks are not
     # activated after a rejected step.
-    return alive_interval > 0 && ((integrator.stats.naccept % alive_interval == 0  &&
+    return alive_interval > 0 && ((integrator.stats.naccept % alive_interval == 0 &&
              (analysis_interval == 0 ||
               integrator.stats.naccept % analysis_interval != 0)) ||
             isfinished(integrator))

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -26,8 +26,8 @@ or `extra_analysis_errors = (:conservation_error,)`.
 If you want to omit the computation (to safe compute-time) of the [`default_analysis_errors`](@ref), specify
 `analysis_errors = Symbol[]`.
 Note: `default_analysis_errors` are `:l2_error` and `:linf_error` for all equations.
-If you want to compute `extra_analysis_errors` such as `:conservation_error` solely, i.e., 
-without `:l2_error, :linf_error` you need to specify 
+If you want to compute `extra_analysis_errors` such as `:conservation_error` solely, i.e.,
+without `:l2_error, :linf_error` you need to specify
 `analysis_errors = [:conservation_error]` instead of `extra_analysis_errors = [:conservation_error]`.
 
 Further scalar functions `func` in `extra_analysis_integrals` are applied to the numerical
@@ -119,9 +119,7 @@ function AnalysisCallback(mesh, equations::AbstractEquations, solver, cache;
     # We need to check the number of accepted steps since callbacks are not
     # activated after a rejected step.
     condition = (u, t, integrator) -> interval > 0 &&
-        ((integrator.stats.naccept % interval == 0 &&
-          !(integrator.stats.naccept == 0 && integrator.iter > 0)) ||
-         isfinished(integrator))
+        (integrator.stats.naccept % interval == 0 || isfinished(integrator))
 
     analyzer = SolutionAnalyzer(solver; kwargs...)
     cache_analysis = create_cache_analysis(analyzer, mesh, equations, solver, cache,
@@ -696,7 +694,7 @@ include("analysis_dg3d_parallel.jl")
 
 # Special analyze for `SemidiscretizationHyperbolicParabolic` such that
 # precomputed gradients are available. Required for `enstrophy` (see above) and viscous forces.
-# Note that this needs to be included after `analysis_surface_integral_2d.jl` to 
+# Note that this needs to be included after `analysis_surface_integral_2d.jl` to
 # have `VariableViscous` available.
 function analyze(quantity::AnalysisSurfaceIntegral{Variable},
                  du, u, t,

--- a/src/callbacks_step/save_restart.jl
+++ b/src/callbacks_step/save_restart.jl
@@ -83,8 +83,7 @@ function (restart_callback::SaveRestartCallback)(u, t, integrator)
     #    (total #steps)       (#accepted steps)
     # We need to check the number of accepted steps since callbacks are not
     # activated after a rejected step.
-    return interval > 0 && (((integrator.stats.naccept % interval == 0) &&
-             !(integrator.stats.naccept == 0 && integrator.iter > 0)) ||
+    return interval > 0 && (integrator.stats.naccept % interval == 0 ||
             (save_final_restart && isfinished(integrator)))
 end
 
@@ -198,7 +197,7 @@ function load_adaptive_time_integrator!(integrator, restart_file::AbstractString
         # Reevaluate integrator.fsal_first on the first step
         integrator.reeval_fsal = true
         # Load additional parameters for PIDController
-        if hasproperty(controller, :err) # Distinguish PIDController from PIController 
+        if hasproperty(controller, :err) # Distinguish PIDController from PIController
             controller.err[:] = read(attributes(file)["time_integrator_controller_err"])
         end
     end

--- a/src/callbacks_step/save_solution.jl
+++ b/src/callbacks_step/save_solution.jl
@@ -174,8 +174,7 @@ function (solution_callback::SaveSolutionCallback)(u, t, integrator)
     #    (total #steps)       (#accepted steps)
     # We need to check the number of accepted steps since callbacks are not
     # activated after a rejected step.
-    return interval_or_dt > 0 && (((integrator.stats.naccept % interval_or_dt == 0) &&
-             !(integrator.stats.naccept == 0 && integrator.iter > 0)) ||
+    return interval_or_dt > 0 && (integrator.stats.naccept % interval_or_dt == 0 ||
             (save_final_solution && isfinished(integrator)))
 end
 

--- a/src/callbacks_step/visualization.jl
+++ b/src/callbacks_step/visualization.jl
@@ -137,8 +137,7 @@ function (visualization_callback::VisualizationCallback)(u, t, integrator)
     #    (total #steps)       (#accepted steps)
     # We need to check the number of accepted steps since callbacks are not
     # activated after a rejected step.
-    return interval > 0 && ((integrator.stats.naccept % interval == 0 &&
-             !(integrator.stats.naccept == 0 && integrator.iter > 0)) ||
+    return interval > 0 && (integrator.stats.naccept % interval == 0 ||
             isfinished(integrator))
 end
 


### PR DESCRIPTION
As discussed with @ranocha, the condition `integrator.stats.naccept == 0 && integrator.iter > 0` is an historical remnant that has just been copied around without really thinking about it.

The callbacks are only triggered for accepted steps, so this is never the case. The callback will only be initially triggered once with `naccept == iter == 0` and then always with `iter >= naccept > 0`.