### PR TITLE
fix links to new docs repo

### DIFF
--- a/.github/review-checklist.md
+++ b/.github/review-checklist.md
@@ -12,7 +12,7 @@ This checklist is meant to assist creators of PRs (to let them know what reviewe
 - [ ] Newly introduced names for variables etc. are self-descriptive and consistent with existing naming conventions.
 - [ ] There are no redundancies that can be removed by simple modularization/refactoring.
 - [ ] There are no leftover debug statements or commented code sections.
-- [ ] The code adheres to our [conventions](https://trixi-framework.github.io/Trixi.jl/stable/conventions/) and [style guide](https://trixi-framework.github.io/Trixi.jl/stable/styleguide/), and to the [Julia guidelines](https://docs.julialang.org/en/v1/manual/style-guide/).
+- [ ] The code adheres to our [conventions](https://trixi-framework.github.io/TrixiDocumentation/stable/conventions/) and [style guide](https://trixi-framework.github.io/TrixiDocumentation/stable/styleguide/), and to the [Julia guidelines](https://docs.julialang.org/en/v1/manual/style-guide/).
 
 #### Documentation
 - [ ] New functions and types are documented with a docstring or top-level comment.
@@ -28,7 +28,7 @@ This checklist is meant to assist creators of PRs (to let them know what reviewe
 
 #### Performance
 - [ ] There are no type instabilities or memory allocations in performance-critical parts.
-- [ ] If the PR intent is to improve performance, before/after [time measurements](https://trixi-framework.github.io/Trixi.jl/stable/performance/#Manual-benchmarking) are posted in the PR.
+- [ ] If the PR intent is to improve performance, before/after [time measurements](https://trixi-framework.github.io/TrixiDocumentation/stable/performance/#Manual-benchmarking) are posted in the PR.
 
 #### Verification
 - [ ] The correctness of the code was verified using appropriate tests.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Trixi.jl
 
-[![Docs-stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://trixi-framework.github.io/Trixi.jl/stable)
-[![Docs-dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://trixi-framework.github.io/Trixi.jl/dev)
+[![Docs-stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://trixi-framework.github.io/TrixiDocumentation/stable)
+[![Docs-dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://trixi-framework.github.io/TrixiDocumentation/dev)
 [![Slack](https://img.shields.io/badge/chat-slack-e01e5a)](https://join.slack.com/t/trixi-framework/shared_invite/zt-sgkc6ppw-6OXJqZAD5SPjBYqLd8MU~g)
 [![Youtube](https://img.shields.io/youtube/channel/views/UCpd92vU2HjjTPup-AIN0pkg?style=social)](https://www.youtube.com/@trixi-framework)
 [![Build Status](https://github.com/trixi-framework/Trixi.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/trixi-framework/Trixi.jl/actions?query=workflow%3ACI)
@@ -26,7 +26,7 @@ having an extensible design with a fast implementation, Trixi.jl is
 focused on being easy to use for new or inexperienced users, including the
 installation and postprocessing procedures. Its features include:
 
-* 1D, 2D, and 3D simulations on [line/quad/hex/simplex meshes](https://trixi-framework.github.io/Trixi.jl/stable/overview/#Semidiscretizations)
+* 1D, 2D, and 3D simulations on [line/quad/hex/simplex meshes](https://trixi-framework.github.io/TrixiDocumentation/stable/overview/#Semidiscretizations)
   * Cartesian and curvilinear meshes
   * Conforming and non-conforming meshes
   * Structured and unstructured meshes
@@ -186,7 +186,7 @@ Additional documentation is available that contains more information on how to
 modify/extend Trixi.jl's implementation, how to visualize output files etc. It
 also includes a section on our preferred development workflow and some tips for
 using Git. The latest documentation can be accessed either
-[online](https://trixi-framework.github.io/Trixi.jl/stable) or under [`docs/src`](docs/src).
+[online](https://trixi-framework.github.io/TrixiDocumentation/stable) or under [`docs/src`](docs/src).
 
 
 ## Referencing

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -2,7 +2,7 @@
 
 This folder contains some benchmark setups based on
 [PkgBenchmark.jl](https://github.com/JuliaCI/PkgBenchmark.jl)
-as described in the [documentation of Trixi.jl](https://trixi-framework.github.io/Trixi.jl/stable)
+as described in the [documentation of Trixi.jl](https://trixi-framework.github.io/TrixiDocumentation/stable)
 in the "Performance" section.
 Additionally, it contains subdirectories dedicated to specific micro benchmarks
 used when developing Trixi.jl, e.g. `multiply_dimensionwise`.

--- a/docs/literate/src/files/adding_nonconservative_equation.jl
+++ b/docs/literate/src/files/adding_nonconservative_equation.jl
@@ -174,7 +174,7 @@ error_1 / error_2
 # to an experimental order of convergence of 4 (for polynomials of degree 3).
 
 # For non-trivial boundary conditions involving non-conservative terms,
-# please refer to the section on [Other available example elixirs with non-trivial BC](https://trixi-framework.github.io/Trixi.jl/stable/tutorials/non_periodic_boundaries/#Other-available-example-elixirs-with-non-trivial-BC).
+# please refer to the section on [Other available example elixirs with non-trivial BC](https://trixi-framework.github.io/TrixiDocumentation/stable/tutorials/non_periodic_boundaries/#Other-available-example-elixirs-with-non-trivial-BC).
 
 # ## Summary of the code
 

--- a/docs/literate/src/files/custom_semidiscretization.jl
+++ b/docs/literate/src/files/custom_semidiscretization.jl
@@ -117,7 +117,7 @@ end
 plot!(sol.u[1], semi, label = "u0", linestyle = :dot, legend = :topleft)
 
 # You can of course also use some
-# [callbacks](https://trixi-framework.github.io/Trixi.jl/stable/callbacks/)
+# [callbacks](https://trixi-framework.github.io/TrixiDocumentation/stable/callbacks/)
 # provided by Trixi.jl as usual.
 
 summary_callback = SummaryCallback()

--- a/docs/literate/src/files/first_steps/create_first_setup.jl
+++ b/docs/literate/src/files/first_steps/create_first_setup.jl
@@ -92,7 +92,7 @@ solver = DGSEM(polydeg = 3)
 # condition, but might also be used to describe an analytical solution if known. If you use the
 # initial condition as analytical solution, you can analyze your numerical solution by computing
 # the error, see also the
-# [section about analyzing the solution](https://trixi-framework.github.io/Trixi.jl/stable/callbacks/#Analyzing-the-numerical-solution).
+# [section about analyzing the solution](https://trixi-framework.github.io/TrixiDocumentation/stable/callbacks/#Analyzing-the-numerical-solution).
 
 function initial_condition_sinpi(x, t, equations::LinearScalarAdvectionEquation2D)
     u = sinpi(x[1]) * sinpi(x[2])

--- a/docs/literate/src/files/hohqmesh_tutorial.jl
+++ b/docs/literate/src/files/hohqmesh_tutorial.jl
@@ -42,7 +42,7 @@ end #hide #md
 
 # This will compute a smooth, manufactured solution test case for the 2D compressible Euler equations
 # on the curved quadrilateral mesh described in the
-# [Trixi.jl documentation](https://trixi-framework.github.io/Trixi.jl/stable/meshes/unstructured_quad_mesh/).
+# [Trixi.jl documentation](https://trixi-framework.github.io/TrixiDocumentation/stable/meshes/unstructured_quad_mesh/).
 
 # Apart from the usual error and timing output provided by the Trixi.jl run, it is useful to visualize and inspect
 # the solution. One option available in the Trixi.jl framework to visualize the solution on
@@ -531,7 +531,7 @@ mesh = UnstructuredMesh2D(mesh_file);
 # ```
 
 # Now, you can create a `P4estMesh` from your mesh file. It is described in detail in the
-# [P4est-based mesh](https://trixi-framework.github.io/Trixi.jl/stable/meshes/p4est_mesh/#P4est-based-mesh)
+# [P4est-based mesh](https://trixi-framework.github.io/TrixiDocumentation/stable/meshes/p4est_mesh/#P4est-based-mesh)
 # part of the Trixi.jl docs.
 # ```julia
 # using Trixi
@@ -559,7 +559,7 @@ mesh = UnstructuredMesh2D(mesh_file);
 # ```
 
 # We can then post-process the solution file at the final time on the new mesh with `Trixi2Vtk` and visualize
-# with ParaView, see the appropriate [visualization section](https://trixi-framework.github.io/Trixi.jl/stable/visualization/#Trixi2Vtk)
+# with ParaView, see the appropriate [visualization section](https://trixi-framework.github.io/TrixiDocumentation/stable/visualization/#Trixi2Vtk)
 # for details.
 
 # ![simulation_straight_sides_p4est_amr](https://user-images.githubusercontent.com/74359358/168049930-8abce6ac-cd47-4d04-b40b-0fa459bbd98d.png)

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -313,7 +313,7 @@ julia --project=docs --color=yes docs/make.jl
 from the Trixi.jl main directory. Then, you can look at the html files generated in
 `docs/build`.
 For PRs triggered from branches inside the Trixi.jl main repository previews of
-the new documentation are generated at `https://trixi-framework.github.io/Trixi.jl/previews/PRXXX`,
+the new documentation are generated at `https://trixi-framework.github.io/TrixiDocumentation/previews/PRXXX`,
 where `XXX` is the number of the PR.
 This does not work for PRs from forks for security reasons (since anyone could otherwise push
 arbitrary stuff to the Trixi.jl website, including malicious code).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,7 @@
 # Trixi.jl
 
-[![Docs-stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://trixi-framework.github.io/Trixi.jl/stable)
-[![Docs-dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://trixi-framework.github.io/Trixi.jl/dev)
+[![Docs-stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://trixi-framework.github.io/TrixiDocumentation/stable)
+[![Docs-dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://trixi-framework.github.io/TrixiDocumentation/dev)
 [![Slack](https://img.shields.io/badge/chat-slack-e01e5a)](https://join.slack.com/t/trixi-framework/shared_invite/zt-sgkc6ppw-6OXJqZAD5SPjBYqLd8MU~g)
 [![Youtube](https://img.shields.io/youtube/channel/views/UCpd92vU2HjjTPup-AIN0pkg?style=social)](https://www.youtube.com/@trixi-framework)
 [![Build Status](https://github.com/trixi-framework/Trixi.jl/workflows/CI/badge.svg)](https://github.com/trixi-framework/Trixi.jl/actions?query=workflow%3ACI)
@@ -20,7 +20,7 @@ having an extensible design with a fast implementation, Trixi.jl is
 focused on being easy to use for new or inexperienced users, including the
 installation and postprocessing procedures. Its features include:
 
-* 1D, 2D, and 3D simulations on [line/quad/hex/simplex meshes](https://trixi-framework.github.io/Trixi.jl/stable/overview/#Semidiscretizations)
+* 1D, 2D, and 3D simulations on [line/quad/hex/simplex meshes](https://trixi-framework.github.io/TrixiDocumentation/stable/overview/#Semidiscretizations)
   * Cartesian and curvilinear meshes
   * Conforming and non-conforming meshes
   * Structured and unstructured meshes

--- a/docs/src/meshes/structured_mesh.md
+++ b/docs/src/meshes/structured_mesh.md
@@ -3,7 +3,7 @@
 The [`StructuredMesh`](@ref) is a structured, curvilinear, conforming
 mesh type available for one-, two-, and three-dimensional simulations.
 An application of the [`StructuredMesh`](@ref) using a user-defined mapping 
-is provided by [one of the tutorials](https://trixi-framework.github.io/Trixi.jl/stable/tutorials/structured_mesh_mapping/).
+is provided by [one of the tutorials](https://trixi-framework.github.io/TrixiDocumentation/stable/tutorials/structured_mesh_mapping/).
 
 Due to its curvilinear nature, (numerical) fluxes need to implement methods
 dispatching on the `normal::AbstractVector`. Rotationally invariant equations

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -67,7 +67,7 @@ different features on different mesh types.
 Note that except for [`TreeMesh`](@ref) all meshes are of *curvilinear* type,
 which means that a (unit) vector normal to the interface (`normal_direction`) needs to be supplied to the
 numerical flux function.
-You can check the [reference](https://trixi-framework.github.io/Trixi.jl/stable/reference-trixi/) if a certain
+You can check the [reference](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/) if a certain
 numerical flux is implemented with a `normal_direction`
 or if currently only the *Cartesian* version (for [`TreeMesh`](@ref)) exists.
 In this case, you can still use this flux on curvilinear meshes by rotating it, see [`FluxRotated`](@ref).

--- a/docs/src/parallelization.md
+++ b/docs/src/parallelization.md
@@ -74,7 +74,7 @@ in `lib/` or `local/lib/` in the installation directory of `t8code`.
 The preferences for [HDF5.jl](https://github.com/JuliaIO/HDF5.jl) always need to be set, even if you
 do not want to use `HDF5` from Trixi.jl, see also [issue #1079 in HDF5.jl](https://github.com/JuliaIO/HDF5.jl/issues/1079).
 To set the preferences for HDF5.jl, follow the instructions described
-[here](https://trixi-framework.github.io/Trixi.jl/stable/parallelization/#Using-parallel-input-and-output).
+[here](https://trixi-framework.github.io/TrixiDocumentation/stable/parallelization/#Using-parallel-input-and-output).
 
 In total, in your active Julia project you should have a `LocalPreferences.toml` file with sections
 `[MPIPreferences]`, `[T8code]` (only needed if `T8codeMesh` is used), `[P4est]` (only needed if

--- a/docs/src/time_integration.md
+++ b/docs/src/time_integration.md
@@ -57,12 +57,12 @@ Formally, this boils down to an optimization problem of the form
 ```math
 \underset{P_{p;S} \, \in \, \mathcal{P}_{p;S}}{\max} \Delta t \text{ such that } \big \vert P_{p;S}(\Delta t \lambda_m) \big \vert \leq 1, \quad  m = 1 , \dots , M \tag{1}
 ```
-where $p$ denotes the order of consistency of the scheme, $S$ is the number of stage evaluations and $M$ denotes the number of eigenvalues $\lambda_m$ of the Jacobian matrix $J \coloneqq \frac{\partial \boldsymbol F}{\partial \boldsymbol U}$ of the right-hand side of the [semidiscretized PDE](https://trixi-framework.github.io/Trixi.jl/stable/overview/#overview-semidiscretizations):
+where $p$ denotes the order of consistency of the scheme, $S$ is the number of stage evaluations and $M$ denotes the number of eigenvalues $\lambda_m$ of the Jacobian matrix $J \coloneqq \frac{\partial \boldsymbol F}{\partial \boldsymbol U}$ of the right-hand side of the [semidiscretized PDE](https://trixi-framework.github.io/TrixiDocumentation/stable/overview/#overview-semidiscretizations):
 ```math
 \dot{\boldsymbol U} = \boldsymbol F(\boldsymbol U) \tag{2} \: .
 ```
 In particular, for $S > p$ the Runge-Kutta method includes some free coefficients which may be used to adapt the domain of absolute stability to the problem at hand.
-Since Trixi.jl [supports exact computation of the Jacobian $J$ by means of automatic differentiation](https://trixi-framework.github.io/Trixi.jl/stable/tutorials/differentiable_programming/), we have access to the Jacobian of a given simulation setup.
+Since Trixi.jl [supports exact computation of the Jacobian $J$ by means of automatic differentiation](https://trixi-framework.github.io/TrixiDocumentation/stable/tutorials/differentiable_programming/), we have access to the Jacobian of a given simulation setup.
 For small (say, up to roughly $10^4$ DoF) systems, the spectrum $\boldsymbol \sigma = \left \{ \lambda_m \right \}_{m=1, \dots, M}$ can be computed directly using [`LinearAlgebra.eigvals(J)`](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.eigvals).
 For larger systems, we recommend the procedure outlined in section 4.1 of [Doehring et al. (2024)](https://doi.org/10.1016/j.jcp.2024.113223). This approach computes a reduced set of (estimated) eigenvalues $\widetilde{\boldsymbol \sigma}$ around the convex hull of the spectrum by means of the [Arnoldi method](https://github.com/JuliaLinearAlgebra/Arpack.jl).
 
@@ -153,7 +153,7 @@ Next, we will construct the time integrator. In order to do this, you need the f
   This defines the bounds for the bisection routine for the optimal timestep $\Delta t$ used in calculating the polynomial coefficients at optimization stage.
   This variable is already defined in step 5.
   - Semidiscretization (`semi`): The semidiscretization setup that includes the mesh, equations, initial condition, and solver. In this example, this variable is already defined in step 3.
-  In the background, we compute from `semi` the Jacobian $J$ evaluated at the initial condition using [`jacobian_ad_forward`](https://trixi-framework.github.io/Trixi.jl/stable/reference-trixi/#Trixi.jacobian_ad_forward-Tuple{Trixi.AbstractSemidiscretization}).
+  In the background, we compute from `semi` the Jacobian $J$ evaluated at the initial condition using [`jacobian_ad_forward`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.jacobian_ad_forward-Tuple{Trixi.AbstractSemidiscretization}).
   This is then followed by the computation of the spectrum $\boldsymbol \sigma(J)$ using `LinearAlgebra.eigvals`.
   Equipped with the spectrum, the optimal stability polynomial is computed, from which the corresponding Runge-Kutta method is derived. Other constructors (if the coefficients $\boldsymbol{\alpha}$ of the stability polynomial are already available, or if a reduced spectrum $\widetilde{\boldsymbol{\sigma}}$ should be used) are discussed below.
 

--- a/examples/p4est_3d_dgsem/elixir_linearizedeuler_convergence.jl
+++ b/examples/p4est_3d_dgsem/elixir_linearizedeuler_convergence.jl
@@ -16,7 +16,7 @@ coordinates_max = (1.0, 1.0, 1.0) # maximum coordinates (max(x), max(y), max(z))
 
 # `initial_refinement_level` is provided here to allow for a
 # convenient convergence test, see
-# https://trixi-framework.github.io/Trixi.jl/stable/#Performing-a-convergence-analysis
+# https://trixi-framework.github.io/TrixiDocumentation/stable/#Performing-a-convergence-analysis
 trees_per_dimension = (4, 4, 4)
 mesh = P4estMesh(trees_per_dimension, polydeg = 3,
                  coordinates_min = coordinates_min,

--- a/src/auxiliary/p4est.jl
+++ b/src/auxiliary/p4est.jl
@@ -24,7 +24,7 @@ function init_p4est()
         p4est_init(C_NULL, SC_LP_ERROR)
     else
         @warn "Preferences for P4est.jl are not set correctly. Until fixed, using `P4estMesh` will result in a crash. " *
-              "See also https://trixi-framework.github.io/Trixi.jl/stable/parallelization/#parallel_system_MPI"
+              "See also https://trixi-framework.github.io/TrixiDocumentation/stable/parallelization/#parallel_system_MPI"
     end
 
     return nothing

--- a/src/auxiliary/t8code.jl
+++ b/src/auxiliary/t8code.jl
@@ -45,7 +45,7 @@ function init_t8code()
         t8_init(LOG_LEVEL)
     else
         @warn "Preferences for T8code.jl are not set correctly. Until fixed, using `T8codeMesh` will result in a crash. " *
-              "See also https://trixi-framework.github.io/Trixi.jl/stable/parallelization/#parallel_system_MPI"
+              "See also https://trixi-framework.github.io/TrixiDocumentation/stable/parallelization/#parallel_system_MPI"
     end
 
     return nothing


### PR DESCRIPTION
The redirect implemented in https://github.com/trixi-framework/trixi-framework.github.io/pull/81 does not work as desired right now. This fixes all of our internal links.

Related to https://github.com/trixi-framework/Trixi.jl/pull/2376

Update: The redirect is fixed. However, we should still replace the old links to improve the user experience.