### PR TITLE
Canonical use of `initial_condition`

### DIFF
--- a/examples/tree_1d_dgsem/elixir_advection_diffusion.jl
+++ b/examples/tree_1d_dgsem/elixir_advection_diffusion.jl
@@ -53,7 +53,7 @@ boundary_conditions_parabolic = boundary_condition_periodic
 
 # A semidiscretization collects data structures and functions for the spatial discretization
 semi = SemidiscretizationHyperbolicParabolic(mesh, (equations, equations_parabolic),
-                                             initial_condition_diffusive_convergence_test,
+                                             initial_condition,
                                              solver;
                                              boundary_conditions = (boundary_conditions,
                                                                     boundary_conditions_parabolic))


### PR DESCRIPTION
See the other examples:

https://github.com/trixi-framework/Trixi.jl/blob/b592f3cbc7c784a6579e95a6e0aad05865e89c0a/examples/tree_3d_dgsem/elixir_advection_diffusion_amr.jl#L37-L46

https://github.com/trixi-framework/Trixi.jl/blob/b592f3cbc7c784a6579e95a6e0aad05865e89c0a/examples/p4est_2d_dgsem/elixir_advection_diffusion_periodic.jl#L34-L51

https://github.com/trixi-framework/Trixi.jl/blob/b592f3cbc7c784a6579e95a6e0aad05865e89c0a/examples/p4est_2d_dgsem/elixir_advection_diffusion_periodic_amr.jl#L38-L43

https://github.com/trixi-framework/Trixi.jl/blob/b592f3cbc7c784a6579e95a6e0aad05865e89c0a/examples/p4est_2d_dgsem/elixir_advection_diffusion_periodic_curved.jl#L34-L56

https://github.com/trixi-framework/Trixi.jl/blob/b592f3cbc7c784a6579e95a6e0aad05865e89c0a/examples/tree_2d_dgsem/elixir_advection_diffusion.jl#L39-L48
