### PR TITLE
`remake` for `SemidiscretizationEulerGravity`

### DIFF
--- a/src/semidiscretization/semidiscretization_euler_gravity.jl
+++ b/src/semidiscretization/semidiscretization_euler_gravity.jl
@@ -135,7 +135,7 @@ function SemidiscretizationEulerGravity(semi_euler::SemiEuler,
 end
 
 function remake(semi::SemidiscretizationEulerGravity;
-                uEltype = real(semi.solver),
+                uEltype = real(semi.semi_gravity.solver),
                 semi_euler = semi.semi_euler,
                 semi_gravity = semi.semi_gravity,
                 parameters = semi.parameters)

--- a/src/semidiscretization/semidiscretization_euler_gravity.jl
+++ b/src/semidiscretization/semidiscretization_euler_gravity.jl
@@ -139,7 +139,6 @@ function remake(semi::SemidiscretizationEulerGravity;
                 semi_euler = semi.semi_euler,
                 semi_gravity = semi.semi_gravity,
                 parameters = semi.parameters)
-    
     semi_euler = remake(semi_euler, uEltype = uEltype)
     semi_gravity = remake(semi_gravity, uEltype = uEltype)
 

--- a/src/semidiscretization/semidiscretization_euler_gravity.jl
+++ b/src/semidiscretization/semidiscretization_euler_gravity.jl
@@ -134,7 +134,27 @@ function SemidiscretizationEulerGravity(semi_euler::SemiEuler,
                                                                       parameters, cache)
 end
 
-# TODO: AD, add appropriate method for remake
+function remake(semi::SemidiscretizationEulerGravity;
+                uEltype = real(semi.solver),
+                semi_euler = semi.semi_euler,
+                semi_gravity = semi.semi_gravity,
+                parameters = semi.parameters)
+    
+    semi_euler = remake(semi_euler, uEltype = uEltype)
+    semi_gravity = remake(semi_gravity, uEltype = uEltype)
+
+    # Recreate cache, i.e., registers for u with e.g. AD datatype
+    u_ode = compute_coefficients(zero(real(semi_gravity)), semi_gravity)
+    du_ode = similar(u_ode)
+    u_tmp1_ode = similar(u_ode)
+    u_tmp2_ode = similar(u_ode)
+    cache = (; u_ode, du_ode, u_tmp1_ode, u_tmp2_ode)
+
+    SemidiscretizationEulerGravity{typeof(semi_euler), typeof(semi_gravity),
+                                   typeof(parameters), typeof(cache)}(semi_euler,
+                                                                      semi_gravity,
+                                                                      parameters, cache)
+end
 
 function Base.show(io::IO, semi::SemidiscretizationEulerGravity)
     @nospecialize semi # reduce precompilation time

--- a/test/test_special_elixirs.jl
+++ b/test/test_special_elixirs.jl
@@ -254,6 +254,17 @@ end
                       tspan = (0.0, 0.0), initial_refinement_level = 0)
         @test_nowarn jacobian_ad_forward(semi)
     end
+
+    @timed_testset "EulerGravity" begin
+        trixi_include(@__MODULE__,
+                      joinpath(EXAMPLES_DIR,
+                               "paper_self_gravitating_gas_dynamics",
+                               "elixir_eulergravity_convergence.jl"),
+                      tspan = (0.0, 0.0), initial_refinement_level = 1)
+        J = jacobian_ad_forward(semi)
+        λ = eigvals(J)
+        @test maximum(real, λ) < 1.5
+    end
 end
 
 @timed_testset "Test linear structure (3D)" begin


### PR DESCRIPTION
Enables `jacobian_ad_forward` for `SemidiscretizationEulerGravity`.

Comparison to `jacobian_fd` 

![Comparison_AD_FD_EG](https://github.com/user-attachments/assets/b876a72b-fc00-460c-aacf-cb828bed1abf)
