### PR TITLE
Use TrixiTest.jl

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -26,6 +26,7 @@ Quadmath = "be4d8f0f-7fa4-5f49-b795-2f01399ab2dd"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TrixiTest = "0a316866-cbd0-4425-8bcb-08103b2c1f26"
 
 [compat]
 ADTypes = "1.11"
@@ -55,3 +56,4 @@ Quadmath = "0.5.10"
 Random = "1"
 StableRNGs = "1.0.2"
 Test = "1"
+TrixiTest = "0.1"

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -125,7 +125,7 @@ macro test_nowarn_mod(expr, additional_ignore_content = [])
             r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:136 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n"
         ]
         append!($additional_ignore_content, add_to_additional_ignore_content)
-        @trixi_test_nowarn $esc(expr) $additional_ignore_content
+        @trixi_test_nowarn $(esc(expr)) $additional_ignore_content
     end
 end
 

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -1,4 +1,5 @@
 using Test: @test
+using TrixiTest: @trixi_test_nowarn
 import Trixi
 
 # Use a macro to avoid world age issues when defining new initial conditions etc.
@@ -109,60 +110,22 @@ function expr_to_named_tuple(expr)
     return result
 end
 
-# Modified version of `@test_nowarn` that prints the content of `stderr` when
-# it is not empty and ignores module replacements.
 macro test_nowarn_mod(expr, additional_ignore_content = String[])
     quote
