### PR TITLE
Level Info `TreeMesh` without AMR

### DIFF
--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -521,7 +521,7 @@ function print_level_information(callbacks, mesh::TreeMesh, solver, cache)
         print_level_information(mesh, solver, cache, min_level, max_level)
         # Special check for `TreeMesh`es without AMR.
         # These meshes may still be non-uniform due to `refinement_patches`, see 
-        # `refine_box!`, `coarsen_box`, and `refine_sphere!`.
+        # `refine_box!`, `coarsen_box!`, and `refine_sphere!`.
     elseif minimum_level(mesh.tree) != maximum_level(mesh.tree)
         min_level = minimum_level(mesh.tree)
         max_level = maximum_level(mesh.tree)

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -314,7 +314,7 @@ function (analysis_callback::AnalysisCallback)(u_ode, du_ode, integrator, semi)
         mpi_println(" #elements:      " *
                     @sprintf("% 14d", nelementsglobal(mesh, solver, cache)))
 
-        # Level information (only for AMR or non-uniform `TreeMesh`es)
+        # Level information (only for AMR and/or non-uniform `TreeMesh`es)
         print_level_information(integrator.opts.callback, mesh, solver, cache)
         mpi_println()
 

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -314,7 +314,7 @@ function (analysis_callback::AnalysisCallback)(u_ode, du_ode, integrator, semi)
         mpi_println(" #elements:      " *
                     @sprintf("% 14d", nelementsglobal(mesh, solver, cache)))
 
-        # Level information (only show for AMR)
+        # Level information (only for AMR or non-uniform `TreeMesh`es)
         print_level_information(integrator.opts.callback, mesh, solver, cache)
         mpi_println()
 


### PR DESCRIPTION
Motivation: Refinement patches for `TreeMesh`. Example [`tree_2d_dgsem/elixir_advection_mortar.jl`](https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_advection_mortar.jl).

Previously:

