### PR TITLE
WIP: modify `calc_node_coordinates!` to allow for `P4estMesh{2}` with 3D coordinates

### DIFF
--- a/src/solvers/dgsem_p4est/containers_2d.jl
+++ b/src/solvers/dgsem_p4est/containers_2d.jl
@@ -43,7 +43,8 @@ function calc_node_coordinates!(node_coordinates,
     # places and the additional information passed to the compiler makes them faster
     # than native `Array`s.
     tmp1 = StrideArray(undef, real(mesh),
-                       StaticInt(2), static_length(nodes), static_length(mesh.nodes))
+                       StaticInt(size(mesh.tree_node_coordinates, 1)),
+                       static_length(nodes), static_length(mesh.nodes))
     matrix1 = StrideArray(undef, real(mesh),
                           static_length(nodes), static_length(mesh.nodes))
     matrix2 = similar(matrix1)


### PR DESCRIPTION
In [TrixiAtmo.jl](https://github.com/trixi-framework/TrixiAtmo.jl), we solve PDEs on two-dimensional surfaces in three-dimensional space by using `P4estMesh{2}` with three-dimensional node coordinates and redefining `init_elements` accordingly to set up the appropriate containers for such meshes. We currently replace `calc_node_coordinates!` with a function which is otherwise identical to the corresponding Trixi.jl function, but changes the line
```
tmp1 = StrideArray(undef, real(mesh),
                       StaticInt(2),
                       static_length(nodes), static_length(mesh.nodes))
```
to the following:

```
tmp1 = StrideArray(undef, real(mesh),
                       StaticInt(size(mesh.tree_node_coordinates, 1)),
                       static_length(nodes), static_length(mesh.nodes))
```

If this doesn't cause any issues elsewhere, it would be helpful for our purposes to have this change be part of Trixi.jl, not only because it avoids repetition of the entire function in TrixiAtmo.jl, but also because Trixi2Vtk.jl calls `Trixi.calc_node_coordinates!` and thus requires such a change in order for [this PR](https://github.com/trixi-framework/Trixi2Vtk.jl/pull/82) to be used for plotting 2D surfaces in 3D. Similar modifications could be made to other mesh types/dimensions, but since I don't see a use case for that currently, I haven't done that in this PR.


