### PR TITLE
Use standard `max` `min` to find elixirs that should crash via CI

### DIFF
--- a/src/auxiliary/math.jl
+++ b/src/auxiliary/math.jl
@@ -306,7 +306,7 @@ julia> max(2, 5, 1)
 5
 ```
 """
-@inline max(args...) = @fastmath max(args...)
+#@inline max(args...) = @fastmath max(args...)
 
 """
     Trixi.min(x, y, ...)
@@ -325,7 +325,7 @@ julia> min(2, 5, 1)
 1
 ```
 """
-@inline min(args...) = @fastmath min(args...)
+#@inline min(args...) = @fastmath min(args...)
 
 """
     Trixi.positive_part(x)


### PR DESCRIPTION
Following up on the discussion during the meeting