### PR TITLE
Finalize callbacks for custom time integrators

### DIFF
--- a/src/time_integration/methods_2N.jl
+++ b/src/time_integration/methods_2N.jl
@@ -161,6 +161,8 @@ function solve!(integrator::SimpleIntegrator2N)
         step!(integrator)
     end # "main loop" timer
 
+    finalize_callbacks(integrator)
+
     return TimeIntegratorSolution((first(prob.tspan), integrator.t),
                                   (prob.u0, integrator.u),
                                   integrator.sol.prob)

--- a/src/time_integration/methods_3Sstar.jl
+++ b/src/time_integration/methods_3Sstar.jl
@@ -218,6 +218,8 @@ function solve!(integrator::SimpleIntegrator3Sstar)
         step!(integrator)
     end # "main loop" timer
 
+    finalize_callbacks(integrator)
+
     return TimeIntegratorSolution((first(prob.tspan), integrator.t),
                                   (prob.u0, integrator.u),
                                   integrator.sol.prob)

--- a/src/time_integration/methods_SSP.jl
+++ b/src/time_integration/methods_SSP.jl
@@ -231,6 +231,10 @@ function solve!(integrator::SimpleIntegratorSSP)
     # This cannot be done in terminate!(integrator::SimpleIntegratorSSP) because DiffEqCallbacks.PeriodicCallbackAffect would return at error.
     extract_all!(integrator.opts.tstops)
 
+    for stage_callback in alg.stage_callbacks
+        finalize_callback(stage_callback, integrator.p)
+    end
+
     finalize_callbacks(integrator)
 
     return TimeIntegratorSolution((first(prob.tspan), integrator.t),

--- a/src/time_integration/methods_SSP.jl
+++ b/src/time_integration/methods_SSP.jl
@@ -231,9 +231,7 @@ function solve!(integrator::SimpleIntegratorSSP)
     # This cannot be done in terminate!(integrator::SimpleIntegratorSSP) because DiffEqCallbacks.PeriodicCallbackAffect would return at error.
     extract_all!(integrator.opts.tstops)
 
-    for stage_callback in alg.stage_callbacks
-        finalize_callback(stage_callback, integrator.p)
-    end
+    finalize_callbacks(integrator)
 
     return TimeIntegratorSolution((first(prob.tspan), integrator.t),
                                   (prob.u0, integrator.u), prob)

--- a/src/time_integration/paired_explicit_runge_kutta/paired_explicit_runge_kutta.jl
+++ b/src/time_integration/paired_explicit_runge_kutta/paired_explicit_runge_kutta.jl
@@ -110,6 +110,8 @@ function solve!(integrator::AbstractPairedExplicitRKIntegrator)
         step!(integrator)
     end
 
+    finalize_callbacks(integrator)
+
     return TimeIntegratorSolution((first(prob.tspan), integrator.t),
                                   (prob.u0, integrator.u),
                                   integrator.sol.prob)

--- a/src/time_integration/time_integration.jl
+++ b/src/time_integration/time_integration.jl
@@ -27,6 +27,21 @@ function DiffEqBase.get_tstops_max(integrator::AbstractTimeIntegrator)
     return maximum(get_tstops_array(integrator))
 end
 
+function finalize_callbacks(integrator::AbstractTimeIntegrator)
+    @unpack alg = integrator
+    callbacks = integrator.opts.callback
+
+    for stage_callback in alg.stage_callbacks
+        finalize_callback(stage_callback, integrator.p)
+    end
+
+    if callbacks isa CallbackSet
+        foreach(callbacks.discrete_callbacks) do cb
+            cb.finalize(cb, integrator.u, integrator.t, integrator)
+        end
+    end
+end
+
 include("methods_2N.jl")
 include("methods_3Sstar.jl")
 include("methods_SSP.jl")

--- a/src/time_integration/time_integration.jl
+++ b/src/time_integration/time_integration.jl
@@ -34,9 +34,9 @@ function finalize_callbacks(integrator::AbstractTimeIntegrator)
         foreach(callbacks.discrete_callbacks) do cb
             cb.finalize(cb, integrator.u, integrator.t, integrator)
         end
-        foreach(callbacks.continuous_callbacks) do cb 
-             cb.finalize(cb, integrator.u, integrator.t, integrator) 
-         end
+        foreach(callbacks.continuous_callbacks) do cb
+            cb.finalize(cb, integrator.u, integrator.t, integrator)
+        end
     end
 end
 

--- a/src/time_integration/time_integration.jl
+++ b/src/time_integration/time_integration.jl
@@ -28,7 +28,6 @@ function DiffEqBase.get_tstops_max(integrator::AbstractTimeIntegrator)
 end
 
 function finalize_callbacks(integrator::AbstractTimeIntegrator)
-    @unpack alg = integrator
     callbacks = integrator.opts.callback
 
     if callbacks isa CallbackSet

--- a/src/time_integration/time_integration.jl
+++ b/src/time_integration/time_integration.jl
@@ -34,6 +34,9 @@ function finalize_callbacks(integrator::AbstractTimeIntegrator)
         foreach(callbacks.discrete_callbacks) do cb
             cb.finalize(cb, integrator.u, integrator.t, integrator)
         end
+        foreach(callbacks.continuous_callbacks) do cb 
+             cb.finalize(cb, integrator.u, integrator.t, integrator) 
+         end
     end
 end
 

--- a/src/time_integration/time_integration.jl
+++ b/src/time_integration/time_integration.jl
@@ -31,10 +31,6 @@ function finalize_callbacks(integrator::AbstractTimeIntegrator)
     @unpack alg = integrator
     callbacks = integrator.opts.callback
 
-    for stage_callback in alg.stage_callbacks
-        finalize_callback(stage_callback, integrator.p)
-    end
-
     if callbacks isa CallbackSet
         foreach(callbacks.discrete_callbacks) do cb
             cb.finalize(cb, integrator.u, integrator.t, integrator)


### PR DESCRIPTION
As noted by @knstmrd, after having merged #2275, the summary callback is not printed anymore for our custom integrators after the simulation finished. This is because we do not call the callback finalizers in our custom `solve` function. This PR fixes this.