### PR TITLE
Fix sign error in 3D `DGMultiFDSBP` elixir

### DIFF
--- a/src/solvers/dgmulti/sbp.jl
+++ b/src/solvers/dgmulti/sbp.jl
@@ -221,7 +221,10 @@ function calc_volume_integral!(du, u, mesh::DGMultiMesh,
                 for id in nzrange(A_base, i)
                     j = rows[id]
                     u_j = u[j]
-                    A_ij = vals[id]
+
+                    # we use the negative of A_ij since A is skew symemtric, 
+                    # and we are accessing the transpose of A. 
+                    A_ij = -vals[id]
                     AF_ij = 2 * A_ij *
                             volume_flux(u_i, u_j, normal_direction, equations)
                     du_i = du_i + AF_ij

--- a/src/solvers/dgmulti/sbp.jl
+++ b/src/solvers/dgmulti/sbp.jl
@@ -222,7 +222,7 @@ function calc_volume_integral!(du, u, mesh::DGMultiMesh,
                     j = rows[id]
                     u_j = u[j]
 
-                    # we use the negative of A_ij since A is skew symemtric, 
+                    # we use the negative of A_ij since A is skew-symmetric, 
                     # and we are accessing the transpose of A. 
                     A_ij = -vals[id]
                     AF_ij = 2 * A_ij *

--- a/test/test_threaded.jl
+++ b/test/test_threaded.jl
@@ -469,7 +469,8 @@ end
     end
 
     @trixi_testset "elixir_euler_fdsbp_periodic.jl (3D)" begin
-        @test_trixi_include(joinpath(examples_dir(), "dgmulti_3d/elixir_euler_fdsbp_periodic.jl"),
+        @test_trixi_include(joinpath(examples_dir(),
+                                     "dgmulti_3d/elixir_euler_fdsbp_periodic.jl"),
                             l2=[
                                 7.561896970325353e-5,
                                 6.884047859361093e-5,

--- a/test/test_threaded.jl
+++ b/test/test_threaded.jl
@@ -442,7 +442,7 @@ end
         end
     end
 
-    @trixi_testset "elixir_euler_fdsbp_periodic.jl" begin
+    @trixi_testset "elixir_euler_fdsbp_periodic.jl (2D)" begin
         @test_trixi_include(joinpath(examples_dir(), "dgmulti_2d",
                                      "elixir_euler_fdsbp_periodic.jl"),
                             l2=[
@@ -465,6 +465,32 @@ end
             u_ode = sol.u[end]
             du_ode = similar(u_ode)
             @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 5000
+        end
+    end
+
+    @trixi_testset "elixir_euler_fdsbp_periodic.jl (3D)" begin
+        @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_fdsbp_periodic.jl"),
+                            l2=[
+                                7.561896970325353e-5,
+                                6.884047859361093e-5,
+                                6.884047859363204e-5,
+                                6.884047859361148e-5,
+                                0.000201107274617457
+                            ],
+                            linf=[
+                                0.0001337520020225913,
+                                0.00011571467799287305,
+                                0.0001157146779990903,
+                                0.00011571467799376123,
+                                0.0003446082308800058
+                            ])
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
+        let
+            t = sol.t[end]
+            u_ode = sol.u[end]
+            du_ode = similar(u_ode)
+            @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 1000
         end
     end
 end

--- a/test/test_threaded.jl
+++ b/test/test_threaded.jl
@@ -469,7 +469,7 @@ end
     end
 
     @trixi_testset "elixir_euler_fdsbp_periodic.jl (3D)" begin
-        @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_fdsbp_periodic.jl"),
+        @test_trixi_include(joinpath(examples_dir(), "dgmulti_3d/elixir_euler_fdsbp_periodic.jl"),
                             l2=[
                                 7.561896970325353e-5,
                                 6.884047859361093e-5,


### PR DESCRIPTION
There was a sign error in the threaded branch of the code.

This wasn't getting picked up in CI because the 2D elixir wasn't using `VolumeIntegralFluxDifferencing` so it wasn't triggering this branch. I've added a 3D elixir to threaded tests.