### PR TITLE
Specify version of JuliaFormatter in docs

### DIFF
--- a/docs/src/styleguide.md
+++ b/docs/src/styleguide.md
@@ -51,7 +51,7 @@ PRs that verify that running JuliaFormatter.jl again will not change the source 
 To format your contributions before created a PR (or, at least, before requesting a review
 of your PR), you need to install JuliaFormatter.jl first by running
 ```shell
-julia -e 'using Pkg; Pkg.add("JuliaFormatter")'
+julia -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.45"))'
 ```
 You can then recursively format the core Julia files in the Trixi.jl repo by executing
 ```shell


### PR DESCRIPTION
In CI we use JuliaFormatter v1.0.45. So we should also recommend using this version in the docs. The formatting looks very different with another version of JuliaFormatter.jl.