### PR TITLE
Use GitHub workflow commands for improved workflow logs

### DIFF
--- a/examples/tree_2d_dgsem/elixir_advection_basic.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_basic.jl
@@ -4,13 +4,13 @@ using Trixi
 ###############################################################################
 # semidiscretization of the linear advection equation
 
-advection_velocity = (0.2, -0.7)
+advection_velocity = (0.3, -0.7)
 equations = LinearScalarAdvectionEquation2D(advection_velocity)
 
 # Create DG solver with polynomial degree = 3 and (local) Lax-Friedrichs/Rusanov flux as surface flux
 solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
 
-coordinates_min = (-1.0, -1.0) # minimum coordinates (min(x), min(y))
+coordinates_min = (-1.1, -1.0) # minimum coordinates (min(x), min(y))
 coordinates_max = (1.0, 1.0) # maximum coordinates (max(x), max(y))
 
 # Create a uniformly refined mesh with periodic boundaries

--- a/examples/tree_2d_dgsem/elixir_advection_basic.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_basic.jl
@@ -10,7 +10,7 @@ equations = LinearScalarAdvectionEquation2D(advection_velocity)
 # Create DG solver with polynomial degree = 3 and (local) Lax-Friedrichs/Rusanov flux as surface flux
 solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
 
-coordinates_min = (-1.1, -1.0) # minimum coordinates (min(x), min(y))
+coordinates_min = (-11.1, -1.0) # minimum coordinates (min(x), min(y))
 coordinates_max = (1.0, 1.0) # maximum coordinates (max(x), max(y))
 
 # Create a uniformly refined mesh with periodic boundaries

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -178,8 +178,9 @@ macro timed_testset(name, expr)
     lineno = string(__source__.line)
     quote
         local time_start = time_ns()
-        println("::notice file=", $filename, ",line=", $lineno, ",title=", $name, "::")
+        println("::notice file=", $filename, ",line=", $lineno, ",endLine=", $lineno, "::", $name)
         println("::group::", $name)
+        println("Testset started at: ", $file, ":", $lineno)
         @testset $name $expr
         local time_stop = time_ns()
         if Trixi.mpi_isroot()
@@ -227,8 +228,10 @@ macro trixi_testset(name, expr)
         catch
             nothing
         end
-        println("::notice file=", $filename, ",line=", $lineno, ",title=", $name, "::")
+        println("::notice file=", $filename, ",line=", $lineno, ",endLine=", $lineno, "::", $name)
         println("::group::", $name)
+        println("notice file=", $filename, ",line=", $lineno, ",endLine=", $lineno, "::", $name)
+        println("Testset started at: ", $file, ":", $lineno)
         @testset $name $expr
         end
         local time_stop = time_ns()

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -184,7 +184,6 @@ macro timed_testset(name, expr)
         if CI_ON_GITHUB
             println("::group::>>> Running testset '", $name, "'...")
             println("Testset started at ", $filename, ":", $lineno)
-            println("::notice file=test/test_trixi.jl,line=236::Something to note")
         end
         @testset $name $expr
         local time_stop = time_ns()
@@ -239,7 +238,6 @@ macro trixi_testset(name, expr)
         if CI_ON_GITHUB
             println("::group::>>> Running testset '", $name, "'...")
             println("Testset started at ", $filename, ":", $lineno)
-            println("::notice file=test/test_trixi.jl,line=236::Something to note")
         end
         @testset $name $expr
         end

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -226,7 +226,8 @@ macro trixi_testset(name, expr)
     # module name here.
     quote
         local time_start = time_ns()
-        @eval module TrixiTestModule
+        local tempmod = Module(gensym("TrixiTestModule"))
+        @eval module tempmod
         using Test
         using Trixi
         include(@__FILE__)

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -2,6 +2,9 @@ using Test: @test
 import Trixi
 
 const CI_ON_GITHUB = get(ENV, "GITHUB_ACTIONS", false) == "true"
