### PR TITLE
allow more than 10 initial refinements

### DIFF
--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -145,8 +145,8 @@ function initialize!(cb::DiscreteCallback{Condition, Affect!}, u, t,
             has_changed = amr_callback(integrator,
                                        only_refine = amr_callback.adapt_initial_condition_only_refine)
             iterations = iterations + 1
-            if iterations > max_level(controller)
-                @warn "AMR for initial condition did not settle within $(max_level(controller)) iterations!\n" *
+            if iterations > max_level(amr_callback.controller)
+                @warn "AMR for initial condition did not settle within $(max_level(amr_callback.controller)) iterations!\n" *
                       "Consider adjusting thresholds or setting `adapt_initial_condition_only_refine`."
                 break
             end

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -145,8 +145,9 @@ function initialize!(cb::DiscreteCallback{Condition, Affect!}, u, t,
             has_changed = amr_callback(integrator,
                                        only_refine = amr_callback.adapt_initial_condition_only_refine)
             iterations = iterations + 1
-            if iterations > max_level(amr_callback.controller)
-                @warn "AMR for initial condition did not settle within $(max_level(amr_callback.controller)) iterations!\n" *
+            allowed_max_iterations = max(10,  max_level(amr_callback.controller))
+            if iterations > allowed_max_iterations
+                @warn "AMR for initial condition did not settle within $(allowed_max_iterations) iterations!\n" *
                       "Consider adjusting thresholds or setting `adapt_initial_condition_only_refine`."
                 break
             end

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -145,7 +145,7 @@ function initialize!(cb::DiscreteCallback{Condition, Affect!}, u, t,
             has_changed = amr_callback(integrator,
                                        only_refine = amr_callback.adapt_initial_condition_only_refine)
             iterations = iterations + 1
-            allowed_max_iterations = max(10,  max_level(amr_callback.controller))
+            allowed_max_iterations = max(10, max_level(amr_callback.controller))
             if iterations > allowed_max_iterations
                 @warn "AMR for initial condition did not settle within $(allowed_max_iterations) iterations!\n" *
                       "Consider adjusting thresholds or setting `adapt_initial_condition_only_refine`."

--- a/src/callbacks_step/amr.jl
+++ b/src/callbacks_step/amr.jl
@@ -145,8 +145,8 @@ function initialize!(cb::DiscreteCallback{Condition, Affect!}, u, t,
             has_changed = amr_callback(integrator,
                                        only_refine = amr_callback.adapt_initial_condition_only_refine)
             iterations = iterations + 1
-            if iterations > 10
-                @warn "AMR for initial condition did not settle within 10 iterations!\n" *
+            if iterations > max_level(controller)
+                @warn "AMR for initial condition did not settle within $(max_level(controller)) iterations!\n" *
                       "Consider adjusting thresholds or setting `adapt_initial_condition_only_refine`."
                 break
             end
@@ -623,7 +623,7 @@ function (amr_callback::AMRCallback)(u_ode::AbstractVector, mesh::P4estMesh,
         end
 
         reinitialize_boundaries!(semi.boundary_conditions, cache)
-        # if the semidiscretization also stores parabolic boundary conditions, 
+        # if the semidiscretization also stores parabolic boundary conditions,
         # reinitialize them after each refinement step as well.
         if hasproperty(semi, :boundary_conditions_parabolic)
             reinitialize_boundaries!(semi.boundary_conditions_parabolic, cache)
@@ -867,6 +867,8 @@ function ControllerThreeLevel(semi, indicator; base_level = 1,
                                                                                   cache)
 end
 
+max_level(controller::ControllerThreeLevel) = controller.max_level
+
 function create_cache(indicator_type::Type{ControllerThreeLevel}, semi)
     create_cache(indicator_type, mesh_equations_solver_cache(semi)...)
 end
@@ -1058,6 +1060,8 @@ function ControllerThreeLevelCombined(semi, indicator_primary, indicator_seconda
                                                                              indicator_secondary,
                                                                              cache)
 end
+
+max_level(controller::ControllerThreeLevelCombined) = controller.max_level
 
 function create_cache(indicator_type::Type{ControllerThreeLevelCombined}, semi)
     create_cache(indicator_type, mesh_equations_solver_cache(semi)...)


### PR DESCRIPTION
I would like to use a controller with `max_level = 13` and got the warning that the initial refinement terminated early.