### PR TITLE
Rename `gravity_constant` to `gravity` in the equations constructor

### DIFF
--- a/examples/dgmulti_1d/elixir_shallow_water_quasi_1d.jl
+++ b/examples/dgmulti_1d/elixir_shallow_water_quasi_1d.jl
@@ -5,7 +5,7 @@ using Trixi
 # Semidiscretization of the quasi 1d shallow water equations
 # See Chan et al.  https://doi.org/10.48550/arXiv.2307.12089 for details
 
-equations = ShallowWaterEquationsQuasi1D(gravity_constant = 9.81)
+equations = ShallowWaterEquationsQuasi1D(gravity = 9.81)
 
 initial_condition = initial_condition_convergence_test
 

--- a/examples/dgmulti_2d/elixir_shallowwater_source_terms.jl
+++ b/examples/dgmulti_2d/elixir_shallowwater_source_terms.jl
@@ -4,7 +4,7 @@ using Trixi
 ###############################################################################
 # semidiscretization of the shallow water equations
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+equations = ShallowWaterEquations2D(gravity = 9.81)
 
 initial_condition = initial_condition_convergence_test
 

--- a/examples/p4est_2d_dgsem/elixir_shallowwater_source_terms.jl
+++ b/examples/p4est_2d_dgsem/elixir_shallowwater_source_terms.jl
@@ -4,7 +4,7 @@ using Trixi
 ###############################################################################
 # semidiscretization of the shallow water equations
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+equations = ShallowWaterEquations2D(gravity = 9.81)
 
 initial_condition = initial_condition_convergence_test # MMS EOC test
 

--- a/examples/structured_2d_dgsem/elixir_shallowwater_source_terms.jl
+++ b/examples/structured_2d_dgsem/elixir_shallowwater_source_terms.jl
@@ -4,7 +4,7 @@ using Trixi
 ###############################################################################
 # semidiscretization of the shallow water equations
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+equations = ShallowWaterEquations2D(gravity = 9.81)
 
 initial_condition = initial_condition_convergence_test
 

--- a/examples/structured_2d_dgsem/elixir_shallowwater_well_balanced.jl
+++ b/examples/structured_2d_dgsem/elixir_shallowwater_well_balanced.jl
@@ -5,7 +5,7 @@ using Trixi
 # semidiscretization of the shallow water equations with a discontinuous
 # bottom topography function (set in the initial conditions)
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81, H0 = 3.0)
+equations = ShallowWaterEquations2D(gravity = 9.81, H0 = 3.0)
 
 # An initial condition with constant total water height and zero velocities to test well-balancedness.
 # Note, this routine is used to compute errors in the analysis callback but the initialization is

--- a/examples/t8code_2d_dgsem/elixir_shallowwater_source_terms.jl
+++ b/examples/t8code_2d_dgsem/elixir_shallowwater_source_terms.jl
@@ -4,7 +4,7 @@ using Trixi
 ###############################################################################
 # Semidiscretization of the shallow water equations.
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+equations = ShallowWaterEquations2D(gravity = 9.81)
 
 initial_condition = initial_condition_convergence_test # MMS EOC test
 

--- a/examples/tree_1d_dgsem/elixir_shallow_water_quasi_1d_source_terms.jl
+++ b/examples/tree_1d_dgsem/elixir_shallow_water_quasi_1d_source_terms.jl
@@ -5,7 +5,7 @@ using Trixi
 # Semidiscretization of the quasi 1d shallow water equations
 # See Chan et al.  https://doi.org/10.48550/arXiv.2307.12089 for details
 
-equations = ShallowWaterEquationsQuasi1D(gravity_constant = 9.81)
+equations = ShallowWaterEquationsQuasi1D(gravity = 9.81)
 
 initial_condition = initial_condition_convergence_test
 

--- a/examples/tree_1d_dgsem/elixir_shallowwater_ec.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_ec.jl
@@ -5,7 +5,7 @@ using Trixi
 # Semidiscretization of the shallow water equations with a discontinuous
 # bottom topography function
 
