### PR TITLE
Use linear extrapolation in `cell2node` function

### DIFF
--- a/src/visualization/utilities.jl
+++ b/src/visualization/utilities.jl
@@ -531,18 +531,21 @@ function cell2node(cell_centered_data)
         tmp[2:(end - 1), 2:(end - 1)] .= cell_data
 
         # Linear extrapolation of top and bottom rows
-        tmp[1, 2:end-1] .= cell_data[1, :] .+ (cell_data[1, :] .- cell_data[2, :])
-        tmp[end, 2:end-1] .= cell_data[end, :] .+ (cell_data[end, :] .- cell_data[end-1, :])
+        tmp[1, 2:(end - 1)] .= cell_data[1, :] .+ (cell_data[1, :] .- cell_data[2, :])
+        tmp[end, 2:(end - 1)] .= (cell_data[end, :] .+
+                                  (cell_data[end, :] .- cell_data[end - 1, :]))
 
         # Linear extrapolatation of left and right columns
-        tmp[2:end-1, 1] .= cell_data[:, 1] .+ (cell_data[:, 1] .- cell_data[:, 2])
-        tmp[2:end-1, end] .= cell_data[:, end] .+ (cell_data[:, end] .- cell_data[:, end-1])
+        tmp[2:(end - 1), 1] .= cell_data[:, 1] .+ (cell_data[:, 1] .- cell_data[:, 2])
+        tmp[2:(end - 1), end] .= (cell_data[:, end] .+
+                                  (cell_data[:, end] .- cell_data[:, end - 1]))
 
         # Corners perform the linear extrapolatation along diagonals
-        tmp[1, 1]     = tmp[2, 1] + (tmp[2, 1] - tmp[3, 1])
-        tmp[1, end]   = tmp[2, end] + (tmp[2, end] - tmp[3, end])
-        tmp[end, 1]   = tmp[end-1, 1] + (tmp[end-1, 1] - tmp[end-2, 1])
-        tmp[end, end] = tmp[end-1, end] + (tmp[end-1, end] - tmp[end-2, end])
+        tmp[1, 1] = tmp[2, 2] + (tmp[2, 2] - tmp[3, 3])
+        tmp[1, end] = tmp[2, end - 1] + (tmp[2, end - 1] - tmp[3, end - 2])
+        tmp[end, 1] = tmp[end - 1, 2] + (tmp[end - 1, 2] - tmp[end - 2, 3])
+        tmp[end, end] = (tmp[end - 1, end - 1] +
+                         (tmp[end - 1, end - 1] - tmp[end - 2, end - 2]))
 
         # Obtain node-centered value by averaging over neighboring cell-centered values
         for j in 1:resolution_out

--- a/src/visualization/utilities.jl
+++ b/src/visualization/utilities.jl
@@ -510,7 +510,8 @@ function get_unstructured_data(func::Function, solution_variables,
 end
 
 # Convert cell-centered values to node-centered values by averaging over all
-# four neighbors and making use of the periodicity of the solution
+# four neighbors. Solution values at the edges are padded with ghost values
+# computed via linear extrapolation.
 #
 # Note: This is a low-level function that is not considered as part of Trixi.jl's interface and may
 #       thus be changed in future releases.
@@ -529,18 +530,19 @@ function cell2node(cell_centered_data)
         # Fill center with original data
         tmp[2:(end - 1), 2:(end - 1)] .= cell_data
 
-        # Fill sides with opposite data (periodic domain)
-        # x-direction
-        tmp[1, 2:(end - 1)] .= cell_data[end, :]
-        tmp[end, 2:(end - 1)] .= cell_data[1, :]
-        # y-direction
-        tmp[2:(end - 1), 1] .= cell_data[:, end]
-        tmp[2:(end - 1), end] .= cell_data[:, 1]
-        # Corners
-        tmp[1, 1] = cell_data[end, end]
-        tmp[end, 1] = cell_data[1, end]
-        tmp[1, end] = cell_data[end, 1]
-        tmp[end, end] = cell_data[1, 1]
+        # Linear extrapolation of top and bottom rows
+        tmp[1, 2:end-1] .= cell_data[1, :] .+ (cell_data[1, :] .- cell_data[2, :])
+        tmp[end, 2:end-1] .= cell_data[end, :] .+ (cell_data[end, :] .- cell_data[end-1, :])
+
+        # Linear extrapolatation of left and right columns
+        tmp[2:end-1, 1] .= cell_data[:, 1] .+ (cell_data[:, 1] .- cell_data[:, 2])
+        tmp[2:end-1, end] .= cell_data[:, end] .+ (cell_data[:, end] .- cell_data[:, end-1])
+
+        # Corners perform the linear extrapolatation along diagonals
+        tmp[1, 1]     = tmp[2, 1] + (tmp[2, 1] - tmp[3, 1])
+        tmp[1, end]   = tmp[2, end] + (tmp[2, end] - tmp[3, end])
+        tmp[end, 1]   = tmp[end-1, 1] + (tmp[end-1, 1] - tmp[end-2, 1])
+        tmp[end, end] = tmp[end-1, end] + (tmp[end-1, end] - tmp[end-2, end])
 
         # Obtain node-centered value by averaging over neighboring cell-centered values
         for j in 1:resolution_out


### PR DESCRIPTION
This fixes the computation of values by `PlotData2D` on `TreeMesh` that may (artificially) enforce that a solution is periodic. Now ghost layer values are computed via linear extrapolation. I am not sure if this will influence any of the testing / docs.

Closes #1256 . Closes #1265 . Closes #1341 

Below is an example comparing the old and new plots (contour and surface) produced for the bottom topography using the shallow equations with a non-periodic bottom topography function.

```julia
b = 2 + 0.5f0 * sinpi(sqrt(convert(RealT, 2)) * x1) * cospi(sqrt(convert(RealT, 3)) * x2) +
    0.5f0 * sinpi(sqrt(convert(RealT, 2)) * x2) * cospi(sqrt(convert(RealT, 5)) * x1) -
    pi / exp(0.5 * ((x1 - 0.75)^2 + (x2 + 0.0)^2))
```

Strategy in `main`:
<img width="460" alt="Screenshot 2025-04-24 at 22 50 54" src="https://github.com/user-attachments/assets/9bd705f2-2400-4489-8c89-e06c51501ef6" />

<img width="470" alt="Screenshot 2025-04-24 at 22 50 41" src="https://github.com/user-attachments/assets/cb4a16c6-c7ef-4b11-aefe-1d116c73dd02" />


Strategy from this PR:
<img width="461" alt="Screenshot 2025-04-24 at 22 51 41" src="https://github.com/user-attachments/assets/5f378f3b-e15a-476b-948c-127a6c612c98" />

<img width="477" alt="Screenshot 2025-04-24 at 22 51 20" src="https://github.com/user-attachments/assets/de1c2840-563c-4669-9310-b7abd5cc97f7" />

