### PR TITLE
Thread Parallel Reduction for `integrate_via_indices`

### DIFF
--- a/src/callbacks_step/analysis_dg1d.jl
+++ b/src/callbacks_step/analysis_dg1d.jl
@@ -120,32 +120,6 @@ function calc_error_norms(func, u, t, analyzer,
 end
 
 function integrate_via_indices(func::Func, u,
-                               mesh::StructuredMesh{1}, equations, dg::DGSEM, cache,
-                               args...; normalize = true) where {Func}
-    @unpack weights = dg.basis
-
-    # Initialize integral with zeros of the right shape
-    integral = zero(func(u, 1, 1, equations, dg, args...))
-    total_volume = zero(real(mesh))
-
-    # Use quadrature to numerically integrate over entire domain
-    for element in eachelement(dg, cache)
-        for i in eachnode(dg)
-            jacobian_volume = abs(inv(cache.elements.inverse_jacobian[i, element]))
-            integral += jacobian_volume * weights[i] *
-                        func(u, i, element, equations, dg, args...)
-            total_volume += jacobian_volume * weights[i]
-        end
-    end
-    # Normalize with total volume
-    if normalize
-        integral = integral / total_volume
-    end
-
-    return integral
-end
-
-function integrate_via_indices(func::Func, u,
                                mesh::TreeMesh{1}, equations, dg::DGSEM, cache,
                                args...; normalize = true) where {Func}
     @unpack weights = dg.basis
@@ -154,7 +128,7 @@ function integrate_via_indices(func::Func, u,
     integral = zero(func(u, 1, 1, equations, dg, args...))
 
     # Use quadrature to numerically integrate over entire domain
-    for element in eachelement(dg, cache)
+    @batch reduction=(+, integral) for element in eachelement(dg, cache)
         volume_jacobian_ = volume_jacobian(element, mesh, cache)
         for i in eachnode(dg)
             integral += volume_jacobian_ * weights[i] *
@@ -165,6 +139,33 @@ function integrate_via_indices(func::Func, u,
     # Normalize with total volume
     if normalize
         integral = integral / total_volume(mesh)
+    end
+
+    return integral
+end
+
+function integrate_via_indices(func::Func, u,
+                               mesh::StructuredMesh{1}, equations, dg::DGSEM, cache,
+                               args...; normalize = true) where {Func}
+    @unpack weights = dg.basis
+
+    # Initialize integral with zeros of the right shape
+    integral = zero(func(u, 1, 1, equations, dg, args...))
+    total_volume = zero(real(mesh))
+
+    # Use quadrature to numerically integrate over entire domain
+    @batch reduction=((+, integral), (+, total_volume)) for element in eachelement(dg,
+                                                                                   cache)
+        for i in eachnode(dg)
+            jacobian_volume = abs(inv(cache.elements.inverse_jacobian[i, element]))
+            integral += jacobian_volume * weights[i] *
+                        func(u, i, element, equations, dg, args...)
+            total_volume += jacobian_volume * weights[i]
+        end
+    end
+    # Normalize with total volume
+    if normalize
+        integral = integral / total_volume
     end
 
     return integral

--- a/src/callbacks_step/analysis_dg2d.jl
+++ b/src/callbacks_step/analysis_dg2d.jl
@@ -190,7 +190,7 @@ function integrate_via_indices(func::Func, u,
     integral = zero(func(u, 1, 1, 1, equations, dg, args...))
 
     # Use quadrature to numerically integrate over entire domain
-    for element in eachelement(dg, cache)
+    @batch reduction=(+, integral) for element in eachelement(dg, cache)
         volume_jacobian_ = volume_jacobian(element, mesh, cache)
         for j in eachnode(dg), i in eachnode(dg)
             integral += volume_jacobian_ * weights[i] * weights[j] *
@@ -219,7 +219,8 @@ function integrate_via_indices(func::Func, u,
     total_volume = zero(real(mesh))
 
     # Use quadrature to numerically integrate over entire domain
-    for element in eachelement(dg, cache)
+    @batch reduction=((+, integral), (+, total_volume)) for element in eachelement(dg,
+                                                                                   cache)
         for j in eachnode(dg), i in eachnode(dg)
             volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, element]))
             integral += volume_jacobian * weights[i] * weights[j] *

--- a/src/callbacks_step/analysis_dg2d_parallel.jl
+++ b/src/callbacks_step/analysis_dg2d_parallel.jl
@@ -187,7 +187,7 @@ function integrate_via_indices(func::Func, u,
     volume = zero(real(mesh))
 
     # Use quadrature to numerically integrate over entire domain
-    for element in eachelement(dg, cache)
+    @batch reduction=((+, integral), (+, volume)) for element in eachelement(dg, cache)
         for j in eachnode(dg), i in eachnode(dg)
             volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, element]))
             integral += volume_jacobian * weights[i] * weights[j] *

--- a/src/callbacks_step/analysis_dg3d.jl
+++ b/src/callbacks_step/analysis_dg3d.jl
@@ -218,7 +218,7 @@ function integrate_via_indices(func::Func, u,
     integral = zero(func(u, 1, 1, 1, 1, equations, dg, args...))
 
     # Use quadrature to numerically integrate over entire domain
-    for element in eachelement(dg, cache)
+    @batch reduction=(+, integral) for element in eachelement(dg, cache)
         volume_jacobian_ = volume_jacobian(element, mesh, cache)
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
             integral += volume_jacobian_ * weights[i] * weights[j] * weights[k] *
@@ -246,7 +246,8 @@ function integrate_via_indices(func::Func, u,
     total_volume = zero(real(mesh))
 
     # Use quadrature to numerically integrate over entire domain
-    for element in eachelement(dg, cache)
+    @batch reduction=((+, integral), (+, total_volume)) for element in eachelement(dg,
+                                                                                   cache)
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
             volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, k, element]))
             integral += volume_jacobian * weights[i] * weights[j] * weights[k] *