-equations = ShallowWaterEquations1D(gravity_constant = 9.81)
+equations = ShallowWaterEquations1D(gravity = 9.81)
 
 # Initial condition with a truly discontinuous water height, velocity, and bottom
 # topography function as an academic testcase for entropy conservation.

--- a/examples/tree_1d_dgsem/elixir_shallowwater_quasi_1d_discontinuous.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_quasi_1d_discontinuous.jl
@@ -5,7 +5,7 @@ using Trixi
 # Semidiscretization of the quasi 1d shallow water equations
 # See Chan et al.  https://doi.org/10.48550/arXiv.2307.12089 for details
 
-equations = ShallowWaterEquationsQuasi1D(gravity_constant = 9.81)
+equations = ShallowWaterEquationsQuasi1D(gravity = 9.81)
 
 function initial_condition_discontinuity(x, t, equations::ShallowWaterEquationsQuasi1D)
     RealT = eltype(x)

--- a/examples/tree_1d_dgsem/elixir_shallowwater_quasi_1d_well_balanced.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_quasi_1d_well_balanced.jl
@@ -5,7 +5,7 @@ using Trixi
 # semidiscretization of the shallow water equations with a discontinuous
 # bottom topography function and channel width function
 
-equations = ShallowWaterEquationsQuasi1D(gravity_constant = 9.81, H0 = 2.0)
+equations = ShallowWaterEquationsQuasi1D(gravity = 9.81, H0 = 2.0)
 
 # Setup a truly discontinuous bottom topography function and channel width for
 # this academic testcase of well-balancedness. The errors from the analysis

--- a/examples/tree_1d_dgsem/elixir_shallowwater_shock_capturing.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_shock_capturing.jl
@@ -4,7 +4,7 @@ using Trixi
 ###############################################################################
 # Semidiscretization of the shallow water equations
 
-equations = ShallowWaterEquations1D(gravity_constant = 9.812, H0 = 1.75)
+equations = ShallowWaterEquations1D(gravity = 9.812, H0 = 1.75)
 
 # Initial condition with a truly discontinuous velocity and bottom topography.
 # Works as intended for TreeMesh1D with `initial_refinement_level=3`. If the mesh

--- a/examples/tree_1d_dgsem/elixir_shallowwater_source_terms.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_source_terms.jl
@@ -4,7 +4,7 @@ using Trixi
 ###############################################################################
 # Semidiscretization of the shallow water equations
 
-equations = ShallowWaterEquations1D(gravity_constant = 9.81)
+equations = ShallowWaterEquations1D(gravity = 9.81)
 
 initial_condition = initial_condition_convergence_test
 

--- a/examples/tree_1d_dgsem/elixir_shallowwater_source_terms_dirichlet.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_source_terms_dirichlet.jl
@@ -4,7 +4,7 @@ using Trixi
 ###############################################################################
 # Semidiscretization of the shallow water equations
 
-equations = ShallowWaterEquations1D(gravity_constant = 9.81)
+equations = ShallowWaterEquations1D(gravity = 9.81)
 
 initial_condition = initial_condition_convergence_test
 

--- a/examples/tree_1d_dgsem/elixir_shallowwater_well_balanced.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_well_balanced.jl
@@ -5,7 +5,7 @@ using Trixi
 # semidiscretization of the shallow water equations with a discontinuous
 # bottom topography function
 
-equations = ShallowWaterEquations1D(gravity_constant = 9.81, H0 = 3.25)
+equations = ShallowWaterEquations1D(gravity = 9.81, H0 = 3.25)
 
 # Setup a truly discontinuous bottom topography function for this academic
 # testcase of well-balancedness. The errors from the analysis callback are

--- a/examples/tree_1d_dgsem/elixir_shallowwater_well_balanced_nonperiodic.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_well_balanced_nonperiodic.jl
@@ -4,7 +4,7 @@ using Trixi
 ###############################################################################
 # Semidiscretization of the shallow water equations
 
