### PR TITLE
Remove trailing semicolons in elixirs

### DIFF
--- a/examples/dgmulti_2d/elixir_navierstokes_lid_driven_cavity.jl
+++ b/examples/dgmulti_2d/elixir_navierstokes_lid_driven_cavity.jl
@@ -57,7 +57,7 @@ semi = SemidiscretizationHyperbolicParabolic(mesh, (equations, equations_parabol
 
 # Create ODE problem with time span `tspan`
 tspan = (0.0, 10.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)

--- a/examples/p4est_2d_dgsem/elixir_advection_basic.jl
+++ b/examples/p4est_2d_dgsem/elixir_advection_basic.jl
@@ -31,7 +31,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/p4est_2d_dgsem/elixir_advection_diffusion_nonperiodic_curved.jl
+++ b/examples/p4est_2d_dgsem/elixir_advection_diffusion_nonperiodic_curved.jl
@@ -68,7 +68,7 @@ semi = SemidiscretizationHyperbolicParabolic(mesh, (equations, equations_parabol
 
 # Create ODE problem with time span `tspan`
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/p4est_2d_dgsem/elixir_advection_diffusion_periodic.jl
+++ b/examples/p4est_2d_dgsem/elixir_advection_diffusion_periodic.jl
@@ -55,7 +55,7 @@ semi = SemidiscretizationHyperbolicParabolic(mesh,
 
 # Create ODE problem with time span `tspan`
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/p4est_2d_dgsem/elixir_advection_diffusion_periodic_amr.jl
+++ b/examples/p4est_2d_dgsem/elixir_advection_diffusion_periodic_amr.jl
@@ -47,7 +47,7 @@ semi = SemidiscretizationHyperbolicParabolic(mesh,
 
 # Create ODE problem with time span `tspan`
 tspan = (0.0, 0.5)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/p4est_2d_dgsem/elixir_advection_diffusion_periodic_curved.jl
+++ b/examples/p4est_2d_dgsem/elixir_advection_diffusion_periodic_curved.jl
@@ -60,7 +60,7 @@ semi = SemidiscretizationHyperbolicParabolic(mesh,
 
 # Create ODE problem with time span `tspan`
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/p4est_2d_dgsem/elixir_advection_extended.jl
+++ b/examples/p4est_2d_dgsem/elixir_advection_extended.jl
@@ -40,7 +40,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 
 # Create ODE problem with time span from 0.0 to 1.0
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/p4est_2d_dgsem/elixir_advection_nonconforming_flag.jl
+++ b/examples/p4est_2d_dgsem/elixir_advection_nonconforming_flag.jl
@@ -52,7 +52,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 0.2
-ode = semidiscretize(semi, (0.0, 0.2));
+ode = semidiscretize(semi, (0.0, 0.2))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/p4est_2d_dgsem/elixir_advection_restart.jl
+++ b/examples/p4est_2d_dgsem/elixir_advection_restart.jl
@@ -24,7 +24,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 
 tspan = (load_time(restart_filename), 2.0)
 dt = load_dt(restart_filename)
-ode = semidiscretize(semi, tspan, restart_filename);
+ode = semidiscretize(semi, tspan, restart_filename)
 
 # Do not overwrite the initial snapshot written by elixir_advection_extended.jl.
 save_solution.condition.save_initial_solution = false

--- a/examples/p4est_2d_dgsem/elixir_advection_restart_amr.jl
+++ b/examples/p4est_2d_dgsem/elixir_advection_restart_amr.jl
@@ -24,7 +24,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 
 tspan = (load_time(restart_filename), 2.0)
 dt = load_dt(restart_filename)
-ode = semidiscretize(semi, tspan, restart_filename);
+ode = semidiscretize(semi, tspan, restart_filename)
 
 # Do not overwrite the initial snapshot written by elixir_advection_extended.jl.
 save_solution.condition.save_initial_solution = false

--- a/examples/p4est_2d_dgsem/elixir_eulergravity_convergence.jl
+++ b/examples/p4est_2d_dgsem/elixir_eulergravity_convergence.jl
@@ -50,7 +50,7 @@ semi = SemidiscretizationEulerGravity(semi_euler, semi_gravity, parameters)
 ###############################################################################
 # ODE solvers, callbacks etc.
 tspan = (0.0, 0.5)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/p4est_2d_dgsem/elixir_navierstokes_lid_driven_cavity.jl
+++ b/examples/p4est_2d_dgsem/elixir_navierstokes_lid_driven_cavity.jl
@@ -61,7 +61,7 @@ semi = SemidiscretizationHyperbolicParabolic(mesh, (equations, equations_parabol
 
 # Create ODE problem with time span `tspan`
 tspan = (0.0, 25.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 100)

--- a/examples/p4est_2d_dgsem/elixir_navierstokes_lid_driven_cavity_amr.jl
+++ b/examples/p4est_2d_dgsem/elixir_navierstokes_lid_driven_cavity_amr.jl
@@ -61,7 +61,7 @@ semi = SemidiscretizationHyperbolicParabolic(mesh, (equations, equations_parabol
 
 # Create ODE problem with time span `tspan`
 tspan = (0.0, 25.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 2000)

--- a/examples/p4est_3d_dgsem/elixir_advection_restart.jl
+++ b/examples/p4est_3d_dgsem/elixir_advection_restart.jl
@@ -22,7 +22,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 
 tspan = (load_time(restart_filename), 2.0)
 dt = load_dt(restart_filename)
-ode = semidiscretize(semi, tspan, restart_filename);
+ode = semidiscretize(semi, tspan, restart_filename)
 
 # Do not overwrite the initial snapshot written by elixir_advection_extended.jl.
 save_solution.condition.save_initial_solution = false

--- a/examples/p4est_3d_dgsem/elixir_advection_unstructured_curved.jl
+++ b/examples/p4est_3d_dgsem/elixir_advection_unstructured_curved.jl
@@ -60,7 +60,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 0.1
-ode = semidiscretize(semi, (0.0, 0.1));
+ode = semidiscretize(semi, (0.0, 0.1))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/paper_self_gravitating_gas_dynamics/elixir_eulergravity_convergence.jl
+++ b/examples/paper_self_gravitating_gas_dynamics/elixir_eulergravity_convergence.jl
@@ -48,7 +48,7 @@ semi = SemidiscretizationEulerGravity(semi_euler, semi_gravity, parameters)
 ###############################################################################
 # ODE solvers, callbacks etc.
 tspan = (0.0, 0.5)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/paper_self_gravitating_gas_dynamics/elixir_eulergravity_jeans_instability.jl
+++ b/examples/paper_self_gravitating_gas_dynamics/elixir_eulergravity_jeans_instability.jl
@@ -101,7 +101,7 @@ semi = SemidiscretizationEulerGravity(semi_euler, semi_gravity, parameters)
 ###############################################################################
 # ODE solvers, callbacks etc.
 tspan = (0.0, 5.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/paper_self_gravitating_gas_dynamics/elixir_eulergravity_sedov_blast_wave.jl
+++ b/examples/paper_self_gravitating_gas_dynamics/elixir_eulergravity_sedov_blast_wave.jl
@@ -183,7 +183,7 @@ semi = SemidiscretizationEulerGravity(semi_euler, semi_gravity, parameters)
 ###############################################################################
 # ODE solvers, callbacks etc.
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/paper_self_gravitating_gas_dynamics/elixir_hypdiff_convergence.jl
+++ b/examples/paper_self_gravitating_gas_dynamics/elixir_hypdiff_convergence.jl
@@ -33,7 +33,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 5.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/structured_1d_dgsem/elixir_advection_basic.jl
+++ b/examples/structured_1d_dgsem/elixir_advection_basic.jl
@@ -28,7 +28,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/structured_2d_dgsem/elixir_advection_basic.jl
+++ b/examples/structured_2d_dgsem/elixir_advection_basic.jl
@@ -29,7 +29,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/structured_2d_dgsem/elixir_advection_coupled.jl
+++ b/examples/structured_2d_dgsem/elixir_advection_coupled.jl
@@ -181,7 +181,7 @@ semi = SemidiscretizationCoupled(semi1, semi2, semi3, semi4)
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 2.0
-ode = semidiscretize(semi, (0.0, 2.0));
+ode = semidiscretize(semi, (0.0, 2.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/structured_2d_dgsem/elixir_advection_extended.jl
+++ b/examples/structured_2d_dgsem/elixir_advection_extended.jl
@@ -38,7 +38,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 
 # Create ODE problem with time span from 0.0 to 1.0
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/structured_2d_dgsem/elixir_advection_free_stream.jl
+++ b/examples/structured_2d_dgsem/elixir_advection_free_stream.jl
@@ -40,7 +40,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/structured_2d_dgsem/elixir_advection_meshview.jl
+++ b/examples/structured_2d_dgsem/elixir_advection_meshview.jl
@@ -83,7 +83,7 @@ semi = SemidiscretizationCoupled(semi1, semi2)
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/structured_2d_dgsem/elixir_advection_parallelogram.jl
+++ b/examples/structured_2d_dgsem/elixir_advection_parallelogram.jl
@@ -58,7 +58,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_parallelo
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/structured_2d_dgsem/elixir_advection_restart.jl
+++ b/examples/structured_2d_dgsem/elixir_advection_restart.jl
@@ -23,7 +23,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 
 tspan = (load_time(restart_filename), 2.0)
 dt = load_dt(restart_filename)
-ode = semidiscretize(semi, tspan, restart_filename);
+ode = semidiscretize(semi, tspan, restart_filename)
 
 # Do not overwrite the initial snapshot written by elixir_advection_extended.jl.
 save_solution.condition.save_initial_solution = false

--- a/examples/structured_2d_dgsem/elixir_advection_rotated.jl
+++ b/examples/structured_2d_dgsem/elixir_advection_rotated.jl
@@ -86,7 +86,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/structured_2d_dgsem/elixir_advection_waving_flag.jl
+++ b/examples/structured_2d_dgsem/elixir_advection_waving_flag.jl
@@ -32,7 +32,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/structured_2d_dgsem/elixir_hypdiff_harmonic_nonperiodic.jl
+++ b/examples/structured_2d_dgsem/elixir_hypdiff_harmonic_nonperiodic.jl
@@ -48,7 +48,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 5.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/structured_2d_dgsem/elixir_hypdiff_nonperiodic.jl
+++ b/examples/structured_2d_dgsem/elixir_hypdiff_nonperiodic.jl
@@ -46,7 +46,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 30.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/structured_3d_dgsem/elixir_advection_basic.jl
+++ b/examples/structured_3d_dgsem/elixir_advection_basic.jl
@@ -28,7 +28,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/structured_3d_dgsem/elixir_advection_free_stream.jl
+++ b/examples/structured_3d_dgsem/elixir_advection_free_stream.jl
@@ -48,7 +48,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_constant,
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/structured_3d_dgsem/elixir_advection_restart.jl
+++ b/examples/structured_3d_dgsem/elixir_advection_restart.jl
@@ -22,7 +22,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 
 tspan = (load_time(restart_filename), 2.0)
 dt = load_dt(restart_filename)
-ode = semidiscretize(semi, tspan, restart_filename);
+ode = semidiscretize(semi, tspan, restart_filename)
 
 # Do not overwrite the initial snapshot written by elixir_advection_extended.jl.
 save_solution.condition.save_initial_solution = false

--- a/examples/t8code_2d_dgsem/elixir_advection_basic.jl
+++ b/examples/t8code_2d_dgsem/elixir_advection_basic.jl
@@ -30,7 +30,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/t8code_2d_dgsem/elixir_advection_extended.jl
+++ b/examples/t8code_2d_dgsem/elixir_advection_extended.jl
@@ -40,7 +40,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 
 # Create ODE problem with time span from 0.0 to 1.0
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/t8code_2d_dgsem/elixir_advection_nonconforming_flag.jl
+++ b/examples/t8code_2d_dgsem/elixir_advection_nonconforming_flag.jl
@@ -60,7 +60,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 0.2
-ode = semidiscretize(semi, (0.0, 0.2));
+ode = semidiscretize(semi, (0.0, 0.2))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/t8code_2d_dgsem/elixir_advection_restart.jl
+++ b/examples/t8code_2d_dgsem/elixir_advection_restart.jl
@@ -24,7 +24,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 
 tspan = (load_time(restart_filename), 2.0)
 dt = load_dt(restart_filename)
-ode = semidiscretize(semi, tspan, restart_filename);
+ode = semidiscretize(semi, tspan, restart_filename)
 
 # Do not overwrite the initial snapshot written by elixir_advection_extended.jl.
 save_solution.condition.save_initial_solution = false

--- a/examples/t8code_2d_dgsem/elixir_advection_restart_amr.jl
+++ b/examples/t8code_2d_dgsem/elixir_advection_restart_amr.jl
@@ -24,7 +24,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 
 tspan = (load_time(restart_filename), 2.0)
 dt = load_dt(restart_filename)
-ode = semidiscretize(semi, tspan, restart_filename);
+ode = semidiscretize(semi, tspan, restart_filename)
 
 # Do not overwrite the initial snapshot written by elixir_advection_extended.jl.
 save_solution.condition.save_initial_solution = false

--- a/examples/t8code_2d_dgsem/elixir_eulergravity_convergence.jl
+++ b/examples/t8code_2d_dgsem/elixir_eulergravity_convergence.jl
@@ -50,7 +50,7 @@ semi = SemidiscretizationEulerGravity(semi_euler, semi_gravity, parameters)
 ###############################################################################
 # ODE solvers, callbacks etc.
 tspan = (0.0, 0.5)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/t8code_3d_dgsem/elixir_advection_restart.jl
+++ b/examples/t8code_3d_dgsem/elixir_advection_restart.jl
@@ -21,7 +21,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 
 tspan = (load_time(restart_filename), 2.0)
 dt = load_dt(restart_filename)
-ode = semidiscretize(semi, tspan, restart_filename);
+ode = semidiscretize(semi, tspan, restart_filename)
 
 # Do not overwrite the initial snapshot written by elixir_advection_extended.jl.
 save_solution.condition.save_initial_solution = false

--- a/examples/t8code_3d_dgsem/elixir_advection_unstructured_curved.jl
+++ b/examples/t8code_3d_dgsem/elixir_advection_unstructured_curved.jl
@@ -59,7 +59,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 0.1
-ode = semidiscretize(semi, (0.0, 0.1));
+ode = semidiscretize(semi, (0.0, 0.1))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/tree_1d_dgsem/elixir_advection_basic.jl
+++ b/examples/tree_1d_dgsem/elixir_advection_basic.jl
@@ -27,7 +27,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/tree_1d_dgsem/elixir_advection_diffusion.jl
+++ b/examples/tree_1d_dgsem/elixir_advection_diffusion.jl
@@ -63,7 +63,7 @@ semi = SemidiscretizationHyperbolicParabolic(mesh, (equations, equations_parabol
 
 # Create ODE problem with time span from 0.0 to 1.0
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/tree_1d_dgsem/elixir_advection_diffusion_restart.jl
+++ b/examples/tree_1d_dgsem/elixir_advection_diffusion_restart.jl
@@ -15,7 +15,7 @@ restart_file = "restart_000000018.h5"
 restart_filename = joinpath("out", restart_file)
 tspan = (load_time(restart_filename), 2.0)
 
-ode = semidiscretize(semi, tspan, restart_filename);
+ode = semidiscretize(semi, tspan, restart_filename)
 
 # Do not save restart files here
 callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback)

--- a/examples/tree_1d_dgsem/elixir_advection_extended.jl
+++ b/examples/tree_1d_dgsem/elixir_advection_extended.jl
@@ -38,7 +38,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 
 # Create ODE problem with time span from 0.0 to 1.0
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/tree_1d_dgsem/elixir_advection_finite_volume.jl
+++ b/examples/tree_1d_dgsem/elixir_advection_finite_volume.jl
@@ -28,7 +28,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/tree_1d_dgsem/elixir_advection_perk2.jl
+++ b/examples/tree_1d_dgsem/elixir_advection_perk2.jl
@@ -32,7 +32,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 
 # Create ODE problem with time span from 0.0 to 20.0
 tspan = (0.0, 20.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/tree_1d_dgsem/elixir_advection_perk2_optimal_cfl.jl
+++ b/examples/tree_1d_dgsem/elixir_advection_perk2_optimal_cfl.jl
@@ -29,7 +29,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 
 # Create ODE problem with time span from 0.0 to 20.0
 tspan = (0.0, 20.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/tree_1d_dgsem/elixir_eulergravity_convergence.jl
+++ b/examples/tree_1d_dgsem/elixir_eulergravity_convergence.jl
@@ -45,7 +45,7 @@ semi = SemidiscretizationEulerGravity(semi_euler, semi_gravity, parameters)
 ###############################################################################
 # ODE solvers, callbacks etc.
 tspan = (0.0, 0.5)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_1d_dgsem/elixir_hypdiff_harmonic_nonperiodic.jl
+++ b/examples/tree_1d_dgsem/elixir_hypdiff_harmonic_nonperiodic.jl
@@ -52,7 +52,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 30.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_1d_dgsem/elixir_hypdiff_nonperiodic.jl
+++ b/examples/tree_1d_dgsem/elixir_hypdiff_nonperiodic.jl
@@ -28,7 +28,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 5.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_1d_dgsem/elixir_maxwell_E_excitation.jl
+++ b/examples/tree_1d_dgsem/elixir_maxwell_E_excitation.jl
@@ -36,7 +36,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 
 # As the wave speed is equal to the speed of light which is on the order of 3 * 10^8
 # we consider only a small time horizon.
-ode = semidiscretize(semi, (0.0, 1e-7));
+ode = semidiscretize(semi, (0.0, 1e-7))
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_1d_dgsem/elixir_maxwell_convergence.jl
+++ b/examples/tree_1d_dgsem/elixir_maxwell_convergence.jl
@@ -25,7 +25,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 
 # As the wave speed is equal to the speed of light which is on the order of 3 * 10^8
 # we consider only a small time horizon.
-ode = semidiscretize(semi, (0.0, 1e-8));
+ode = semidiscretize(semi, (0.0, 1e-8))
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_2d_dgsem/elixir_advection_basic.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_basic.jl
@@ -27,7 +27,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/tree_2d_dgsem/elixir_advection_callbacks.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_callbacks.jl
@@ -115,7 +115,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_2d_dgsem/elixir_advection_diffusion_nonperiodic.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_diffusion_nonperiodic.jl
@@ -59,7 +59,7 @@ semi = SemidiscretizationHyperbolicParabolic(mesh,
 
 # Create ODE problem with time span `tspan`
 tspan = (0.0, 1.5)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/tree_2d_dgsem/elixir_advection_extended.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_extended.jl
@@ -38,7 +38,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 
 # Create ODE problem with time span from 0.0 to 1.0
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/tree_2d_dgsem/elixir_advection_restart.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_restart.jl
@@ -22,7 +22,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 
 tspan = (load_time(restart_filename), 10.0)
 dt = load_dt(restart_filename)
-ode = semidiscretize(semi, tspan, restart_filename);
+ode = semidiscretize(semi, tspan, restart_filename)
 
 # Do not overwrite the initial snapshot written by elixir_advection_extended.jl.
 save_solution.condition.save_initial_solution = false

--- a/examples/tree_2d_dgsem/elixir_advection_restart_amr.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_restart_amr.jl
@@ -22,7 +22,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 
 tspan = (load_time(restart_filename), 5.0)
 dt = load_dt(restart_filename)
-ode = semidiscretize(semi, tspan, restart_filename);
+ode = semidiscretize(semi, tspan, restart_filename)
 
 # Do not overwrite the initial snapshot written by elixir_advection_extended.jl.
 save_solution.condition.save_initial_solution = false

--- a/examples/tree_2d_dgsem/elixir_advection_timeintegration.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_timeintegration.jl
@@ -23,7 +23,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_2d_dgsem/elixir_hypdiff_godunov.jl
+++ b/examples/tree_2d_dgsem/elixir_hypdiff_godunov.jl
@@ -57,7 +57,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 2.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_2d_dgsem/elixir_hypdiff_harmonic_nonperiodic.jl
+++ b/examples/tree_2d_dgsem/elixir_hypdiff_harmonic_nonperiodic.jl
@@ -49,7 +49,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 5.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_2d_dgsem/elixir_hypdiff_lax_friedrichs.jl
+++ b/examples/tree_2d_dgsem/elixir_hypdiff_lax_friedrichs.jl
@@ -55,7 +55,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 2.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_2d_dgsem/elixir_hypdiff_nonperiodic.jl
+++ b/examples/tree_2d_dgsem/elixir_hypdiff_nonperiodic.jl
@@ -31,7 +31,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 5.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_2d_dgsem/elixir_navierstokes_lid_driven_cavity.jl
+++ b/examples/tree_2d_dgsem/elixir_navierstokes_lid_driven_cavity.jl
@@ -57,7 +57,7 @@ semi = SemidiscretizationHyperbolicParabolic(mesh, (equations, equations_parabol
 
 # Create ODE problem with time span `tspan`
 tspan = (0.0, 25.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 100)

--- a/examples/tree_2d_fdsbp/elixir_advection_extended.jl
+++ b/examples/tree_2d_fdsbp/elixir_advection_extended.jl
@@ -32,7 +32,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_2d_fdsbp/elixir_euler_convergence.jl
+++ b/examples/tree_2d_fdsbp/elixir_euler_convergence.jl
@@ -36,7 +36,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 2.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_2d_fdsbp/elixir_euler_kelvin_helmholtz_instability.jl
+++ b/examples/tree_2d_fdsbp/elixir_euler_kelvin_helmholtz_instability.jl
@@ -49,7 +49,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 3.7)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_2d_fdsbp/elixir_euler_vortex.jl
+++ b/examples/tree_2d_fdsbp/elixir_euler_vortex.jl
@@ -78,7 +78,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 20.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_3d_dgsem/elixir_advection_basic.jl
+++ b/examples/tree_3d_dgsem/elixir_advection_basic.jl
@@ -27,7 +27,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/tree_3d_dgsem/elixir_advection_diffusion_nonperiodic.jl
+++ b/examples/tree_3d_dgsem/elixir_advection_diffusion_nonperiodic.jl
@@ -61,7 +61,7 @@ semi = SemidiscretizationHyperbolicParabolic(mesh,
 
 # Create ODE problem with time span `tspan`
 tspan = (0.0, 0.5)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/tree_3d_dgsem/elixir_advection_extended.jl
+++ b/examples/tree_3d_dgsem/elixir_advection_extended.jl
@@ -38,7 +38,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 
 # Create ODE problem with time span from 0.0 to 1.0
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/tree_3d_dgsem/elixir_advection_restart.jl
+++ b/examples/tree_3d_dgsem/elixir_advection_restart.jl
@@ -20,7 +20,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 
 tspan = (load_time(restart_filename), 2.0)
 dt = load_dt(restart_filename)
-ode = semidiscretize(semi, tspan, restart_filename);
+ode = semidiscretize(semi, tspan, restart_filename)
 
 # Do not overwrite the initial snapshot written by elixir_advection_extended.jl.
 save_solution.condition.save_initial_solution = false

--- a/examples/tree_3d_dgsem/elixir_eulergravity_convergence.jl
+++ b/examples/tree_3d_dgsem/elixir_eulergravity_convergence.jl
@@ -46,7 +46,7 @@ semi = SemidiscretizationEulerGravity(semi_euler, semi_gravity, parameters)
 ###############################################################################
 # ODE solvers, callbacks etc.
 tspan = (0.0, 0.5)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_3d_dgsem/elixir_hypdiff_lax_friedrichs.jl
+++ b/examples/tree_3d_dgsem/elixir_hypdiff_lax_friedrichs.jl
@@ -59,7 +59,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 2.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_3d_dgsem/elixir_hypdiff_nonperiodic.jl
+++ b/examples/tree_3d_dgsem/elixir_hypdiff_nonperiodic.jl
@@ -32,7 +32,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 5.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/tree_3d_fdsbp/elixir_advection_extended.jl
+++ b/examples/tree_3d_fdsbp/elixir_advection_extended.jl
@@ -32,7 +32,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 # ODE solvers, callbacks etc.
 
 tspan = (0.0, 1.0)
-ode = semidiscretize(semi, tspan);
+ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 

--- a/examples/unstructured_2d_dgsem/elixir_advection_basic.jl
+++ b/examples/unstructured_2d_dgsem/elixir_advection_basic.jl
@@ -30,7 +30,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergen
 # ODE solvers, callbacks etc.
 
 # Create ODE problem with time span from 0.0 to 1.0
-ode = semidiscretize(semi, (0.0, 1.0));
+ode = semidiscretize(semi, (0.0, 1.0))
 
 # At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
 # and resets the timers

--- a/examples/unstructured_2d_dgsem/elixir_euler_restart.jl
+++ b/examples/unstructured_2d_dgsem/elixir_euler_restart.jl
@@ -22,7 +22,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 
 tspan = (load_time(restart_filename), 1.0)
 dt = load_dt(restart_filename)
-ode = semidiscretize(semi, tspan, restart_filename);
+ode = semidiscretize(semi, tspan, restart_filename)
 
 # Do not overwrite the initial snapshot written by elixir_advection_extended.jl.
 save_solution.condition.save_initial_solution = false


### PR DESCRIPTION
As discussed with @DanielDoehring in https://github.com/trixi-framework/Trixi.jl/pull/2156#discussion_r1838449889. Turns out 80 out of 424 elixirs had this semicolon.

<details>
<summary>I used the following script for that</summary>

```julia
for (root, _, files) in walkdir("examples")
    for file in files
        if endswith(file, ".jl")
            path = joinpath(root, file)
            lines = readlines(path)
            open(path, "w") do io
                for line in lines
                    if startswith(line, "ode =") && endswith(line, ";")
                        println(io, line[1:(end - 1)])
                    else
                        println(io, line)
                    end
                end
            end
        end
    end
end

```

</details>