### PR TITLE
Indicator `ThreeLevelCombined` unified for all `TreeMesh`es

### DIFF
--- a/src/callbacks_step/amr_dg1d.jl
+++ b/src/callbacks_step/amr_dg1d.jl
@@ -291,7 +291,7 @@ function create_cache(::Type{ControllerThreeLevel}, mesh::TreeMesh{1}, equations
     return (; controller_value)
 end
 
-function create_cache(::Type{ControllerThreeLevelCombined}, mesh::TreeMesh{1},
+function create_cache(::Type{ControllerThreeLevelCombined}, mesh::TreeMesh,
                       equations, dg::DG, cache)
     controller_value = Vector{Int}(undef, nelements(dg, cache))
     return (; controller_value)

--- a/src/callbacks_step/amr_dg2d.jl
+++ b/src/callbacks_step/amr_dg2d.jl
@@ -579,9 +579,4 @@ function create_cache(::Type{ControllerThreeLevel},
     return (; controller_value)
 end
 
-function create_cache(::Type{ControllerThreeLevelCombined}, mesh::TreeMesh{2},
-                      equations, dg::DG, cache)
-    controller_value = Vector{Int}(undef, nelements(dg, cache))
-    return (; controller_value)
-end
 end # @muladd

--- a/src/callbacks_step/amr_dg2d.jl
+++ b/src/callbacks_step/amr_dg2d.jl
@@ -578,5 +578,4 @@ function create_cache(::Type{ControllerThreeLevel},
     controller_value = Vector{Int}(undef, nelements(dg, cache))
     return (; controller_value)
 end
-
 end # @muladd


### PR DESCRIPTION
Previously you could not use `ControllerThreeLevelCombined` for 3D `TreeMesh`es.