### PR TITLE
Remove remark for subcell limiting support in Trixi2Vtk from docs

### DIFF
--- a/docs/literate/src/files/subcell_shock_capturing.jl
+++ b/docs/literate/src/files/subcell_shock_capturing.jl
@@ -229,8 +229,6 @@ plot(sol)
 # approach using the [`SaveSolutionCallback`](@ref), [`Trixi2Vtk`](https://github.com/trixi-framework/Trixi2Vtk.jl)
 # and [ParaView](https://www.paraview.org/download/). More details about this procedure
 # can be found in the [visualization documentation](@ref visualization).
-# Unfortunately, the support for subcell limiting data is not yet merged into the main branch
-# of Trixi2Vtk but lies in the branch [`bennibolm/node-variables`](https://github.com/bennibolm/Trixi2Vtk.jl/tree/node-variables).
 #-
 # With that implementation and the standard procedure used for Trixi2Vtk you get the following
 # dropdown menu in ParaView.


### PR DESCRIPTION
https://github.com/trixi-framework/Trixi2Vtk.jl/pull/67 was finally merged :partying_face: So, the support for subcell data as used in subcell limiting is now in main of Trixi2Vtk.jl.

This PR removes a remark in the Trixi docs.

Mergeable after next Trixi2Vtk release.