### PR TITLE
Use reduction for max wave speed computation in `max_dt`

### DIFF
--- a/src/callbacks_step/stepsize_dg1d.jl
+++ b/src/callbacks_step/stepsize_dg1d.jl
@@ -11,7 +11,7 @@ function max_dt(u, t, mesh::TreeMesh{1},
     # e.g. for steady-state linear advection
     max_scaled_speed = nextfloat(zero(t))
 
-    for element in eachelement(dg, cache)
+    @batch reduction=(max, max_scaled_speed) for element in eachelement(dg, cache)
         max_lambda1 = zero(max_scaled_speed)
         for i in eachnode(dg)
             u_node = get_node_vars(u, equations, dg, i, element)
@@ -31,7 +31,7 @@ function max_dt(u, t, mesh::TreeMesh{1},
     # e.g. for steady-state linear advection
     max_scaled_speed = nextfloat(zero(t))
 
-    for element in eachelement(dg, cache)
+    @batch reduction=(max, max_scaled_speed) for element in eachelement(dg, cache)
         max_lambda1, = max_abs_speeds(equations)
         inv_jacobian = cache.elements.inverse_jacobian[element]
         max_scaled_speed = max(max_scaled_speed, inv_jacobian * max_lambda1)
@@ -46,7 +46,7 @@ function max_dt(u, t, mesh::StructuredMesh{1},
     # e.g. for steady-state linear advection
     max_scaled_speed = nextfloat(zero(t))
 
-    for element in eachelement(dg, cache)
+    @batch reduction=(max, max_scaled_speed) for element in eachelement(dg, cache)
         max_lambda1 = zero(max_scaled_speed)
 
         for i in eachnode(dg)
@@ -70,7 +70,7 @@ function max_dt(u, t, mesh::StructuredMesh{1},
     # e.g. for steady-state linear advection
     max_scaled_speed = nextfloat(zero(t))
 
-    for element in eachelement(dg, cache)
+    @batch reduction=(max, max_scaled_speed) for element in eachelement(dg, cache)
         max_lambda1, = max_abs_speeds(equations)
 
         for i in eachnode(dg)

--- a/src/callbacks_step/stepsize_dg2d.jl
+++ b/src/callbacks_step/stepsize_dg2d.jl
@@ -11,7 +11,7 @@ function max_dt(u, t, mesh::TreeMesh{2},
     # e.g. for steady-state linear advection
     max_scaled_speed = nextfloat(zero(t))
 
-    for element in eachelement(dg, cache)
+    @batch reduction=(max, max_scaled_speed) for element in eachelement(dg, cache)
         max_lambda1 = max_lambda2 = zero(max_scaled_speed)
         for j in eachnode(dg), i in eachnode(dg)
             u_node = get_node_vars(u, equations, dg, i, j, element)
@@ -33,7 +33,7 @@ function max_dt(u, t, mesh::TreeMesh{2},
     # e.g. for steady-state linear advection
     max_scaled_speed = nextfloat(zero(t))
 
-    for element in eachelement(dg, cache)
+    @batch reduction=(max, max_scaled_speed) for element in eachelement(dg, cache)
         max_lambda1, max_lambda2 = max_abs_speeds(equations)
         inv_jacobian = cache.elements.inverse_jacobian[element]
         max_scaled_speed = max(max_scaled_speed,
@@ -87,7 +87,7 @@ function max_dt(u, t,
 
     @unpack contravariant_vectors, inverse_jacobian = cache.elements
 
-    for element in eachelement(dg, cache)
+    @batch reduction=(max, max_scaled_speed) for element in eachelement(dg, cache)
         max_lambda1 = max_lambda2 = zero(max_scaled_speed)
         for j in eachnode(dg), i in eachnode(dg)
             u_node = get_node_vars(u, equations, dg, i, j, element)
@@ -125,7 +125,7 @@ function max_dt(u, t,
 
     max_lambda1, max_lambda2 = max_abs_speeds(equations)
 
-    for element in eachelement(dg, cache)
+    @batch reduction=(max, max_scaled_speed) for element in eachelement(dg, cache)
         for j in eachnode(dg), i in eachnode(dg)
             # Local speeds transformed to the reference element
             Ja11, Ja12 = get_contravariant_vector(1, contravariant_vectors, i, j,

--- a/src/callbacks_step/stepsize_dg3d.jl
+++ b/src/callbacks_step/stepsize_dg3d.jl
@@ -11,7 +11,7 @@ function max_dt(u, t, mesh::TreeMesh{3},
     # e.g. for steady-state linear advection
     max_scaled_speed = nextfloat(zero(t))
 
-    for element in eachelement(dg, cache)
+    @batch reduction=(max, max_scaled_speed) for element in eachelement(dg, cache)
         max_lambda1 = max_lambda2 = max_lambda3 = zero(max_scaled_speed)
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
             u_node = get_node_vars(u, equations, dg, i, j, k, element)
@@ -34,7 +34,7 @@ function max_dt(u, t, mesh::TreeMesh{3},
     # e.g. for steady-state linear advection
     max_scaled_speed = nextfloat(zero(t))
 
-    for element in eachelement(dg, cache)
+    @batch reduction=(max, max_scaled_speed) for element in eachelement(dg, cache)
         max_lambda1, max_lambda2, max_lambda3 = max_abs_speeds(equations)
         inv_jacobian = cache.elements.inverse_jacobian[element]
         max_scaled_speed = max(max_scaled_speed,
@@ -52,7 +52,7 @@ function max_dt(u, t, mesh::Union{StructuredMesh{3}, P4estMesh{3}, T8codeMesh{3}
 
     @unpack contravariant_vectors = cache.elements
 
-    for element in eachelement(dg, cache)
+    @batch reduction=(max, max_scaled_speed) for element in eachelement(dg, cache)
         max_lambda1 = max_lambda2 = max_lambda3 = zero(max_scaled_speed)
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
             u_node = get_node_vars(u, equations, dg, i, j, k, element)
@@ -92,7 +92,7 @@ function max_dt(u, t, mesh::Union{StructuredMesh{3}, P4estMesh{3}, T8codeMesh{3}
 
     max_lambda1, max_lambda2, max_lambda3 = max_abs_speeds(equations)
 
-    for element in eachelement(dg, cache)
+    @batch reduction=(max, max_scaled_speed) for element in eachelement(dg, cache)
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
             Ja11, Ja12, Ja13 = get_contravariant_vector(1, contravariant_vectors, i, j,
                                                         k, element)


### PR DESCRIPTION
For one standard simulation in my workflow (viscous flow over airfoil, 2D simulation, ~8000 elements) parallelized with 20 threads the serial version costs

```julia
  Step-Callbacks                                          5.14k    6.49s    5.1%  1.26ms   26.5MiB    3.5%  5.28KiB
    calculate dt                                          5.14k    5.85s    4.6%  1.14ms     0.00B    0.0%    0.00B
```

while the parallelized version now costs only a fraction:

```julia
  Step-Callbacks                                          5.14k    942ms    0.8%   183μs   28.0MiB    3.7%  5.58KiB
    calculate dt                                          5.14k    334ms    0.3%  64.9μs   1.49MiB    0.2%     304B
```