### PR TITLE
Check that `coordinates_min[dim] < coordinates_max[dim]`

### DIFF
--- a/src/meshes/abstract_tree.jl
+++ b/src/meshes/abstract_tree.jl
@@ -393,6 +393,8 @@ end
     end
 end
 
+# For the p4est and the t8code mesh we allow `coordinates_min` and `coordinates_max` to be `nothing`
+coordinate_min_max_check(::Nothing, ::Nothing) = nothing
 # Refine all leaf cells with coordinates in a given rectangular box
 function refine_box!(t::AbstractTree{NDIMS},
                      coordinates_min,

--- a/src/meshes/abstract_tree.jl
+++ b/src/meshes/abstract_tree.jl
@@ -389,7 +389,7 @@ end
 
 @inline function coordinate_min_max_check(coordinates_min, coordinates_max)
     for dim in eachindex(coordinates_min)
-        @assert coordinates_min[dim]<coordinates_max[dim] "coordinates_min[$dim] must be smaller than coordinates_min[$dim]!"
+        @assert coordinates_min[dim]<coordinates_max[dim] "coordinates_min[$dim] must be smaller than coordinates_max[$dim]!"
     end
 end
 

--- a/src/meshes/abstract_tree.jl
+++ b/src/meshes/abstract_tree.jl
@@ -387,19 +387,20 @@ function refine!(t::AbstractTree, cell_ids,
     return refined_original_cells
 end
 
-@inline function coordinate_min_max_check(coordinates_min, coordinates_max)
+@inline function coordinates_min_max_check(coordinates_min, coordinates_max)
     for dim in eachindex(coordinates_min)
         @assert coordinates_min[dim]<coordinates_max[dim] "coordinates_min[$dim] must be smaller than coordinates_max[$dim]!"
     end
 end
+# For the p4est and the t8code mesh we allow `coordinates_min` and `coordinates_max` to be `nothing`.
+# This corresponds to meshes constructed from analytic mapping functions.
+coordinates_min_max_check(::Nothing, ::Nothing) = nothing
 
-# For the p4est and the t8code mesh we allow `coordinates_min` and `coordinates_max` to be `nothing`
-coordinate_min_max_check(::Nothing, ::Nothing) = nothing
 # Refine all leaf cells with coordinates in a given rectangular box
 function refine_box!(t::AbstractTree{NDIMS},
                      coordinates_min,
                      coordinates_max) where {NDIMS}
-    coordinate_min_max_check(coordinates_min, coordinates_max)
+    coordinates_min_max_check(coordinates_min, coordinates_max)
 
     # Find all leaf cells within box
     cells = filter_leaf_cells(t) do cell_id

--- a/src/meshes/abstract_tree.jl
+++ b/src/meshes/abstract_tree.jl
@@ -387,13 +387,17 @@ function refine!(t::AbstractTree, cell_ids,
     return refined_original_cells
 end
 
+@inline function coordinate_min_max_check(coordinates_min, coordinates_max)
+    for dim in eachindex(coordinates_min)
+        @assert coordinates_min[dim]<coordinates_max[dim] "coordinates_min[$dim] must be smaller than coordinates_min[$dim]!"
+    end
+end
+
 # Refine all leaf cells with coordinates in a given rectangular box
 function refine_box!(t::AbstractTree{NDIMS},
                      coordinates_min,
                      coordinates_max) where {NDIMS}
-    for dim in 1:NDIMS
-        @assert coordinates_min[dim]<coordinates_max[dim] "Minimum coordinates are not minimum."
-    end
+    coordinate_min_max_check(coordinates_min, coordinates_max)
 
     # Find all leaf cells within box
     cells = filter_leaf_cells(t) do cell_id

--- a/src/meshes/p4est_mesh.jl
+++ b/src/meshes/p4est_mesh.jl
@@ -191,9 +191,7 @@ function P4estMesh(trees_per_dimension; polydeg,
                    p4est_partition_allow_for_coarsening = true)
     @assert ((coordinates_min === nothing)===(coordinates_max === nothing)) "Either both or none of coordinates_min and coordinates_max must be specified"
 
-    for dim in eachindex(coordinates_min)
-        @assert coordinates_max[dim] > coordinates_min[dim] "coordinates_max[$dim] must be greater than coordinates_min[$dim] for each dimension"
-    end
+    coordinate_min_max_check(coordinates_min, coordinates_max)
 
     @assert count(i -> i !== nothing,
                   (mapping, faces, coordinates_min))==1 "Exactly one of mapping, faces and coordinates_min/max must be specified"

--- a/src/meshes/p4est_mesh.jl
+++ b/src/meshes/p4est_mesh.jl
@@ -191,7 +191,7 @@ function P4estMesh(trees_per_dimension; polydeg,
                    p4est_partition_allow_for_coarsening = true)
     @assert ((coordinates_min === nothing)===(coordinates_max === nothing)) "Either both or none of coordinates_min and coordinates_max must be specified"
 
-    coordinate_min_max_check(coordinates_min, coordinates_max)
+    coordinates_min_max_check(coordinates_min, coordinates_max)
 
     @assert count(i -> i !== nothing,
                   (mapping, faces, coordinates_min))==1 "Exactly one of mapping, faces and coordinates_min/max must be specified"

--- a/src/meshes/p4est_mesh.jl
+++ b/src/meshes/p4est_mesh.jl
@@ -191,7 +191,9 @@ function P4estMesh(trees_per_dimension; polydeg,
                    p4est_partition_allow_for_coarsening = true)
     @assert ((coordinates_min === nothing)===(coordinates_max === nothing)) "Either both or none of coordinates_min and coordinates_max must be specified"
 
-    coordinate_min_max_check(coordinates_min, coordinates_max)
+    if coordinates_min !== nothing && coordinates_max !== nothing
+        coordinate_min_max_check(coordinates_min, coordinates_max)
+    end
 
     @assert count(i -> i !== nothing,
                   (mapping, faces, coordinates_min))==1 "Exactly one of mapping, faces and coordinates_min/max must be specified"

--- a/src/meshes/p4est_mesh.jl
+++ b/src/meshes/p4est_mesh.jl
@@ -191,6 +191,10 @@ function P4estMesh(trees_per_dimension; polydeg,
                    p4est_partition_allow_for_coarsening = true)
     @assert ((coordinates_min === nothing)===(coordinates_max === nothing)) "Either both or none of coordinates_min and coordinates_max must be specified"
 
+    for dim in eachindex(coordinates_min)
+        @assert coordinates_max[dim] > coordinates_min[dim] "coordinates_max[$dim] must be greater than coordinates_min[$dim] for each dimension"
+    end
+
     @assert count(i -> i !== nothing,
                   (mapping, faces, coordinates_min))==1 "Exactly one of mapping, faces and coordinates_min/max must be specified"
 

--- a/src/meshes/p4est_mesh.jl
+++ b/src/meshes/p4est_mesh.jl
@@ -191,9 +191,7 @@ function P4estMesh(trees_per_dimension; polydeg,
                    p4est_partition_allow_for_coarsening = true)
     @assert ((coordinates_min === nothing)===(coordinates_max === nothing)) "Either both or none of coordinates_min and coordinates_max must be specified"
 
-    if coordinates_min !== nothing && coordinates_max !== nothing
-        coordinate_min_max_check(coordinates_min, coordinates_max)
-    end
+    coordinate_min_max_check(coordinates_min, coordinates_max)
 
     @assert count(i -> i !== nothing,
                   (mapping, faces, coordinates_min))==1 "Exactly one of mapping, faces and coordinates_min/max must be specified"

--- a/src/meshes/structured_mesh.jl
+++ b/src/meshes/structured_mesh.jl
@@ -140,7 +140,7 @@ function StructuredMesh(cells_per_dimension, coordinates_min, coordinates_max;
                         periodicity = true)
     RealT = promote_type(eltype(coordinates_min), eltype(coordinates_max))
 
-    coordinate_min_max_check(coordinates_min, coordinates_max)
+    coordinates_min_max_check(coordinates_min, coordinates_max)
 
     mapping = coordinates2mapping(coordinates_min, coordinates_max)
     mapping_as_string = """

--- a/src/meshes/structured_mesh.jl
+++ b/src/meshes/structured_mesh.jl
@@ -140,9 +140,7 @@ function StructuredMesh(cells_per_dimension, coordinates_min, coordinates_max;
                         periodicity = true)
     RealT = promote_type(eltype(coordinates_min), eltype(coordinates_max))
 
-    for dim in eachindex(coordinates_min)
-        @assert coordinates_max[dim] > coordinates_min[dim] "coordinates_max[$dim] must be greater than coordinates_min[$dim] for each dimension"
-    end
+    coordinate_min_max_check(coordinates_min, coordinates_max)
 
     mapping = coordinates2mapping(coordinates_min, coordinates_max)
     mapping_as_string = """

--- a/src/meshes/structured_mesh.jl
+++ b/src/meshes/structured_mesh.jl
@@ -140,6 +140,10 @@ function StructuredMesh(cells_per_dimension, coordinates_min, coordinates_max;
                         periodicity = true)
     RealT = promote_type(eltype(coordinates_min), eltype(coordinates_max))
 
+    for dim in eachindex(coordinates_min)
+        @assert coordinates_max[dim] > coordinates_min[dim] "coordinates_max[$dim] must be greater than coordinates_min[$dim] for each dimension"
+    end
+
     mapping = coordinates2mapping(coordinates_min, coordinates_max)
     mapping_as_string = """
         coordinates_min = $coordinates_min

--- a/src/meshes/t8code_mesh.jl
+++ b/src/meshes/t8code_mesh.jl
@@ -427,7 +427,9 @@ function T8codeMesh(trees_per_dimension; polydeg = 1,
                     periodicity = true)
     @assert ((coordinates_min === nothing)===(coordinates_max === nothing)) "Either both or none of coordinates_min and coordinates_max must be specified"
 
-    coordinate_min_max_check(coordinates_min, coordinates_max)
+    if coordinates_min !== nothing && coordinates_max !== nothing
+        coordinate_min_max_check(coordinates_min, coordinates_max)
+    end
 
     @assert count(i -> i !== nothing,
                   (mapping, faces, coordinates_min))==1 "Exactly one of mapping, faces and coordinates_min/max must be specified"

--- a/src/meshes/t8code_mesh.jl
+++ b/src/meshes/t8code_mesh.jl
@@ -427,9 +427,7 @@ function T8codeMesh(trees_per_dimension; polydeg = 1,
                     periodicity = true)
     @assert ((coordinates_min === nothing)===(coordinates_max === nothing)) "Either both or none of coordinates_min and coordinates_max must be specified"
 
-    if coordinates_min !== nothing && coordinates_max !== nothing
-        coordinate_min_max_check(coordinates_min, coordinates_max)
-    end
+    coordinate_min_max_check(coordinates_min, coordinates_max)
 
     @assert count(i -> i !== nothing,
                   (mapping, faces, coordinates_min))==1 "Exactly one of mapping, faces and coordinates_min/max must be specified"

--- a/src/meshes/t8code_mesh.jl
+++ b/src/meshes/t8code_mesh.jl
@@ -427,9 +427,7 @@ function T8codeMesh(trees_per_dimension; polydeg = 1,
                     periodicity = true)
     @assert ((coordinates_min === nothing)===(coordinates_max === nothing)) "Either both or none of coordinates_min and coordinates_max must be specified"
 
-    for dim in eachindex(coordinates_min)
-        @assert coordinates_max[dim] > coordinates_min[dim] "coordinates_max[$dim] must be greater than coordinates_min[$dim] for each dimension"
-    end
+    coordinate_min_max_check(coordinates_min, coordinates_max)
 
     @assert count(i -> i !== nothing,
                   (mapping, faces, coordinates_min))==1 "Exactly one of mapping, faces and coordinates_min/max must be specified"

--- a/src/meshes/t8code_mesh.jl
+++ b/src/meshes/t8code_mesh.jl
@@ -427,7 +427,7 @@ function T8codeMesh(trees_per_dimension; polydeg = 1,
                     periodicity = true)
     @assert ((coordinates_min === nothing)===(coordinates_max === nothing)) "Either both or none of coordinates_min and coordinates_max must be specified"
 
-    coordinate_min_max_check(coordinates_min, coordinates_max)
+    coordinates_min_max_check(coordinates_min, coordinates_max)
 
     @assert count(i -> i !== nothing,
                   (mapping, faces, coordinates_min))==1 "Exactly one of mapping, faces and coordinates_min/max must be specified"

--- a/src/meshes/t8code_mesh.jl
+++ b/src/meshes/t8code_mesh.jl
@@ -427,6 +427,10 @@ function T8codeMesh(trees_per_dimension; polydeg = 1,
                     periodicity = true)
     @assert ((coordinates_min === nothing)===(coordinates_max === nothing)) "Either both or none of coordinates_min and coordinates_max must be specified"
 
+    for dim in eachindex(coordinates_min)
+        @assert coordinates_max[dim] > coordinates_min[dim] "coordinates_max[$dim] must be greater than coordinates_min[$dim] for each dimension"
+    end
+
     @assert count(i -> i !== nothing,
                   (mapping, faces, coordinates_min))==1 "Exactly one of mapping, faces and coordinates_min/max must be specified"
 

--- a/src/meshes/tree_mesh.jl
+++ b/src/meshes/tree_mesh.jl
@@ -134,9 +134,7 @@ function TreeMesh(coordinates_min::NTuple{NDIMS, Real},
         end
     end
 
-    for dim in eachindex(coordinates_min)
-        @assert coordinates_max[dim] > coordinates_min[dim] "coordinates_max[$dim] must be greater than coordinates_min[$dim] for each dimension"
-    end
+    coordinate_min_max_check(coordinates_min, coordinates_max)
 
     # TreeMesh requires equal domain lengths in all dimensions
     domain_center = @. convert(RealT, (coordinates_min + coordinates_max) / 2)

--- a/src/meshes/tree_mesh.jl
+++ b/src/meshes/tree_mesh.jl
@@ -134,6 +134,10 @@ function TreeMesh(coordinates_min::NTuple{NDIMS, Real},
         end
     end
 
+    for dim in eachindex(coordinates_min)
+        @assert coordinates_max[dim] > coordinates_min[dim] "coordinates_max[$dim] must be greater than coordinates_min[$dim] for each dimension"
+    end
+
     # TreeMesh requires equal domain lengths in all dimensions
     domain_center = @. convert(RealT, (coordinates_min + coordinates_max) / 2)
     domain_length = convert(RealT, coordinates_max[1] - coordinates_min[1])

--- a/src/meshes/tree_mesh.jl
+++ b/src/meshes/tree_mesh.jl
@@ -134,7 +134,7 @@ function TreeMesh(coordinates_min::NTuple{NDIMS, Real},
         end
     end
 
-    coordinate_min_max_check(coordinates_min, coordinates_max)
+    coordinates_min_max_check(coordinates_min, coordinates_max)
 
     # TreeMesh requires equal domain lengths in all dimensions
     domain_center = @. convert(RealT, (coordinates_min + coordinates_max) / 2)


### PR DESCRIPTION
Currently you do not get any error if you accidentally use the same values for `coordinates_min` and `coordinates_max`, but only a one-step simulation (not even a `Instability Detected warning):

```julia
────────────────────────────────────────────────────────────────────────────────────────────────────
 Simulation running 'LinearScalarAdvectionEquation1D' with DGSEM(polydeg=3)
────────────────────────────────────────────────────────────────────────────────────────────────────
 #timesteps:                  0                run time:       8.60000000e-07 s
 Δt:             1.00000000e+00                └── GC time:    0.00000000e+00 s (0.000%)
 sim. time:      0.00000000e+00 (0.000%)       time/DOF/rhs!:         NaN s
                                               PID:                   Inf s
 #DOFs per field:            64                alloc'd memory:        370.678 MiB
 #elements:                  16

 Variable:       scalar        
 L2 error:             NaN
 Linf error:     5.55111512e-16
 ∑∂S/∂U ⋅ Uₜ :         NaN
────────────────────────────────────────────────────────────────────────────────────────────────────


────────────────────────────────────────────────────────────────────────────────────────────────────
 Simulation running 'LinearScalarAdvectionEquation1D' with DGSEM(polydeg=3)
────────────────────────────────────────────────────────────────────────────────────────────────────
 #timesteps:                  1                run time:       3.59785263e-01 s
 Δt:             1.00000000e+00                └── GC time:    0.00000000e+00 s (0.000%)
 sim. time:      1.00000000e+00 (100.000%)     time/DOF/rhs!:  4.42649554e-07 s
                                               PID:            6.32586375e-04 s
 #DOFs per field:            64                alloc'd memory:        386.021 MiB
 #elements:                  16

 Variable:       scalar        
 L2 error:             NaN
 Linf error:     0.00000000e+00
 ∑∂S/∂U ⋅ Uₜ :         NaN
────────────────────────────────────────────────────────────────────────────────────────────────────
```

The above output is for the 1D Tree Advection example with same values for min and max coords.

Now:

```julia
ERROR: AssertionError: coordinates_min[1] must be smaller than coordinates_min[1]!
Stacktrace:
 [1] coordinate_min_max_check
   @ ~/git/Trixi.jl/src/meshes/abstract_tree.jl:392 [inlined]
 [2] TreeMesh(coordinates_min::Tuple{…}, coordinates_max::Tuple{…}; n_cells_max::Int64, periodicity::Bool, initial_refinement_level::Int64, refinement_patches::Tuple{}, coarsening_patches::Tuple{}, RealT::Type)
   @ Trixi ~/git/Trixi.jl/src/meshes/tree_mesh.jl:137
 [3] TreeMesh
   @ ~/git/Trixi.jl/src/meshes/tree_mesh.jl:111 [inlined]
 [4] #TreeMesh#213
   @ ~/git/Trixi.jl/src/meshes/tree_mesh.jl:206 [inlined]
 [5] top-level scope
   @ ~/git/Trixi.jl/examples/tree_1d_dgsem/elixir_advection_basic.jl:17
Some type information was truncated. Use `show(err)` to see complete types.
```