### PR TITLE
`calc_volume_integral!` for all meshes supported by `fv_kernel!`

### DIFF
--- a/src/solvers/dgsem_tree/dg_1d.jl
+++ b/src/solvers/dgsem_tree/dg_1d.jl
@@ -294,7 +294,7 @@ end
 
 # TODO: Taal dimension agnostic
 function calc_volume_integral!(du, u,
-                               mesh::TreeMesh{1},
+                               mesh::Union{TreeMesh{1}, StructuredMesh{1}},
                                nonconservative_terms, equations,
                                volume_integral::VolumeIntegralPureLGLFiniteVolume,
                                dg::DGSEM, cache)

--- a/src/solvers/dgsem_tree/dg_2d.jl
+++ b/src/solvers/dgsem_tree/dg_2d.jl
@@ -376,7 +376,9 @@ end
 
 # TODO: Taal dimension agnostic
 function calc_volume_integral!(du, u,
-                               mesh::TreeMesh{2},
+                               mesh::Union{TreeMesh{2}, StructuredMesh{2},
+                                           UnstructuredMesh2D, P4estMesh{2},
+                                           T8codeMesh{2}},
                                nonconservative_terms, equations,
                                volume_integral::VolumeIntegralPureLGLFiniteVolume,
                                dg::DGSEM, cache)

--- a/src/solvers/dgsem_tree/dg_3d.jl
+++ b/src/solvers/dgsem_tree/dg_3d.jl
@@ -424,7 +424,8 @@ end
 
 # TODO: Taal dimension agnostic
 function calc_volume_integral!(du, u,
-                               mesh::TreeMesh{3},
+                               mesh::Union{TreeMesh{3}, StructuredMesh{3}, P4estMesh{3},
+                                           T8codeMesh{3}},
                                nonconservative_terms, equations,
                                volume_integral::VolumeIntegralPureLGLFiniteVolume,
                                dg::DGSEM, cache)

--- a/test/test_p4est_2d.jl
+++ b/test/test_p4est_2d.jl
@@ -675,8 +675,8 @@ end
                         # Let this test run longer to cover some lines in flux_hllc
                         coverage_override=(maxiters = 10^5, tspan = (0.0, 0.1)),
                         mesh=P4estMesh((64, 64), polydeg = 3,
-                                              coordinates_min = (-2.0, -2.0),
-                                              coordinates_max = (2.0, 2.0)))
+                                       coordinates_min = (-2.0, -2.0),
+                                       coordinates_max = (2.0, 2.0)))
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     let

--- a/test/test_p4est_2d.jl
+++ b/test/test_p4est_2d.jl
@@ -672,8 +672,6 @@ end
                             2.4656795949035857,
                         ],
                         tspan=(0.0, 0.5),
-                        # Let this test run longer to cover some lines in flux_hllc
-                        coverage_override=(maxiters = 10^5, tspan = (0.0, 0.1)),
                         mesh=P4estMesh((64, 64), polydeg = 3,
                                        coordinates_min = (-2.0, -2.0),
                                        coordinates_max = (2.0, 2.0)))

--- a/test/test_p4est_2d.jl
+++ b/test/test_p4est_2d.jl
@@ -655,6 +655,37 @@ end
     @test isapprox(lift, 0.029076443678087403, atol = 1e-13)
     @test isapprox(drag, 0.13564720009197903, atol = 1e-13)
 end
+
+@trixi_testset "elixir_euler_blast_wave_pure_fv.jl" begin
+    @test_trixi_include(joinpath(pkgdir(Trixi, "examples", "tree_2d_dgsem"),
+                                 "elixir_euler_blast_wave_pure_fv.jl"),
+                        l2=[
+                            0.39957047631960346,
+                            0.21006912294983154,
+                            0.21006903549932,
+                            0.6280328163981136,
+                        ],
+                        linf=[
+                            2.20417889887697,
+                            1.5487238480003327,
+                            1.5486788679247812,
+                            2.4656795949035857,
+                        ],
+                        tspan=(0.0, 0.5),
+                        # Let this test run longer to cover some lines in flux_hllc
+                        coverage_override=(maxiters = 10^5, tspan = (0.0, 0.1)),
+                        mesh=mesh = P4estMesh((64, 64), polydeg = 3,
+                                              coordinates_min = (-2.0, -2.0),
+                                              coordinates_max = (2.0, 2.0)))
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    let
+        t = sol.t[end]
+        u_ode = sol.u[end]
+        du_ode = similar(u_ode)
+        @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 1000
+    end
+end
 end
 
 # Clean up afterwards: delete Trixi.jl output directory

