### PR TITLE
Enhanced Docstring BR1; Mention LDG in diffusion-dominated testcase

### DIFF
--- a/examples/tree_1d_dgsem/elixir_navierstokes_viscous_shock.jl
+++ b/examples/tree_1d_dgsem/elixir_navierstokes_viscous_shock.jl
@@ -145,6 +145,11 @@ boundary_condition_parabolic = BoundaryConditionNavierStokesWall(velocity_bc, he
 boundary_conditions_parabolic = (; x_neg = boundary_condition_parabolic,
                                  x_pos = boundary_condition_parabolic)
 
+# We use by default the Bassi-Rebay 1 scheme.
+# Since this is a diffusion-dominated problem, it might be better to use the LDG scheme
+# by specifying the keyword
+# solver_parabolic = ViscousFormulationLocalDG()
+# in the semidiscretization call below.
 semi = SemidiscretizationHyperbolicParabolic(mesh, (equations, equations_parabolic),
                                              initial_condition, solver;
                                              boundary_conditions = (boundary_conditions,

--- a/examples/tree_1d_dgsem/elixir_navierstokes_viscous_shock.jl
+++ b/examples/tree_1d_dgsem/elixir_navierstokes_viscous_shock.jl
@@ -146,8 +146,9 @@ boundary_conditions_parabolic = (; x_neg = boundary_condition_parabolic,
                                  x_pos = boundary_condition_parabolic)
 
 # We use by default the Bassi-Rebay 1 scheme.
-# Since this is a diffusion-dominated problem, it might be better to use the LDG scheme
-# by specifying the keyword
+# Since this is a diffusion-dominated problem, using the LDG scheme should achieve optimal rates of convergence. 
+# In contrast, BR-1 may achieve suboptimal rates of convergence in diffusion-dominated regimes. 
+# The LDG scheme can be used by specifying the keyword
 # solver_parabolic = ViscousFormulationLocalDG()
 # in the semidiscretization call below.
 semi = SemidiscretizationHyperbolicParabolic(mesh, (equations, equations_parabolic),

--- a/src/solvers/solvers_parabolic.jl
+++ b/src/solvers/solvers_parabolic.jl
@@ -7,6 +7,15 @@ The classical BR1 flux from
   A High-Order Accurate Discontinuous Finite Element Method for
   the Numerical Solution of the Compressible Navier-Stokes Equations
   [DOI: 10.1006/jcph.1996.5572](https://doi.org/10.1006/jcph.1996.5572)
+
+A more detailed study of the BR1 scheme for the DGSEM can be found in
+- G. J. Gassner, A. R. Winters, F. J. Hindenlang, D. Kopriva (2018)
+  The BR1 Scheme is Stable for the Compressible Navier-Stokes Equations
+  [DOI: 10.1007/s10915-018-0702-1](https://doi.org/10.1007/s10915-018-0702-1)
+
+The BR1 scheme works well for convection-dominated problems, but may cause instabilities or 
+reduced convergence for diffusion-dominated problems. 
+In the latter case, the [`ViscousFormulationLocalDG`](@ref) scheme is recommended.
 """
 struct ViscousFormulationBassiRebay1 end
 


### PR DESCRIPTION
I added the paper by Gassner et al. to the BR1 docstring as I see many people immediately discarding BR1 as unstable/unreliable.

For the viscous shock testcase I also now mention the LDG scheme as a better alternative, see the convergence study:

LDG:

```julia
####################################################################################################
l2
rho                 rho_v1              rho_e               
error     EOC       error     EOC       error     EOC       
1.79e-04  -         1.44e-04  -         1.39e-04  -         
2.25e-05  2.99      1.14e-05  3.67      1.31e-05  3.41      
1.54e-06  3.87      6.78e-07  4.07      8.19e-07  3.99      
8.79e-08  4.13      3.77e-08  4.17      4.49e-08  4.19      
5.29e-09  4.05      2.26e-09  4.06      2.68e-09  4.06      

mean      3.76      mean      3.99      mean      3.91      
----------------------------------------------------------------------------------------------------
linf
rho                 rho_v1              rho_e               
error     EOC       error     EOC       error     EOC       
1.37e-03  -         1.17e-03  -         9.87e-04  -         
1.91e-04  2.85      1.10e-04  3.41      1.20e-04  3.04      
1.35e-05  3.82      7.75e-06  3.82      8.01e-06  3.90      
7.59e-07  4.15      4.52e-07  4.10      4.72e-07  4.09      
4.59e-08  4.05      2.77e-08  4.03      2.90e-08  4.02      

mean      3.72      mean      3.84      mean      3.76      
----------------------------------------------------------------------------------------------------
```

BR1:

```julia
####################################################################################################
l2
rho                 rho_v1              rho_e               
error     EOC       error     EOC       error     EOC       
2.58e-04  -         1.43e-04  -         1.74e-04  -         
2.82e-05  3.19      1.38e-05  3.37      1.75e-05  3.31      
1.55e-06  4.19      7.49e-07  4.21      9.23e-07  4.25      
1.01e-07  3.94      4.85e-08  3.95      5.78e-08  4.00      
6.78e-09  3.89      3.21e-09  3.91      4.43e-09  3.71      

mean      3.80      mean      3.86      mean      3.81      
----------------------------------------------------------------------------------------------------
linf
rho                 rho_v1              rho_e               
error     EOC       error     EOC       error     EOC       
1.67e-03  -         1.06e-03  -         1.15e-03  -         
2.19e-04  2.94      1.34e-04  2.99      1.58e-04  2.86      
1.19e-05  4.20      7.38e-06  4.18      8.87e-06  4.15      
9.58e-07  3.63      4.98e-07  3.89      5.68e-07  3.97      
1.17e-07  3.03      3.24e-08  3.94      6.28e-08  3.18      

mean      3.45      mean      3.75      mean      3.54      
----------------------------------------------------------------------------------------------------
```