+const GITHUB_BASE_URL = get(ENV, "GITHUB_SERVER_URL", "https://github.com") *
+    "/" * get(ENV, "GITHUB_REPOSITORY", "") * "/blob/" * get(ENV, "GITHUB_REF", "") * "/"
+const GITHUB_TEST_URL = GITHUB_BASE_URL * "test/"
 
 # Use a macro to avoid world age issues when defining new initial conditions etc.
 # inside an elixir.
@@ -183,7 +186,7 @@ macro timed_testset(name, expr)
         # Use GitHub workflow commands for improved CI logs
         if CI_ON_GITHUB
             println("::group::>>> Running testset '", $name, "'...")
-            println("Testset started at ", $filename, ":", $lineno)
+            println("Testset started at ", $GITHUB_TEST_URL, $filename, "#L", $lineno)
         end
         @testset $name $expr
         local time_stop = time_ns()
@@ -237,7 +240,7 @@ macro trixi_testset(name, expr)
         # Use GitHub workflow commands for improved CI logs
         if CI_ON_GITHUB
             println("::group::>>> Running testset '", $name, "'...")
-            println("Testset started at ", $filename, ":", $lineno)
+            println("Testset started at ", $GITHUB_TEST_URL, $filename, "#L", $lineno)
         end
         @testset $name $expr
         end

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -226,8 +226,7 @@ macro trixi_testset(name, expr)
     # module name here.
     quote
         local time_start = time_ns()
-        local tempmod = Module(gensym("TrixiTestModule"))
-        @eval module tempmod
+        @eval module TrixiTestModule
         using Test
         using Trixi
         include(@__FILE__)

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -3,7 +3,8 @@ import Trixi
 
 const CI_ON_GITHUB = get(ENV, "GITHUB_ACTIONS", false) == "true"
 const GITHUB_BASE_URL = get(ENV, "GITHUB_SERVER_URL", "https://github.com") *
-    "/" * get(ENV, "GITHUB_REPOSITORY", "") * "/blob/" * get(ENV, "GITHUB_SHA", "") * "/"
+                        "/" * get(ENV, "GITHUB_REPOSITORY", "") * "/blob/" *
+                        get(ENV, "GITHUB_SHA", "") * "/"
 const GITHUB_TEST_URL = GITHUB_BASE_URL * "test/"
 
 # Use a macro to avoid world age issues when defining new initial conditions etc.

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -180,7 +180,7 @@ macro timed_testset(name, expr)
         local time_start = time_ns()
         println("::notice file=", $filename, ",line=", $lineno, ",endLine=", $lineno, "::", $name)
         println("::group::", $name)
-        println("Testset started at: ", $file, ":", $lineno)
+        println(">>> Testset started at ", $filename, ":", $lineno)
         @testset $name $expr
         local time_stop = time_ns()
         if Trixi.mpi_isroot()
@@ -231,7 +231,7 @@ macro trixi_testset(name, expr)
         println("::notice file=", $filename, ",line=", $lineno, ",endLine=", $lineno, "::", $name)
         println("::group::", $name)
         println("notice file=", $filename, ",line=", $lineno, ",endLine=", $lineno, "::", $name)
-        println("Testset started at: ", $file, ":", $lineno)
+        println(">>> Testset started at ", $filename, ":", $lineno)
         @testset $name $expr
         end
         local time_stop = time_ns()

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -174,8 +174,12 @@ after execution.
 """
 macro timed_testset(name, expr)
     @assert name isa String
+    filename = string(__source__.file)
+    lineno = string(__source__.line)
     quote
         local time_start = time_ns()
+        println("::notice file=", $filename, ",line=", $lineno, ",title=", $name, "::")
+        println("::group::", $name)
         @testset $name $expr
         local time_stop = time_ns()
         if Trixi.mpi_isroot()
@@ -184,6 +188,7 @@ macro timed_testset(name, expr)
                   *string(1.0e-9 * (time_stop - time_start))*" seconds.\n")
             flush(stdout)
         end
+        println("::endgroup::")
     end
 end
 
@@ -197,6 +202,8 @@ of the testset similarly to [`timed_testset`](@ref).
 """
 macro trixi_testset(name, expr)
     @assert name isa String
+    filename = string(__source__.file)
+    lineno = string(__source__.line)
     # TODO: `@eval` is evil
     # We would like to use
     #   mod = gensym(name)
