### PR TITLE
Add numerical support for other real types (`fluxes`)

### DIFF
--- a/src/equations/numerical_fluxes.jl
+++ b/src/equations/numerical_fluxes.jl
@@ -21,7 +21,7 @@ DG method (except floating point errors).
     f_rr = flux(u_rr, orientation_or_normal_direction, equations)
 
     # Average regular fluxes
-    return 0.5 * (f_ll + f_rr)
+    return 0.5f0 * (f_ll + f_rr)
 end
 
 """
@@ -172,7 +172,7 @@ DissipationLocalLaxFriedrichs() = DissipationLocalLaxFriedrichs(max_abs_speed_na
                                                               equations)
     λ = dissipation.max_abs_speed(u_ll, u_rr, orientation_or_normal_direction,
                                   equations)
-    return -0.5 * λ * (u_rr - u_ll)
+    return -0.5f0 * λ * (u_rr - u_ll)
 end
 
 function Base.show(io::IO, d::DissipationLocalLaxFriedrichs)

--- a/test/test_type.jl
+++ b/test/test_type.jl
@@ -45,39 +45,17 @@ isdir(outdir) && rm(outdir, recursive = true)
 
             for orientation in orientations
                 for direction in directions
-                    if RealT == Float32
-                        # check `surface_flux_function` (test broken)
-                        @test_broken eltype(@inferred boundary_condition_wall(u_inner,
-                                                                              orientation,
-                                                                              direction, x,
-                                                                              t,
-                                                                              surface_flux_function,
-                                                                              equations)) ==
-                                     RealT
-                    else
-                        @test eltype(@inferred boundary_condition_wall(u_inner, orientation,
-                                                                       direction, x, t,
-                                                                       surface_flux_function,
-                                                                       equations)) == RealT
-                    end
+                    @test eltype(@inferred boundary_condition_wall(u_inner, orientation,
+                                                                   direction, x, t,
+                                                                   surface_flux_function,
+                                                                   equations)) == RealT
                 end
             end
-
-            if RealT == Float32
-                # check `surface_flux_function` (test broken)
-                @test_broken eltype(@inferred boundary_condition_slip_wall(u_inner,
-                                                                           normal_direction,
-                                                                           x, t,
-                                                                           surface_flux_function,
-                                                                           equations)) ==
-                             RealT
-            else
-                @test eltype(@inferred boundary_condition_slip_wall(u_inner,
-                                                                    normal_direction, x, t,
-                                                                    surface_flux_function,
-                                                                    equations)) ==
-                      RealT
-            end
+            @test eltype(@inferred boundary_condition_slip_wall(u_inner,
+                                                                normal_direction, x, t,
+                                                                surface_flux_function,
+                                                                equations)) ==
+                  RealT
 
             @test eltype(@inferred flux(u, normal_direction, equations)) == RealT
             @test typeof(@inferred max_abs_speed_naive(u_ll, u_rr, normal_direction,
@@ -850,25 +828,13 @@ isdir(outdir) && rm(outdir, recursive = true)
                   RealT
 
             for direction in directions
-                if RealT == Float32
-                    # check `surface_flux_function` (test broken)
-                    @test_broken eltype(@inferred boundary_condition_poisson_nonperiodic(u_inner,
-                                                                                         orientation,
-                                                                                         direction,
-                                                                                         x,
-                                                                                         t,
-                                                                                         surface_flux_function,
-                                                                                         equations)) ==
-                                 RealT
-                else
-                    @test eltype(@inferred boundary_condition_poisson_nonperiodic(u_inner,
-                                                                                  orientation,
-                                                                                  direction,
-                                                                                  x, t,
-                                                                                  surface_flux_function,
-                                                                                  equations)) ==
-                          RealT
-                end
+                @test eltype(@inferred boundary_condition_poisson_nonperiodic(u_inner,
+                                                                              orientation,
+                                                                              direction,
+                                                                              x, t,
+                                                                              surface_flux_function,
+                                                                              equations)) ==
+                      RealT
             end
 
             @test eltype(@inferred flux(u, orientation, equations)) == RealT
@@ -911,25 +877,13 @@ isdir(outdir) && rm(outdir, recursive = true)
 
             for orientation in orientations
                 for direction in directions
-                    if RealT == Float32
-                        # check `surface_flux_function` (test broken)
-                        @test_broken eltype(@inferred boundary_condition_poisson_nonperiodic(u_inner,
-                                                                                             orientation,
-                                                                                             direction,
-                                                                                             x,
-                                                                                             t,
-                                                                                             surface_flux_function,
-                                                                                             equations)) ==
-                                     RealT
-                    else
-                        @test eltype(@inferred boundary_condition_poisson_nonperiodic(u_inner,
-                                                                                      orientation,
-                                                                                      direction,
-                                                                                      x, t,
-                                                                                      surface_flux_function,
-                                                                                      equations)) ==
-                              RealT
-                    end
+                    @test eltype(@inferred boundary_condition_poisson_nonperiodic(u_inner,
+                                                                                  orientation,
+                                                                                  direction,
+                                                                                  x, t,
+                                                                                  surface_flux_function,
+                                                                                  equations)) ==
+                          RealT
                 end
             end
 
@@ -985,25 +939,13 @@ isdir(outdir) && rm(outdir, recursive = true)
 
             for orientation in orientations
                 for direction in directions
-                    if RealT == Float32
-                        # check `surface_flux_function` (test broken)
-                        @test_broken eltype(@inferred boundary_condition_poisson_nonperiodic(u_inner,
-                                                                                             orientation,
-                                                                                             direction,
-                                                                                             x,
-                                                                                             t,
-                                                                                             surface_flux_function,
-                                                                                             equations)) ==
-                                     RealT
-                    else
-                        @test eltype(@inferred boundary_condition_poisson_nonperiodic(u_inner,
-                                                                                      orientation,
-                                                                                      direction,
-                                                                                      x, t,
-                                                                                      surface_flux_function,
-                                                                                      equations)) ==
-                              RealT
-                    end
+                    @test eltype(@inferred boundary_condition_poisson_nonperiodic(u_inner,
+                                                                                  orientation,
+                                                                                  direction,
+                                                                                  x, t,
+                                                                                  surface_flux_function,
+                                                                                  equations)) ==
+                          RealT
                 end
             end
 
@@ -1631,24 +1573,13 @@ isdir(outdir) && rm(outdir, recursive = true)
                   RealT
 
             for direction in directions
-                if RealT == Float32
-                    # check `surface_flux_function` (test broken)
-                    @test_broken eltype(@inferred Trixi.boundary_condition_linear_x(u_inner,
-                                                                                    orientation,
-                                                                                    direction,
-                                                                                    x, t,
-                                                                                    surface_flux_function,
-                                                                                    equations)) ==
-                                 RealT
-                else
-                    @test eltype(@inferred Trixi.boundary_condition_linear_x(u_inner,
-                                                                             orientation,
-                                                                             direction, x,
-                                                                             t,
-                                                                             surface_flux_function,
-                                                                             equations)) ==
-                          RealT
-                end
+                @test eltype(@inferred Trixi.boundary_condition_linear_x(u_inner,
+                                                                         orientation,
+                                                                         direction, x,
+                                                                         t,
+                                                                         surface_flux_function,
+                                                                         equations)) ==
+                      RealT
             end
 
             @test eltype(@inferred flux(u, orientation, equations)) == RealT
@@ -1701,58 +1632,30 @@ isdir(outdir) && rm(outdir, recursive = true)
 
             for orientation in orientations
                 for direction in directions
-                    if RealT == Float32
-                        # check `surface_flux_function` (test broken)
-                        @test_broken eltype(@inferred Trixi.boundary_condition_linear_x_y(u_inner,
-                                                                                          orientation,
-                                                                                          direction,
-                                                                                          x,
-                                                                                          t,
-                                                                                          surface_flux_function,
-                                                                                          equations)) ==
-                                     RealT
-                        @test_broken eltype(@inferred Trixi.boundary_condition_linear_x(u_inner,
-                                                                                        orientation,
-                                                                                        direction,
-                                                                                        x,
-                                                                                        t,
-                                                                                        surface_flux_function,
-                                                                                        equations)) ==
-                                     RealT
-                        @test_broken eltype(@inferred Trixi.boundary_condition_linear_y(u_inner,
-                                                                                        orientation,
-                                                                                        direction,
-                                                                                        x,
-                                                                                        t,
-                                                                                        surface_flux_function,
-                                                                                        equations)) ==
-                                     RealT
-                    else
-                        @test eltype(@inferred Trixi.boundary_condition_linear_x_y(u_inner,
-                                                                                   orientation,
-                                                                                   direction,
-                                                                                   x,
-                                                                                   t,
-                                                                                   surface_flux_function,
-                                                                                   equations)) ==
-                              RealT
-                        @test eltype(@inferred Trixi.boundary_condition_linear_x(u_inner,
-                                                                                 orientation,
-                                                                                 direction,
-                                                                                 x,
-                                                                                 t,
-                                                                                 surface_flux_function,
-                                                                                 equations)) ==
-                              RealT
-                        @test eltype(@inferred Trixi.boundary_condition_linear_y(u_inner,
-                                                                                 orientation,
-                                                                                 direction,
-                                                                                 x,
-                                                                                 t,
-                                                                                 surface_flux_function,
-                                                                                 equations)) ==
-                              RealT
-                    end
+                    @test eltype(@inferred Trixi.boundary_condition_linear_x_y(u_inner,
+                                                                               orientation,
+                                                                               direction,
+                                                                               x,
+                                                                               t,
+                                                                               surface_flux_function,
+                                                                               equations)) ==
+                          RealT
+                    @test eltype(@inferred Trixi.boundary_condition_linear_x(u_inner,
+                                                                             orientation,
+                                                                             direction,
+                                                                             x,
+                                                                             t,
+                                                                             surface_flux_function,
+                                                                             equations)) ==
+                          RealT
+                    @test eltype(@inferred Trixi.boundary_condition_linear_y(u_inner,
+                                                                             orientation,
+                                                                             direction,
+                                                                             x,
+                                                                             t,
+                                                                             surface_flux_function,
+                                                                             equations)) ==
+                          RealT
                 end
             end
 
@@ -1806,26 +1709,14 @@ isdir(outdir) && rm(outdir, recursive = true)
 
             for orientation in orientations
                 for direction in directions
-                    if RealT == Float32
-                        # check `surface_flux_function` (test broken)
-                        @test_broken eltype(@inferred Trixi.boundary_condition_linear_z(u_inner,
-                                                                                        orientation,
-                                                                                        direction,
-                                                                                        x,
-                                                                                        t,
-                                                                                        surface_flux_function,
-                                                                                        equations)) ==
-                                     RealT
-                    else
-                        @test eltype(@inferred Trixi.boundary_condition_linear_z(u_inner,
-                                                                                 orientation,
-                                                                                 direction,
-                                                                                 x,
-                                                                                 t,
-                                                                                 surface_flux_function,
-                                                                                 equations)) ==
-                              RealT
-                    end
+                    @test eltype(@inferred Trixi.boundary_condition_linear_z(u_inner,
+                                                                             orientation,
+                                                                             direction,
+                                                                             x,
+                                                                             t,
+                                                                             surface_flux_function,
+                                                                             equations)) ==
+                          RealT
                 end
             end
 
@@ -1904,24 +1795,12 @@ isdir(outdir) && rm(outdir, recursive = true)
                   RealT
 
             for direction in directions
-                if RealT == Float32
-                    # check `surface_flux_function` (test broken)
-                    @test_broken eltype(@inferred boundary_condition_slip_wall(u_inner,
-                                                                               orientation,
-                                                                               direction,
-                                                                               x, t,
-                                                                               surface_flux_function,
-                                                                               equations)) ==
-                                 RealT
-                else
-                    @test eltype(@inferred boundary_condition_slip_wall(u_inner,
-                                                                        orientation,
-                                                                        direction,
-                                                                        x, t,
-                                                                        surface_flux_function,
-                                                                        equations)) == RealT
-                end
-
+                @test eltype(@inferred boundary_condition_slip_wall(u_inner,
+                                                                    orientation,
+                                                                    direction,
+                                                                    x, t,
+                                                                    surface_flux_function,
+                                                                    equations)) == RealT
                 @test eltype(@inferred Trixi.calc_wavespeed_roe(u_ll, u_rr, direction,
                                                                 equations)) ==
                       RealT
@@ -2006,22 +1885,12 @@ isdir(outdir) && rm(outdir, recursive = true)
                   RealT
             @test eltype(@inferred initial_condition_weak_blast_wave(x, t, equations)) ==
                   RealT
+            @test eltype(@inferred boundary_condition_slip_wall(u_inner,
+                                                                normal_direction,
+                                                                x, t,
+                                                                surface_flux_function,
+                                                                equations)) == RealT
 
-            if RealT == Float32
-                # check `surface_flux_function` (test broken)
-                @test_broken eltype(@inferred boundary_condition_slip_wall(u_inner,
-                                                                           normal_direction,
-                                                                           x, t,
-                                                                           surface_flux_function,
-                                                                           equations)) ==
-                             RealT
-            else
-                @test eltype(@inferred boundary_condition_slip_wall(u_inner,
-                                                                    normal_direction,
-                                                                    x, t,
-                                                                    surface_flux_function,
-                                                                    equations)) == RealT
-            end
             @test eltype(@inferred flux(u, normal_direction, equations)) == RealT
             @test eltype(@inferred flux_nonconservative_wintermeyer_etal(u_ll, u_rr,
                                                                          normal_direction_ll,
@@ -2063,23 +1932,12 @@ isdir(outdir) && rm(outdir, recursive = true)
 
             for orientation in orientations
                 for direction in directions
-                    if RealT == Float32
-                        # check `surface_flux_function` (test broken)
-                        @test_broken eltype(@inferred boundary_condition_slip_wall(u_inner,
-                                                                                   orientation,
-                                                                                   direction,
-                                                                                   x, t,
-                                                                                   surface_flux_function,
-                                                                                   equations)) ==
-                                     RealT
-                    else
-                        @test eltype(@inferred boundary_condition_slip_wall(u_inner,
-                                                                            orientation,
-                                                                            direction, x, t,
-                                                                            surface_flux_function,
-                                                                            equations)) ==
-                              RealT
-                    end
+                    @test eltype(@inferred boundary_condition_slip_wall(u_inner,
+                                                                        orientation,
+                                                                        direction, x, t,
+                                                                        surface_flux_function,
+                                                                        equations)) ==
+                          RealT
                 end
 
                 @test eltype(@inferred flux(u, orientation, equations)) == RealT


### PR DESCRIPTION
Continue #1909. This PR would finish all the primary work for #591 with single precision float numbers (`Float32`). Other helper work will continue here #1948.

Tasks:
- [x] numerical_fluxes 
- [x] fix related broken tests