### PR TITLE
Add `TreeMesh` mortar support for LDG 

### DIFF
--- a/examples/tree_2d_dgsem/elixir_advection_diffusion_amr.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_diffusion_amr.jl
@@ -1,0 +1,92 @@
+using OrdinaryDiffEqSSPRK, OrdinaryDiffEqLowStorageRK
+using Trixi
+
+###############################################################################
+# semidiscretization of the linear advection equation
+
+advection_velocity = (0.2, -0.7)
+equations = LinearScalarAdvectionEquation2D(advection_velocity)
+
+diffusivity() = 5.0e-4
+equations_parabolic = LaplaceDiffusion2D(diffusivity(), equations)
+
+solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
+
+coordinates_min = (-1.0, -1.0)
+coordinates_max = (1.0, 1.0)
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 4,
+                n_cells_max = 80_000)
+
+# Define initial condition
+function initial_condition_diffusive_convergence_test(x, t,
+                                                      equation::LinearScalarAdvectionEquation2D)
+    # Store translated coordinate for easy use of exact solution
+    x_trans = x - equation.advection_velocity * t
+
+    nu = diffusivity()
+    c = 1.0
+    A = 0.5
+    L = 2
+    f = 1 / L
+    omega = 2 * pi * f
+    scalar = c + A * sin(omega * sum(x_trans)) * exp(-2 * nu * omega^2 * t)
+    return SVector(scalar)
+end
+initial_condition = initial_condition_diffusive_convergence_test
+
+# define periodic boundary conditions everywhere
+boundary_conditions = boundary_condition_periodic
+boundary_conditions_parabolic = boundary_condition_periodic
+
+# A semidiscretization collects data structures and functions for the spatial discretization
+semi = SemidiscretizationHyperbolicParabolic(mesh,
+                                             (equations, equations_parabolic),
+                                             initial_condition, solver;
+                                             solver_parabolic = ViscousFormulationBassiRebay1(),
+                                             boundary_conditions = (boundary_conditions,
+                                                                    boundary_conditions_parabolic))
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 0.2)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval,
+                                     extra_analysis_integrals = (entropy,))
+
+alive_callback = AliveCallback(analysis_interval = analysis_interval)
+
+save_solution = SaveSolutionCallback(interval = 100,
+                                     save_initial_solution = true,
+                                     save_final_solution = true,
+                                     solution_variables = cons2prim)
+
+amr_controller = ControllerThreeLevel(semi, IndicatorMax(semi, variable = first),
+                                      base_level = 3,
+                                      med_level = 4, med_threshold = 1.2,
+                                      max_level = 5, max_threshold = 1.45)
+amr_callback = AMRCallback(semi, amr_controller,
+                           interval = 5,
+                           adapt_initial_condition = true,
+                           adapt_initial_condition_only_refine = true)
+
+stepsize_callback = StepsizeCallback(cfl = 1.0)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback,
+                        alive_callback,
+                        save_solution,
+                        amr_callback,
+                        stepsize_callback)
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition = false);
+            dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            ode_default_options()..., callback = callbacks);

--- a/examples/tree_2d_dgsem/elixir_advection_diffusion_amr.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_diffusion_amr.jl
@@ -15,7 +15,7 @@ solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
 coordinates_min = (-1.0, -1.0)
 coordinates_max = (1.0, 1.0)
 mesh = TreeMesh(coordinates_min, coordinates_max,
-                initial_refinement_level = 4,
+                initial_refinement_level = 2,
                 n_cells_max = 80_000)
 
 # Define initial condition

--- a/examples/tree_2d_dgsem/elixir_advection_diffusion_amr.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_diffusion_amr.jl
@@ -43,7 +43,7 @@ boundary_conditions_parabolic = boundary_condition_periodic
 semi = SemidiscretizationHyperbolicParabolic(mesh,
                                              (equations, equations_parabolic),
                                              initial_condition, solver;
-                                             solver_parabolic = ViscousFormulationBassiRebay1(),
+                                             solver_parabolic = ViscousFormulationLocalDG(),
                                              boundary_conditions = (boundary_conditions,
                                                                     boundary_conditions_parabolic))
 

