### PR TITLE
Update JuliaCon schedule (once more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ from the Trixi Framework ecosystem:
 
 * [**Julia for Particle-Based Multiphysics with TrixiParticles.jl**](https://pretalx.com/juliacon2024/talk/TPFF8L/),<br/>
   [*Erik Faulhaber*](https://github.com/efaulhaber/), [*Niklas Neher*](https://github.com/lasnikas/),
-  10th July 2024, 11:00am–11:30pm, Function (4.1)
+  10th July 2024, 11:00–11:30, Function (4.1)
 * [**Towards Aerodynamic Simulations in Julia with Trixi.jl**](https://pretalx.com/juliacon2024/talk/XH8KBG/),<br/>
   [*Daniel Doehring*](https://github.com/danieldoehring/),
-  10th July 2024, 15:30pm–16:00pm, While Loop (4.2)
+  10th July 2024, 15:30–16:00, While Loop (4.2)
 * [**libtrixi: serving legacy codes in earth system modeling with fresh Julia CFD**](https://pretalx.com/juliacon2024/talk/SXC7LA/),<br/>
   [*Benedict Geihe*](https://github.com/benegee/),
-  12th July 2024, 14:00pm–17:00pm, Function (4.1)
+  12th July 2024, 14:00–17:00, Function (4.1)
 
 The last talk is part of the 
 [Julia for High-Performance Computing](https://juliacon.org/2024/minisymposia/hpc/)

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ from the Trixi Framework ecosystem:
 
 * [**Julia for Particle-Based Multiphysics with TrixiParticles.jl**](https://pretalx.com/juliacon2024/talk/TPFF8L/),<br/>
   [*Erik Faulhaber*](https://github.com/efaulhaber/), [*Niklas Neher*](https://github.com/lasnikas/),
-  10th July 2024, 11:30am–12:00pm, Function (4.1)
+  10th July 2024, 11:00am–11:30pm, Function (4.1)
 * [**Towards Aerodynamic Simulations in Julia with Trixi.jl**](https://pretalx.com/juliacon2024/talk/XH8KBG/),<br/>
   [*Daniel Doehring*](https://github.com/danieldoehring/),
-  10th July 2024, 15:00pm–15:30pm, While Loop (4.2)
+  10th July 2024, 15:30pm–16:00pm, While Loop (4.2)
 * [**libtrixi: serving legacy codes in earth system modeling with fresh Julia CFD**](https://pretalx.com/juliacon2024/talk/SXC7LA/),<br/>
   [*Benedict Geihe*](https://github.com/benegee/),
   12th July 2024, 14:00pm–17:00pm, Function (4.1)


### PR DESCRIPTION
The talk by @efaulhaber and @LasNikas was brought forward to **11am** (was: 11:30am).

The talk by @DanielDoehring was moved backward to **3:30pm** (was: 3pm).