@@ -220,6 +227,8 @@ macro trixi_testset(name, expr)
         catch
             nothing
         end
+        println("::notice file=", $filename, ",line=", $lineno, ",title=", $name, "::")
+        println("::group::", $name)
         @testset $name $expr
         end
         local time_stop = time_ns()
@@ -228,6 +237,7 @@ macro trixi_testset(name, expr)
             @info("Testset "*$name*" finished in "
                   *string(1.0e-9 * (time_stop - time_start))*" seconds.\n")
         end
+        println("::endgroup::")
         nothing
     end
 end

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -1,6 +1,8 @@
 using Test: @test
 import Trixi
 
+const CI_ON_GITHUB = get(ENV, "GITHUB_ACTIONS", false) == "true"
+
 # Use a macro to avoid world age issues when defining new initial conditions etc.
 # inside an elixir.
 """
@@ -178,9 +180,12 @@ macro timed_testset(name, expr)
     lineno = string(__source__.line)
     quote
         local time_start = time_ns()
-        println("::notice file=", $filename, ",line=", $lineno, ",endLine=", $lineno, "::", $name)
-        println("::group::", $name)
-        println(">>> Testset started at ", $filename, ":", $lineno)
+        # Use GitHub workflow commands for improved CI logs
+        if CI_ON_GITHUB
+            println("::group::>>> Running testset '", $name, "'...")
+            println("Testset started at ", $filename, ":", $lineno)
+            println("::notice file=test/test_trixi.jl,line=236::Something to note")
+        end
         @testset $name $expr
         local time_stop = time_ns()
         if Trixi.mpi_isroot()
@@ -189,7 +194,9 @@ macro timed_testset(name, expr)
                   *string(1.0e-9 * (time_stop - time_start))*" seconds.\n")
             flush(stdout)
         end
-        println("::endgroup::")
+        if CI_ON_GITHUB
+            println("::endgroup::")
+        end
     end
 end
 
@@ -228,10 +235,12 @@ macro trixi_testset(name, expr)
         catch
             nothing
         end
-        println("::notice file=", $filename, ",line=", $lineno, ",endLine=", $lineno, "::", $name)
-        println("::group::", $name)
-        println("notice file=", $filename, ",line=", $lineno, ",endLine=", $lineno, "::", $name)
-        println(">>> Testset started at ", $filename, ":", $lineno)
+        # Use GitHub workflow commands for improved CI logs
+        if CI_ON_GITHUB
+            println("::group::>>> Running testset '", $name, "'...")
+            println("Testset started at ", $filename, ":", $lineno)
+            println("::notice file=test/test_trixi.jl,line=236::Something to note")
+        end
         @testset $name $expr
         end
         local time_stop = time_ns()
@@ -240,7 +249,9 @@ macro trixi_testset(name, expr)
             @info("Testset "*$name*" finished in "
                   *string(1.0e-9 * (time_stop - time_start))*" seconds.\n")
         end
-        println("::endgroup::")
+        if CI_ON_GITHUB
+            println("::endgroup::")
+        end
         nothing
     end
 end

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -3,7 +3,7 @@ import Trixi
 
 const CI_ON_GITHUB = get(ENV, "GITHUB_ACTIONS", false) == "true"
 const GITHUB_BASE_URL = get(ENV, "GITHUB_SERVER_URL", "https://github.com") *
-    "/" * get(ENV, "GITHUB_REPOSITORY", "") * "/blob/" * get(ENV, "GITHUB_REF", "") * "/"
+    "/" * get(ENV, "GITHUB_REPOSITORY", "") * "/blob/" * get(ENV, "GITHUB_SHA", "") * "/"
 const GITHUB_TEST_URL = GITHUB_BASE_URL * "test/"
 
 # Use a macro to avoid world age issues when defining new initial conditions etc.
@@ -179,7 +179,7 @@ after execution.
 """
 macro timed_testset(name, expr)
     @assert name isa String
-    filename = string(__source__.file)
+    filename = basename(string(__source__.file))
     lineno = string(__source__.line)
     quote
         local time_start = time_ns()
