### PR TITLE
Add nonconservative terms to p4est 3D `calc_boundary_flux`

### DIFF
--- a/src/solvers/dgsem_p4est/dg_3d.jl
+++ b/src/solvers/dgsem_p4est/dg_3d.jl
@@ -353,12 +353,11 @@ function prolong2boundaries!(cache, u,
     return nothing
 end
 
-function calc_boundary_flux!(cache, t, boundary_condition, boundary_indexing,
+function calc_boundary_flux!(cache, t, boundary_condition::BC, boundary_indexing,
                              mesh::Union{P4estMesh{3}, T8codeMesh{3}},
-                             equations, surface_integral, dg::DG)
+                             equations, surface_integral, dg::DG) where {BC}
     @unpack boundaries = cache
-    @unpack surface_flux_values, node_coordinates, contravariant_vectors = cache.elements
-    @unpack surface_flux = surface_integral
+    @unpack surface_flux_values = cache.elements
     index_range = eachnode(dg)
 
     @threaded for local_index in eachindex(boundary_indexing)
@@ -449,7 +448,7 @@ end
                             boundary_index)
 
     # Outward-pointing normal direction (not normalized)
-    normal_direction = get_normal_direction(direction, contravariant_vectors,
+    normal_direction = get_normal_direction(direction_index, contravariant_vectors,
                                             i_index, j_index, k_index, element_index)
 
     # Coordinates at boundary node
@@ -467,7 +466,7 @@ end
         # the interpretation of global SBP operators coupled discontinuously via
         # central fluxes/SATs
         surface_flux_values[v, i_node_index, j_node_index,
-                            direction_index, element_index] = flux_[v] + 0.5f0 *
+                            direction_index, element_index] = flux[v] + 0.5f0 *
                                                               noncons_flux[v]
     end
 end

--- a/src/solvers/dgsem_p4est/dg_3d.jl
+++ b/src/solvers/dgsem_p4est/dg_3d.jl
@@ -384,26 +384,10 @@ function calc_boundary_flux!(cache, t, boundary_condition, boundary_indexing,
         k_node = k_node_start
         for j in eachnode(dg)
             for i in eachnode(dg)
-                # Extract solution data from boundary container
-                u_inner = get_node_vars(boundaries.u, equations, dg, i, j, boundary)
-
-                # Outward-pointing normal direction (not normalized)
-                normal_direction = get_normal_direction(direction,
-                                                        contravariant_vectors,
-                                                        i_node, j_node, k_node, element)
-
-                # Coordinates at boundary node
-                x = get_node_coords(node_coordinates, equations, dg,
-                                    i_node, j_node, k_node, element)
-
-                flux_ = boundary_condition(u_inner, normal_direction, x, t,
-                                           surface_flux, equations)
-
-                # Copy flux to element storage in the correct orientation
-                for v in eachvariable(equations)
-                    surface_flux_values[v, i, j, direction, element] = flux_[v]
-                end
-
+                calc_boundary_flux!(surface_flux_values, t, boundary_condition, mesh,
+                                    have_nonconservative_terms(equations), equations,
+                                    surface_integral, dg, cache, i_node, j_node, k_node,
+                                    i, j, direction, element, boundary)
                 i_node += i_node_step_i
                 j_node += j_node_step_i
                 k_node += k_node_step_i
@@ -412,6 +396,79 @@ function calc_boundary_flux!(cache, t, boundary_condition, boundary_indexing,
             j_node += j_node_step_j
             k_node += k_node_step_j
         end
+    end
+end
+
+# inlined version of the boundary flux calculation along a physical interface
+@inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition,
+                                     mesh::Union{P4estMesh{3}, T8codeMesh{3}},
+                                     nonconservative_terms::False, equations,
+                                     surface_integral, dg::DG, cache, i_index, j_index,
+                                     k_index, i_node_index, j_node_index, direction_index,
+                                     element_index, boundary_index)
+    @unpack boundaries = cache
+    @unpack node_coordinates, contravariant_vectors = cache.elements
+    @unpack surface_flux = surface_integral
+
+    # Extract solution data from boundary container
+    u_inner = get_node_vars(boundaries.u, equations, dg, i_node_index, j_node_index,
+                            boundary_index)
+
+    # Outward-pointing normal direction (not normalized)
+    normal_direction = get_normal_direction(direction, contravariant_vectors,
+                                            i_index, j_index, k_index, element_index)
+
+    # Coordinates at boundary node
+    x = get_node_coords(node_coordinates, equations, dg,
+                        i_index, j_index, k_index, element_index)
+
+    flux_ = boundary_condition(u_inner, normal_direction, x, t,
+                               surface_flux, equations)
+
+    # Copy flux to element storage in the correct orientation
+    for v in eachvariable(equations)
+        surface_flux_values[v, i_node_index, j_node_index,
+                            direction_index, element_index] = flux_[v]
+    end
+end
+
+
+# inlined version of the boundary flux calculation along a physical interface
+@inline function calc_boundary_flux!(surface_flux_values, t, boundary_condition,
+                                     mesh::Union{P4estMesh{3}, T8codeMesh{3}},
+                                     nonconservative_terms::True, equations,
+                                     surface_integral, dg::DG, cache, i_index, j_index,
+                                     k_index, i_node_index, j_node_index, direction_index,
+                                     element_index, boundary_index)
+    @unpack boundaries = cache
+    @unpack node_coordinates, contravariant_vectors = cache.elements
+    @unpack surface_flux = surface_integral
+
+    # Extract solution data from boundary container
+    u_inner = get_node_vars(boundaries.u, equations, dg, i_node_index, j_node_index,
+                            boundary_index)
+
+    # Outward-pointing normal direction (not normalized)
+    normal_direction = get_normal_direction(direction, contravariant_vectors,
+                                            i_index, j_index, k_index, element_index)
+
+    # Coordinates at boundary node
+    x = get_node_coords(node_coordinates, equations, dg,
+                        i_index, j_index, k_index, element_index)
+
+    # Call pointwise numerical flux functions for the conservative and nonconservative part
+    # in the normal direction on the boundary
+    flux, noncons_flux = boundary_condition(u_inner, normal_direction, x, t,
+                                            surface_flux, equations)
+
+    # Copy flux to element storage in the correct orientation
+    for v in eachvariable(equations)
+        # Note the factor 0.5 necessary for the nonconservative fluxes based on
+        # the interpretation of global SBP operators coupled discontinuously via
+        # central fluxes/SATs
+        surface_flux_values[v, i_node_index, j_node_index,
+                            direction_index, element_index] = flux_[v] + 0.5f0 *
+                                                              noncons_flux[v]
     end
 end
 


### PR DESCRIPTION
This was missing. I tried to do it in analogy to the 2D case.

A test is still missing.