### PR TITLE
Always process code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,9 +127,11 @@ jobs:
           PYTHON: ''
           TRIXI_TEST: ${{ matrix.trixi_test }}
       - uses: julia-actions/julia-processcoverage@v1
+        if: always()
         with:
           directories: src,examples,ext
       - uses: codecov/codecov-action@v5
+        if: always()
         with:
           files: ./lcov.info
           flags: unittests
@@ -153,6 +155,7 @@ jobs:
       # - Download and merge individual coverage reports in another step
       # - Upload only the merged coverage report to Coveralls
       - shell: bash
+        if: always()
         run: |
           cp ./lcov.info ./lcov-${{ matrix.trixi_test }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}.info
       - uses: actions/upload-artifact@v4
@@ -162,6 +165,7 @@ jobs:
 
   finish:
     needs: test
+    if: always()
     runs-on: ubuntu-latest
     steps:
       # The standard setup of Coveralls is just annoying for parallel builds, see, e.g.,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,11 +127,11 @@ jobs:
           PYTHON: ''
           TRIXI_TEST: ${{ matrix.trixi_test }}
       - uses: julia-actions/julia-processcoverage@v1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           directories: src,examples,ext
       - uses: codecov/codecov-action@v5
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           files: ./lcov.info
           flags: unittests
@@ -155,7 +155,7 @@ jobs:
       # - Download and merge individual coverage reports in another step
       # - Upload only the merged coverage report to Coveralls
       - shell: bash
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           cp ./lcov.info ./lcov-${{ matrix.trixi_test }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}.info
       - uses: actions/upload-artifact@v4
@@ -165,7 +165,7 @@ jobs:
 
   finish:
     needs: test
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       # The standard setup of Coveralls is just annoying for parallel builds, see, e.g.,


### PR DESCRIPTION
Currently when a single test fails we do not upload code coverage to either codecov.io or coveralls.

This confused me recently while looking at #2254 since coverage seemed to drop by 10% since some files were not processed.

