### PR TITLE
Use `reinterpret` when applying `solution_variables`  for visualization

### DIFF
--- a/src/visualization/utilities.jl
+++ b/src/visualization/utilities.jl
@@ -465,25 +465,15 @@ function get_unstructured_data(u, solution_variables, mesh, equations, solver, c
         raw_data = u
         n_vars = size(raw_data, 1)
     else
-        # FIXME: Remove this comment once the implementation following it has been verified
         # Reinterpret the solution array as an array of conservative variables,
         # compute the solution variables via broadcasting, and reinterpret the
         # result as a plain array of floating point numbers
-        # raw_data = Array(reinterpret(eltype(u),
-        #        solution_variables.(reinterpret(SVector{nvariables(equations),eltype(u)}, u),
-        #                   Ref(equations))))
-        # n_vars = size(raw_data, 1)
-        n_vars_in = nvariables(equations)
-        n_vars = length(solution_variables(get_node_vars(u, equations, solver),
-                                           equations))
-        raw_data = Array{eltype(u)}(undef, n_vars, Base.tail(size(u))...)
-        reshaped_u = reshape(u, n_vars_in, :)
-        reshaped_r = reshape(raw_data, n_vars, :)
-        for idx in axes(reshaped_u, 2)
-            reshaped_r[:, idx] = solution_variables(get_node_vars(reshaped_u, equations,
-                                                                  solver, idx),
-                                                    equations)
-        end
+        raw_data = Array(reinterpret(eltype(u),
+                                     solution_variables.(reinterpret(SVector{nvariables(equations),
+                                                                             eltype(u)},
+                                                                     u),
+                                                         Ref(equations))))
+        n_vars = size(raw_data, 1)
     end
 
     unstructured_data = Array{eltype(raw_data)}(undef,

--- a/src/visualization/utilities.jl
+++ b/src/visualization/utilities.jl
@@ -465,15 +465,25 @@ function get_unstructured_data(u, solution_variables, mesh, equations, solver, c
         raw_data = u
         n_vars = size(raw_data, 1)
     else
+        # FIXME: Remove this comment once the implementation following it has been verified
         # Reinterpret the solution array as an array of conservative variables,
         # compute the solution variables via broadcasting, and reinterpret the
         # result as a plain array of floating point numbers
-        raw_data = Array(reinterpret(eltype(u),
-                                     solution_variables.(reinterpret(SVector{nvariables(equations),
-                                                                             eltype(u)},
-                                                                     u),
-                                                         Ref(equations))))
-        n_vars = size(raw_data, 1)
+        # raw_data = Array(reinterpret(eltype(u),
+        #        solution_variables.(reinterpret(SVector{nvariables(equations),eltype(u)}, u),
+        #                   Ref(equations))))
+        # n_vars = size(raw_data, 1)
+        n_vars_in = nvariables(equations)
+        n_vars = length(solution_variables(get_node_vars(u, equations, solver),
+                                           equations))
+        raw_data = Array{eltype(u)}(undef, n_vars, Base.tail(size(u))...)
+        reshaped_u = reshape(u, n_vars_in, :)
+        reshaped_r = reshape(raw_data, n_vars, :)
+        for idx in axes(reshaped_u, 2)
+            reshaped_r[:, idx] = solution_variables(get_node_vars(reshaped_u, equations,
+                                                                  solver, idx),
+                                                    equations)
+        end
     end
 
     unstructured_data = Array{eltype(raw_data)}(undef,

--- a/src/visualization/utilities.jl
+++ b/src/visualization/utilities.jl
@@ -465,14 +465,9 @@ function get_unstructured_data(u, solution_variables, mesh, equations, solver, c
         raw_data = u
         n_vars = size(raw_data, 1)
     else
-        # FIXME: Remove this comment once the implementation following it has been verified
-        # Reinterpret the solution array as an array of conservative variables,
-        # compute the solution variables via broadcasting, and reinterpret the
-        # result as a plain array of floating point numbers
-        # raw_data = Array(reinterpret(eltype(u),
-        #        solution_variables.(reinterpret(SVector{nvariables(equations),eltype(u)}, u),
-        #                   Ref(equations))))
-        # n_vars = size(raw_data, 1)
+        # Similar to `save_solution_file` in `callbacks_step/save_solution_dg.jl`.
+        # However, we cannot use `reinterpret` here as `u` might have a non-bits type.
+        # See https://github.com/trixi-framework/Trixi.jl/pull/2388
         n_vars_in = nvariables(equations)
         n_vars = length(solution_variables(get_node_vars(u, equations, solver),
                                            equations))


### PR DESCRIPTION
It seems to me https://github.com/trixi-framework/Trixi.jl/blob/bdc17ffb50e26aa19aac8a841811d65d62066cb8/src/visualization/utilities.jl#L468-L486
is very similar to
https://github.com/trixi-framework/Trixi.jl/blob/bdc17ffb50e26aa19aac8a841811d65d62066cb8/src/callbacks_step/save_solution_dg.jl#L34-L43
Maybe we can resolve this todo.