--- a/examples/tree_3d_dgsem/elixir_advection_diffusion_amr.jl
+++ b/examples/tree_3d_dgsem/elixir_advection_diffusion_amr.jl
@@ -43,6 +43,7 @@ boundary_conditions_parabolic = boundary_condition_periodic
 semi = SemidiscretizationHyperbolicParabolic(mesh,
                                              (equations, equations_parabolic),
                                              initial_condition, solver;
+                                             solver_parabolic = ViscousFormulationBassiRebay1(),
                                              boundary_conditions = (boundary_conditions,
                                                                     boundary_conditions_parabolic))
 

--- a/src/solvers/dgsem_tree/dg_2d_parabolic.jl
+++ b/src/solvers/dgsem_tree/dg_2d_parabolic.jl
@@ -98,7 +98,7 @@ function rhs_parabolic!(du, u, t, mesh::Union{TreeMesh{2}, TreeMesh{3}},
     @trixi_timeit timer() "mortar flux" begin
         calc_mortar_flux!(cache_parabolic.elements.surface_flux_values,
                           mesh, equations_parabolic, dg.mortar, dg.surface_integral,
-                          dg, parabolic_scheme, cache)
+                          dg, parabolic_scheme, Divergence(), cache)
     end
 
     # Calculate surface integrals
@@ -624,7 +624,8 @@ function calc_mortar_flux!(surface_flux_values,
                            mesh::TreeMesh{2},
                            equations_parabolic::AbstractEquationsParabolic,
                            mortar_l2::LobattoLegendreMortarL2,
-                           surface_integral, dg::DG, parabolic_scheme,
+                           surface_integral, dg::DG,
+                           parabolic_scheme, gradient_or_divergence,
                            cache)
     @unpack surface_flux = surface_integral
     @unpack u_lower, u_upper, orientations = cache.mortars