-equations = ShallowWaterEquations1D(gravity_constant = 1.0, H0 = 3.0)
+equations = ShallowWaterEquations1D(gravity = 1.0, H0 = 3.0)
 
 # An initial condition with constant total water height and zero velocities to test well-balancedness.
 function initial_condition_well_balancedness(x, t, equations::ShallowWaterEquations1D)

--- a/examples/tree_2d_dgsem/elixir_shallowwater_ec.jl
+++ b/examples/tree_2d_dgsem/elixir_shallowwater_ec.jl
@@ -5,7 +5,7 @@ using Trixi
 # semidiscretization of the shallow water equations with a discontinuous
 # bottom topography function
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+equations = ShallowWaterEquations2D(gravity = 9.81)
 
 # Note, this initial condition is used to compute errors in the analysis callback but the initialization is
 # overwritten by `initial_condition_ec_discontinuous_bottom` below.

--- a/examples/tree_2d_dgsem/elixir_shallowwater_source_terms.jl
+++ b/examples/tree_2d_dgsem/elixir_shallowwater_source_terms.jl
@@ -4,7 +4,7 @@ using Trixi
 ###############################################################################
 # semidiscretization of the shallow water equations
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+equations = ShallowWaterEquations2D(gravity = 9.81)
 
 initial_condition = initial_condition_convergence_test # MMS EOC test
 

--- a/examples/tree_2d_dgsem/elixir_shallowwater_source_terms_dirichlet.jl
+++ b/examples/tree_2d_dgsem/elixir_shallowwater_source_terms_dirichlet.jl
@@ -4,7 +4,7 @@ using Trixi
 ###############################################################################
 # Semidiscretization of the shallow water equations
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+equations = ShallowWaterEquations2D(gravity = 9.81)
 
 initial_condition = initial_condition_convergence_test
 

--- a/examples/tree_2d_dgsem/elixir_shallowwater_wall.jl
+++ b/examples/tree_2d_dgsem/elixir_shallowwater_wall.jl
@@ -4,7 +4,7 @@ using Trixi
 ###############################################################################
 # Semidiscretization of the shallow water equations
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81, H0 = 3.25)
+equations = ShallowWaterEquations2D(gravity = 9.81, H0 = 3.25)
 
 # An initial condition with a bottom topography and a perturbation in the waterheight to test
 # boundary_condition_slip_wall

--- a/examples/tree_2d_dgsem/elixir_shallowwater_well_balanced.jl
+++ b/examples/tree_2d_dgsem/elixir_shallowwater_well_balanced.jl
@@ -5,7 +5,7 @@ using Trixi
 # semidiscretization of the shallow water equations with a discontinuous
 # bottom topography function
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81, H0 = 3.25)
+equations = ShallowWaterEquations2D(gravity = 9.81, H0 = 3.25)
 
 # An initial condition with constant total water height and zero velocities to test well-balancedness.
 # Note, this routine is used to compute errors in the analysis callback but the initialization is

--- a/examples/tree_2d_dgsem/elixir_shallowwater_well_balanced_wall.jl
+++ b/examples/tree_2d_dgsem/elixir_shallowwater_well_balanced_wall.jl
@@ -5,7 +5,7 @@ using Trixi
 # semidiscretization of the shallow water equations with a discontinuous
 # bottom topography function
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81, H0 = 3.25)
+equations = ShallowWaterEquations2D(gravity = 9.81, H0 = 3.25)
 
 # An initial condition with constant total water height and zero velocities to test well-balancedness.
 # Note, this routine is used to compute errors in the analysis callback but the initialization is

--- a/examples/unstructured_2d_dgsem/elixir_shallowwater_dirichlet.jl
+++ b/examples/unstructured_2d_dgsem/elixir_shallowwater_dirichlet.jl
@@ -5,7 +5,7 @@ using Trixi
 # semidiscretization of the shallow water equations with a continuous
 # bottom topography function (set in the initial conditions)
 
-equations = ShallowWaterEquations2D(gravity_constant = 1.0, H0 = 3.0)
+equations = ShallowWaterEquations2D(gravity = 1.0, H0 = 3.0)
 
 # An initial condition with constant total water height and zero velocities to test well-balancedness.
 function initial_condition_well_balancedness(x, t, equations::ShallowWaterEquations2D)

