### PR TITLE
Fix timings for `SemidiscretizationCoupled`

### DIFF
--- a/src/semidiscretization/semidiscretization_coupled.jl
+++ b/src/semidiscretization/semidiscretization_coupled.jl
@@ -125,7 +125,7 @@ end
 
 """
     ndofsglobal(semi::SemidiscretizationCoupled)
-    
+
 Return the global number of degrees of freedom associated with each scalar variable across all MPI ranks, and summed up over all coupled systems.
 This is the same as [`ndofs`](@ref) for simulations running in serial or
 parallelized via threads. It will in general be different for simulations
@@ -180,12 +180,10 @@ function rhs!(du_ode, u_ode, semi::SemidiscretizationCoupled, t)
     end
 
     # Call rhs! for each semidiscretization
-    @trixi_timeit timer() "copy to coupled boundaries" begin
-        foreach_enumerate(semi.semis) do (i, semi_)
-            u_loc = get_system_u_ode(u_ode, i, semi)
-            du_loc = get_system_u_ode(du_ode, i, semi)
-            rhs!(du_loc, u_loc, semi_, t)
-        end
+    foreach_enumerate(semi.semis) do (i, semi_)
+        u_loc = get_system_u_ode(u_ode, i, semi)
+        du_loc = get_system_u_ode(du_ode, i, semi)
+        rhs!(du_loc, u_loc, semi_, t)
     end
 
     runtime = time_ns() - time_start


### PR DESCRIPTION
The `rhs!` calls were counted as "copy to coupled boundaries", producing this weird timer output:
```
 Section                          ncalls     time    %tot     avg     alloc    %tot      avg
 ───────────────────────────────────────────────────────────────────────────────────────────
 copy to coupled boundaries        7.20k    4.72s   81.7%   656μs   3.31GiB   96.2%   481KiB
   ~copy to coupled boundaries~    7.20k    4.33s   74.9%   601μs   3.31GiB   96.2%   481KiB
   rhs!                            21.6k    395ms    6.8%  18.3μs   5.14KiB    0.0%    0.24B
     volume integral               21.6k    209ms    3.6%  9.65μs     0.00B    0.0%    0.00B
     interface flux                21.6k   62.8ms    1.1%  2.91μs     0.00B    0.0%    0.00B
     surface integral              21.6k   46.5ms    0.8%  2.15μs     0.00B    0.0%    0.00B
     boundary flux                 21.6k   32.6ms    0.6%  1.51μs     0.00B    0.0%    0.00B
     Jacobian                      21.6k   21.3ms    0.4%   985ns     0.00B    0.0%    0.00B
     reset ∂u/∂t                   21.6k   12.9ms    0.2%   597ns     0.00B    0.0%    0.00B
     ~rhs!~                        21.6k   10.1ms    0.2%   467ns   5.14KiB    0.0%    0.24B
     source terms                  21.6k    247μs    0.0%  11.4ns     0.00B    0.0%    0.00B
```
The new output looks like this:
```
 Section                      ncalls     time    %tot     avg     alloc    %tot      avg
 ───────────────────────────────────────────────────────────────────────────────────────
 copy to coupled boundaries    3.60k    4.01s   88.3%  1.11ms   3.28GiB   99.3%   956KiB
 rhs!                          21.6k    388ms    8.5%  18.0μs   5.14KiB    0.0%    0.24B
   volume integral             21.6k    207ms    4.6%  9.58μs     0.00B    0.0%    0.00B
   interface flux              21.6k   61.0ms    1.3%  2.82μs     0.00B    0.0%    0.00B
   surface integral            21.6k   46.3ms    1.0%  2.14μs     0.00B    0.0%    0.00B
   boundary flux               21.6k   31.6ms    0.7%  1.46μs     0.00B    0.0%    0.00B
   Jacobian                    21.6k   21.1ms    0.5%   976ns     0.00B    0.0%    0.00B
   reset ∂u/∂t                 21.6k   11.6ms    0.3%   536ns     0.00B    0.0%    0.00B
   ~rhs!~                      21.6k   9.07ms    0.2%   420ns   5.14KiB    0.0%    0.24B
   source terms                21.6k    254μs    0.0%  11.8ns     0.00B    0.0%    0.00B
```