### PR TITLE
Optimized `stolarsky_mean`

### DIFF
--- a/src/auxiliary/math.jl
+++ b/src/auxiliary/math.jl
@@ -412,8 +412,10 @@ Given ε = 1.0e-4, we use the following algorithm.
         c3 = convert(RealT, -1 / 21) * (2 * gamma * (gamma - 2) - 9) * c2
         return 0.5f0 * (x + y) * @evalpoly(f2, 1, c1, c2, c3)
     else
-        return (gamma - 1) / gamma * (y^gamma - x^gamma) /
-               (y^(gamma - 1) - x^(gamma - 1))
+        yg = exp(gamma*log(y))
+        xg = exp(gamma*log(x))
+        return (gamma - 1) / gamma * (yg - xg) /
+               (yg/y - xg/x)
     end
 end
 end # @muladd

--- a/src/auxiliary/math.jl
+++ b/src/auxiliary/math.jl
@@ -412,10 +412,10 @@ Given ε = 1.0e-4, we use the following algorithm.
         c3 = convert(RealT, -1 / 21) * (2 * gamma * (gamma - 2) - 9) * c2
         return 0.5f0 * (x + y) * @evalpoly(f2, 1, c1, c2, c3)
     else
-        yg = exp(gamma*log(y))
-        xg = exp(gamma*log(x))
+        yg = exp(gamma * log(y))
+        xg = exp(gamma * log(x))
         return (gamma - 1) / gamma * (yg - xg) /
-               (yg/y - xg/x)
+               (yg / y - xg / x)
     end
 end
 end # @muladd


### PR DESCRIPTION
The stolarsky mean will come in handy in Trixi Atmo. Here an optimized version is proposed. 

```julia-repl
julia> @inline function stolarsky_mean(x::RealT, y::RealT, gamma::RealT) where {RealT <: Real}
           epsilon_f2 = convert(RealT, 1.0e-4)
           f2 = (x * (x - 2 * y) + y * y) / (x * (x + 2 * y) + y * y) # f2 = f^2
           if f2 < epsilon_f2
               # convenience coefficients
               c1 = convert(RealT, 1 / 3) * (gamma - 2)
               c2 = convert(RealT, -1 / 15) * (gamma + 1) * (gamma - 3) * c1
               c3 = convert(RealT, -1 / 21) * (2 * gamma * (gamma - 2) - 9) * c2
               return 0.5f0 * (x + y) * @evalpoly(f2, 1, c1, c2, c3)
           else
               return (gamma - 1) / gamma * (y^gamma - x^gamma) /
                      (y^(gamma - 1) - x^(gamma - 1))
           end
       end
stolarsky_mean (generic function with 1 method)

julia> @inline function stolarsky_mean_2(x::RealT, y::RealT, gamma::RealT) where {RealT <: Real}
           epsilon_f2 = convert(RealT, 1.0e-4)
           f2 = (x * (x - 2 * y) + y * y) / (x * (x + 2 * y) + y * y) # f2 = f^2
           if f2 < epsilon_f2
               # convenience coefficients
               c1 = convert(RealT, 1 / 3) * (gamma - 2)
               c2 = convert(RealT, -1 / 15) * (gamma + 1) * (gamma - 3) * c1
               c3 = convert(RealT, -1 / 21) * (2 * gamma * (gamma - 2) - 9) * c2
               return 0.5f0 * (x + y) * @evalpoly(f2, 1, c1, c2, c3)
           else
               expy = exp(gamma*log(y))
               expx = exp(gamma*log(x))
               return (gamma - 1) / gamma * (expy - expx) /
                      (expy/y - expx/x)
           end
       end
stolarsky_mean_2 (generic function with 1 method)

julia> @benchmark value = stolarsky_mean($(Ref(300.1))[], $(Ref(410.7))[], $(Ref(1.4))[])
BenchmarkTools.Trial: 10000 samples with 989 evaluations per sample.
 Range (min … max):  45.982 ns … 61.638 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     46.163 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   46.301 ns ±  0.665 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▁▅██▅             ▁▁                                        ▂
  █████▇▆▅▄▁▃▃▄▄▄▁▄▇█████▇▇▆▆▄▆▅▅▄▅▄▅▅▇▇▇▆▆▄▅▅▅▄▃▅▆▄▅▃▃▄▆▆█▇▇ █
  46 ns        Histogram: log(frequency) by time      49.5 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark value = stolarsky_mean_2($(Ref(300.1))[], $(Ref(410.7))[], $(Ref(1.4))[])
BenchmarkTools.Trial: 10000 samples with 997 evaluations per sample.
 Range (min … max):  19.342 ns … 630.474 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     19.566 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   20.007 ns ±   6.343 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▇█    ▂▂▄                                                    ▁
  ██▇▇▇█████▇▇▇█▇▄▅▄▁▃▁▄▃▁▄▄▄▁▄▁▃▃▁▁▃▄▃▃▄▄▄▃▄▅▅▅▅▅▅▆▆▆▆▅▅▆▆▅▅▅ █
  19.3 ns       Histogram: log(frequency) by time      30.9 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

Simulation of EC Polytropic Euler with the previous stolarsky mean:
```julia-repl
────────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                      Time                    Allocations      
                                  ───────────────────────   ────────────────────────
        Tot / % measured:              1.62s /  99.1%           2.34MiB /  90.4%    