--- a/examples/unstructured_2d_dgsem/elixir_shallowwater_ec.jl
+++ b/examples/unstructured_2d_dgsem/elixir_shallowwater_ec.jl
@@ -5,7 +5,7 @@ using Trixi
 # semidiscretization of the shallow water equations with a discontinuous
 # bottom topography function
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+equations = ShallowWaterEquations2D(gravity = 9.81)
 
 # Note, this initial condition is used to compute errors in the analysis callback but the initialization is
 # overwritten by `initial_condition_ec_discontinuous_bottom` below.

--- a/examples/unstructured_2d_dgsem/elixir_shallowwater_ec_float32.jl
+++ b/examples/unstructured_2d_dgsem/elixir_shallowwater_ec_float32.jl
@@ -8,7 +8,7 @@ using Trixi
 # semidiscretization of the shallow water equations with a discontinuous
 # bottom topography function
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81f0)
+equations = ShallowWaterEquations2D(gravity = 9.81f0)
 
 # Note, this initial condition is used to compute errors in the analysis callback but the initialization is
 # overwritten by `initial_condition_ec_discontinuous_bottom` below.

--- a/examples/unstructured_2d_dgsem/elixir_shallowwater_ec_shockcapturing.jl
+++ b/examples/unstructured_2d_dgsem/elixir_shallowwater_ec_shockcapturing.jl
@@ -5,7 +5,7 @@ using Trixi
 # semidiscretization of the shallow water equations with a discontinuous
 # bottom topography function
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+equations = ShallowWaterEquations2D(gravity = 9.81)
 
 # Note, this initial condition is used to compute errors in the analysis callback but the initialization is
 # overwritten by `initial_condition_ec_discontinuous_bottom` below.

--- a/examples/unstructured_2d_dgsem/elixir_shallowwater_source_terms.jl
+++ b/examples/unstructured_2d_dgsem/elixir_shallowwater_source_terms.jl
@@ -5,7 +5,7 @@ using Trixi
 # semidiscretization of the shallow water equations with a periodic
 # bottom topography function (set in the initial conditions)
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+equations = ShallowWaterEquations2D(gravity = 9.81)
 
 initial_condition = initial_condition_convergence_test
 

--- a/examples/unstructured_2d_dgsem/elixir_shallowwater_wall_bc_shockcapturing.jl
+++ b/examples/unstructured_2d_dgsem/elixir_shallowwater_wall_bc_shockcapturing.jl
@@ -5,7 +5,7 @@ using Trixi
 # semidiscretization of the shallow water equations with a continuous
 # bottom topography function
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.812, H0 = 2.0)
+equations = ShallowWaterEquations2D(gravity = 9.812, H0 = 2.0)
 
 function initial_condition_stone_throw(x, t, equations::ShallowWaterEquations2D)
     # Set up polar coordinates

--- a/examples/unstructured_2d_dgsem/elixir_shallowwater_well_balanced.jl
+++ b/examples/unstructured_2d_dgsem/elixir_shallowwater_well_balanced.jl
@@ -5,7 +5,7 @@ using Trixi
 # semidiscretization of the shallow water equations with a discontinuous
 # bottom topography function (set in the initial conditions)
 
-equations = ShallowWaterEquations2D(gravity_constant = 9.81, H0 = 3.0)
+equations = ShallowWaterEquations2D(gravity = 9.81, H0 = 3.0)
 
 # An initial condition with constant total water height and zero velocities to test well-balancedness.
 # Note, this routine is used to compute errors in the analysis callback but the initialization is

