### PR TITLE
Do not set `finalstep = false` in PERK2 `step!`

### DIFF
--- a/src/time_integration/paired_explicit_runge_kutta/methods_PERK2.jl
+++ b/src/time_integration/paired_explicit_runge_kutta/methods_PERK2.jl
@@ -296,8 +296,6 @@ function step!(integrator::PairedExplicitRK2Integrator)
     t_end = last(prob.tspan)
     callbacks = integrator.opts.callback
 
-    integrator.finalstep = false
-
     @assert !integrator.finalstep
     if isnan(integrator.dt)
         error("time step size `dt` is NaN")


### PR DESCRIPTION
The correct place to set this is in the `solve!` function:

https://github.com/trixi-framework/Trixi.jl/blob/5398b2257a68c8795be4ee06b5ee3e947e006ff8/src/time_integration/paired_explicit_runge_kutta/methods_PERK2.jl#L279-L286