-        let fname = tempname()
-            try
-                ret = open(fname, "w") do f
-                    redirect_stderr(f) do
-                        $(esc(expr))
-                    end
-                end
-                stderr_content = read(fname, String)
-                if !isempty(stderr_content)
-                    println("Content of `stderr`:\n", stderr_content)
-                end
-
-                # Patterns matching the following ones will be ignored. Additional patterns
-                # passed as arguments can also be regular expressions, so we just use the
-                # type `Any` for `ignore_content`.
-                ignore_content = Any[
-                                     # We need to ignore steady state information reported by our callbacks
-                                     r"┌ Info:   Steady state tolerance reached\n│   steady_state_callback .+\n└   t = .+\n",
-                                     # We also ignore our own compilation messages
-                                     "[ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.\n",
-                                     # TODO: Upstream (PlotUtils). This should be removed again once the
-                                     #       deprecated stuff is fixed upstream.
-                                     "WARNING: importing deprecated binding Colors.RGB1 into Plots.\n",
-                                     "WARNING: importing deprecated binding Colors.RGB4 into Plots.\n",
-                                     r"┌ Warning: Keyword argument letter not supported with Plots.+\n└ @ Plots.+\n",
-                                     r"┌ Warning: `parse\(::Type, ::Coloarant\)` is deprecated.+\n│.+\n│.+\n└ @ Plots.+\n",
-                                     # TODO: Silence warning introduced by Flux v0.13.13. Should be properly fixed.
-                                     r"┌ Warning: Layer with Float32 parameters got Float64 input.+\n│.+\n│.+\n│.+\n└ @ Flux.+\n",
-                                     # NOTE: These warnings arose from Julia 1.10 onwards
-                                     r"WARNING: Method definition .* in module .* at .* overwritten .*.\n",
-                                     # Warnings from third party packages
-                                     r"┌ Warning: Problem status ALMOST_INFEASIBLE; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n",
-                                     r"┌ Warning: Problem status ALMOST_OPTIMAL; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n",
-                                     # Warnings for higher-precision floating data types
-                                     r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:118 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n",
-                                     r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:136 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n"]
-                append!(ignore_content, $additional_ignore_content)
-                for pattern in ignore_content
-                    stderr_content = replace(stderr_content, pattern => "")
-                end
-
-                # We also ignore simple module redefinitions for convenience. Thus, we
-                # check whether every line of `stderr_content` is of the form of a
-                # module replacement warning.
-                @test occursin(r"^(WARNING: replacing module .+\.\n)*$", stderr_content)
-                ret
-            finally
-                rm(fname, force = true)
-            end
-        end
+        add_to_additional_ignore_content = [
+            # We need to ignore steady state information reported by our callbacks
+            r"┌ Info:   Steady state tolerance reached\n│   steady_state_callback .+\n└   t = .+\n",
+            # NOTE: These warnings arose from Julia 1.10 onwards
+            r"WARNING: Method definition .* in module .* at .* overwritten .*.\n",
+            # Warnings from third party packages
+            r"┌ Warning: Problem status ALMOST_INFEASIBLE; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n",
+            r"┌ Warning: Problem status ALMOST_OPTIMAL; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n",
+            # Warnings for higher-precision floating data types
+            r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:118 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n",
+            r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:136 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n"
+        ]
+        append!($additional_ignore_content, add_to_additional_ignore_content)
+        @trixi_test_nowarn $expr $additional_ignore_content
     end
 end
 

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -110,19 +110,20 @@ function expr_to_named_tuple(expr)
     return result
 end
 
-macro test_nowarn_mod(expr, additional_ignore_content = String[])
+macro test_nowarn_mod(expr, additional_ignore_content = [])
     quote
-        add_to_additional_ignore_content = Any[
-                                               # We need to ignore steady state information reported by our callbacks
-                                               r"┌ Info:   Steady state tolerance reached\n│   steady_state_callback .+\n└   t = .+\n",
-                                               # NOTE: These warnings arose from Julia 1.10 onwards
-                                               r"WARNING: Method definition .* in module .* at .* overwritten .*.\n",
-                                               # Warnings from third party packages
-                                               r"┌ Warning: Problem status ALMOST_INFEASIBLE; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n",
-                                               r"┌ Warning: Problem status ALMOST_OPTIMAL; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n",
-                                               # Warnings for higher-precision floating data types
-                                               r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:118 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n",
-                                               r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:136 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n"]
+        add_to_additional_ignore_content = [
+            # We need to ignore steady state information reported by our callbacks
+            r"┌ Info:   Steady state tolerance reached\n│   steady_state_callback .+\n└   t = .+\n",
+            # NOTE: These warnings arose from Julia 1.10 onwards
+            r"WARNING: Method definition .* in module .* at .* overwritten .*.\n",
+            # Warnings from third party packages
+            r"┌ Warning: Problem status ALMOST_INFEASIBLE; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n",
+            r"┌ Warning: Problem status ALMOST_OPTIMAL; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n",
+            # Warnings for higher-precision floating data types
+            r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:118 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n",
+            r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:136 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n"
+        ]
         append!($additional_ignore_content, add_to_additional_ignore_content)
         @trixi_test_nowarn $expr $additional_ignore_content
     end

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -125,7 +125,7 @@ macro test_nowarn_mod(expr, additional_ignore_content = [])
             r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:136 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n"
         ]
         append!($additional_ignore_content, add_to_additional_ignore_content)
-        @trixi_test_nowarn $expr $additional_ignore_content
+        @trixi_test_nowarn $esc(expr) $additional_ignore_content
     end
 end
 

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -112,18 +112,17 @@ end
 
 macro test_nowarn_mod(expr, additional_ignore_content = String[])
     quote
-        add_to_additional_ignore_content = [
-            # We need to ignore steady state information reported by our callbacks
-            r"┌ Info:   Steady state tolerance reached\n│   steady_state_callback .+\n└   t = .+\n",
-            # NOTE: These warnings arose from Julia 1.10 onwards
-            r"WARNING: Method definition .* in module .* at .* overwritten .*.\n",
-            # Warnings from third party packages
-            r"┌ Warning: Problem status ALMOST_INFEASIBLE; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n",
-            r"┌ Warning: Problem status ALMOST_OPTIMAL; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n",
-            # Warnings for higher-precision floating data types
-            r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:118 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n",
-            r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:136 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n"
-        ]
+        add_to_additional_ignore_content = Any[
+                                               # We need to ignore steady state information reported by our callbacks
+                                               r"┌ Info:   Steady state tolerance reached\n│   steady_state_callback .+\n└   t = .+\n",
+                                               # NOTE: These warnings arose from Julia 1.10 onwards
+                                               r"WARNING: Method definition .* in module .* at .* overwritten .*.\n",
+                                               # Warnings from third party packages
+                                               r"┌ Warning: Problem status ALMOST_INFEASIBLE; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n",
+                                               r"┌ Warning: Problem status ALMOST_OPTIMAL; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n",
+                                               # Warnings for higher-precision floating data types
+                                               r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:118 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n",
+                                               r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:136 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n"]
         append!($additional_ignore_content, add_to_additional_ignore_content)
         @trixi_test_nowarn $expr $additional_ignore_content
     end

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -35,9 +35,9 @@ test_examples_2d = Dict("TreeMesh" => ("tree_2d_dgsem",
 @testset "PlotData2D, PlotDataSeries, PlotMesh with $mesh" for mesh in keys(test_examples_2d)
     # Run Trixi.jl
     directory, elixir = test_examples_2d[mesh]
+    path = joinpath(examples_dir(), directory, elixir)
     @test_nowarn_mod trixi_include(@__MODULE__,
-                                   joinpath(examples_dir(), directory, elixir),
-                                   tspan = (0, 0.1))
+                                   path, tspan = (0, 0.1))
 
     # Constructor tests
     if mesh == "TreeMesh"

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -35,9 +35,9 @@ test_examples_2d = Dict("TreeMesh" => ("tree_2d_dgsem",
 @testset "PlotData2D, PlotDataSeries, PlotMesh with $mesh" for mesh in keys(test_examples_2d)
     # Run Trixi.jl
     directory, elixir = test_examples_2d[mesh]
-    path = joinpath(examples_dir(), directory, elixir)
     @test_nowarn_mod trixi_include(@__MODULE__,
-                                   path, tspan = (0, 0.1))
+                                   joinpath(examples_dir(), directory, elixir),
+                                   tspan = (0, 0.1))
 
     # Constructor tests
     if mesh == "TreeMesh"


### PR DESCRIPTION
Now that TrixiTest.jl is registered, we can adapt `@test_nowarn_mod`. We need to append the additional ignore content to the new `@trixi_test_include`. I also removed some of the legacy ignore content, that's hopefully (?) not needed anymore.