### PR TITLE
Show for Indicator Vortex

### DIFF
--- a/examples/tree_2d_dgsem/elixir_euler_vortex_amr.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_vortex_amr.jl
@@ -27,7 +27,6 @@ function (indicator_vortex::IndicatorVortex)(u::AbstractArray{<:Any, 4},
                                              t, kwargs...)
     mesh = indicator_vortex.cache.mesh
     alpha = indicator_vortex.cache.alpha
-    indicator_threaded = indicator_vortex.cache.indicator_threaded
     resize!(alpha, nelements(dg, cache))
 
     # get analytical vortex center (based on assumption that center=[0.0,0.0]
@@ -55,6 +54,11 @@ function periodic_distance_2d(coordinates, center, domain_length)
     dx = @. abs(coordinates - center)
     dx_periodic = @. min(dx, domain_length - dx)
     return sqrt(sum(abs2, dx_periodic))
+end
+
+# Optional: Nicer display of the indicator
+function Base.show(io::IO, ::MIME"text/plain", indicator::IndicatorVortex)
+    Trixi.summary_box(io, "IndicatorVortex")
 end
 
 end # module TrixiExtension


### PR DESCRIPTION
I use the isentropic vortex with AMR for convergence studies a lot. One thing that bothered me all the time is this abomination of a print you get when you run the example:

![Screenshot from 2024-09-03 18-18-54](https://github.com/user-attachments/assets/bc97a9de-a700-4b22-8ce3-1553d671bbfc)

Now you see this.

![Screenshot from 2024-09-03 18-19-42](https://github.com/user-attachments/assets/02561c72-b44f-4273-96fb-815e9ea39ae1)
