### PR TITLE
fix IndicatorLöhner on ARM with multiple threads

### DIFF
--- a/src/solvers/dgsem_tree/indicators_1d.jl
+++ b/src/solvers/dgsem_tree/indicators_1d.jl
@@ -131,6 +131,7 @@ function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any, 3},
                                    kwargs...)
     @assert nnodes(dg)>=3 "IndicatorLöhner only works for nnodes >= 3 (polydeg > 1)"
     @unpack alpha, indicator_threaded = löhner.cache
+    @unpack variable = löhner
     resize!(alpha, nelements(dg, cache))
 
     @threaded for element in eachelement(dg, cache)
@@ -139,7 +140,7 @@ function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any, 3},
         # Calculate indicator variables at Gauss-Lobatto nodes
         for i in eachnode(dg)
             u_local = get_node_vars(u, equations, dg, i, element)
-            indicator[i] = löhner.variable(u_local, equations)
+            indicator[i] = variable(u_local, equations)
         end
 
         estimate = zero(real(dg))

--- a/src/solvers/dgsem_tree/indicators_2d.jl
+++ b/src/solvers/dgsem_tree/indicators_2d.jl
@@ -155,6 +155,7 @@ function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any, 4},
                                    kwargs...)
     @assert nnodes(dg)>=3 "IndicatorLöhner only works for nnodes >= 3 (polydeg > 1)"
     @unpack alpha, indicator_threaded = löhner.cache
+    @unpack variable = löhner
     resize!(alpha, nelements(dg, cache))
 
     @threaded for element in eachelement(dg, cache)
@@ -163,7 +164,7 @@ function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any, 4},
         # Calculate indicator variables at Gauss-Lobatto nodes
         for j in eachnode(dg), i in eachnode(dg)
             u_local = get_node_vars(u, equations, dg, i, j, element)
-            indicator[i, j] = löhner.variable(u_local, equations)
+            indicator[i, j] = variable(u_local, equations)
         end
 
         estimate = zero(real(dg))

--- a/src/solvers/dgsem_tree/indicators_3d.jl
+++ b/src/solvers/dgsem_tree/indicators_3d.jl
@@ -173,6 +173,7 @@ function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any, 5},
                                    kwargs...)
     @assert nnodes(dg)>=3 "IndicatorLöhner only works for nnodes >= 3 (polydeg > 1)"
     @unpack alpha, indicator_threaded = löhner.cache
+    @unpack variable = löhner
     resize!(alpha, nelements(dg, cache))
 
     @threaded for element in eachelement(dg, cache)
@@ -181,7 +182,7 @@ function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any, 5},
         # Calculate indicator variables at Gauss-Lobatto nodes
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
             u_local = get_node_vars(u, equations, dg, i, j, k, element)
-            indicator[i, j, k] = löhner.variable(u_local, equations)
+            indicator[i, j, k] = variable(u_local, equations)
         end
 
         estimate = zero(real(dg))

--- a/test/test_threaded.jl
+++ b/test/test_threaded.jl
@@ -138,6 +138,31 @@ Trixi.MPI.Barrier(Trixi.mpi_comm())
         end
     end
 
+    @trixi_testset "elixir_euler_positivity.jl" begin
+        @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_positivity.jl"),
+                            l2=[
+                                0.48862067511841695,
+                                0.16787541578869494,
+                                0.16787541578869422,
+                                0.6184319933114926
+                            ],
+                            linf=[
+                                2.6766520821013002,
+                                1.2910938760258996,
+                                1.2910938760258899,
+                                6.473385481404865
+                            ],
+                            tspan=(0.0, 1.0),)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
+        let
+            t = sol.t[end]
+            u_ode = sol.u[end]
+            du_ode = similar(u_ode)
+            @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 1000
+        end
+    end
+
     @trixi_testset "elixir_advection_diffusion.jl" begin
         @test_trixi_include(joinpath(examples_dir(), "tree_2d_dgsem",
                                      "elixir_advection_diffusion.jl"),

--- a/test/test_threaded.jl
+++ b/test/test_threaded.jl
@@ -139,7 +139,8 @@ Trixi.MPI.Barrier(Trixi.mpi_comm())
     end
 
     @trixi_testset "elixir_euler_positivity.jl" begin
-        @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_positivity.jl"),
+        @test_trixi_include(joinpath(examples_dir(), "tree_2d_dgsem",
+                                     "elixir_euler_positivity.jl"),
                             l2=[
                                 0.48862067511841695,
                                 0.16787541578869494,

--- a/test/test_threaded.jl
+++ b/test/test_threaded.jl
@@ -160,7 +160,7 @@ Trixi.MPI.Barrier(Trixi.mpi_comm())
             t = sol.t[end]
             u_ode = sol.u[end]
             du_ode = similar(u_ode)
-            @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 1000
+            @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 5000
         end
     end
 


### PR DESCRIPTION
Without this fix, we get errors like

```
ERROR: LoadError: cfunction: closures are not supported on this platform
Stacktrace:
  [1] macro expansion
    @ ~/.julia/packages/Polyester/eqrC9/src/batch.jl:36 [inlined]
  [2] batch_closure
    @ ~/.julia/packages/Polyester/eqrC9/src/batch.jl:29 [inlined]
  [3] macro expansion
    @ ~/.julia/packages/Polyester/eqrC9/src/batch.jl:186 [inlined]
  [4] _batch_no_reserve
    @ ~/.julia/packages/Polyester/eqrC9/src/batch.jl:168 [inlined]
  [5] batch
    @ ~/.julia/packages/Polyester/eqrC9/src/batch.jl:334 [inlined]
  [6] macro expansion
    @ ~/.julia/packages/Polyester/eqrC9/src/closure.jl:456 [inlined]
  [7] macro expansion
    @ ~/.julia/dev/Trixi/src/auxiliary/auxiliary.jl:213 [inlined]
  [8] (::IndicatorLöhner{…})(u::StrideArraysCore.PtrArray{…}, mesh::TreeMesh{…}, equations::CompressibleEulerEquations2D{…}, dg::DGSEM{…}, cache::@NamedTuple{…}; kwargs::@Kwargs{…})
    @ Trixi ~/.julia/dev/Trixi/src/solvers/dgsem_tree/indicators_2d.jl:160
  [9] IndicatorLöhner
    @ ~/.julia/dev/Trixi/src/solvers/dgsem_tree/indicators_2d.jl:153 [inlined]
```

for this indicator with multiple threads on ARM.