### PR TITLE
document and export `waterheight` and `waterheight_pressure`

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -230,7 +230,7 @@ export initial_condition_eoc_test_coupled_euler_gravity,
 export cons2cons, cons2prim, prim2cons, cons2macroscopic, cons2state, cons2mean,
        cons2entropy, entropy2cons
 export density, pressure, density_pressure, velocity, global_mean_vars,
-       equilibrium_distribution, waterheight_pressure
+       equilibrium_distribution, waterheight, waterheight_pressure
 export entropy, energy_total, energy_kinetic, energy_internal, energy_magnetic,
        cross_helicity,
        enstrophy, magnetic_field, divergence_cleaning_field

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -490,6 +490,29 @@ of the correct length `nvariables(equations)`.
 """
 function density_pressure end
 
+"""
+    waterheight(u, equations)
+
+Return the water height associated to the conserved variables `u` for a given set of
+`equations`, e.g., the [`ShallowWaterEquations2D`](@ref).
+
+`u` is a vector of the conserved variables at a single node, i.e., a vector
+of the correct length `nvariables(equations)`.
+"""
+function waterheight end
+
+"""
+    waterheight_pressure(u, equations)
+
+Return the product of the [`waterheight`](@ref) and the [`pressure`](@ref)
+associated to the conserved variables `u` for a given set of
+`equations`, e.g., the [`ShallowWaterEquations2D`](@ref).
+
+`u` is a vector of the conserved variables at a single node, i.e., a vector
+of the correct length `nvariables(equations)`.
+"""
+function waterheight_pressure end
+
 # Default implementation of gradient for `variable`. Used for subcell limiting.
 # Implementing a gradient function for a specific variable improves the performance.
 @inline function gradient_conservative(variable, u, equations)


### PR DESCRIPTION
I noticed that `waterheight` was not exported (and did not even have a docstring) when reviewing https://github.com/trixi-framework/TrixiShallowWater.jl/pull/45.

@andrewwinters5000 @patrickersing: You can simplify TrixiShallowWater.jl elixirs to use `waterheight` instead of `Trixi.waterheight` when this is released.