Section                   ncalls     time    %tot     avg     alloc    %tot      avg
────────────────────────────────────────────────────────────────────────────────────
rhs!                       1.42k    1.57s   97.7%  1.11ms   5.14KiB    0.2%    3.70B
  volume integral          1.42k    1.41s   87.8%   994μs     0.00B    0.0%    0.00B
  interface flux           1.42k    131ms    8.2%  92.4μs     0.00B    0.0%    0.00B
  surface integral         1.42k   14.9ms    0.9%  10.5μs     0.00B    0.0%    0.00B
  Jacobian                 1.42k   7.29ms    0.5%  5.13μs     0.00B    0.0%    0.00B
  reset ∂u/∂t              1.42k   3.83ms    0.2%  2.70μs     0.00B    0.0%    0.00B
  ~rhs!~                   1.42k    956μs    0.1%   673ns   5.14KiB    0.2%    3.70B
  boundary flux            1.42k   61.6μs    0.0%  43.3ns     0.00B    0.0%    0.00B
  source terms             1.42k   24.5μs    0.0%  17.3ns     0.00B    0.0%    0.00B
calculate dt                 285   26.0ms    1.6%  91.2μs     0.00B    0.0%    0.00B
analyze solution               4   6.36ms    0.4%  1.59ms    314KiB   14.5%  78.6KiB
I/O                            5   5.35ms    0.3%  1.07ms   1.81MiB   85.3%   370KiB
  save solution                4   5.00ms    0.3%  1.25ms   1.80MiB   84.9%   461KiB
  ~I/O~                        5    352μs    0.0%  70.5μs   8.83KiB    0.4%  1.77KiB
  save mesh                    4    755ns    0.0%   189ns     0.00B    0.0%    0.00B
  get element variables        4    477ns    0.0%   119ns     0.00B    0.0%    0.00B
  get node variables           4   86.0ns    0.0%  21.5ns     0.00B    0.0%    0.00B
────────────────────────────────────────────────────────────────────────────────────
```

Results for the optimized version
```julia-repl
────────────────────────────────────────────────────────────────────────────────────
             Trixi.jl                      Time                    Allocations      
                                  ───────────────────────   ────────────────────────
        Tot / % measured:              1.62s /  99.1%           2.34MiB /  90.4%    

Section                   ncalls     time    %tot     avg     alloc    %tot      avg
────────────────────────────────────────────────────────────────────────────────────
rhs!                       1.42k    1.57s   97.7%  1.11ms   5.14KiB    0.2%    3.70B
  volume integral          1.42k    1.41s   87.8%   994μs     0.00B    0.0%    0.00B
  interface flux           1.42k    131ms    8.2%  92.4μs     0.00B    0.0%    0.00B
  surface integral         1.42k   14.9ms    0.9%  10.5μs     0.00B    0.0%    0.00B
  Jacobian                 1.42k   7.29ms    0.5%  5.13μs     0.00B    0.0%    0.00B
  reset ∂u/∂t              1.42k   3.83ms    0.2%  2.70μs     0.00B    0.0%    0.00B
  ~rhs!~                   1.42k    956μs    0.1%   673ns   5.14KiB    0.2%    3.70B
  boundary flux            1.42k   61.6μs    0.0%  43.3ns     0.00B    0.0%    0.00B
  source terms             1.42k   24.5μs    0.0%  17.3ns     0.00B    0.0%    0.00B
calculate dt                 285   26.0ms    1.6%  91.2μs     0.00B    0.0%    0.00B
analyze solution               4   6.36ms    0.4%  1.59ms    314KiB   14.5%  78.6KiB
I/O                            5   5.35ms    0.3%  1.07ms   1.81MiB   85.3%   370KiB
  save solution                4   5.00ms    0.3%  1.25ms   1.80MiB   84.9%   461KiB
  ~I/O~                        5    352μs    0.0%  70.5μs   8.83KiB    0.4%  1.77KiB
  save mesh                    4    755ns    0.0%   189ns     0.00B    0.0%    0.00B
  get element variables        4    477ns    0.0%   119ns     0.00B    0.0%    0.00B
  get node variables           4   86.0ns    0.0%  21.5ns     0.00B    0.0%    0.00B
────────────────────────────────────────────────────────────────────────────────────
```

