### PR TITLE
Increase minimum supported Julia version to v1.10

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-downgrade-compat@v1
         with:
-          skip: LinearAlgebra,Printf,SparseArrays,UUIDs,DiffEqBase,DelimitedFiles,Test,Downloads
+          skip: LinearAlgebra,Printf,SparseArrays,UUIDs,DiffEqBase,DelimitedFiles,Test,Downloads,Random
           projects: ., test
       - uses: julia-actions/julia-buildpkg@v1
         env:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -35,8 +35,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9'
-          # - '~1.9.0-0' # including development versions
+          - '1.10'
+          # - '~1.10.0-0' # including development versions
           # - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-downgrade-compat@v1
         with:
-          skip: LinearAlgebra,Printf,SparseArrays,UUIDs,DiffEqBase,DelimitedFiles
+          skip: LinearAlgebra,Printf,SparseArrays,UUIDs,DiffEqBase,DelimitedFiles,Test,Downloads
           projects: ., test
       - uses: julia-actions/julia-buildpkg@v1
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,7 @@ jobs:
           - mpi
           - threaded
         include:
-          - version: '1.8'
-            os: ubuntu-latest
-            arch: x64
-            trixi_test: threaded_legacy
-          - version: '1.9'
+          - version: '1.11'
             os: ubuntu-latest
             arch: x64
             trixi_test: threaded_legacy

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9'
+          - '1.10'
         os:
           - ubuntu-latest
         arch:

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@ for human readability.
 - `LobattoLegendreBasis` and related datastructures made fully floating-type general,
   enabling calculations with higher than double (`Float64`) precision ([#2128])
 
+#### Changed
+
+- The required Julia version is updated to v1.10.
+
 ## Changes when updating to v0.9 from v0.8.x
 
 #### Added

--- a/Project.toml
+++ b/Project.toml
@@ -115,7 +115,7 @@ TriplotBase = "0.1"
 TriplotRecipes = "0.1"
 TrixiBase = "0.1.3"
 UUIDs = "1.6"
-julia = "1.8"
+julia = "1.10"
 
 [extras]
 Convex = "f65535da-76fb-5f13-bab9-19810c17039a"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ installation and postprocessing procedures. Its features include:
 ## Installation
 If you have not yet installed Julia, please [follow the instructions for your
 operating system](https://julialang.org/downloads/platform/). Trixi.jl works
-with Julia v1.8 and newer. We recommend using the latest stable release of Julia.
+with Julia v1.10 and newer. We recommend using the latest stable release of Julia.
 
 ### For users
 Trixi.jl and its related tools are registered Julia packages. Hence, you

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -68,7 +68,7 @@ installation and postprocessing procedures. Its features include:
 ## Installation
 If you have not yet installed Julia, please [follow the instructions for your
 operating system](https://julialang.org/downloads/platform/). Trixi.jl works
-with Julia v1.8 and newer. We recommend using the latest stable release of Julia.
+with Julia v1.10 and newer. We recommend using the latest stable release of Julia.
 
 ### For users
 Trixi.jl and its related tools are registered Julia packages. Hence, you

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -157,8 +157,7 @@ Julia compiles code to get good (C/Fortran-like) performance. At the same time,
 Julia provides a dynamic environment and usually compiles code just before using
 it. Over time, Julia has improved its caching infrastructure, allowing to store
 and reuse more results from (pre-)compilation. This often results in an
-increased time to install/update packages, in particular when updating
-to Julia v1.8 or v1.9 from older versions.
+increased time to install/update packages.
 
 Some packages used together with [Trixi.jl](https://github.com/trixi-framework/Trixi.jl)
 provide options to configure the amount of precompilation. For example,

--- a/ext/TrixiConvexECOSExt.jl
+++ b/ext/TrixiConvexECOSExt.jl
@@ -2,14 +2,8 @@
 module TrixiConvexECOSExt
 
 # Required for coefficient optimization in PERK scheme integrators
-if isdefined(Base, :get_extension)
-    using Convex: MOI, solve!, Variable, minimize, evaluate
-    using ECOS: Optimizer
-else
-    # Until Julia v1.9 is the minimum required version for Trixi.jl, we still support Requires.jl
-    using ..Convex: MOI, solve!, Variable, minimize, evaluate
-    using ..ECOS: Optimizer
-end
+using Convex: MOI, solve!, Variable, minimize, evaluate
+using ECOS: Optimizer
 
 # Use other necessary libraries
 using LinearAlgebra: eigvals

--- a/ext/TrixiMakieExt.jl
+++ b/ext/TrixiMakieExt.jl
@@ -2,12 +2,7 @@
 module TrixiMakieExt
 
 # Required for visualization code
-if isdefined(Base, :get_extension)
-    using Makie: Makie, GeometryBasics
-else
-    # Until Julia v1.9 is the minimum required version for Trixi.jl, we still support Requires.jl
-    using ..Makie: Makie, GeometryBasics
-end
+using Makie: Makie, GeometryBasics
 
 # Use all exported symbols to avoid having to rewrite `recipes_makie.jl`
 using Trixi

--- a/ext/TrixiNLsolveExt.jl
+++ b/ext/TrixiNLsolveExt.jl
@@ -3,12 +3,7 @@ module TrixiNLsolveExt
 
 # Required for finding coefficients in Butcher tableau in the third order of 
 # PERK scheme integrators
-if isdefined(Base, :get_extension)
-    using NLsolve: nlsolve
-else
-    # Until Julia v1.9 is the minimum required version for Trixi.jl, we still support Requires.jl
-    using ..NLsolve: nlsolve
-end
+using NLsolve: nlsolve
 
 # We use a random initialization of the nonlinear solver.
 # To make the tests reproducible, we need to seed the RNG

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -311,49 +311,6 @@ function __init__()
     @require Plots="91a5bcdd-55d7-5caf-9e0b-520d859cae80" begin
         using .Plots: Plots
     end
-
-    # Until Julia v1.9 is the minimum required version for Trixi.jl, we still support Requires.jl
-    @static if !isdefined(Base, :get_extension)
-        @require Makie="ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" begin
-            include("../ext/TrixiMakieExt.jl")
-        end
-    end
-
-    @static if !isdefined(Base, :get_extension)
-        @require Convex="f65535da-76fb-5f13-bab9-19810c17039a" begin
-            @require ECOS="e2685f51-7e38-5353-a97d-a921fd2c8199" begin
-                include("../ext/TrixiConvexECOSExt.jl")
-            end
-        end
-    end
-
-    @static if !isdefined(Base, :get_extension)
-        @require NLsolve="2774e3e8-f4cf-5e23-947b-6d7e65073b56" begin
-            include("../ext/TrixiNLsolveExt.jl")
-        end
-    end
-
-    # FIXME upstream. This is a hacky workaround for
-    #       https://github.com/trixi-framework/Trixi.jl/issues/628
-    #       https://github.com/trixi-framework/Trixi.jl/issues/1185
-    # The related upstream issues appear to be
-    #       https://github.com/JuliaLang/julia/issues/35800
-    #       https://github.com/JuliaLang/julia/issues/32552
-    #       https://github.com/JuliaLang/julia/issues/41740
-    # See also https://discourse.julialang.org/t/performance-depends-dramatically-on-compilation-order/58425
-    if VERSION < v"1.9.0"
-        let
-            for T in (Float32, Float64)
-                u_mortars_2d = zeros(T, 2, 2, 2, 2, 2)
-                u_view_2d = view(u_mortars_2d, 1, :, 1, :, 1)
-                LoopVectorization.axes(u_view_2d)
-
-                u_mortars_3d = zeros(T, 2, 2, 2, 2, 2, 2)
-                u_view_3d = view(u_mortars_3d, 1, :, 1, :, :, 1)
-                LoopVectorization.axes(u_view_3d)
-            end
-        end
-    end
 end
 
 include("auxiliary/precompile.jl")

--- a/src/auxiliary/precompile.jl
+++ b/src/auxiliary/precompile.jl
@@ -600,17 +600,15 @@ function _precompile_manual_()
     return nothing
 end
 
-# Explicit precompilation running code only on Julia v1.9 and newer
+# Explicit precompilation including running code
 using PrecompileTools: @setup_workload, @compile_workload
 
-@static if VERSION >= v"1.9.0-beta4"
-    @setup_workload begin
-        # Setup code can go here
+@setup_workload begin
+    # Setup code can go here
 
-        @compile_workload begin
-            # Everything inside this block will run at precompile time, saving the
-            # binary code to a cache in newer versions of Julia.
-            DGSEM(3)
-        end
+    @compile_workload begin
+        # Everything inside this block will run at precompile time, saving the
+        # binary code to a cache in newer versions of Julia.
+        DGSEM(3)
     end
 end

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -87,15 +87,8 @@ end
 
 @inline Base.ndims(::AbstractEquations{NDIMS}) where {NDIMS} = NDIMS
 
-# TODO: @ranocha may this be removed?
 # Equations act like scalars in broadcasting.
-# Using `Ref(equations)` would be more convenient in some circumstances.
-# However, this does not work with Julia v1.9.3 correctly due to a (performance)
-# bug in Julia, see
-# - https://github.com/trixi-framework/Trixi.jl/pull/1618
-# - https://github.com/JuliaLang/julia/issues/51118
-# Thus, we use the workaround below.
-Base.broadcastable(equations::AbstractEquations) = (equations,)
+Base.broadcastable(equations::AbstractEquations) = Ref(equations)
 
 """
     flux(u, orientation_or_normal, equations)

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -88,7 +88,10 @@ end
 @inline Base.ndims(::AbstractEquations{NDIMS}) where {NDIMS} = NDIMS
 
 # Equations act like scalars in broadcasting.
-Base.broadcastable(equations::AbstractEquations) = Ref(equations)
+# The manual recommends `Ref`, but a single-argument tuple is morally equivalent.
+# For code that is allocation sensitive tuple is preferable, since `Ref` relies on the optimizer
+# to prove it non-escaping which is more precarious than just using an immutable tuple.
+Base.broadcastable(equations::AbstractEquations) = (equations,)
 
 """
     flux(u, orientation_or_normal, equations)

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -87,6 +87,7 @@ end
 
 @inline Base.ndims(::AbstractEquations{NDIMS}) where {NDIMS} = NDIMS
 
+# TODO: @ranocha may this be removed?
 # Equations act like scalars in broadcasting.
 # Using `Ref(equations)` would be more convenient in some circumstances.
 # However, this does not work with Julia v1.9.3 correctly due to a (performance)


### PR DESCRIPTION
~~Please do not merge yet until we are sure that everything still works, including downstream packages.~~

Organizational checks have been completed - now this is just a regular PR as any other.

### TODO
- [x] Create issue to turn Plots.jl functionality into an extension, such that we can get rid of Requires.jl for good ($\to$ #2216)
- [x] Check Trixi2Vtk.jl and make it fit for Julia v1.10 (trixi-framework/Trixi2Vtk.jl#101)
- [x] Check other main downstream packages' CI (TrixiSW, TrixiA, libtrixi)
- [x] Fix failed tests