### PR TITLE
Update parallelization.md: Mention issues with `MPIPreferences`

### DIFF
--- a/docs/src/parallelization.md
+++ b/docs/src/parallelization.md
@@ -130,7 +130,8 @@ After the preferences are set, restart the Julia REPL again.
 !!! note 
     If multiple MPI installations are present on a system (as is typically the case on a cluster), calling 
     `MPIPreferences.use_system_binary()` may lead to an undesired selection of the MPI implementation - 
-    make sure to check the `LocalPreferences.toml` in any case!
+    make sure to check the `LocalPreferences.toml` in any case. 
+    You can also check at runtime of your Julia seesion the MPI configuration with `using MPI; MPI..versioninfo()`.
 
 ### [Usage](@id parallel_usage)
 

--- a/docs/src/parallelization.md
+++ b/docs/src/parallelization.md
@@ -131,7 +131,8 @@ After the preferences are set, restart the Julia REPL again.
     If multiple MPI installations are present on a system (as is typically the case on a cluster), calling 
     `MPIPreferences.use_system_binary()` may lead to an undesired selection of the MPI implementation - 
     make sure to check the `LocalPreferences.toml` in any case. 
-    You can also check at runtime of your Julia seesion the MPI configuration with `using MPI; MPI..versioninfo()`.
+    You can also check at runtime of your Julia seesion the MPI configuration with 
+    `using MPI; MPI..versioninfo()`.
 
 ### [Usage](@id parallel_usage)
 

--- a/docs/src/parallelization.md
+++ b/docs/src/parallelization.md
@@ -67,7 +67,7 @@ T8code.jl that can be ignored if you do not use these libraries from Trixi.jl. N
 In order to use system-provided `p4est` and `t8code` installations, [P4est.jl](https://github.com/trixi-framework/P4est.jl)
 and [T8code.jl](https://github.com/DLR-AMR/T8code.jl) need to be configured to use the custom
 installations. Follow the steps described [here](https://github.com/trixi-framework/P4est.jl/blob/main/README.md#installation) and
-[here]( ttps://github.com/DLR-AMR/T8code.jl/blob/main/README.md#installation) for the configuration.
+[here](https://github.com/DLR-AMR/T8code.jl/blob/main/README.md#installation) for the configuration.
 The paths that point to `libp4est.so` (and potentially to `libsc.so`) need to be
 the same for P4est.jl and T8code.jl. This could, e.g., be `libp4est.so` that usually can be found
 in `lib/` or `local/lib/` in the installation directory of `t8code`.

--- a/docs/src/parallelization.md
+++ b/docs/src/parallelization.md
@@ -132,7 +132,7 @@ After the preferences are set, restart the Julia REPL again.
     `MPIPreferences.use_system_binary()` may lead to an undesired selection of the MPI implementation - 
     make sure to check the `LocalPreferences.toml` in any case. 
     You can also check at runtime of your Julia session the MPI configuration with 
-    `using MPI; MPI..versioninfo()`.
+    `using MPI; MPI.versioninfo()`.
 
 ### [Usage](@id parallel_usage)
 

--- a/docs/src/parallelization.md
+++ b/docs/src/parallelization.md
@@ -129,7 +129,8 @@ After the preferences are set, restart the Julia REPL again.
 
 !!! note 
     If multiple MPI installations are present on a system (as is typically the case on a cluster), calling 
-    `MPIPreferences.use_system_binary()` may lead to an undesired selection of the MPI implementation.
+    `MPIPreferences.use_system_binary()` may lead to an undesired selection of the MPI implementation - 
+    make sure to check the `LocalPreferences.toml` in any case!
 
 ### [Usage](@id parallel_usage)
 

--- a/docs/src/parallelization.md
+++ b/docs/src/parallelization.md
@@ -131,7 +131,7 @@ After the preferences are set, restart the Julia REPL again.
     If multiple MPI installations are present on a system (as is typically the case on a cluster), calling 
     `MPIPreferences.use_system_binary()` may lead to an undesired selection of the MPI implementation - 
     make sure to check the `LocalPreferences.toml` in any case. 
-    You can also check at runtime of your Julia seesion the MPI configuration with 
+    You can also check at runtime of your Julia session the MPI configuration with 
     `using MPI; MPI..versioninfo()`.
 
 ### [Usage](@id parallel_usage)

--- a/docs/src/parallelization.md
+++ b/docs/src/parallelization.md
@@ -66,8 +66,8 @@ T8code.jl that can be ignored if you do not use these libraries from Trixi.jl. N
 `t8code` already comes with a `p4est` installation, so it suffices to install `t8code`.
 In order to use system-provided `p4est` and `t8code` installations, [P4est.jl](https://github.com/trixi-framework/P4est.jl)
 and [T8code.jl](https://github.com/DLR-AMR/T8code.jl) need to be configured to use the custom
-installations. Follow the steps described [here](https://github.com/DLR-AMR/T8code.jl/blob/main/README.md#installation) and
-[here](https://github.com/trixi-framework/P4est.jl/blob/main/README.md#installation) for the configuration.
+installations. Follow the steps described [here](https://github.com/trixi-framework/P4est.jl/blob/main/README.md#installation) and
+[here]( ttps://github.com/DLR-AMR/T8code.jl/blob/main/README.md#installation) for the configuration.
 The paths that point to `libp4est.so` (and potentially to `libsc.so`) need to be
 the same for P4est.jl and T8code.jl. This could, e.g., be `libp4est.so` that usually can be found
 in `lib/` or `local/lib/` in the installation directory of `t8code`.
@@ -126,6 +126,10 @@ julia> using HDF5
 julia> HDF5.API.set_libraries!("/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so", "/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5_hl.so")
 ```
 After the preferences are set, restart the Julia REPL again.
+
+!!! note 
+    If multiple MPI installations are present on a system (as is typically the case on a cluster), calling 
+    `MPIPreferences.use_system_binary()` may lead to an undesired selection of the MPI implementation.
 
 ### [Usage](@id parallel_usage)
 


### PR DESCRIPTION
I switched the order of two links and added a note on the potential erronous/undesired behaviour of `MPIPreferences.use_system_binary()`