### PR TITLE
Similiarize `Structured1D` to `Tree1D`

### DIFF
--- a/examples/structured_1d_dgsem/elixir_traffic_flow_lwr_greenlight.jl
+++ b/examples/structured_1d_dgsem/elixir_traffic_flow_lwr_greenlight.jl
@@ -8,8 +8,8 @@ equations = TrafficFlowLWREquations1D()
 
 solver = DGSEM(polydeg = 3, surface_flux = FluxHLL(min_max_speed_davis))
 
-coordinates_min = (-1.0,) # minimum coordinate
-coordinates_max = (1.0,) # maximum coordinate
+coordinates_min = -1.0 # minimum coordinate
+coordinates_max = 1.0 # maximum coordinate
 cells_per_dimension = (64,)
 
 mesh = StructuredMesh(cells_per_dimension, coordinates_min, coordinates_max,

--- a/src/meshes/structured_mesh.jl
+++ b/src/meshes/structured_mesh.jl
@@ -171,6 +171,11 @@ end
 function coordinates2mapping(coordinates_min::NTuple{1}, coordinates_max::NTuple{1})
     mapping(xi) = linear_interpolate(xi, coordinates_min[1], coordinates_max[1])
 end
+# Convenience constructor for 1D: Do not insist on tuples
+function coordinates2mapping(coordinates_min::RealT,
+                             coordinates_max::RealT) where {RealT <: Real}
+    mapping(xi) = linear_interpolate(xi, coordinates_min, coordinates_max)
+end
 
 function coordinates2mapping(coordinates_min::NTuple{2}, coordinates_max::NTuple{2})
     function mapping(xi, eta)

--- a/src/meshes/structured_mesh.jl
+++ b/src/meshes/structured_mesh.jl
@@ -171,7 +171,7 @@ end
 function coordinates2mapping(coordinates_min::NTuple{1}, coordinates_max::NTuple{1})
     mapping(xi) = linear_interpolate(xi, coordinates_min[1], coordinates_max[1])
 end
-# Convenience constructor for 1D: Do not insist on tuples
+# Convenience function for 1D: Do not insist on tuples
 function coordinates2mapping(coordinates_min::RealT,
                              coordinates_max::RealT) where {RealT <: Real}
     mapping(xi) = linear_interpolate(xi, coordinates_min, coordinates_max)


### PR DESCRIPTION
For 1D `TreeMeshes`, the user can specify the coordinates as a tuple `(1.0)` or as a Float: `1.0`. This was not possible for 1D `StructuredMesh`. Loosely related to #1194 