### PR TITLE
[Proof of Concept] Make ForwardDiff work with implicit time integration

### DIFF
--- a/src/semidiscretization/semidiscretization_hyperbolic.jl
+++ b/src/semidiscretization/semidiscretization_hyperbolic.jl
@@ -413,6 +413,13 @@ end
 function rhs!(du_ode, u_ode, semi::SemidiscretizationHyperbolic, t)
     @unpack mesh, equations, boundary_conditions, source_terms, solver, cache = semi
 
+    if du_ode isa AbstractArray{<:ForwardDiff.Dual{<:Any, <:Any, 1}} && haskey(cache, :semi_dual)
+        return rhs!(du_ode, u_ode, semi.cache.semi_dual, t)
+    end
+    if du_ode isa AbstractArray{<:ForwardDiff.Dual{<:Any, <:Any, 11}} && haskey(cache, :semi_dual11)
+        return rhs!(du_ode, u_ode, semi.cache.semi_dual11, t)
+    end
+
     u = wrap_array(u_ode, mesh, equations, solver, cache)
     du = wrap_array(du_ode, mesh, equations, solver, cache)
 


### PR DESCRIPTION
A beautiful solution for https://github.com/trixi-framework/Trixi.jl/issues/2369.

I think it's pretty clear that I have absolutely no idea what I'm doing.
I have no idea where the numbers 1 and 11 come from (are these the chunk sizes?), but it works like that for this specific elixir.

We would need to know all dual types that the `rhs!` will be called with, and then we can construct a cache (or in this case a whole semidiscretization) for each of them.
No idea how to implement this in a clean way, but at least it demonstrates that this can be done and especially that it can be done in a minimally invasive way without changing all the data structures.