--- a/src/equations/shallow_water_1d.jl
+++ b/src/equations/shallow_water_1d.jl
@@ -6,7 +6,7 @@
 #! format: noindent
 
 @doc raw"""
-    ShallowWaterEquations1D(; gravity_constant, H0 = 0)
+    ShallowWaterEquations1D(; gravity, H0 = 0)
 
 Shallow water equations (SWE) in one space dimension. The equations are given by
 ```math
@@ -17,7 +17,7 @@ Shallow water equations (SWE) in one space dimension. The equations are given by
 \end{aligned}
 ```
 The unknown quantities of the SWE are the water height ``h`` and the velocity ``v``.
-The gravitational constant is denoted by `g` and the (possibly) variable bottom topography function ``b(x)``.
+The gravitational acceleration is denoted by `g` and the (possibly) variable bottom topography function ``b(x)``.
 Conservative variable water height ``h`` is measured from the bottom topography ``b``, therefore one
 also defines the total water height as ``H = h + b``.
 
@@ -45,16 +45,16 @@ References for the SWE are many but a good introduction is available in Chapter 
   [DOI: 10.1017/CBO9780511791253](https://doi.org/10.1017/CBO9780511791253)
 """
 struct ShallowWaterEquations1D{RealT <: Real} <: AbstractShallowWaterEquations{1, 3}
-    gravity::RealT # gravitational constant
+    gravity::RealT # gravitational acceleration
     H0::RealT      # constant "lake-at-rest" total water height
 end
 
-# Allow for flexibility to set the gravitational constant within an elixir depending on the
-# application where `gravity_constant=1.0` or `gravity_constant=9.81` are common values.
+# Allow for flexibility to set the gravitational acceleration within an elixir depending on the
+# application where `gravity=1.0` or `gravity=9.81` are common values.
 # The reference total water height H0 defaults to 0.0 but is used for the "lake-at-rest"
 # well-balancedness test cases.
-function ShallowWaterEquations1D(; gravity_constant, H0 = zero(gravity_constant))
-    ShallowWaterEquations1D(gravity_constant, H0)
+function ShallowWaterEquations1D(; gravity, H0 = zero(gravity))
+    ShallowWaterEquations1D(gravity, H0)
 end
 
 have_nonconservative_terms(::ShallowWaterEquations1D) = True()

--- a/src/equations/shallow_water_2d.jl
+++ b/src/equations/shallow_water_2d.jl
@@ -6,7 +6,7 @@
 #! format: noindent
 
 @doc raw"""
-    ShallowWaterEquations2D(; gravity_constant, H0 = 0)
+    ShallowWaterEquations2D(; gravity, H0 = 0)
 
 Shallow water equations (SWE) in two space dimensions. The equations are given by
 ```math
@@ -20,7 +20,7 @@ Shallow water equations (SWE) in two space dimensions. The equations are given b
 \end{aligned}
 ```
 The unknown quantities of the SWE are the water height ``h`` and the velocities ``\mathbf{v} = (v_1, v_2)^T``.
-The gravitational constant is denoted by `g` and the (possibly) variable bottom topography function ``b(x,y)``.
+The gravitational acceleration is denoted by `g` and the (possibly) variable bottom topography function ``b(x,y)``.
 Conservative variable water height ``h`` is measured from the bottom topography ``b``, therefore one
 also defines the total water height as ``H = h + b``.
 
@@ -48,17 +48,17 @@ References for the SWE are many but a good introduction is available in Chapter 
   [DOI: 10.1017/CBO9780511791253](https://doi.org/10.1017/CBO9780511791253)
 """
 struct ShallowWaterEquations2D{RealT <: Real} <: AbstractShallowWaterEquations{2, 4}
-    gravity::RealT # gravitational constant
+    gravity::RealT # gravitational acceleration
     H0::RealT      # constant "lake-at-rest" total water height
 end
 
-# Allow for flexibility to set the gravitational constant within an elixir depending on the
-# application where `gravity_constant=1.0` or `gravity_constant=9.81` are common values.
+# Allow for flexibility to set the gravitational acceleration within an elixir depending on the
+# application where `gravity=1.0` or `gravity=9.81` are common values.
 # The reference total water height H0 defaults to 0.0 but is used for the "lake-at-rest"
 # well-balancedness test cases.
 # Strict default values for thresholds that performed well in many numerical experiments
