### PR TITLE
Update JuliaFormatter to the latest version

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -6,3 +6,6 @@ yas_style_nesting = true
 
 # Align struct fields for better readability of large struct definitions
 align_struct_field = true
+
+# Add trailing comma in lists
+trailing_comma = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -29,7 +29,7 @@ jobs:
         # TODO: Change the call below to
         #       format(".")
         run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.45"))'
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.60"))'
           julia  -e 'using JuliaFormatter; format(["benchmark", "examples", "ext", "src", "test", "utils"])'
       - name: Format check
         run: |


### PR DESCRIPTION
Alternative to #2071.
The default for the option `trailing_comma` was changed to `false` in the newer versions.
We can either go with this and remove trailing commas (#2071) or override this option and stick with trailing commas (this PR).