### PR TITLE
Update feature table: parabolic terms not supported for `StructuredMesh`

### DIFF
--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -60,15 +60,15 @@ different features on different mesh types.
 | Flux differencing                                            |          ✅         |             ✅            |               ✅              |          ✅          |               ✅            | [`VolumeIntegralFluxDifferencing`](@ref)
 | Shock capturing                                              |          ✅         |             ✅            |               ✅              |          ✅          |               ❌            | [`VolumeIntegralShockCapturingHG`](@ref)
 | Nonconservative equations                                    |          ✅         |             ✅            |               ✅              |          ✅          |               ✅            | e.g., GLM MHD or shallow water equations
-| Parabolic terms                                              |          ✅         |             ✅            |               ❌              |          ✅          |               ✅            | e.g., [`CompressibleNavierStokesDiffusion2D`](@ref)
+| Parabolic terms                                              |          ✅         |             ❌            |               ❌              |          ✅          |               ✅            | e.g., [`CompressibleNavierStokesDiffusion2D`](@ref)
 
 ᵃ: quad = quadrilateral, hex = hexahedron
 
-Note that except for [`TreeMesh`](@ref) all meshes are of *curvilinear* type, 
-which means that a (unit) vector normal to the interface (`normal_direction`) needs to be supplied to the 
+Note that except for [`TreeMesh`](@ref) all meshes are of *curvilinear* type,
+which means that a (unit) vector normal to the interface (`normal_direction`) needs to be supplied to the
 numerical flux function.
-You can check the [reference](https://trixi-framework.github.io/Trixi.jl/stable/reference-trixi/) if a certain 
-numerical flux is implemented with a `normal_direction` 
+You can check the [reference](https://trixi-framework.github.io/Trixi.jl/stable/reference-trixi/) if a certain
+numerical flux is implemented with a `normal_direction`
 or if currently only the *Cartesian* version (for [`TreeMesh`](@ref)) exists.
 In this case, you can still use this flux on curvilinear meshes by rotating it, see [`FluxRotated`](@ref).
 


### PR DESCRIPTION
This came up in https://discourse.julialang.org/t/structuredmesh-parabolic-equations-supported-trixi/117231.