-function ShallowWaterEquations2D(; gravity_constant, H0 = zero(gravity_constant))
-    ShallowWaterEquations2D(gravity_constant, H0)
+function ShallowWaterEquations2D(; gravity, H0 = zero(gravity))
+    ShallowWaterEquations2D(gravity, H0)
 end
 
 have_nonconservative_terms(::ShallowWaterEquations2D) = True()

--- a/src/equations/shallow_water_quasi_1d.jl
+++ b/src/equations/shallow_water_quasi_1d.jl
@@ -6,7 +6,7 @@
 #! format: noindent
 
 @doc raw"""
-    ShallowWaterEquationsQuasi1D(; gravity_constant, H0 = 0)
+    ShallowWaterEquationsQuasi1D(; gravity, H0 = 0)
 
 The quasi-1D shallow water equations (SWE). The equations are given by
 ```math
@@ -17,7 +17,9 @@ The quasi-1D shallow water equations (SWE). The equations are given by
 \end{aligned}
 ```
 The unknown quantities of the Quasi-1D SWE are the water height ``h`` and the scaled velocity ``v``.
-The gravitational constant is denoted by `g`, the (possibly) variable bottom topography function ``b(x)``, and (possibly) variable channel width ``a(x)``. The water height ``h`` is measured from the bottom topography ``b``, therefore one also defines the total water height as ``H = h + b``.
+The gravitational acceleration is denoted by `g`, the (possibly) variable bottom topography function ``b(x)``,
+and (possibly) variable channel width ``a(x)``. The water height ``h`` is measured from the bottom topography ``b``,
+therefore one also defines the total water height as ``H = h + b``.
 
 The additional quantity ``H_0`` is also available to store a reference value for the total water height that
 is useful to set initial conditions or test the "lake-at-rest" well-balancedness.
@@ -32,24 +34,24 @@ on the fly during the approximation as well as computing auxiliary quantities li
 or the entropy variables.
 This affects the implementation and use of these equations in various ways:
 * The flux values corresponding to the bottom topography and channel width must be zero.
-* The bottom topography and channel width values must be included when defining initial conditions, boundary conditions or
-  source terms.
+* The bottom topography and channel width values must be included when defining initial conditions, 
+  boundary conditions or source terms.
 * [`AnalysisCallback`](@ref) analyzes this variable.
 * Trixi.jl's visualization tools will visualize the bottom topography and channel width by default.
 """
 struct ShallowWaterEquationsQuasi1D{RealT <: Real} <:
        AbstractShallowWaterEquations{1, 4}
-    gravity::RealT # gravitational constant
+    gravity::RealT # gravitational acceleration
     H0::RealT      # constant "lake-at-rest" total water height
 end
 
-# Allow for flexibility to set the gravitational constant within an elixir depending on the
-# application where `gravity_constant=1.0` or `gravity_constant=9.81` are common values.
+# Allow for flexibility to set the gravitational acceleration within an elixir depending on the
+# application where `gravity=1.0` or `gravity=9.81` are common values.
 # The reference total water height H0 defaults to 0.0 but is used for the "lake-at-rest"
 # well-balancedness test cases.
 # Strict default values for thresholds that performed well in many numerical experiments
-function ShallowWaterEquationsQuasi1D(; gravity_constant, H0 = zero(gravity_constant))
-    ShallowWaterEquationsQuasi1D(gravity_constant, H0)
+function ShallowWaterEquationsQuasi1D(; gravity, H0 = zero(gravity))
+    ShallowWaterEquationsQuasi1D(gravity, H0)
 end
 
 have_nonconservative_terms(::ShallowWaterEquationsQuasi1D) = True()

--- a/test/test_type.jl
+++ b/test/test_type.jl
@@ -2320,7 +2320,7 @@ isdir(outdir) && rm(outdir, recursive = true)
 
     @timed_testset "Shallow Water 1D" begin
         for RealT in (Float32, Float64)
-            equations = @inferred ShallowWaterEquations1D(gravity_constant = RealT(9.81))
+            equations = @inferred ShallowWaterEquations1D(gravity = RealT(9.81))
 
             x = SVector(zero(RealT))
             t = zero(RealT)