--- a/src/callbacks_step/analysis_dg3d_parallel.jl
+++ b/src/callbacks_step/analysis_dg3d_parallel.jl
@@ -82,7 +82,7 @@ function integrate_via_indices(func::Func, u,
     volume = zero(real(mesh))
 
     # Use quadrature to numerically integrate over entire domain
-    for element in eachelement(dg, cache)
+    @batch reduction=((+, integral), (+, volume)) for element in eachelement(dg, cache)
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
             volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, k, element]))
             integral += volume_jacobian * weights[i] * weights[j] * weights[k] *

--- a/src/solvers/fdsbp_tree/fdsbp_1d.jl
+++ b/src/solvers/fdsbp_tree/fdsbp_1d.jl
@@ -271,7 +271,7 @@ function integrate_via_indices(func::Func, u,
     integral = zero(func(u, 1, 1, equations, dg, args...))
 
     # Use quadrature to numerically integrate over entire domain
-    for element in eachelement(dg, cache)
+    @batch reduction=(+, integral) for element in eachelement(dg, cache)
         volume_jacobian_ = volume_jacobian(element, mesh, cache)
         for i in eachnode(dg)
             integral += volume_jacobian_ * weights[i] *

--- a/src/solvers/fdsbp_tree/fdsbp_2d.jl
+++ b/src/solvers/fdsbp_tree/fdsbp_2d.jl
@@ -326,7 +326,7 @@ function integrate_via_indices(func::Func, u,
     integral = zero(func(u, 1, 1, 1, equations, dg, args...))
 
     # Use quadrature to numerically integrate over entire domain
-    for element in eachelement(dg, cache)
+    @batch reduction=(+, integral) for element in eachelement(dg, cache)
         volume_jacobian_ = volume_jacobian(element, mesh, cache)
         for j in eachnode(dg), i in eachnode(dg)
             integral += volume_jacobian_ * weights[i] * weights[j] *

--- a/src/solvers/fdsbp_tree/fdsbp_3d.jl
+++ b/src/solvers/fdsbp_tree/fdsbp_3d.jl
@@ -378,7 +378,7 @@ function integrate_via_indices(func::Func, u,
     integral = zero(func(u, 1, 1, 1, 1, equations, dg, args...))
 
     # Use quadrature to numerically integrate over entire domain
-    for element in eachelement(dg, cache)
+    @batch reduction=(+, integral) for element in eachelement(dg, cache)
         volume_jacobian_ = volume_jacobian(element, mesh, cache)
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
             integral += volume_jacobian_ * weights[i] * weights[j] * weights[k] *

--- a/src/solvers/fdsbp_unstructured/fdsbp_2d.jl
+++ b/src/solvers/fdsbp_unstructured/fdsbp_2d.jl
@@ -247,7 +247,8 @@ function integrate_via_indices(func::Func, u,
     total_volume = zero(real(mesh))
 
     # Use quadrature to numerically integrate over entire domain
-    for element in eachelement(dg, cache)
+    @batch reduction=((+, integral), (+, total_volume)) for element in eachelement(dg,
+                                                                                   cache)
         for j in eachnode(dg), i in eachnode(dg)
             volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, element]))
             integral += volume_jacobian * weights[i] * weights[j] *


### PR DESCRIPTION
As suggested by @efaulhaber one can use the [reduction operation/macro](https://github.com/JuliaSIMD/Polyester.jl?tab=readme-ov-file#reduction) from [`Polyester.jl`](https://github.com/JuliaSIMD/Polyester.jl) to speed up stuff like integrals (and errors, to come).

The larger the simulation, the larger the speedup. But even for something with relatively few elements (I used https://github.com/trixi-framework/Trixi.jl/blob/main/examples/p4est_2d_dgsem/elixir_euler_supersonic_cylinder.jl stopping at `2e-2` with element hierarchy

```julia
 #DOFs per field:         75648
 #elements:                4728
 ├── level 5:              1440
 ├── level 4:              1320
 ├── level 3:              1160
 ├── level 2:               193
 ├── level 1:               121
 └── level 0:               494
```

Using 2 threads to compute `Trixi.analyze(Trixi.entropy_timederivative, u_wrap, u_wrap, tspan[2], mesh, equations, solver, semi.cache)` (which is computed in every `AnalysisCallback` call by default) results in 

```julia
BenchmarkTools.Trial: 6955 samples with 1 evaluation.
 Range (min … max):  608.541 μs …   2.511 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     692.610 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   716.382 μs ± 107.030 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

       ▁▃▅██▇▇▅▅▄▃▃▂▁▂▂ ▁                                       ▂
  ▂▅▅▆██████████████████████▇▆▆▇▇▇▇▇▇▆▆▆▅▆▅▆▅▄▂▅▃▅▆▃▄▄▂▅▃▃▄▅▃▅▆ █
  609 μs        Histogram: log(frequency) by time        1.1 ms <

 Memory estimate: 592 bytes, allocs estimate: 4.
 ```
 
 compared to 1 thread:
 
 ```julia
 1 Thread:
 
BenchmarkTools.Trial: 5175 samples with 1 evaluation.
 Range (min … max):  850.861 μs …  1.893 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     956.059 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   963.495 μs ± 38.375 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                            ▄█                                  
  ▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▃▃▂▃▃██▇▇▆▅▅▇▅▄▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂ ▃
  851 μs          Histogram: frequency by time         1.07 ms <

 Memory estimate: 144 bytes, allocs estimate: 3.
 ```