@@ -212,7 +212,7 @@ of the testset similarly to [`timed_testset`](@ref).
 """
 macro trixi_testset(name, expr)
     @assert name isa String
-    filename = string(__source__.file)
+    filename = basename(string(__source__.file))
     lineno = string(__source__.line)
     # TODO: `@eval` is evil
     # We would like to use

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -224,7 +224,7 @@ end
     @trixi_testset "Create 1D plot along curve" begin
         using OrdinaryDiffEqSSPRK
 
-        @timed_testset "$MeshType" for MeshType in (P4estMesh, T8codeMesh)
+        @testset "$MeshType" for MeshType in (P4estMesh, T8codeMesh)
             equations = CompressibleEulerEquations2D(1.4)
             solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
 
@@ -516,7 +516,7 @@ end
         @trixi_testset "Create 1D plot along curve" begin
             using OrdinaryDiffEqSSPRK
 
-            @timed_testset "$MeshType" for MeshType in (P4estMesh, T8codeMesh)
+            @testset "$MeshType" for MeshType in (P4estMesh, T8codeMesh)
                 equations = CompressibleEulerEquations3D(1.4)
                 solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
 

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -32,7 +32,7 @@ test_examples_2d = Dict("TreeMesh" => ("tree_2d_dgsem",
                                         "elixir_euler_source_terms_nonconforming_unstructured_flag.jl"),
                         "DGMulti" => ("dgmulti_2d", "elixir_euler_weakform.jl"))
 
-@timed_testset "PlotData2D, PlotDataSeries, PlotMesh with $mesh" for mesh in keys(test_examples_2d)
+@testset "PlotData2D, PlotDataSeries, PlotMesh with $mesh" for mesh in keys(test_examples_2d)
     # Run Trixi.jl
     directory, elixir = test_examples_2d[mesh]
     @test_nowarn_mod trixi_include(@__MODULE__,

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -18,7 +18,7 @@ outdir = "out"
 isdir(outdir) && rm(outdir, recursive = true)
 
 # Run various visualization tests
-@testset "Visualization tests" begin
+@timed_testset "Visualization tests" begin
 #! format: noindent
 
 # Run 2D tests with elixirs for all mesh types
@@ -32,7 +32,7 @@ test_examples_2d = Dict("TreeMesh" => ("tree_2d_dgsem",
                                         "elixir_euler_source_terms_nonconforming_unstructured_flag.jl"),
                         "DGMulti" => ("dgmulti_2d", "elixir_euler_weakform.jl"))
 
-@testset "PlotData2D, PlotDataSeries, PlotMesh with $mesh" for mesh in keys(test_examples_2d)
+@timed_testset "PlotData2D, PlotDataSeries, PlotMesh with $mesh" for mesh in keys(test_examples_2d)
     # Run Trixi.jl
     directory, elixir = test_examples_2d[mesh]
     @test_nowarn_mod trixi_include(@__MODULE__,
@@ -88,7 +88,7 @@ test_examples_2d = Dict("TreeMesh" => ("tree_2d_dgsem",
     @test_nowarn_mod show(stdout, getmesh(pd))
     println(stdout)
 
-    @testset "2D plot recipes" begin
+    @timed_testset "2D plot recipes" begin
         pd = PlotData2D(sol)
 
         @test_nowarn_mod Plots.plot(sol)
@@ -112,9 +112,9 @@ test_examples_2d = Dict("TreeMesh" => ("tree_2d_dgsem",
         end
     end
 
-    @testset "1D plot from 2D solution" begin
+    @timed_testset "1D plot from 2D solution" begin
         if mesh != "DGMulti"
-            @testset "Create 1D plot as slice" begin
+            @timed_testset "Create 1D plot as slice" begin
                 @test_nowarn_mod PlotData1D(sol, slice = :y, point = (0.5, 0.0)) isa
                                  PlotData1D
                 @test_nowarn_mod PlotData1D(sol, slice = :x, point = (0.5, 0.0)) isa
@@ -122,7 +122,7 @@ test_examples_2d = Dict("TreeMesh" => ("tree_2d_dgsem",
                 pd1D = PlotData1D(sol, slice = :y, point = (0.5, 0.0))
                 @test_nowarn_mod Plots.plot(pd1D)
 
-                @testset "Create 1D plot along curve" begin
+                @timed_testset "Create 1D plot along curve" begin
                     curve = zeros(2, 10)
                     curve[1, :] = range(-1, 1, length = 10)
                     @test_nowarn_mod PlotData1D(sol, curve = curve) isa PlotData1D
@@ -186,7 +186,7 @@ end
     pd2 = PlotData1D(sol, nvisnodes = 2)
     @test size(pd2.data) == (128, 3)
 
-    @testset "1D plot recipes" begin
+    @timed_testset "1D plot recipes" begin
         pd = PlotData1D(sol)
 
         @test_nowarn_mod Plots.plot(sol)
@@ -202,7 +202,7 @@ end
 
     # Fake a PlotDataXD objects to test code for plotting multiple variables on at least two rows
     # with at least one plot remaining empty
-    @testset "plotting multiple variables" begin
+    @timed_testset "plotting multiple variables" begin
         x = collect(0.0:0.1:1.0)
         data1d = rand(5, 11)
         variable_names = string.('a':'e')
@@ -224,7 +224,7 @@ end
     @trixi_testset "Create 1D plot along curve" begin
         using OrdinaryDiffEqSSPRK
 
-        @testset "$MeshType" for MeshType in (P4estMesh, T8codeMesh)
+        @timed_testset "$MeshType" for MeshType in (P4estMesh, T8codeMesh)
             equations = CompressibleEulerEquations2D(1.4)
             solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
 
@@ -320,7 +320,7 @@ end
         x_curve = range(0, 1, length = 1000)
         curve = vcat(x_curve', x_curve')
 
-        @testset "TreeMesh" begin
+        @timed_testset "TreeMesh" begin
             pd_tree = @inferred PlotData1D(ode_tree.u0, ode_tree.p; curve)
             @test pd_tree.x ≈ range(0, 1, length = length(x_curve)) * sqrt(2)
 
@@ -336,7 +336,7 @@ end
             end
         end
 
-        @testset "P4estMesh" begin
+        @timed_testset "P4estMesh" begin
             pd_p4est = @inferred PlotData1D(ode_p4est.u0, ode_p4est.p; curve)
             @test pd_p4est.x ≈ range(0, 1, length = length(x_curve)) * sqrt(2)
 
@@ -352,7 +352,7 @@ end
             end
         end
 
-        @testset "T8codeMesh" begin
+        @timed_testset "T8codeMesh" begin
             pd_t8code = @inferred PlotData1D(ode_t8code.u0, ode_t8code.p; curve)
             @test pd_t8code.x ≈ range(0, 1, length = length(x_curve)) * sqrt(2)
 
@@ -371,7 +371,7 @@ end
             end
         end
 
-        @testset "StructuredMesh" begin
+        @timed_testset "StructuredMesh" begin
             pd_structured = @inferred PlotData1D(ode_structured.u0, ode_structured.p;
                                                  curve)
             @test pd_structured.x ≈ range(0, 1, length = length(x_curve)) * sqrt(2)
@@ -468,8 +468,8 @@ end
     @test PlotData2D(sol, slice = :yz) isa Trixi.PlotData2DCartesian
     @test PlotData2D(sol, slice = :xz) isa Trixi.PlotData2DCartesian
 
-    @testset "1D plot from 3D solution and Tree-mesh" begin
-        @testset "Create 1D plot as slice" begin
+    @timed_testset "1D plot from 3D solution and Tree-mesh" begin
+        @timed_testset "Create 1D plot as slice" begin
             @test_nowarn_mod PlotData1D(sol) isa PlotData1D
             pd1D = PlotData1D(sol)
             @test_nowarn_mod Plots.plot(pd1D)
@@ -479,7 +479,7 @@ end
                              PlotData1D
         end
 
-        @testset "Create 1D plot along curve" begin
+        @timed_testset "Create 1D plot along curve" begin
             curve = zeros(3, 10)
             curve[1, :] = range(-1.0, -0.5, length = 10)
             @test_nowarn_mod PlotData1D(sol, curve = curve) isa PlotData1D
@@ -492,8 +492,8 @@ end
                                    joinpath(examples_dir(), "structured_3d_dgsem",
                                             "elixir_advection_basic.jl"))
 
-    @testset "1D plot from 3D solution and general mesh" begin
-        @testset "Create 1D plot as slice" begin
+    @timed_testset "1D plot from 3D solution and general mesh" begin
+        @timed_testset "Create 1D plot as slice" begin
             @test_nowarn_mod PlotData1D(sol) isa PlotData1D
             pd1D = PlotData1D(sol)
             @test_nowarn_mod Plots.plot(pd1D)
@@ -503,7 +503,7 @@ end
                              PlotData1D
         end
 
-        @testset "Create 1D plot along curve" begin
+        @timed_testset "Create 1D plot along curve" begin
             curve = zeros(3, 10)
             curve[1, :] = range(-1.0, 1.0, length = 10)
             @test_nowarn_mod PlotData1D(sol, curve = curve) isa PlotData1D
@@ -516,7 +516,7 @@ end
         @trixi_testset "Create 1D plot along curve" begin
             using OrdinaryDiffEqSSPRK
 
-            @testset "$MeshType" for MeshType in (P4estMesh, T8codeMesh)
+            @timed_testset "$MeshType" for MeshType in (P4estMesh, T8codeMesh)
                 equations = CompressibleEulerEquations3D(1.4)
                 solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
 
@@ -615,7 +615,7 @@ end
         x_curve = range(0, 1, length = 1000)
         curve = vcat(x_curve', x_curve', x_curve')
 
-        @testset "TreeMesh" begin
+        @timed_testset "TreeMesh" begin
             pd_tree = @inferred PlotData1D(ode_tree.u0, ode_tree.p; curve)
             @test pd_tree.x ≈ range(0, 1, length = length(x_curve)) * sqrt(3)
 
@@ -633,7 +633,7 @@ end
             end
         end
 
-        @testset "P4estMesh" begin
+        @timed_testset "P4estMesh" begin
             pd_p4est = @inferred PlotData1D(ode_p4est.u0, ode_p4est.p; curve)
             @test pd_p4est.x ≈ range(0, 1, length = length(x_curve)) * sqrt(3)
 
@@ -651,7 +651,7 @@ end
             end
         end
 
-        @testset "T8codeMesh" begin
+        @timed_testset "T8codeMesh" begin
             pd_t8code = @inferred PlotData1D(ode_t8code.u0, ode_t8code.p; curve)
             @test pd_t8code.x ≈ range(0, 1, length = length(x_curve)) * sqrt(3)
 
@@ -669,7 +669,7 @@ end
             end
         end
 
-        @testset "StructuredMesh" begin
+        @timed_testset "StructuredMesh" begin
             pd_structured = @inferred PlotData1D(ode_structured.u0, ode_structured.p;
                                                  curve)
             @test pd_structured.x ≈ range(0, 1, length = length(x_curve)) * sqrt(3)
@@ -718,13 +718,13 @@ end
                                                                          plot_creator = Trixi.save_plot),
                                    tspan = (0.0, 3.0))
 
-    @testset "elixir_advection_amr_visualization.jl with save_plot" begin
+    @timed_testset "elixir_advection_amr_visualization.jl with save_plot" begin
         @test isfile(joinpath(outdir, "solution_000000000.png"))
         @test isfile(joinpath(outdir, "solution_000000020.png"))
         @test isfile(joinpath(outdir, "solution_000000022.png"))
     end
 
-    @testset "show" begin
+    @timed_testset "show" begin
         @test_nowarn_mod show(stdout, visualization)
         println(stdout)
 


### PR DESCRIPTION
Group testsets to make the logs easier to digest for humans (https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines).

Also print out the location where the `@testset` macro was *invoked* to make it easier to find the corresponding test.

Note: Originally I also tried to link to the testset using the `notice` feature ([ref](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-notice-message)), but that only printed a message but did not seem to provide a clickable link.

Compare to #2353 for current state. Close & delete #2353 once this is merged (or deleted).