@@ -2410,7 +2410,7 @@ isdir(outdir) && rm(outdir, recursive = true)
 
     @timed_testset "Shallow Water 2D" begin
         for RealT in (Float32, Float64)
-            equations = @inferred ShallowWaterEquations2D(gravity_constant = RealT(9.81))
+            equations = @inferred ShallowWaterEquations2D(gravity = RealT(9.81))
 
             x = SVector(zero(RealT), zero(RealT))
             t = zero(RealT)
@@ -2541,7 +2541,7 @@ isdir(outdir) && rm(outdir, recursive = true)
 
     @timed_testset "Shallow Water Quasi 1D" begin
         for RealT in (Float32, Float64)
-            equations = @inferred ShallowWaterEquationsQuasi1D(gravity_constant = RealT(9.81))
+            equations = @inferred ShallowWaterEquationsQuasi1D(gravity = RealT(9.81))
 
             x = SVector(zero(RealT))
             t = zero(RealT)

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -588,7 +588,7 @@ end
 @timed_testset "Shallow water conversion between conservative/entropy variables" begin
     H, v1, v2, b, a = 3.5, 0.25, 0.1, 0.4, 0.3
 
-    let equations = ShallowWaterEquations1D(gravity_constant = 9.8)
+    let equations = ShallowWaterEquations1D(gravity = 9.8)
         cons_vars = prim2cons(SVector(H, v1, b), equations)
         entropy_vars = cons2entropy(cons_vars, equations)
         @test cons_vars ≈ entropy2cons(entropy_vars, equations)
@@ -602,7 +602,7 @@ end
         @test cons_vars ≈ entropy2cons(entropy_vars, equations)
     end
 
-    let equations = ShallowWaterEquations2D(gravity_constant = 9.8)
+    let equations = ShallowWaterEquations2D(gravity = 9.8)
         cons_vars = prim2cons(SVector(H, v1, v2, b), equations)
         entropy_vars = cons2entropy(cons_vars, equations)
         @test cons_vars ≈ entropy2cons(entropy_vars, equations)
@@ -616,7 +616,7 @@ end
         @test cons_vars ≈ entropy2cons(entropy_vars, equations)
     end
 
-    let equations = ShallowWaterEquationsQuasi1D(gravity_constant = 9.8)
+    let equations = ShallowWaterEquationsQuasi1D(gravity = 9.8)
         cons_vars = prim2cons(SVector(H, v1, b, a), equations)
         entropy_vars = cons2entropy(cons_vars, equations)
 
@@ -789,7 +789,7 @@ end
 @timed_testset "Consistency check for HLL flux (naive): SWE" begin
     flux_hll = FluxHLL(min_max_speed_naive)
 
-    equations = ShallowWaterEquations1D(gravity_constant = 9.81)
+    equations = ShallowWaterEquations1D(gravity = 9.81)
     u = SVector(1, 0.5, 0.0)
     @test flux_hll(u, u, 1, equations) ≈ flux(u, 1, equations)
 
@@ -801,7 +801,7 @@ end
     u_rr = SVector(0.1, -1.0, 0.0)
     @test flux_hll(u_ll, u_rr, 1, equations) ≈ flux(u_rr, 1, equations)
 
