### PR TITLE
WIP: Add option to subtract a reference state in SaveSolutionCallback

### DIFF
--- a/examples/structured_2d_dgsem/elixir_euler_warm_bubble.jl
+++ b/examples/structured_2d_dgsem/elixir_euler_warm_bubble.jl
@@ -172,7 +172,7 @@ background_state = compute_reference_state(hydrostatic_background, semi, cons2pr
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      save_initial_solution = true,
                                      save_final_solution = true,
-                                     output_directory = "out_bubble",
+                                     output_directory = "out",
                                      solution_variables = cons2prim,
                                      reference_solution = background_state)
 

--- a/examples/structured_2d_dgsem/elixir_euler_warm_bubble.jl
+++ b/examples/structured_2d_dgsem/elixir_euler_warm_bubble.jl
@@ -26,6 +26,22 @@ struct WarmBubbleSetup
     end
 end
 
+@inline function cons2potentialtemperature(u, equations::CompressibleEulerEquations2D)
+    p_0 = 1.0f5 # Pascals
+    c_p = 1004.0f0
+    c_v = 717.0f0
+    R = c_p - c_v
+    rho, v1, v2, p = cons2prim(u, equations)
+    exner_pressure = (p / p_0)^(R / c_p)
+    T = p / (rho * R)
+    potential_temperature = T / exner_pressure
+    return SVector(rho, v1, v2, potential_temperature)
+end
+
+function Trixi.varnames(::typeof(cons2potentialtemperature), ::CompressibleEulerEquations2D)
+    return ("rho", "v1", "v2", "Potential temperature")
+end
+
 # Initial condition
 function (setup::WarmBubbleSetup)(x, t, equations::CompressibleEulerEquations2D)
     @unpack g, c_p, c_v = setup
@@ -73,8 +89,36 @@ end
     return SVector(zero(eltype(u)), zero(eltype(u)), -g * rho, -g * rho_v2)
 end
 
+# Background reference state
+function hydrostatic_background(x, t, equations::CompressibleEulerEquations2D)
+    g = 9.81
+    c_p = 1004.0f0
+    c_v = 717.0f0
+    potential_temperature = 300.0
+
+    # Exner pressure, solves hydrostatic equation for x[2]
+    exner = 1 - g / (c_p * potential_temperature) * x[2]
+
+    # pressure
+    p_0 = 100_000.0  # reference pressure
+    R = c_p - c_v    # gas constant (dry air)
+    p = p_0 * exner^(c_p / R)
+
+    # temperature
+    T = potential_temperature * exner
+
+    # density
+    rho = p / (R * T)
+
+    v1 = 20.0
+    v2 = 0.0
+    E = c_v * T + 0.5 * (v1^2 + v2^2)
+    return SVector(rho, rho * v1, rho * v2, rho * E)
+end
+
 ###############################################################################
 # semidiscretization of the compressible Euler equations
+
 warm_bubble_setup = WarmBubbleSetup()
 
 equations = CompressibleEulerEquations2D(warm_bubble_setup.gamma)
@@ -92,14 +136,14 @@ basis = LobattoLegendreBasis(polydeg)
 surface_flux = FluxLMARS(340.0)
 
 volume_flux = flux_kennedy_gruber
-volume_integral = VolumeIntegralFluxDifferencing(volume_flux)
-
+#volume_integral = VolumeIntegralFluxDifferencing(volume_flux)
+volume_integral = VolumeIntegralWeakForm()
 solver = DGSEM(basis, surface_flux, volume_integral)
 
 coordinates_min = (0.0, 0.0)
 coordinates_max = (20_000.0, 10_000.0)
 
-cells_per_dimension = (64, 32)
+cells_per_dimension = (200, 100)
 mesh = StructuredMesh(cells_per_dimension, coordinates_min, coordinates_max,
                       periodicity = (true, false))
 
@@ -123,11 +167,14 @@ analysis_callback = AnalysisCallback(semi, interval = analysis_interval,
 
 alive_callback = AliveCallback(analysis_interval = analysis_interval)
 
+background_state = compute_reference_state(hydrostatic_background, semi, cons2prim)
+
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      save_initial_solution = true,
                                      save_final_solution = true,
-                                     output_directory = "out",
-                                     solution_variables = cons2prim)
+                                     output_directory = "out_bubble",
+                                     solution_variables = cons2prim,
+                                     reference_solution = background_state)
 
 stepsize_callback = StepsizeCallback(cfl = 1.0)
 
@@ -139,6 +186,7 @@ callbacks = CallbackSet(summary_callback,
 
 ###############################################################################
 # run the simulation
+
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition = false),
             maxiters = 1.0e7,
             dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -268,6 +268,8 @@ export SummaryCallback, SteadyStateCallback, AnalysisCallback, AliveCallback,
        AnalysisSurfaceIntegral, DragCoefficientPressure, LiftCoefficientPressure,
        DragCoefficientShearStress, LiftCoefficientShearStress
 
+export compute_reference_state
+
 export load_mesh, load_time, load_timestep, load_timestep!, load_dt,
        load_adaptive_time_integrator!
 


### PR DESCRIPTION
This PR allows one to subtract a reference solution state (e.g. a steady base flow or exact solution) when using `SaveSolutionCallback`, allowing one to more easily plot perturbations using Trixi2Vtk. This is used in the [warm bubble example](https://github.com/tristanmontoya/Trixi.jl/blob/3b86205ceee7244f9e221478dbaf742142322228/examples/structured_2d_dgsem/elixir_euler_warm_bubble.jl) to save the solution as a perturbation of a hydrostatically balanced base state.