```julia
────────────────────────────────────────────────────────────────────────────────────────────────────
 Simulation running 'LinearScalarAdvectionEquation2D' with DGSEM(polydeg=3)
────────────────────────────────────────────────────────────────────────────────────────────────────
 #timesteps:                  9                run time:       4.80654000e-04 s
 Δt:             1.11111111e-01                └── GC time:    0.00000000e+00 s (0.000%)
 sim. time:      1.00000000e+00 (100.000%)     time/DOF/rhs!:  1.08330120e-08 s
                                               PID:            1.12534647e-08 s
 #DOFs per field:           640                alloc'd memory:        202.493 MiB
 #elements:                  40

 Variable:       scalar        
 L2 error:       1.51884667e-03
 Linf error:     8.44665572e-03
 ∑∂S/∂U ⋅ Uₜ :  -1.29388887e-05
 ∑S          :   5.62489671e-01
────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────
Trixi.jl simulation finished.  Final time: 1.0  Time steps: 9 (accepted), 9 (total)
────────────────────────────────────────────────────────────────────────────────────────────────────

 ─────────────────────────────────────────────────────────────────────────────────
            Trixi.jl                     Time                    Allocations      
                                ───────────────────────   ────────────────────────
        Tot / % measured:            710μs /  79.0%           45.5KiB /  71.0%    

 Section                ncalls     time    %tot     avg     alloc    %tot      avg
 ─────────────────────────────────────────────────────────────────────────────────
 rhs!                       46    309μs   55.1%  6.72μs   9.33KiB   28.9%     208B
   volume integral          46    170μs   30.4%  3.70μs     0.00B    0.0%    0.00B
   interface flux           46   34.3μs    6.1%   746ns     0.00B    0.0%    0.00B
   ~rhs!~                   46   27.5μs    4.9%   597ns   9.33KiB   28.9%     208B
   mortar flux              46   18.1μs    3.2%   394ns     0.00B    0.0%    0.00B
   surface integral         46   16.4μs    2.9%   357ns     0.00B    0.0%    0.00B
   prolong2mortars          46   15.8μs    2.8%   343ns     0.00B    0.0%    0.00B
   prolong2interfaces       46   14.4μs    2.6%   313ns     0.00B    0.0%    0.00B
   Jacobian                 46   7.80μs    1.4%   169ns     0.00B    0.0%    0.00B
   reset ∂u/∂t              46   1.91μs    0.3%  41.6ns     0.00B    0.0%    0.00B
   prolong2boundaries       46   1.14μs    0.2%  24.8ns     0.00B    0.0%    0.00B
   boundary flux            46    756ns    0.1%  16.4ns     0.00B    0.0%    0.00B
   source terms             46    679ns    0.1%  14.8ns     0.00B    0.0%    0.00B
 analyze solution            2    252μs   44.8%   126μs   23.0KiB   71.1%  11.5KiB
 calculate dt               10    668ns    0.1%  66.8ns     0.00B    0.0%    0.00B
 ─────────────────────────────────────────────────────────────────────────────────
 ```
 
 Now:
 
 ```julia
  ────────────────────────────────────────────────────────────────────────────────────────────────────
 Simulation running 'LinearScalarAdvectionEquation2D' with DGSEM(polydeg=3)
────────────────────────────────────────────────────────────────────────────────────────────────────
 #timesteps:                  9                run time:       7.94432000e-04 s
 Δt:             1.11111111e-01                └── GC time:    0.00000000e+00 s (0.000%)
 sim. time:      1.00000000e+00 (100.000%)     time/DOF/rhs!:  1.92273604e-08 s
                                               PID:            2.00654212e-08 s
 #DOFs per field:           640                alloc'd memory:        229.145 MiB
 #elements:                  40
 ├── level 3:                32
 └── level 2:                 8

 Variable:       scalar        
 L2 error:       1.51884667e-03
 Linf error:     8.44665572e-03
 ∑∂S/∂U ⋅ Uₜ :  -1.29388887e-05
 ∑S          :   5.62489671e-01
────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────
Trixi.jl simulation finished.  Final time: 1.0  Time steps: 9 (accepted), 9 (total)
────────────────────────────────────────────────────────────────────────────────────────────────────

 ─────────────────────────────────────────────────────────────────────────────────
            Trixi.jl                     Time                    Allocations      
                                ───────────────────────   ────────────────────────
        Tot / % measured:           1.16ms /  83.7%           58.5KiB /  77.5%    

 Section                ncalls     time    %tot     avg     alloc    %tot      avg
 ─────────────────────────────────────────────────────────────────────────────────
 rhs!                       46    555μs   57.0%  12.1μs   9.33KiB   20.6%     208B
   volume integral          46    301μs   30.9%  6.54μs     0.00B    0.0%    0.00B
   interface flux           46   69.3μs    7.1%  1.51μs     0.00B    0.0%    0.00B
   ~rhs!~                   46   49.6μs    5.1%  1.08μs   9.33KiB   20.6%     208B
   mortar flux              46   35.1μs    3.6%   763ns     0.00B    0.0%    0.00B
   prolong2mortars          46   31.0μs    3.2%   674ns     0.00B    0.0%    0.00B
   surface integral         46   28.8μs    3.0%   627ns     0.00B    0.0%    0.00B
   prolong2interfaces       46   26.4μs    2.7%   573ns     0.00B    0.0%    0.00B
   Jacobian                 46   6.58μs    0.7%   143ns     0.00B    0.0%    0.00B
   reset ∂u/∂t              46   3.44μs    0.4%  74.8ns     0.00B    0.0%    0.00B
   prolong2boundaries       46   1.69μs    0.2%  36.8ns     0.00B    0.0%    0.00B
   boundary flux            46   1.06μs    0.1%  23.2ns     0.00B    0.0%    0.00B
   source terms             46    970ns    0.1%  21.1ns     0.00B    0.0%    0.00B
 analyze solution            2    417μs   42.9%   209μs   36.0KiB   79.4%  18.0KiB
 calculate dt               10   1.19μs    0.1%   119ns     0.00B    0.0%    0.00B
 ─────────────────────────────────────────────────────────────────────────────────
 ```
