### PR TITLE
Fix the bad code with mixed use of variable scope

### DIFF
--- a/examples/tree_1d_dgsem/elixir_burgers_rarefaction.jl
+++ b/examples/tree_1d_dgsem/elixir_burgers_rarefaction.jl
@@ -43,10 +43,7 @@ end
 ###############################################################################
 # Specify non-periodic boundary conditions
 
-function inflow(x, t, equations::InviscidBurgersEquation1D)
-    return initial_condition_rarefaction(0.0, t, equations)
-end
-boundary_condition_inflow = BoundaryConditionDirichlet(inflow)
+boundary_condition_inflow = BoundaryConditionDirichlet(initial_condition_rarefaction)
 
 function boundary_condition_outflow(u_inner, orientation, normal_direction, x, t,
                                     surface_flux_function,

--- a/examples/tree_1d_dgsem/elixir_burgers_rarefaction.jl
+++ b/examples/tree_1d_dgsem/elixir_burgers_rarefaction.jl
@@ -44,7 +44,7 @@ end
 # Specify non-periodic boundary conditions
 
 function inflow(x, t, equations::InviscidBurgersEquation1D)
-    return initial_condition_rarefaction(coordinate_min, t, equations)
+    return initial_condition_rarefaction(0.0, t, equations)
 end
 boundary_condition_inflow = BoundaryConditionDirichlet(inflow)
 

--- a/examples/tree_1d_dgsem/elixir_burgers_shock.jl
+++ b/examples/tree_1d_dgsem/elixir_burgers_shock.jl
@@ -44,7 +44,7 @@ end
 # Specify non-periodic boundary conditions
 
 function inflow(x, t, equations::InviscidBurgersEquation1D)
-    return initial_condition_shock(coordinate_min, t, equations)
+    return initial_condition_shock(0.0, t, equations)
 end
 boundary_condition_inflow = BoundaryConditionDirichlet(inflow)
 

--- a/examples/tree_1d_dgsem/elixir_burgers_shock.jl
+++ b/examples/tree_1d_dgsem/elixir_burgers_shock.jl
@@ -43,10 +43,7 @@ end
 ###############################################################################
 # Specify non-periodic boundary conditions
 
-function inflow(x, t, equations::InviscidBurgersEquation1D)
-    return initial_condition_shock(0.0, t, equations)
-end
-boundary_condition_inflow = BoundaryConditionDirichlet(inflow)
+boundary_condition_inflow = BoundaryConditionDirichlet(initial_condition_shock)
 
 function boundary_condition_outflow(u_inner, orientation, normal_direction, x, t,
                                     surface_flux_function,


### PR DESCRIPTION
Bad code - `coordinate_min` is a global variable and it should not be used like this. Either pass `coordinate_min` to `inflow` (does not work here) or pass constant directly to `initial_condition_shock`. 

The reviewer should not approve the bad code like this - it will cause big problems somewhere.