### PR TITLE
Add a preference to disable Polyester

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -80,6 +80,7 @@ using Preferences: @load_preference, set_preferences!
 
 const _PREFERENCE_SQRT = @load_preference("sqrt", "sqrt_Trixi_NaN")
 const _PREFERENCE_LOG = @load_preference("log", "log_Trixi_NaN")
+const _PREFERENCE_POLYESTER = parse(Bool, @load_preference("polyester", "true"))
 
 # finite difference SBP operators
 using SummationByPartsOperators: AbstractDerivativeOperator,

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -80,7 +80,7 @@ using Preferences: @load_preference, set_preferences!
 
 const _PREFERENCE_SQRT = @load_preference("sqrt", "sqrt_Trixi_NaN")
 const _PREFERENCE_LOG = @load_preference("log", "log_Trixi_NaN")
-const _PREFERENCE_POLYESTER = parse(Bool, @load_preference("polyester", "true"))
+const _PREFERENCE_POLYESTER = @load_preference("polyester", true)
 
 # finite difference SBP operators
 using SummationByPartsOperators: AbstractDerivativeOperator,

--- a/src/auxiliary/math.jl
+++ b/src/auxiliary/math.jl
@@ -8,6 +8,21 @@
 const TRIXI_UUID = UUID("a7f1ee26-1774-49b1-8366-f1abc58fbfcb")
 
 """
+    Trixi.set_polyester(toggle::Bool; force = true)
+
+Toggle the usage of [Polyester.jl](https://github.com/JuliaSIMD/Polyester.jl) for multithreading.
+By default, Polyester.jl is enabled, but it can
+be useful for performance comparisons to switch to the Julia core backend.
+
+This does not fully disable Polyester.jl,
+buy only its use as part of Trixi.jl's `@threaded` macro.
+"""
+function set_polyester(toggle::Bool; force = true)
+    set_preferences!(TRIXI_UUID, "polyester" => string(toggle), force = force)
+    @info "Please restart Julia and reload Trixi.jl for the `polyester` change to take effect"
+end
+
+"""
     Trixi.set_sqrt_type(type; force = true)
 
 Set the `type` of the square root function to be used in Trixi.jl.

--- a/src/auxiliary/math.jl
+++ b/src/auxiliary/math.jl
@@ -8,7 +8,7 @@
 const TRIXI_UUID = UUID("a7f1ee26-1774-49b1-8366-f1abc58fbfcb")
 
 """
-    Trixi.set_polyester(toggle::Bool; force = true)
+    Trixi.set_polyester!(toggle::Bool; force = true)
 
 Toggle the usage of [Polyester.jl](https://github.com/JuliaSIMD/Polyester.jl) for multithreading.
 By default, Polyester.jl is enabled, but it can
@@ -17,8 +17,8 @@ be useful for performance comparisons to switch to the Julia core backend.
 This does not fully disable Polyester.jl,
 buy only its use as part of Trixi.jl's `@threaded` macro.
 """
-function set_polyester(toggle::Bool; force = true)
-    set_preferences!(TRIXI_UUID, "polyester" => string(toggle), force = force)
+function set_polyester!(toggle::Bool; force = true)
+    set_preferences!(TRIXI_UUID, "polyester" => toggle, force = force)
     @info "Please restart Julia and reload Trixi.jl for the `polyester` change to take effect"
 end
 

--- a/src/callbacks_step/summary.jl
+++ b/src/callbacks_step/summary.jl
@@ -207,6 +207,9 @@ function initialize_summary_callback(cb::DiscreteCallback, u, t, integrator;
 
     # technical details
     setup = Pair{String, Any}["#threads" => Threads.nthreads()]
+    if !_PREFERENCE_POLYESTER
+        push!(setup, "Polyester" => "disabled")
+    end
     if mpi_isparallel()
         push!(setup,
               "#MPI ranks" => mpi_nranks())

--- a/src/solvers/dg.jl
+++ b/src/solvers/dg.jl
@@ -629,7 +629,7 @@ end
     # since LoopVectorization does not support `ForwardDiff.Dual`s. Hence, we use
     # optimized `PtrArray`s whenever possible and fall back to plain `Array`s
     # otherwise.
-    if LoopVectorization.check_args(u_ode)
+    if _PREFERENCE_POLYESTER && LoopVectorization.check_args(u_ode)
         # This version using `PtrArray`s from StrideArrays.jl is very fast and
         # does not result in allocations.
         #


### PR DESCRIPTION
In order to study the performance of the Julia scheduler with Trixi,
I would like to be able to quickly jump between Polyster and Julia's scheduler.

This replaces #1768 with a prefernce switch, default is Polyster on.

Random observation on my AMD Ryzen 7 7840U on `examples/tree_2d_dgsem/elixir_euler_sedov_blast_wave.jl`
`rhs!` evaluation.

| Polyster | NThreads | Time |
| -------- | -------- | ---- |
| Off      | 1        | 37.9s  |
| Off      | 8        |  8.1s  |
| On       | 1        | 29.6s  |
| On       | 8        |  5.9s  |

So the question to solve first is why did the single threaded execution slow down.
