### PR TITLE
Thread-Parallelize blended DG-FV

### DIFF
--- a/src/solvers/dgmulti/shock_capturing.jl
+++ b/src/solvers/dgmulti/shock_capturing.jl
@@ -2,9 +2,6 @@
 function create_cache(mesh::DGMultiMesh{NDIMS}, equations,
                       volume_integral::VolumeIntegralShockCapturingHG,
                       dg::DGMultiFluxDiff{<:GaussSBP}, RealT, uEltype) where {NDIMS}
-    element_ids_dg = Int[]
-    element_ids_dgfv = Int[]
-
     # build element to element (element_to_element_connectivity) connectivity for smoothing of
     # shock capturing parameters.
     face_to_face_connectivity = mesh.md.FToF # num_faces x num_elements matrix
@@ -31,8 +28,7 @@ function create_cache(mesh::DGMultiMesh{NDIMS}, equations,
     sparsity_pattern = sum(map(A -> abs.(A)', sparse_hybridized_SBP_operators)) .>
                        100 * eps()
 
-    return (; element_ids_dg, element_ids_dgfv,
-            sparse_hybridized_SBP_operators, sparsity_pattern,
+    return (; sparse_hybridized_SBP_operators, sparsity_pattern,
             element_to_element_connectivity)
 end
 
@@ -151,70 +147,41 @@ function apply_smoothing!(mesh::DGMultiMesh, alpha, alpha_tmp, dg::DGMulti, cach
     end
 end
 
-#     pure_and_blended_element_ids!(element_ids_dg, element_ids_dgfv, alpha, dg, cache)
-#
-# Given blending factors `alpha` and the solver `dg`, fill
-# `element_ids_dg` with the IDs of elements using a pure DG scheme and
-# `element_ids_dgfv` with the IDs of elements using a blended DG-FV scheme.
-function pure_and_blended_element_ids!(element_ids_dg, element_ids_dgfv, alpha,
-                                       mesh::DGMultiMesh, dg::DGMulti)
-    empty!(element_ids_dg)
-    empty!(element_ids_dgfv)
-    # For `Float64`, this gives 1.8189894035458565e-12
-    # For `Float32`, this gives 1.1920929f-5
-    RealT = eltype(alpha)
-    atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
-
-    for element in eachelement(mesh, dg)
-        # Clip blending factor for values close to zero (-> pure DG)
-        dg_only = isapprox(alpha[element], 0, atol = atol)
-        if dg_only
-            push!(element_ids_dg, element)
-        else
-            push!(element_ids_dgfv, element)
-        end
-    end
-
-    return nothing
-end
-
 function calc_volume_integral!(du, u,
                                mesh::DGMultiMesh,
                                have_nonconservative_terms, equations,
                                volume_integral::VolumeIntegralShockCapturingHG,
                                dg::DGMultiFluxDiff, cache)
-    (; element_ids_dg, element_ids_dgfv) = cache
     (; volume_flux_dg, volume_flux_fv, indicator) = volume_integral
 
     # Calculate blending factors α: u = u_DG * (1 - α) + u_FV * α
     alpha = @trixi_timeit timer() "blending factors" indicator(u, mesh, equations, dg,
                                                                cache)
 
-    # Determine element ids for DG-only and blended DG-FV volume integral
-    pure_and_blended_element_ids!(element_ids_dg, element_ids_dgfv, alpha, mesh, dg)
+    # For `Float64`, this gives 1.8189894035458565e-12
+    # For `Float32`, this gives 1.1920929f-5
+    RealT = eltype(alpha)
+    atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
 
-    # Loop over pure DG elements
-    @trixi_timeit timer() "pure DG" @threaded for idx_element in eachindex(element_ids_dg)
-        element = element_ids_dg[idx_element]
-        flux_differencing_kernel!(du, u, element, mesh, have_nonconservative_terms,
-                                  equations, volume_flux_dg, dg, cache)
-    end
-
-    # Loop over blended DG-FV elements, blend the high and low order RHS contributions
-    # via `rhs_high * (1 - alpha) + rhs_low * (alpha)`.
-    @trixi_timeit timer() "blended DG-FV" @threaded for idx_element in eachindex(element_ids_dgfv)
-        element = element_ids_dgfv[idx_element]
+    @threaded for element in eachelement(mesh, dg)
         alpha_element = alpha[element]
+        # Clip blending factor for values close to zero (-> pure DG)
+        dg_only = isapprox(alpha_element, 0, atol = atol)
 
-        # Calculate DG volume integral contribution
-        flux_differencing_kernel!(du, u, element, mesh,
-                                  have_nonconservative_terms, equations,
-                                  volume_flux_dg, dg, cache, 1 - alpha_element)
+        if dg_only
+            flux_differencing_kernel!(du, u, element, mesh, have_nonconservative_terms,
+                                      equations, volume_flux_dg, dg, cache)
+        else
+            # Calculate DG volume integral contribution
+            flux_differencing_kernel!(du, u, element, mesh,
+                                      have_nonconservative_terms, equations,
+                                      volume_flux_dg, dg, cache, 1 - alpha_element)
 
-        # Calculate "FV" low order volume integral contribution
-        low_order_flux_differencing_kernel!(du, u, element, mesh,
-                                            have_nonconservative_terms, equations,
-                                            volume_flux_fv, dg, cache, alpha_element)
+            # Calculate "FV" low order volume integral contribution
+            low_order_flux_differencing_kernel!(du, u, element, mesh,
+                                                have_nonconservative_terms, equations,
+                                                volume_flux_fv, dg, cache, alpha_element)
+        end
     end
 
     return nothing

--- a/src/solvers/dgsem_tree/dg.jl
+++ b/src/solvers/dgsem_tree/dg.jl
@@ -15,33 +15,6 @@ function reset_du!(du, dg, cache)
     return du
 end
 
-#     pure_and_blended_element_ids!(element_ids_dg, element_ids_dgfv, alpha, dg, cache)
-#
-# Given blending factors `alpha` and the solver `dg`, fill
-# `element_ids_dg` with the IDs of elements using a pure DG scheme and
-# `element_ids_dgfv` with the IDs of elements using a blended DG-FV scheme.
-function pure_and_blended_element_ids!(element_ids_dg, element_ids_dgfv, alpha, dg::DG,
-                                       cache)
-    empty!(element_ids_dg)
-    empty!(element_ids_dgfv)
-    # For `Float64`, this gives 1.8189894035458565e-12
-    # For `Float32`, this gives 1.1920929f-5
-    RealT = eltype(alpha)
-    atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
-
-    for element in eachelement(dg, cache)
-        # Clip blending factor for values close to zero (-> pure DG)
-        dg_only = isapprox(alpha[element], 0, atol = atol)
-        if dg_only
-            push!(element_ids_dg, element)
-        else
-            push!(element_ids_dgfv, element)
-        end
-    end
-
-    return nothing
-end
-
 function volume_jacobian(element, mesh::TreeMesh, cache)
     return inv(cache.elements.inverse_jacobian[element])^ndims(mesh)
 end

--- a/src/solvers/dgsem_tree/dg_1d.jl
+++ b/src/solvers/dgsem_tree/dg_1d.jl
@@ -258,6 +258,8 @@ function calc_volume_integral!(du, u,
     alpha = @trixi_timeit timer() "blending factors" indicator(u, mesh, equations, dg,
                                                                cache)
 
+    # For `Float64`, this gives 1.8189894035458565e-12
+    # For `Float32`, this gives 1.1920929f-5
     RealT = eltype(alpha)
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
     @threaded for element in eachelement(dg, cache)

--- a/src/solvers/dgsem_tree/dg_1d.jl
+++ b/src/solvers/dgsem_tree/dg_1d.jl
@@ -42,9 +42,6 @@ end
 function create_cache(mesh::Union{TreeMesh{1}, StructuredMesh{1}, P4estMesh{1}},
                       equations,
                       volume_integral::VolumeIntegralShockCapturingHG, dg::DG, uEltype)
-    element_ids_dg = Int[]
-    element_ids_dgfv = Int[]
-
     cache = create_cache(mesh, equations,
                          VolumeIntegralFluxDifferencing(volume_integral.volume_flux_dg),
                          dg, uEltype)
@@ -55,8 +52,7 @@ function create_cache(mesh::Union{TreeMesh{1}, StructuredMesh{1}, P4estMesh{1}},
     fstar1_R_threaded = A2dp1_x[A2dp1_x(undef, nvariables(equations), nnodes(dg) + 1)
                                 for _ in 1:Threads.nthreads()]
 
-    return (; cache..., element_ids_dg, element_ids_dgfv, fstar1_L_threaded,
-            fstar1_R_threaded)
+    return (; cache..., fstar1_L_threaded, fstar1_R_threaded)
 end
 
 function create_cache(mesh::Union{TreeMesh{1}, StructuredMesh{1}, P4estMesh{1}},
@@ -256,37 +252,33 @@ function calc_volume_integral!(du, u,
                                nonconservative_terms, equations,
                                volume_integral::VolumeIntegralShockCapturingHG,
                                dg::DGSEM, cache)
-    @unpack element_ids_dg, element_ids_dgfv = cache
     @unpack volume_flux_dg, volume_flux_fv, indicator = volume_integral
 
     # Calculate blending factors α: u = u_DG * (1 - α) + u_FV * α
     alpha = @trixi_timeit timer() "blending factors" indicator(u, mesh, equations, dg,
                                                                cache)
 
-    # Determine element ids for DG-only and blended DG-FV volume integral
-    pure_and_blended_element_ids!(element_ids_dg, element_ids_dgfv, alpha, dg, cache)
-
-    # Loop over pure DG elements
-    @trixi_timeit timer() "pure DG" @threaded for idx_element in eachindex(element_ids_dg)
-        element = element_ids_dg[idx_element]
-        flux_differencing_kernel!(du, u, element, mesh, nonconservative_terms,
-                                  equations,
-                                  volume_flux_dg, dg, cache)
-    end
-
-    # Loop over blended DG-FV elements
-    @trixi_timeit timer() "blended DG-FV" @threaded for idx_element in eachindex(element_ids_dgfv)
-        element = element_ids_dgfv[idx_element]
+    RealT = eltype(alpha)
+    atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
+    @threaded for element in eachelement(dg, cache)
         alpha_element = alpha[element]
+        # Clip blending factor for values close to zero (-> pure DG)
+        dg_only = isapprox(alpha_element, 0, atol = atol)
 
-        # Calculate DG volume integral contribution
-        flux_differencing_kernel!(du, u, element, mesh, nonconservative_terms,
-                                  equations,
-                                  volume_flux_dg, dg, cache, 1 - alpha_element)
+        if dg_only
+            flux_differencing_kernel!(du, u, element, mesh,
+                                      nonconservative_terms, equations,
+                                      volume_flux_dg, dg, cache)
+        else
+            # Calculate DG volume integral contribution
+            flux_differencing_kernel!(du, u, element, mesh,
+                                      nonconservative_terms, equations,
+                                      volume_flux_dg, dg, cache, 1 - alpha_element)
 
-        # Calculate FV volume integral contribution
-        fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv,
-                   dg, cache, element, alpha_element)
+            # Calculate FV volume integral contribution
+            fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv,
+                       dg, cache, element, alpha_element)
+        end
     end
 
     return nothing

--- a/src/solvers/dgsem_tree/dg_2d.jl
+++ b/src/solvers/dgsem_tree/dg_2d.jl
@@ -47,9 +47,6 @@ end
 function create_cache(mesh::Union{TreeMesh{2}, StructuredMesh{2}, UnstructuredMesh2D,
                                   P4estMesh{2}, T8codeMesh{2}}, equations,
                       volume_integral::VolumeIntegralShockCapturingHG, dg::DG, uEltype)
-    element_ids_dg = Int[]
-    element_ids_dgfv = Int[]
-
     cache = create_cache(mesh, equations,
                          VolumeIntegralFluxDifferencing(volume_integral.volume_flux_dg),
                          dg, uEltype)
@@ -66,7 +63,7 @@ function create_cache(mesh::Union{TreeMesh{2}, StructuredMesh{2}, UnstructuredMe
     fstar2_R_threaded = A3dp1_y[A3dp1_y(undef, nvariables(equations), nnodes(dg),
                                         nnodes(dg) + 1) for _ in 1:Threads.nthreads()]
 
-    return (; cache..., element_ids_dg, element_ids_dgfv,
+    return (; cache...,
             fstar1_L_threaded, fstar1_R_threaded, fstar2_L_threaded, fstar2_R_threaded)
 end
 
@@ -338,39 +335,11 @@ function calc_volume_integral!(du, u,
                                nonconservative_terms, equations,
                                volume_integral::VolumeIntegralShockCapturingHG,
                                dg::DGSEM, cache)
-    @unpack element_ids_dg, element_ids_dgfv = cache
     @unpack volume_flux_dg, volume_flux_fv, indicator = volume_integral
 
     # Calculate blending factors α: u = u_DG * (1 - α) + u_FV * α
     alpha = @trixi_timeit timer() "blending factors" indicator(u, mesh, equations, dg,
                                                                cache)
-    #=                                                       
-    # Determine element ids for DG-only and blended DG-FV volume integral
-    pure_and_blended_element_ids!(element_ids_dg, element_ids_dgfv, alpha, dg, cache)
-
-    # Loop over pure DG elements
-    @trixi_timeit timer() "pure DG" @threaded for idx_element in eachindex(element_ids_dg)
-        element = element_ids_dg[idx_element]
-        flux_differencing_kernel!(du, u, element, mesh,
-                                  nonconservative_terms, equations,
-                                  volume_flux_dg, dg, cache)
-    end
-
-    # Loop over blended DG-FV elements
-    @trixi_timeit timer() "blended DG-FV" @threaded for idx_element in eachindex(element_ids_dgfv)
-        element = element_ids_dgfv[idx_element]
-        alpha_element = alpha[element]
-
-        # Calculate DG volume integral contribution
-        flux_differencing_kernel!(du, u, element, mesh,
-                                  nonconservative_terms, equations,
-                                  volume_flux_dg, dg, cache, 1 - alpha_element)
-
-        # Calculate FV volume integral contribution
-        fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv,
-                   dg, cache, element, alpha_element)
-    end
-    =#
 
     RealT = eltype(alpha)
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))

--- a/src/solvers/dgsem_tree/dg_2d.jl
+++ b/src/solvers/dgsem_tree/dg_2d.jl
@@ -341,6 +341,8 @@ function calc_volume_integral!(du, u,
     alpha = @trixi_timeit timer() "blending factors" indicator(u, mesh, equations, dg,
                                                                cache)
 
+    # For `Float64`, this gives 1.8189894035458565e-12
+    # For `Float32`, this gives 1.1920929f-5
     RealT = eltype(alpha)
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
     @threaded for element in eachelement(dg, cache)

--- a/src/solvers/dgsem_tree/dg_2d.jl
+++ b/src/solvers/dgsem_tree/dg_2d.jl
@@ -344,16 +344,15 @@ function calc_volume_integral!(du, u,
     RealT = eltype(alpha)
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
     @threaded for element in eachelement(dg, cache)
+        alpha_element = alpha[element]
         # Clip blending factor for values close to zero (-> pure DG)
-        dg_only = isapprox(alpha[element], 0, atol = atol)
+        dg_only = isapprox(alpha_element, 0, atol = atol)
 
         if dg_only
             flux_differencing_kernel!(du, u, element, mesh,
                                       nonconservative_terms, equations,
                                       volume_flux_dg, dg, cache)
         else
-            alpha_element = alpha[element]
-
             # Calculate DG volume integral contribution
             flux_differencing_kernel!(du, u, element, mesh,
                                       nonconservative_terms, equations,

--- a/src/solvers/dgsem_tree/dg_3d.jl
+++ b/src/solvers/dgsem_tree/dg_3d.jl
@@ -388,6 +388,8 @@ function calc_volume_integral!(du, u,
     alpha = @trixi_timeit timer() "blending factors" indicator(u, mesh, equations, dg,
                                                                cache)
 
+    # For `Float64`, this gives 1.8189894035458565e-12
+    # For `Float32`, this gives 1.1920929f-5
     RealT = eltype(alpha)
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
     @threaded for element in eachelement(dg, cache)

--- a/src/solvers/dgsem_tree/dg_3d.jl
+++ b/src/solvers/dgsem_tree/dg_3d.jl
@@ -47,9 +47,6 @@ function create_cache(mesh::Union{TreeMesh{3}, StructuredMesh{3}, P4estMesh{3},
                                   T8codeMesh{3}},
                       equations,
                       volume_integral::VolumeIntegralShockCapturingHG, dg::DG, uEltype)
-    element_ids_dg = Int[]
-    element_ids_dgfv = Int[]
-
     cache = create_cache(mesh, equations,
                          VolumeIntegralFluxDifferencing(volume_integral.volume_flux_dg),
                          dg, uEltype)
@@ -76,8 +73,7 @@ function create_cache(mesh::Union{TreeMesh{3}, StructuredMesh{3}, P4estMesh{3},
                                         nnodes(dg), nnodes(dg) + 1)
                                 for _ in 1:Threads.nthreads()]
 
-    return (; cache..., element_ids_dg, element_ids_dgfv, fstar1_L_threaded,
-            fstar1_R_threaded,
+    return (; cache..., fstar1_L_threaded, fstar1_R_threaded,
             fstar2_L_threaded, fstar2_R_threaded, fstar3_L_threaded, fstar3_R_threaded)
 end
 
@@ -386,37 +382,33 @@ function calc_volume_integral!(du, u,
                                nonconservative_terms, equations,
                                volume_integral::VolumeIntegralShockCapturingHG,
                                dg::DGSEM, cache)
-    @unpack element_ids_dg, element_ids_dgfv = cache
     @unpack volume_flux_dg, volume_flux_fv, indicator = volume_integral
 
     # Calculate blending factors α: u = u_DG * (1 - α) + u_FV * α
     alpha = @trixi_timeit timer() "blending factors" indicator(u, mesh, equations, dg,
                                                                cache)
 
-    # Determine element ids for DG-only and blended DG-FV volume integral
-    pure_and_blended_element_ids!(element_ids_dg, element_ids_dgfv, alpha, dg, cache)
-
-    # Loop over pure DG elements
-    @trixi_timeit timer() "pure DG" @threaded for idx_element in eachindex(element_ids_dg)
-        element = element_ids_dg[idx_element]
-        flux_differencing_kernel!(du, u, element, mesh,
-                                  nonconservative_terms, equations,
-                                  volume_flux_dg, dg, cache)
-    end
-
-    # Loop over blended DG-FV elements
-    @trixi_timeit timer() "blended DG-FV" @threaded for idx_element in eachindex(element_ids_dgfv)
-        element = element_ids_dgfv[idx_element]
+    RealT = eltype(alpha)
+    atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
+    @threaded for element in eachelement(dg, cache)
         alpha_element = alpha[element]
+        # Clip blending factor for values close to zero (-> pure DG)
+        dg_only = isapprox(alpha_element, 0, atol = atol)
 
-        # Calculate DG volume integral contribution
-        flux_differencing_kernel!(du, u, element, mesh,
-                                  nonconservative_terms, equations,
-                                  volume_flux_dg, dg, cache, 1 - alpha_element)
+        if dg_only
+            flux_differencing_kernel!(du, u, element, mesh,
+                                      nonconservative_terms, equations,
+                                      volume_flux_dg, dg, cache)
+        else
+            # Calculate DG volume integral contribution
+            flux_differencing_kernel!(du, u, element, mesh,
+                                      nonconservative_terms, equations,
+                                      volume_flux_dg, dg, cache, 1 - alpha_element)
 
-        # Calculate FV volume integral contribution
-        fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv,
-                   dg, cache, element, alpha_element)
+            # Calculate FV volume integral contribution
+            fv_kernel!(du, u, mesh, nonconservative_terms, equations, volume_flux_fv,
+                       dg, cache, element, alpha_element)
+        end
     end
 
     return nothing


### PR DESCRIPTION
The current version of determining whether the DG-FV stabilization should be used for an `element` is not thread-parallelized. This is disadvantageous when considering scaling to large machines. The proposed implementation is thread-parallelized and reduces allocations.

Example for https://github.com/trixi-framework/Trixi.jl/blob/main/examples/tree_2d_dgsem/elixir_euler_sedov_blast_wave.jl without AMR on $2^8 \times 2^8$ mesh with 2 threads:

Old version:

```julia
────────────────────────────────────────────────────────────────────────────────────────────────────
 Simulation running 'CompressibleEulerEquations2D' with DGSEM(polydeg=3)
────────────────────────────────────────────────────────────────────────────────────────────────────
 #timesteps:                664                run time:       1.25009769e+02 s
 Δt:             1.38512407e-04                └── GC time:    0.00000000e+00 s (0.000%)
 sim. time:      5.00000000e-01 (100.000%)     time/DOF/rhs!:  2.98306094e-08 s
                                               PID:            3.60262119e-08 s
 #DOFs per field:       1048576                alloc'd memory:        721.856 MiB
 #elements:               65536

────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────
Trixi.jl simulation finished.  Final time: 0.5  Time steps: 664 (accepted), 664 (total)
────────────────────────────────────────────────────────────────────────────────────────────────────

──────────────────────────────────────────────────────────────────────────────────
            Trixi.jl                     Time                    Allocations      
                                ───────────────────────   ────────────────────────
       Tot / % measured:              125s /  84.6%           95.9MiB /  40.2%    

Section                 ncalls     time    %tot     avg     alloc    %tot      avg
──────────────────────────────────────────────────────────────────────────────────
rhs!                     3.32k     103s   97.4%  31.0ms   8.92MiB   23.2%  2.75KiB
  volume integral        3.32k    71.9s   67.9%  21.6ms   4.46MiB   11.6%  1.37KiB
    pure DG              3.32k    59.7s   56.4%  18.0ms   1.42MiB    3.7%     448B
    blending factors     3.32k    8.28s    7.8%  2.49ms   1.57MiB    4.1%     496B
    blended DG-FV        3.32k    3.06s    2.9%   921μs   1.42MiB    3.7%     448B
    ~volume integral~    3.32k    857ms    0.8%   258μs   48.6KiB    0.1%    15.0B
  interface flux         3.32k    8.79s    8.3%  2.65ms   1.27MiB    3.3%     400B
  prolong2interfaces     3.32k    7.56s    7.1%  2.28ms   1.17MiB    3.0%     368B
  surface integral       3.32k    7.09s    6.7%  2.13ms   1.06MiB    2.8%     336B
  Jacobian               3.32k    3.89s    3.7%  1.17ms   0.96MiB    2.5%     304B
  reset ∂u/∂t            3.32k    3.86s    3.6%  1.16ms     0.00B    0.0%    0.00B
  ~rhs!~                 3.32k   28.7ms    0.0%  8.65μs   9.33KiB    0.0%    2.88B
  prolong2boundaries     3.32k   1.54ms    0.0%   465ns     0.00B    0.0%    0.00B
  prolong2mortars        3.32k   1.43ms    0.0%   431ns     0.00B    0.0%    0.00B
  mortar flux            3.32k    837μs    0.0%   252ns     0.00B    0.0%    0.00B
  source terms           3.32k    127μs    0.0%  38.3ns     0.00B    0.0%    0.00B
  boundary flux          3.32k   79.2μs    0.0%  23.9ns     0.00B    0.0%    0.00B
calculate dt               665    2.48s    2.3%  3.73ms     0.00B    0.0%    0.00B
analyze solution             8    268ms    0.3%  33.5ms   29.6MiB   76.8%  3.70MiB
──────────────────────────────────────────────────────────────────────────────────
```


New version:

```julia
────────────────────────────────────────────────────────────────────────────────────────────────────
 Simulation running 'CompressibleEulerEquations2D' with DGSEM(polydeg=3)
────────────────────────────────────────────────────────────────────────────────────────────────────
 #timesteps:                664                run time:       1.20725893e+02 s
 Δt:             1.38512407e-04                └── GC time:    0.00000000e+00 s (0.000%)
 sim. time:      5.00000000e-01 (100.000%)     time/DOF/rhs!:  2.92807732e-08 s
                                               PID:            3.50903734e-08 s
 #DOFs per field:       1048576                alloc'd memory:        734.587 MiB
 #elements:               65536

────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────
Trixi.jl simulation finished.  Final time: 0.5  Time steps: 664 (accepted), 664 (total)
────────────────────────────────────────────────────────────────────────────────────────────────────

──────────────────────────────────────────────────────────────────────────────────
            Trixi.jl                     Time                    Allocations      
                                ───────────────────────   ────────────────────────
       Tot / % measured:              121s /  85.1%           92.4MiB /  37.9%    

Section                 ncalls     time    %tot     avg     alloc    %tot      avg
──────────────────────────────────────────────────────────────────────────────────
rhs!                     3.32k     100s   97.3%  30.2ms   7.31MiB   20.8%  2.25KiB
  volume integral        3.32k    70.8s   68.8%  21.3ms   2.84MiB    8.1%     896B
    ~volume integral~    3.32k    63.2s   61.5%  19.0ms   1.42MiB    4.1%     448B
    blending factors     3.32k    7.57s    7.4%  2.28ms   1.42MiB    4.0%     448B
  interface flux         3.32k    8.49s    8.3%  2.56ms   1.27MiB    3.6%     400B
  prolong2interfaces     3.32k    7.03s    6.8%  2.12ms   1.17MiB    3.3%     368B
  surface integral       3.32k    6.59s    6.4%  1.99ms   1.06MiB    3.0%     336B
  reset ∂u/∂t            3.32k    3.64s    3.5%  1.09ms     0.00B    0.0%    0.00B
  Jacobian               3.32k    3.55s    3.5%  1.07ms   0.96MiB    2.7%     304B
  ~rhs!~                 3.32k   27.8ms    0.0%  8.37μs   9.33KiB    0.0%    2.88B
  prolong2boundaries     3.32k   1.29ms    0.0%   388ns     0.00B    0.0%    0.00B
  prolong2mortars        3.32k   1.19ms    0.0%   359ns     0.00B    0.0%    0.00B
  mortar flux            3.32k    730μs    0.0%   220ns     0.00B    0.0%    0.00B
  boundary flux          3.32k    116μs    0.0%  34.9ns     0.00B    0.0%    0.00B
  source terms           3.32k   95.3μs    0.0%  28.7ns     0.00B    0.0%    0.00B
calculate dt               665    2.47s    2.4%  3.71ms     0.00B    0.0%    0.00B
analyze solution             8    266ms    0.3%  33.2ms   27.7MiB   79.2%  3.47MiB
──────────────────────────────────────────────────────────────────────────────────
```