### PR TITLE
Move dimension check in the constructor of SemidiscretizationHyperbolic

### DIFF
--- a/src/semidiscretization/semidiscretization_hyperbolic.jl
+++ b/src/semidiscretization/semidiscretization_hyperbolic.jl
@@ -41,8 +41,6 @@ struct SemidiscretizationHyperbolic{Mesh, Equations, InitialCondition,
                                                                       SourceTerms,
                                                                       Solver,
                                                                       Cache}
-        @assert ndims(mesh) == ndims(equations)
-
         performance_counter = PerformanceCounter()
 
         new(mesh, equations, initial_condition, boundary_conditions, source_terms,
@@ -67,6 +65,8 @@ function SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver
                                       # while `uEltype` is used as element type of solutions etc.
                                       RealT = real(solver), uEltype = RealT,
                                       initial_cache = NamedTuple())
+    @assert ndims(mesh) == ndims(equations)
+
     cache = (; create_cache(mesh, equations, solver, RealT, uEltype)...,
              initial_cache...)
     _boundary_conditions = digest_boundary_conditions(boundary_conditions, mesh, solver,


### PR DESCRIPTION
This PR relocates the dimension check from the internal constructor of `SemidiscretizationHyperbolic` to the high-level constructor used in the elixirs.

This modification is necessary for the solver implemented in [this PR](https://github.com/trixi-framework/TrixiAtmo.jl/pull/25) of TrixiAtmo.jl, which discretizes 3D Cartesian equations on 2D manifolds.