--- a/test/test_p4est_2d.jl
+++ b/test/test_p4est_2d.jl
@@ -674,7 +674,7 @@ end
                         tspan=(0.0, 0.5),
                         # Let this test run longer to cover some lines in flux_hllc
                         coverage_override=(maxiters = 10^5, tspan = (0.0, 0.1)),
-                        mesh=mesh = P4estMesh((64, 64), polydeg = 3,
+                        mesh=P4estMesh((64, 64), polydeg = 3,
                                               coordinates_min = (-2.0, -2.0),
                                               coordinates_max = (2.0, 2.0)))
     # Ensure that we do not have excessive memory allocations

--- a/test/test_structured_1d.jl
+++ b/test/test_structured_1d.jl
@@ -168,6 +168,30 @@ end
         @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 1000
     end
 end
+
+@trixi_testset "elixir_euler_convergence_pure_fv.jl" begin
+    @test_trixi_include(joinpath(pkgdir(Trixi, "examples", "tree_1d_dgsem"),
+                                 "elixir_euler_convergence_pure_fv.jl"),
+                        mesh=StructuredMesh(16, (0.0,), (2.0,)),
+                        l2=[
+                            0.019355699748523896,
+                            0.022326984561234497,
+                            0.02523665947241734,
+                        ],
+                        linf=[
+                            0.02895961127645519,
+                            0.03293442484199227,
+                            0.04246098278632804,
+                        ])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    let
+        t = sol.t[end]
+        u_ode = sol.u[end]
+        du_ode = similar(u_ode)
+        @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 1000
+    end
+end
 end
 
 # Clean up afterwards: delete Trixi.jl output directory

--- a/test/test_t8code_3d.jl
+++ b/test/test_t8code_3d.jl
@@ -282,6 +282,40 @@ mkdir(outdir)
             @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 1000
         end
     end
+
+    @trixi_testset "elixir_euler_convergence_pure_fv.jl" begin
+        @test_trixi_include(joinpath(pkgdir(Trixi, "examples", "tree_3d_dgsem"),
+                                     "elixir_euler_convergence_pure_fv.jl"),
+                            l2=[
+                                0.037182410351406,
+                                0.032062252638283974,
+                                0.032062252638283974,
+                                0.03206225263828395,
+                                0.12228177813586687,
+                            ],
+                            linf=[
+                                0.0693648413632646,
+                                0.0622101894740843,
+                                0.06221018947408474,
+                                0.062210189474084965,
+                                0.24196451799555962,
+                            ],
+                            mesh=T8codeMesh((4, 4, 4), polydeg = 3,
+                                            coordinates_min = (0.0, 0.0, 0.0),
+                                            coordinates_max = (2.0, 2.0, 2.0)),
+                            # Remove SaveSolution callback
+                            callbacks=CallbackSet(summary_callback,
+                                                  analysis_callback, alive_callback,
+                                                  stepsize_callback))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
+        let
+            t = sol.t[end]
+            u_ode = sol.u[end]
+            du_ode = similar(u_ode)
+            @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 1000
+        end
+    end
 end
 
 # Clean up afterwards: delete Trixi.jl output directory


### PR DESCRIPTION
Although `fv_kernel!` is implemented for most (all) available meshes, the calling `calc_volume_integral` was not allowing this.

The only untested case is the `UnstructuredMesh2D` - I could 

1. exclude this from the allowed meshes
2. write a new elixir for this
3. just hope for the best

Xref: https://github.com/trixi-framework/Trixi.jl/pull/425