-    equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+    equations = ShallowWaterEquations2D(gravity = 9.81)
     normal_directions = [SVector(1.0, 0.0),
         SVector(0.0, 1.0),
         SVector(0.5, -0.5),
@@ -1022,11 +1022,11 @@ end
 @timed_testset "Consistency check for HLL flux with Davis wave speed estimates: SWE" begin
     flux_hll = FluxHLL(min_max_speed_davis)
 
-    equations = ShallowWaterEquations1D(gravity_constant = 9.81)
+    equations = ShallowWaterEquations1D(gravity = 9.81)
     u = SVector(1, 0.5, 0.0)
     @test flux_hll(u, u, 1, equations) ≈ flux(u, 1, equations)
 
-    equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+    equations = ShallowWaterEquations2D(gravity = 9.81)
     normal_directions = [SVector(1.0, 0.0),
         SVector(0.0, 1.0),
         SVector(0.5, -0.5),
@@ -1143,11 +1143,11 @@ end
 end
 
 @timed_testset "Consistency check for HLLE flux: SWE" begin
-    equations = ShallowWaterEquations1D(gravity_constant = 9.81)
+    equations = ShallowWaterEquations1D(gravity = 9.81)
     u = SVector(1, 0.5, 0.0)
     @test flux_hlle(u, u, 1, equations) ≈ flux(u, 1, equations)
 
-    equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+    equations = ShallowWaterEquations2D(gravity = 9.81)
     normal_directions = [SVector(1.0, 0.0),
         SVector(0.0, 1.0),
         SVector(0.5, -0.5),
@@ -1583,7 +1583,7 @@ end
     end
 
     @timed_testset "ShallowWaterEquations2D" begin
-        equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+        equations = ShallowWaterEquations2D(gravity = 9.81)
         normal_directions = [SVector(1.0, 0.0),
             SVector(0.0, 1.0),
             SVector(0.5, -0.5),
@@ -2280,7 +2280,7 @@ end
     end
 
     @timed_testset "ShallowWaterEquations1D" begin
-        equations = ShallowWaterEquations1D(gravity_constant = 9.81)
+        equations = ShallowWaterEquations1D(gravity = 9.81)
 
         h_ll_rr = SVector(12.0, 12.0)
         hv_ll_rr = SVector(42.0, 24.0)
@@ -2294,7 +2294,7 @@ end
     end
 
     @timed_testset "ShallowWaterEquations2D" begin
-        equations = ShallowWaterEquations2D(gravity_constant = 9.81)
+        equations = ShallowWaterEquations2D(gravity = 9.81)
 
         h_ll_rr = SVector(12.0, 12.0)
         hv1_ll_rr = SVector(42.0, 24.0)
@@ -2321,7 +2321,7 @@ end
     end
 
     @timed_testset "ShallowWaterEquationsQuasi1D" begin
-        equations = ShallowWaterEquationsQuasi1D(gravity_constant = 9.81)
+        equations = ShallowWaterEquationsQuasi1D(gravity = 9.81)
 
         ah_ll_rr = SVector(12.0, 12.0)
         ahv_ll_rr = SVector(42.0, 24.0)
@@ -2608,12 +2608,12 @@ end
     end
 
     H, b = exp(pi), exp(pi^2)
-    gravity_constant, H0 = 9.91, 0.1 # Standard numbers + 0.1
-    shallow_water_1d = ShallowWaterEquations1D(; gravity_constant, H0)
+    gravity, H0 = 9.91, 0.1 # Standard numbers + 0.1
+    shallow_water_1d = ShallowWaterEquations1D(; gravity, H0)
     u = prim2cons(SVector(H, v1, b), shallow_water_1d)
     @test isapprox(velocity(u, shallow_water_1d), v1)
 
-    shallow_water_2d = ShallowWaterEquations2D(; gravity_constant, H0)
+    shallow_water_2d = ShallowWaterEquations2D(; gravity, H0)
     u = prim2cons(SVector(H, v1, v2, b), shallow_water_2d)
     @test isapprox(velocity(u, shallow_water_2d), SVector(v1, v2))
     @test isapprox(velocity(u, normal_direction_2d, shallow_water_2d), v_normal_2d)


### PR DESCRIPTION
This PR renames the `gravity_constant` keyword in the equations constructor to `gravity` and fixes the docstrings/comments to describe this quantity as the gravitational acceleration instead of the gravitational constant. This will make it consistent with the actual field `equations.gravity` and avoid any confusion between [gravitational acceleration](https://en.wikipedia.org/wiki/Gravitational_acceleration) and the [gravitational constant](https://en.wikipedia.org/wiki/Gravitational_constant). See https://github.com/trixi-framework/TrixiShallowWater.jl/issues/82, https://github.com/trixi-framework/TrixiShallowWater.jl/pull/84.

Since this changes the keyword argument for the equations constructor it must be considered a breaking change.