### PR TITLE
WIP: Add data structure for contours

### DIFF
--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -454,7 +454,6 @@ function ContourData2D(sol, semi)
 
     jstart = 1
     for j in 1:ny
-
         if mod(j, polydeg + 1) == 1 && j != 1
             jstart += 1
         end
@@ -463,7 +462,6 @@ function ContourData2D(sol, semi)
         i = 1
         for element in iterator
             for ilocal in 1:(polydeg + 1)
-
                 jlocal = mod(j, polydeg + 1)
                 jlocal = jlocal == 0 ? polydeg + 1 : jlocal
 


### PR DESCRIPTION
As mentioned here [#2230](https://github.com/trixi-framework/Trixi.jl/issues/2230) the contour works only on a TreeMesh.

This PR adds `cd = ContourData2D(sol,semi)` and the contour can be plotted via CairoMakie package as follows:

`contour(cd.x, cd.y, cd.data)`

For the moment, this works only for structured mesh, including custom mappings (e.g. waving flag)

The function performs a transformation simulating a CG structure. 

- Waving flag

Contour with PlotData2D
![image](https://github.com/user-attachments/assets/8af52ad7-ff8c-432a-a700-d0e529afac7e)

Contour with ContourData2D
![image](https://github.com/user-attachments/assets/0757a603-1d75-4451-971c-d1679dc08146)

![image](https://github.com/user-attachments/assets/287db946-a894-4015-a1e4-97ddc3d7071f)

- Vortex
Contour via PlotData2D
![image](https://github.com/user-attachments/assets/0c824f21-246c-426d-bb0b-95768059ba8d)

Contour via ContourData2D
![image](https://github.com/user-attachments/assets/03df404c-3650-457f-b307-68116579a182)