@@ -637,12 +638,12 @@ function calc_mortar_flux!(surface_flux_values,
 
         # Calculate fluxes
         orientation = orientations[mortar]
-        calc_fstar!(fstar_upper, equations_parabolic, surface_flux,
-                    dg, parabolic_scheme, u_upper, mortar,
-                    orientation)
-        calc_fstar!(fstar_lower, equations_parabolic, surface_flux,
-                    dg, parabolic_scheme, u_lower, mortar,
-                    orientation)
+        calc_fstar!(fstar_upper, mesh, equations_parabolic, surface_flux,
+                    dg, parabolic_scheme, gradient_or_divergence,
+                    u_upper, mortar, orientation)
+        calc_fstar!(fstar_lower, mesh, equations_parabolic, surface_flux,
+                    dg, parabolic_scheme, gradient_or_divergence,
+                    u_lower, mortar, orientation)
 
         mortar_fluxes_to_elements!(surface_flux_values,
                                    mesh, equations_parabolic, mortar_l2, dg, cache,
@@ -653,16 +654,17 @@ function calc_mortar_flux!(surface_flux_values,
 end
 
 @inline function calc_fstar!(destination::AbstractArray{<:Any, 2},
-                             equations_parabolic::AbstractEquationsParabolic,
+                             mesh, equations_parabolic::AbstractEquationsParabolic,
                              surface_flux, dg::DGSEM,
-                             parabolic_scheme,
+                             parabolic_scheme, gradient_or_divergence,
                              u_interfaces, interface, orientation)
     for i in eachnode(dg)
         # Call pointwise two-point numerical flux function
         u_ll, u_rr = get_surface_node_vars(u_interfaces, equations_parabolic, dg, i,
                                            interface)
 
-        flux = 0.5f0 * (u_ll + u_rr) # Bassi-Rebay 1 (BR1)
+        flux = flux_parabolic(u_ll, u_rr, gradient_or_divergence,
+                              mesh, equations_parabolic, parabolic_scheme)
 
         # Copy flux to left and right element storage
         set_node_vars!(destination, flux, equations_parabolic, dg, i)
@@ -856,8 +858,8 @@ function calc_gradient!(gradients, u_transformed, t,
     # Calculate mortar fluxes
     @trixi_timeit timer() "mortar flux" begin
         calc_mortar_flux!(surface_flux_values, mesh, equations_parabolic,
-                          dg.mortar, dg.surface_integral, dg, parabolic_scheme,
-                          cache)
+                          dg.mortar, dg.surface_integral, dg,
+                          parabolic_scheme, Gradient(), cache)
     end
 
     # Calculate surface integrals

--- a/src/solvers/dgsem_tree/dg_3d_parabolic.jl
+++ b/src/solvers/dgsem_tree/dg_3d_parabolic.jl
@@ -722,7 +722,7 @@ end
 function calc_mortar_flux!(surface_flux_values, mesh::TreeMesh{3},
                            equations_parabolic::AbstractEquationsParabolic,
                            mortar_l2::LobattoLegendreMortarL2, surface_integral,
-                           dg::DG, parabolic_scheme, cache)
+                           dg::DG, parabolic_scheme, gradient_or_divergence, cache)
     @unpack surface_flux = surface_integral
     @unpack u_lower_left, u_lower_right, u_upper_left, u_upper_right, orientations = cache.mortars
     @unpack (fstar_primary_upper_left_threaded, fstar_primary_upper_right_threaded,
@@ -739,17 +739,21 @@ function calc_mortar_flux!(surface_flux_values, mesh::TreeMesh{3},
 
         # Calculate fluxes
         orientation = orientations[mortar]
-        calc_fstar!(fstar_upper_left, equations_parabolic,
-                    surface_flux, dg, parabolic_scheme,
+        calc_fstar!(fstar_upper_left, mesh, equations_parabolic,
+                    surface_flux, dg,
+                    parabolic_scheme, gradient_or_divergence,
                     u_upper_left, mortar, orientation)
-        calc_fstar!(fstar_upper_right, equations_parabolic,
-                    surface_flux, dg, parabolic_scheme,
+        calc_fstar!(fstar_upper_right, mesh, equations_parabolic,
+                    surface_flux, dg,
+                    parabolic_scheme, gradient_or_divergence,
                     u_upper_right, mortar, orientation)
-        calc_fstar!(fstar_lower_left, equations_parabolic,
-                    surface_flux, dg, parabolic_scheme,
+        calc_fstar!(fstar_lower_left, mesh, equations_parabolic,
+                    surface_flux, dg,
+                    parabolic_scheme, gradient_or_divergence,
                     u_lower_left, mortar, orientation)
-        calc_fstar!(fstar_lower_right, equations_parabolic,
-                    surface_flux, dg, parabolic_scheme,
+        calc_fstar!(fstar_lower_right, mesh, equations_parabolic,
+                    surface_flux, dg,
+                    parabolic_scheme, gradient_or_divergence,
                     u_lower_right, mortar, orientation)
 
         mortar_fluxes_to_elements!(surface_flux_values,
@@ -763,15 +767,17 @@ function calc_mortar_flux!(surface_flux_values, mesh::TreeMesh{3},
 end
 
 @inline function calc_fstar!(destination::AbstractArray{<:Any, 3},
-                             equations_parabolic::AbstractEquationsParabolic,
+                             mesh, equations_parabolic::AbstractEquationsParabolic,
                              surface_flux, dg::DGSEM,
-                             parabolic_scheme::ViscousFormulationBassiRebay1,
+                             parabolic_scheme, gradient_or_divergence,
                              u_interfaces, interface, orientation)
     for j in eachnode(dg), i in eachnode(dg)
         # Call pointwise two-point numerical flux function
         u_ll, u_rr = get_surface_node_vars(u_interfaces, equations_parabolic, dg, i, j,
                                            interface)
-        flux = 0.5f0 * (u_ll + u_rr)
+
+        flux = flux_parabolic(u_ll, u_rr, gradient_or_divergence,
+                              mesh, equations_parabolic, parabolic_scheme)
 
         # Copy flux to left and right element storage
         set_node_vars!(destination, flux, equations_parabolic, dg, i, j)
@@ -988,8 +994,9 @@ function calc_gradient!(gradients, u_transformed, t,
     @trixi_timeit timer() "mortar flux" begin
         calc_mortar_flux!(surface_flux_values,
                           mesh, equations_parabolic,
-                          dg.mortar, dg.surface_integral,
-                          dg, parabolic_scheme, cache)
+                          dg.mortar, dg.surface_integral, dg,
+                          parabolic_scheme, Gradient(),
+                          cache)
     end
 
     # Calculate surface integrals

--- a/test/test_parabolic_2d.jl
+++ b/test/test_parabolic_2d.jl
@@ -270,6 +270,26 @@ end
     end
 end
 
+@trixi_testset "TreeMesh2D: elixir_advection_diffusion_amr.jl (LDG)" begin
+    @test_trixi_include(joinpath(examples_dir(), "tree_2d_dgsem",
+                                 "elixir_advection_diffusion_amr.jl"),
+                        solver_parabolic=ViscousFormulationLocalDG(),
+                        initial_refinement_level=2,
+                        base_level=2,
+                        med_level=3,
+                        max_level=4,
+                        l2=[0.0009662045510830027],
+                        linf=[0.006121646998993091])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    let
+        t = sol.t[end]
+        u_ode = sol.u[end]
+        du_ode = similar(u_ode)
+        @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 1000
+    end
+end
+
 @trixi_testset "TreeMesh2D: elixir_advection_diffusion_nonperiodic.jl" begin
     @test_trixi_include(joinpath(examples_dir(), "tree_2d_dgsem",
                                  "elixir_advection_diffusion_nonperiodic.jl"),

--- a/test/test_parabolic_2d.jl
+++ b/test/test_parabolic_2d.jl
@@ -270,10 +270,9 @@ end
     end
 end
 
-@trixi_testset "TreeMesh2D: elixir_advection_diffusion_amr.jl (LDG)" begin
+@trixi_testset "TreeMesh2D: elixir_advection_diffusion_amr.jl" begin
     @test_trixi_include(joinpath(examples_dir(), "tree_2d_dgsem",
                                  "elixir_advection_diffusion_amr.jl"),
-                        solver_parabolic=ViscousFormulationLocalDG(),
                         initial_refinement_level=2,
                         base_level=2,
                         med_level=3,

--- a/test/test_parabolic_3d.jl
+++ b/test/test_parabolic_3d.jl
@@ -442,6 +442,26 @@ end
     end
 end
 
+@trixi_testset "TreeMesh3D: elixir_advection_diffusion_amr.jl (LDG)" begin
+    @test_trixi_include(joinpath(examples_dir(), "tree_3d_dgsem",
+                                 "elixir_advection_diffusion_amr.jl"),
+                        solver_parabolic=ViscousFormulationLocalDG(),
+                        initial_refinement_level=2,
+                        base_level=2,
+                        med_level=3,
+                        max_level=4,
+                        l2=[0.00036862382924645736],
+                        linf=[0.0015952118405399007])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    let
+        t = sol.t[end]
+        u_ode = sol.u[end]
+        du_ode = similar(u_ode)
+        @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 1000
+    end
+end
+
 @trixi_testset "TreeMesh3D: elixir_advection_diffusion_nonperiodic.jl" begin
     @test_trixi_include(joinpath(examples_dir(), "tree_3d_dgsem",
                                  "elixir_advection_diffusion_nonperiodic.jl"),


### PR DESCRIPTION
This adds support for mortars using LDG on `TreeMesh` in 2D and 3D. The main changes were adding `mesh` and `gradient_or_divergence` arguments for `calc_mortar_flux!` and `calc_fstar!` so that these could be passed to the internal `flux_parabolic` function for dispatch on BR1 or LDG. 