### PR TITLE
Make line breaks more consistent/semantic

### DIFF
--- a/src/solvers/dgsem_p4est/dg_2d.jl
+++ b/src/solvers/dgsem_p4est/dg_2d.jl
@@ -331,8 +331,8 @@ end
                                             i_index, j_index, element_index)
 
     # Coordinates at boundary node
-    x = get_node_coords(node_coordinates, equations, dg, i_index, j_index,
-                        element_index)
+    x = get_node_coords(node_coordinates, equations, dg,
+                        i_index, j_index, element_index)
 
     flux_ = boundary_condition(u_inner, normal_direction, x, t, surface_flux, equations)
 
@@ -361,8 +361,8 @@ end
                                             i_index, j_index, element_index)
 
     # Coordinates at boundary node
-    x = get_node_coords(node_coordinates, equations, dg, i_index, j_index,
-                        element_index)
+    x = get_node_coords(node_coordinates, equations, dg,
+                        i_index, j_index, element_index)
 
     # Call pointwise numerical flux functions for the conservative and nonconservative part
     # in the normal direction on the boundary
@@ -527,8 +527,8 @@ end
     @unpack u = cache.mortars
     @unpack surface_flux = surface_integral
 
-    u_ll, u_rr = get_surface_node_vars(u, equations, dg, position_index, node_index,
-                                       mortar_index)
+    u_ll, u_rr = get_surface_node_vars(u, equations, dg, position_index,
+                                       node_index, mortar_index)
 
     flux = surface_flux(u_ll, u_rr, normal_direction, equations)
 
@@ -548,8 +548,8 @@ end
     @unpack u = cache.mortars
     surface_flux, nonconservative_flux = surface_integral.surface_flux
 
-    u_ll, u_rr = get_surface_node_vars(u, equations, dg, position_index, node_index,
-                                       mortar_index)
+    u_ll, u_rr = get_surface_node_vars(u, equations, dg, position_index,
+                                       node_index, mortar_index)
 
     # Compute conservative flux
     flux = surface_flux(u_ll, u_rr, normal_direction, equations)

--- a/src/solvers/dgsem_p4est/dg_2d_parabolic.jl
+++ b/src/solvers/dgsem_p4est/dg_2d_parabolic.jl
@@ -176,14 +176,14 @@ function calc_gradient!(gradients, u_transformed, t,
 
                 for ii in eachnode(dg)
                     multiply_add_to_node_vars!(gradients_x, derivative_dhat[ii, i],
-                                               u_node,
-                                               equations_parabolic, dg, ii, j, element)
+                                               u_node, equations_parabolic, dg,
+                                               ii, j, element)
                 end
 
                 for jj in eachnode(dg)
                     multiply_add_to_node_vars!(gradients_y, derivative_dhat[jj, j],
-                                               u_node,
-                                               equations_parabolic, dg, i, jj, element)
+                                               u_node, equations_parabolic, dg,
+                                               i, jj, element)
                 end
             end
 
@@ -196,11 +196,9 @@ function calc_gradient!(gradients, u_transformed, t,
                                                       element)
 
                 gradients_reference_1 = get_node_vars(gradients_x, equations_parabolic,
-                                                      dg,
-                                                      i, j, element)
+                                                      dg, i, j, element)
                 gradients_reference_2 = get_node_vars(gradients_y, equations_parabolic,
-                                                      dg,
-                                                      i, j, element)
+                                                      dg, i, j, element)
 
                 # note that the contravariant vectors are transposed compared with computations of flux
                 # divergences in `calc_volume_integral!`. See
@@ -211,12 +209,10 @@ function calc_gradient!(gradients, u_transformed, t,
                 gradient_y_node = Ja12 * gradients_reference_1 +
                                   Ja22 * gradients_reference_2
 
-                set_node_vars!(gradients_x, gradient_x_node, equations_parabolic, dg, i,
-                               j,
-                               element)
-                set_node_vars!(gradients_y, gradient_y_node, equations_parabolic, dg, i,
-                               j,
-                               element)
+                set_node_vars!(gradients_x, gradient_x_node, equations_parabolic, dg,
+                               i, j, element)
+                set_node_vars!(gradients_y, gradient_y_node, equations_parabolic, dg,
+                               i, j, element)
             end
         end
     end
@@ -485,15 +481,15 @@ function calc_volume_integral!(du, flux_viscous,
     @threaded for element in eachelement(dg, cache)
         # Calculate volume terms in one element
         for j in eachnode(dg), i in eachnode(dg)
-            flux1 = get_node_vars(flux_viscous_x, equations_parabolic, dg, i, j,
-                                  element)
-            flux2 = get_node_vars(flux_viscous_y, equations_parabolic, dg, i, j,
-                                  element)
+            flux1 = get_node_vars(flux_viscous_x, equations_parabolic, dg,
+                                  i, j, element)
+            flux2 = get_node_vars(flux_viscous_y, equations_parabolic, dg,
+                                  i, j, element)
 
             # Compute the contravariant flux by taking the scalar product of the
             # first contravariant vector Ja^1 and the flux vector
-            Ja11, Ja12 = get_contravariant_vector(1, contravariant_vectors, i, j,
-                                                  element)
+            Ja11, Ja12 = get_contravariant_vector(1, contravariant_vectors,
+                                                  i, j, element)
             contravariant_flux1 = Ja11 * flux1 + Ja12 * flux2
             for ii in eachnode(dg)
                 multiply_add_to_node_vars!(du, derivative_dhat[ii, i],
@@ -503,8 +499,8 @@ function calc_volume_integral!(du, flux_viscous,
 
             # Compute the contravariant flux by taking the scalar product of the
             # second contravariant vector Ja^2 and the flux vector
-            Ja21, Ja22 = get_contravariant_vector(2, contravariant_vectors, i, j,
-                                                  element)
+            Ja21, Ja22 = get_contravariant_vector(2, contravariant_vectors,
+                                                  i, j, element)
             contravariant_flux2 = Ja21 * flux1 + Ja22 * flux2
             for jj in eachnode(dg)
                 multiply_add_to_node_vars!(du, derivative_dhat[jj, j],
@@ -753,11 +749,9 @@ function prolong2mortars_divergence!(cache, flux_viscous::Vector{Array{uEltype, 
 
         # Interpolate large element face data from buffer to small face locations
         multiply_dimensionwise!(view(cache.mortars.u, 2, :, 1, :, mortar),
-                                mortar_l2.forward_lower,
-                                u_buffer)
+                                mortar_l2.forward_lower, u_buffer)
         multiply_dimensionwise!(view(cache.mortars.u, 2, :, 2, :, mortar),
-                                mortar_l2.forward_upper,
-                                u_buffer)
+                                mortar_l2.forward_upper, u_buffer)
     end
 
     return nothing

--- a/src/solvers/dgsem_p4est/dg_2d_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_2d_parallel.jl
@@ -177,11 +177,9 @@ function prolong2mpimortars!(cache, u,
 
                 # Interpolate large element face data from buffer to small face locations
                 multiply_dimensionwise!(view(cache.mpi_mortars.u, 2, :, 1, :, mortar),
-                                        mortar_l2.forward_lower,
-                                        u_buffer)
+                                        mortar_l2.forward_lower, u_buffer)
                 multiply_dimensionwise!(view(cache.mpi_mortars.u, 2, :, 2, :, mortar),
-                                        mortar_l2.forward_upper,
-                                        u_buffer)
+                                        mortar_l2.forward_upper, u_buffer)
             else # position in (1, 2) -> small element
                 # Copy solution data from the small elements
                 i_small = i_small_start
@@ -235,8 +233,7 @@ function calc_mpi_mortar_flux!(surface_flux_values,
 
                 calc_mpi_mortar_flux!(fstar, mesh, nonconservative_terms, equations,
                                       surface_integral, dg, cache,
-                                      mortar, position, normal_direction,
-                                      node)
+                                      mortar, position, normal_direction, node)
 
                 i_small += i_small_step
                 j_small += j_small_step

--- a/src/solvers/dgsem_p4est/dg_3d.jl
+++ b/src/solvers/dgsem_p4est/dg_3d.jl
@@ -605,16 +605,16 @@ end
     @unpack u = cache.mortars
     @unpack surface_flux = surface_integral
 
-    u_ll, u_rr = get_surface_node_vars(u, equations, dg, position_index, i_node_index,
-                                       j_node_index, mortar_index)
+    u_ll, u_rr = get_surface_node_vars(u, equations, dg, position_index,
+                                       i_node_index, j_node_index, mortar_index)
 
     flux = surface_flux(u_ll, u_rr, normal_direction, equations)
 
     # Copy flux to buffer
-    set_node_vars!(fstar_primary, flux, equations, dg, i_node_index, j_node_index,
-                   position_index)
-    set_node_vars!(fstar_secondary, flux, equations, dg, i_node_index, j_node_index,
-                   position_index)
+    set_node_vars!(fstar_primary, flux, equations, dg,
+                   i_node_index, j_node_index, position_index)
+    set_node_vars!(fstar_secondary, flux, equations, dg,
+                   i_node_index, j_node_index, position_index)
 end
 
 # Inlined version of the mortar flux computation on small elements for conservation fluxes

--- a/src/solvers/dgsem_p4est/dg_3d_parabolic.jl
+++ b/src/solvers/dgsem_p4est/dg_3d_parabolic.jl
@@ -49,25 +49,25 @@ function calc_gradient!(gradients, u_transformed, t,
 
             # Calculate gradients with respect to reference coordinates in one element
             for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-                u_node = get_node_vars(u_transformed, equations_parabolic, dg, i, j, k,
-                                       element)
+                u_node = get_node_vars(u_transformed, equations_parabolic, dg,
+                                       i, j, k, element)
 
                 for ii in eachnode(dg)
                     multiply_add_to_node_vars!(gradients_x, derivative_dhat[ii, i],
-                                               u_node, equations_parabolic, dg, ii, j,
-                                               k, element)
+                                               u_node, equations_parabolic, dg,
+                                               ii, j, k, element)
                 end
 
                 for jj in eachnode(dg)
                     multiply_add_to_node_vars!(gradients_y, derivative_dhat[jj, j],
-                                               u_node, equations_parabolic, dg, i, jj,
-                                               k, element)
+                                               u_node, equations_parabolic, dg,
+                                               i, jj, k, element)
                 end
 
                 for kk in eachnode(dg)
                     multiply_add_to_node_vars!(gradients_z, derivative_dhat[kk, k],
-                                               u_node, equations_parabolic, dg, i, j,
-                                               kk, element)
+                                               u_node, equations_parabolic, dg,
+                                               i, j, kk, element)
                 end
             end
 
@@ -82,14 +82,11 @@ function calc_gradient!(gradients, u_transformed, t,
                                                             i, j, k, element)
 
                 gradients_reference_1 = get_node_vars(gradients_x, equations_parabolic,
-                                                      dg,
-                                                      i, j, k, element)
+                                                      dg, i, j, k, element)
                 gradients_reference_2 = get_node_vars(gradients_y, equations_parabolic,
-                                                      dg,
-                                                      i, j, k, element)
+                                                      dg, i, j, k, element)
                 gradients_reference_3 = get_node_vars(gradients_z, equations_parabolic,
-                                                      dg,
-                                                      i, j, k, element)
+                                                      dg, i, j, k, element)
 
                 # note that the contravariant vectors are transposed compared with computations of flux
                 # divergences in `calc_volume_integral!`. See
@@ -394,12 +391,12 @@ function calc_volume_integral!(du, flux_viscous,
     @threaded for element in eachelement(dg, cache)
         # Calculate volume terms in one element
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-            flux1 = get_node_vars(flux_viscous_x, equations_parabolic, dg, i, j, k,
-                                  element)
-            flux2 = get_node_vars(flux_viscous_y, equations_parabolic, dg, i, j, k,
-                                  element)
-            flux3 = get_node_vars(flux_viscous_z, equations_parabolic, dg, i, j, k,
-                                  element)
+            flux1 = get_node_vars(flux_viscous_x, equations_parabolic, dg,
+                                  i, j, k, element)
+            flux2 = get_node_vars(flux_viscous_y, equations_parabolic, dg,
+                                  i, j, k, element)
+            flux3 = get_node_vars(flux_viscous_z, equations_parabolic, dg,
+                                  i, j, k, element)
 
             # Compute the contravariant flux by taking the scalar product of the
             # first contravariant vector Ja^1 and the flux vector
@@ -485,14 +482,11 @@ function prolong2interfaces!(cache_parabolic, flux_viscous,
                 for v in eachvariable(equations_parabolic)
                     # OBS! `interfaces.u` stores the interpolated *fluxes* and *not the solution*!
                     flux_viscous = SVector(flux_viscous_x[v, i_primary, j_primary,
-                                                          k_primary,
-                                                          primary_element],
+                                                          k_primary, primary_element],
                                            flux_viscous_y[v, i_primary, j_primary,
-                                                          k_primary,
-                                                          primary_element],
+                                                          k_primary, primary_element],
                                            flux_viscous_z[v, i_primary, j_primary,
-                                                          k_primary,
-                                                          primary_element])
+                                                          k_primary, primary_element])
 
                     interfaces.u[1, v, i, j, interface] = dot(flux_viscous,
                                                               normal_direction)
@@ -682,14 +676,11 @@ function prolong2mortars_divergence!(cache, flux_viscous,
 
                     for v in eachvariable(equations)
                         flux_viscous = SVector(flux_viscous_x[v, i_small, j_small,
-                                                              k_small,
-                                                              element],
+                                                              k_small, element],
                                                flux_viscous_y[v, i_small, j_small,
-                                                              k_small,
-                                                              element],
+                                                              k_small, element],
                                                flux_viscous_z[v, i_small, j_small,
-                                                              k_small,
-                                                              element])
+                                                              k_small, element])
 
                         cache.mortars.u[1, v, position, i, j, mortar] = dot(flux_viscous,
                                                                             normal_direction)
@@ -984,9 +975,8 @@ function calc_boundary_flux!(cache, t,
                 flux_inner = u_inner
 
                 # Coordinates at boundary node
-                x = get_node_coords(node_coordinates, equations_parabolic, dg, i_node,
-                                    j_node, k_node,
-                                    element)
+                x = get_node_coords(node_coordinates, equations_parabolic, dg,
+                                    i_node, j_node, k_node, element)
 
                 flux_ = boundary_condition_parabolic(flux_inner, u_inner,
                                                      normal_direction,

--- a/src/solvers/dgsem_p4est/dg_3d_parallel.jl
+++ b/src/solvers/dgsem_p4est/dg_3d_parallel.jl
@@ -487,16 +487,16 @@ end
     @unpack u = cache.mpi_mortars
     @unpack surface_flux = surface_integral
 
-    u_ll, u_rr = get_surface_node_vars(u, equations, dg, position_index, i_node_index,
-                                       j_node_index, mortar_index)
+    u_ll, u_rr = get_surface_node_vars(u, equations, dg, position_index,
+                                       i_node_index, j_node_index, mortar_index)
 
     flux = surface_flux(u_ll, u_rr, normal_direction, equations)
 
     # Copy flux to buffer
-    set_node_vars!(fstar_primary, flux, equations, dg, i_node_index, j_node_index,
-                   position_index)
-    set_node_vars!(fstar_secondary, flux, equations, dg, i_node_index, j_node_index,
-                   position_index)
+    set_node_vars!(fstar_primary, flux, equations, dg,
+                   i_node_index, j_node_index, position_index)
+    set_node_vars!(fstar_secondary, flux, equations, dg,
+                   i_node_index, j_node_index, position_index)
 end
 
 # Inlined version of the mortar flux computation on small elements for non-conservative equations

--- a/src/solvers/dgsem_structured/dg_2d.jl
+++ b/src/solvers/dgsem_structured/dg_2d.jl
@@ -80,8 +80,8 @@ See also https://github.com/trixi-framework/Trixi.jl/issues/1671#issuecomment-17
         contravariant_flux1 = Ja11 * flux1 + Ja12 * flux2
         for ii in eachnode(dg)
             multiply_add_to_node_vars!(du, alpha * derivative_dhat[ii, i],
-                                       contravariant_flux1, equations, dg, ii, j,
-                                       element)
+                                       contravariant_flux1, equations, dg,
+                                       ii, j, element)
         end
 
         # Compute the contravariant flux by taking the scalar product of the
@@ -90,8 +90,8 @@ See also https://github.com/trixi-framework/Trixi.jl/issues/1671#issuecomment-17
         contravariant_flux2 = Ja21 * flux1 + Ja22 * flux2
         for jj in eachnode(dg)
             multiply_add_to_node_vars!(du, alpha * derivative_dhat[jj, j],
-                                       contravariant_flux2, equations, dg, i, jj,
-                                       element)
+                                       contravariant_flux2, equations, dg,
+                                       i, jj, element)
         end
     end
 
@@ -126,8 +126,8 @@ end
         for ii in (i + 1):nnodes(dg)
             u_node_ii = get_node_vars(u, equations, dg, ii, j, element)
             # pull the contravariant vectors and compute the average
-            Ja1_node_ii = get_contravariant_vector(1, contravariant_vectors, ii, j,
-                                                   element)
+            Ja1_node_ii = get_contravariant_vector(1, contravariant_vectors,
+                                                   ii, j, element)
             Ja1_avg = 0.5f0 * (Ja1_node + Ja1_node_ii)
             # compute the contravariant sharp flux in the direction of the
             # averaged contravariant vector
@@ -191,8 +191,8 @@ end
         for ii in eachnode(dg)
             u_node_ii = get_node_vars(u, equations, dg, ii, j, element)
             # pull the contravariant vectors and compute the average
-            Ja1_node_ii = get_contravariant_vector(1, contravariant_vectors, ii, j,
-                                                   element)
+            Ja1_node_ii = get_contravariant_vector(1, contravariant_vectors,
+                                                   ii, j, element)
             Ja1_avg = 0.5f0 * (Ja1_node + Ja1_node_ii)
             # Compute the contravariant nonconservative flux.
             fluxtilde1 = nonconservative_flux(u_node, u_node_ii, Ja1_avg,
@@ -205,8 +205,8 @@ end
         for jj in eachnode(dg)
             u_node_jj = get_node_vars(u, equations, dg, i, jj, element)
             # pull the contravariant vectors and compute the average
-            Ja2_node_jj = get_contravariant_vector(2, contravariant_vectors, i, jj,
-                                                   element)
+            Ja2_node_jj = get_contravariant_vector(2, contravariant_vectors,
+                                                   i, jj, element)
             Ja2_avg = 0.5f0 * (Ja2_node + Ja2_node_jj)
             # compute the contravariant nonconservative flux in the direction of the
             # averaged contravariant vector
@@ -317,8 +317,8 @@ end
     fstar1_R[:, nnodes(dg) + 1, :] .= zero(eltype(fstar1_R))
 
     for j in eachnode(dg)
-        normal_direction = get_contravariant_vector(1, contravariant_vectors, 1, j,
-                                                    element)
+        normal_direction = get_contravariant_vector(1, contravariant_vectors,
+                                                    1, j, element)
         for i in 2:nnodes(dg)
             u_ll = get_node_vars(u, equations, dg, i - 1, j, element)
             u_rr = get_node_vars(u, equations, dg, i, j, element)
@@ -356,8 +356,8 @@ end
 
     # Compute inner fluxes
     for i in eachnode(dg)
-        normal_direction = get_contravariant_vector(2, contravariant_vectors, i, 1,
-                                                    element)
+        normal_direction = get_contravariant_vector(2, contravariant_vectors,
+                                                    i, 1, element)
 
         for j in 2:nnodes(dg)
             u_ll = get_node_vars(u, equations, dg, i, j - 1, element)

--- a/src/solvers/dgsem_structured/dg_3d.jl
+++ b/src/solvers/dgsem_structured/dg_3d.jl
@@ -81,8 +81,8 @@ See also https://github.com/trixi-framework/Trixi.jl/issues/1671#issuecomment-17
         contravariant_flux1 = Ja11 * flux1 + Ja12 * flux2 + Ja13 * flux3
         for ii in eachnode(dg)
             multiply_add_to_node_vars!(du, alpha * derivative_dhat[ii, i],
-                                       contravariant_flux1, equations, dg, ii, j, k,
-                                       element)
+                                       contravariant_flux1, equations, dg,
+                                       ii, j, k, element)
         end
 
         # Compute the contravariant flux by taking the scalar product of the
@@ -92,19 +92,19 @@ See also https://github.com/trixi-framework/Trixi.jl/issues/1671#issuecomment-17
         contravariant_flux2 = Ja21 * flux1 + Ja22 * flux2 + Ja23 * flux3
         for jj in eachnode(dg)
             multiply_add_to_node_vars!(du, alpha * derivative_dhat[jj, j],
-                                       contravariant_flux2, equations, dg, i, jj, k,
-                                       element)
+                                       contravariant_flux2, equations, dg,
+                                       i, jj, k, element)
         end
 
         # Compute the contravariant flux by taking the scalar product of the
         # third contravariant vector Ja^3 and the flux vector
-        Ja31, Ja32, Ja33 = get_contravariant_vector(3, contravariant_vectors, i, j, k,
-                                                    element)
+        Ja31, Ja32, Ja33 = get_contravariant_vector(3, contravariant_vectors,
+                                                    i, j, k, element)
         contravariant_flux3 = Ja31 * flux1 + Ja32 * flux2 + Ja33 * flux3
         for kk in eachnode(dg)
             multiply_add_to_node_vars!(du, alpha * derivative_dhat[kk, k],
-                                       contravariant_flux3, equations, dg, i, j, kk,
-                                       element)
+                                       contravariant_flux3, equations, dg,
+                                       i, j, kk, element)
         end
     end
 
@@ -223,8 +223,8 @@ end
         for ii in eachnode(dg)
             u_node_ii = get_node_vars(u, equations, dg, ii, j, k, element)
             # pull the contravariant vectors and compute the average
-            Ja1_node_ii = get_contravariant_vector(1, contravariant_vectors, ii, j, k,
-                                                   element)
+            Ja1_node_ii = get_contravariant_vector(1, contravariant_vectors,
+                                                   ii, j, k, element)
             Ja1_avg = 0.5f0 * (Ja1_node + Ja1_node_ii)
             # compute the contravariant nonconservative flux in the direction of the
             # averaged contravariant vector
@@ -238,8 +238,8 @@ end
         for jj in eachnode(dg)
             u_node_jj = get_node_vars(u, equations, dg, i, jj, k, element)
             # pull the contravariant vectors and compute the average
-            Ja2_node_jj = get_contravariant_vector(2, contravariant_vectors, i, jj, k,
-                                                   element)
+            Ja2_node_jj = get_contravariant_vector(2, contravariant_vectors,
+                                                   i, jj, k, element)
             Ja2_avg = 0.5f0 * (Ja2_node + Ja2_node_jj)
             # compute the contravariant nonconservative flux in the direction of the
             # averaged contravariant vector
@@ -253,8 +253,8 @@ end
         for kk in eachnode(dg)
             u_node_kk = get_node_vars(u, equations, dg, i, j, kk, element)
             # pull the contravariant vectors and compute the average
-            Ja3_node_kk = get_contravariant_vector(3, contravariant_vectors, i, j, kk,
-                                                   element)
+            Ja3_node_kk = get_contravariant_vector(3, contravariant_vectors,
+                                                   i, j, kk, element)
             Ja3_avg = 0.5f0 * (Ja3_node + Ja3_node_kk)
             # compute the contravariant nonconservative flux in the direction of the
             # averaged contravariant vector
@@ -292,8 +292,8 @@ end
     fstar1_R[:, nnodes(dg) + 1, :, :] .= zero(eltype(fstar1_R))
 
     for k in eachnode(dg), j in eachnode(dg)
-        normal_direction = get_contravariant_vector(1, contravariant_vectors, 1, j, k,
-                                                    element)
+        normal_direction = get_contravariant_vector(1, contravariant_vectors,
+                                                    1, j, k, element)
 
         for i in 2:nnodes(dg)
             u_ll = get_node_vars(u, equations, dg, i - 1, j, k, element)
@@ -319,8 +319,8 @@ end
     fstar2_R[:, :, nnodes(dg) + 1, :] .= zero(eltype(fstar2_R))
 
     for k in eachnode(dg), i in eachnode(dg)
-        normal_direction = get_contravariant_vector(2, contravariant_vectors, i, 1, k,
-                                                    element)
+        normal_direction = get_contravariant_vector(2, contravariant_vectors,
+                                                    i, 1, k, element)
 
         for j in 2:nnodes(dg)
             u_ll = get_node_vars(u, equations, dg, i, j - 1, k, element)
@@ -346,8 +346,8 @@ end
     fstar3_R[:, :, :, nnodes(dg) + 1] .= zero(eltype(fstar3_R))
 
     for j in eachnode(dg), i in eachnode(dg)
-        normal_direction = get_contravariant_vector(3, contravariant_vectors, i, j, 1,
-                                                    element)
+        normal_direction = get_contravariant_vector(3, contravariant_vectors,
+                                                    i, j, 1, element)
 
         for k in 2:nnodes(dg)
             u_ll = get_node_vars(u, equations, dg, i, j, k - 1, element)
@@ -390,8 +390,8 @@ end
     fstar1_R[:, nnodes(dg) + 1, :, :] .= zero(eltype(fstar1_R))
 
     for k in eachnode(dg), j in eachnode(dg)
-        normal_direction = get_contravariant_vector(1, contravariant_vectors, 1, j, k,
-                                                    element)
+        normal_direction = get_contravariant_vector(1, contravariant_vectors,
+                                                    1, j, k, element)
 
         for i in 2:nnodes(dg)
             u_ll = get_node_vars(u, equations, dg, i - 1, j, k, element)
@@ -428,8 +428,8 @@ end
     fstar2_R[:, :, nnodes(dg) + 1, :] .= zero(eltype(fstar2_R))
 
     for k in eachnode(dg), i in eachnode(dg)
-        normal_direction = get_contravariant_vector(2, contravariant_vectors, i, 1, k,
-                                                    element)
+        normal_direction = get_contravariant_vector(2, contravariant_vectors,
+                                                    i, 1, k, element)
 
         for j in 2:nnodes(dg)
             u_ll = get_node_vars(u, equations, dg, i, j - 1, k, element)
@@ -466,8 +466,8 @@ end
     fstar3_R[:, :, :, nnodes(dg) + 1] .= zero(eltype(fstar3_R))
 
     for j in eachnode(dg), i in eachnode(dg)
-        normal_direction = get_contravariant_vector(3, contravariant_vectors, i, j, 1,
-                                                    element)
+        normal_direction = get_contravariant_vector(3, contravariant_vectors,
+                                                    i, j, 1, element)
 
         for k in 2:nnodes(dg)
             u_ll = get_node_vars(u, equations, dg, i, j, k - 1, element)

--- a/src/solvers/dgsem_tree/dg_1d.jl
+++ b/src/solvers/dgsem_tree/dg_1d.jl
@@ -543,8 +543,7 @@ function calc_boundary_flux_by_direction!(surface_flux_values::AbstractArray{<:A
         end
         x = get_node_coords(node_coordinates, equations, dg, boundary)
         flux = boundary_condition(u_inner, orientations[boundary], direction, x, t,
-                                  surface_flux,
-                                  equations)
+                                  surface_flux, equations)
 
         # Copy flux to left and right element storage
         for v in eachvariable(equations)

--- a/src/solvers/dgsem_tree/dg_1d_parabolic.jl
+++ b/src/solvers/dgsem_tree/dg_1d_parabolic.jl
@@ -241,13 +241,13 @@ function calc_viscous_fluxes!(flux_viscous, gradients, u_transformed, mesh::Tree
         for i in eachnode(dg)
             # Get solution and gradients
             u_node = get_node_vars(u_transformed, equations_parabolic, dg, i, element)
-            gradients_1_node = get_node_vars(gradients, equations_parabolic, dg, i,
-                                             element)
+            gradients_1_node = get_node_vars(gradients, equations_parabolic, dg,
+                                             i, element)
 
             # Calculate viscous flux and store each component for later use
             flux_viscous_node = flux(u_node, gradients_1_node, 1, equations_parabolic)
-            set_node_vars!(flux_viscous, flux_viscous_node, equations_parabolic, dg, i,
-                           element)
+            set_node_vars!(flux_viscous, flux_viscous_node, equations_parabolic, dg,
+                           i, element)
         end
     end
 end
@@ -453,13 +453,13 @@ function calc_gradient!(gradients, u_transformed, t, mesh::TreeMesh{1},
 
             # Calculate volume terms in one element
             for i in eachnode(dg)
-                u_node = get_node_vars(u_transformed, equations_parabolic, dg, i,
-                                       element)
+                u_node = get_node_vars(u_transformed, equations_parabolic, dg,
+                                       i, element)
 
                 for ii in eachnode(dg)
                     multiply_add_to_node_vars!(gradients, derivative_dhat[ii, i],
-                                               u_node, equations_parabolic, dg, ii,
-                                               element)
+                                               u_node, equations_parabolic, dg,
+                                               ii, element)
                 end
             end
         end

--- a/src/solvers/dgsem_tree/dg_2d_parabolic.jl
+++ b/src/solvers/dgsem_tree/dg_2d_parabolic.jl
@@ -145,10 +145,10 @@ function calc_volume_integral!(du, flux_viscous,
     @threaded for element in eachelement(dg, cache)
         # Calculate volume terms in one element
         for j in eachnode(dg), i in eachnode(dg)
-            flux_1_node = get_node_vars(flux_viscous_x, equations_parabolic, dg, i, j,
-                                        element)
-            flux_2_node = get_node_vars(flux_viscous_y, equations_parabolic, dg, i, j,
-                                        element)
+            flux_1_node = get_node_vars(flux_viscous_x, equations_parabolic, dg,
+                                        i, j, element)
+            flux_2_node = get_node_vars(flux_viscous_y, equations_parabolic, dg,
+                                        i, j, element)
 
             for ii in eachnode(dg)
                 multiply_add_to_node_vars!(du, derivative_dhat[ii, i], flux_1_node,
@@ -270,7 +270,8 @@ function prolong2boundaries!(cache_parabolic, flux_viscous,
             else # Element in +x direction of boundary
                 for l in eachnode(dg), v in eachvariable(equations_parabolic)
                     # OBS! `boundaries_u` stores the interpolated *fluxes* and *not the solution*!
-                    boundaries_u[2, v, l, boundary] = flux_viscous_x[v, 1, l, element]
+                    boundaries_u[2, v, l, boundary] = flux_viscous_x[v, 1, l,
+                                                                     element]
                 end
             end
         else # if orientations[boundary] == 2
@@ -286,7 +287,8 @@ function prolong2boundaries!(cache_parabolic, flux_viscous,
                 # element in +y direction of boundary
                 for l in eachnode(dg), v in eachvariable(equations_parabolic)
                     # OBS! `boundaries_u` stores the interpolated *fluxes* and *not the solution*!
-                    boundaries_u[2, v, l, boundary] = flux_viscous_y[v, l, 1, element]
+                    boundaries_u[2, v, l, boundary] = flux_viscous_y[v, l, 1,
+                                                                     element]
                 end
             end
         end
@@ -306,12 +308,12 @@ function calc_viscous_fluxes!(flux_viscous,
     @threaded for element in eachelement(dg, cache)
         for j in eachnode(dg), i in eachnode(dg)
             # Get solution and gradients
-            u_node = get_node_vars(u_transformed, equations_parabolic, dg, i, j,
-                                   element)
-            gradients_1_node = get_node_vars(gradients_x, equations_parabolic, dg, i, j,
-                                             element)
-            gradients_2_node = get_node_vars(gradients_y, equations_parabolic, dg, i, j,
-                                             element)
+            u_node = get_node_vars(u_transformed, equations_parabolic, dg,
+                                   i, j, element)
+            gradients_1_node = get_node_vars(gradients_x, equations_parabolic, dg,
+                                             i, j, element)
+            gradients_2_node = get_node_vars(gradients_y, equations_parabolic, dg,
+                                             i, j, element)
 
             # Calculate viscous flux and store each component for later use
             flux_viscous_node_x = flux(u_node, (gradients_1_node, gradients_2_node), 1,
@@ -802,19 +804,19 @@ function calc_gradient!(gradients, u_transformed, t,
 
             # Calculate volume terms in one element
             for j in eachnode(dg), i in eachnode(dg)
-                u_node = get_node_vars(u_transformed, equations_parabolic, dg, i, j,
-                                       element)
+                u_node = get_node_vars(u_transformed, equations_parabolic, dg,
+                                       i, j, element)
 
                 for ii in eachnode(dg)
                     multiply_add_to_node_vars!(gradients_x, derivative_dhat[ii, i],
-                                               u_node, equations_parabolic, dg, ii, j,
-                                               element)
+                                               u_node, equations_parabolic, dg,
+                                               ii, j, element)
                 end
 
                 for jj in eachnode(dg)
                     multiply_add_to_node_vars!(gradients_y, derivative_dhat[jj, j],
-                                               u_node, equations_parabolic, dg, i, jj,
-                                               element)
+                                               u_node, equations_parabolic, dg,
+                                               i, jj, element)
                 end
             end
         end

--- a/src/solvers/dgsem_tree/dg_3d.jl
+++ b/src/solvers/dgsem_tree/dg_3d.jl
@@ -848,8 +848,7 @@ function calc_boundary_flux_by_direction!(surface_flux_values::AbstractArray{<:A
             end
             x = get_node_coords(node_coordinates, equations, dg, i, j, boundary)
             flux = boundary_condition(u_inner, orientations[boundary], direction, x, t,
-                                      surface_flux,
-                                      equations)
+                                      surface_flux, equations)
 
             # Copy flux to left and right element storage
             for v in eachvariable(equations)

--- a/src/solvers/dgsem_tree/dg_3d_parabolic.jl
+++ b/src/solvers/dgsem_tree/dg_3d_parabolic.jl
@@ -35,12 +35,12 @@ function calc_volume_integral!(du, flux_viscous,
     @threaded for element in eachelement(dg, cache)
         # Calculate volume terms in one element
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-            flux_1_node = get_node_vars(flux_viscous_x, equations_parabolic, dg, i, j,
-                                        k, element)
-            flux_2_node = get_node_vars(flux_viscous_y, equations_parabolic, dg, i, j,
-                                        k, element)
-            flux_3_node = get_node_vars(flux_viscous_z, equations_parabolic, dg, i, j,
-                                        k, element)
+            flux_1_node = get_node_vars(flux_viscous_x, equations_parabolic, dg,
+                                        i, j, k, element)
+            flux_2_node = get_node_vars(flux_viscous_y, equations_parabolic, dg,
+                                        i, j, k, element)
+            flux_3_node = get_node_vars(flux_viscous_z, equations_parabolic, dg,
+                                        i, j, k, element)
 
             for ii in eachnode(dg)
                 multiply_add_to_node_vars!(du, derivative_dhat[ii, i], flux_1_node,
@@ -137,8 +137,8 @@ function calc_interface_flux!(surface_flux_values, mesh::TreeMesh{3},
         for j in eachnode(dg), i in eachnode(dg)
             # Get precomputed fluxes at interfaces
             flux_ll, flux_rr = get_surface_node_vars(cache_parabolic.interfaces.u,
-                                                     equations_parabolic,
-                                                     dg, i, j, interface)
+                                                     equations_parabolic, dg,
+                                                     i, j, interface)
 
             flux = flux_parabolic(flux_ll, flux_rr, Divergence(),
                                   mesh, equations_parabolic, parabolic_scheme)
@@ -244,12 +244,12 @@ function calc_viscous_fluxes!(flux_viscous,
             # Get solution and gradients
             u_node = get_node_vars(u_transformed, equations_parabolic, dg, i, j, k,
                                    element)
-            gradients_1_node = get_node_vars(gradients_x, equations_parabolic, dg, i, j,
-                                             k, element)
-            gradients_2_node = get_node_vars(gradients_y, equations_parabolic, dg, i, j,
-                                             k, element)
-            gradients_3_node = get_node_vars(gradients_z, equations_parabolic, dg, i, j,
-                                             k, element)
+            gradients_1_node = get_node_vars(gradients_x, equations_parabolic, dg,
+                                             i, j, k, element)
+            gradients_2_node = get_node_vars(gradients_y, equations_parabolic, dg,
+                                             i, j, k, element)
+            gradients_3_node = get_node_vars(gradients_z, equations_parabolic, dg,
+                                             i, j, k, element)
 
             # Calculate viscous flux and store each component for later use
             flux_viscous_node_x = flux(u_node,
@@ -363,8 +363,8 @@ function calc_boundary_flux_by_direction_gradient!(surface_flux_values::Abstract
 
         for j in eachnode(dg), i in eachnode(dg)
             # Get boundary flux
-            u_ll, u_rr = get_surface_node_vars(u, equations_parabolic, dg, i, j,
-                                               boundary)
+            u_ll, u_rr = get_surface_node_vars(u, equations_parabolic, dg,
+                                               i, j, boundary)
             if neighbor_sides[boundary] == 1 # Element is on the left, boundary on the right
                 u_inner = u_ll
             else # Element is on the right, boundary on the left
@@ -376,8 +376,8 @@ function calc_boundary_flux_by_direction_gradient!(surface_flux_values::Abstract
             # which is consistent with BR1, LDG.
             flux_inner = u_inner
 
-            x = get_node_coords(node_coordinates, equations_parabolic, dg, i, j,
-                                boundary)
+            x = get_node_coords(node_coordinates, equations_parabolic, dg,
+                                i, j, boundary)
             flux = boundary_condition(flux_inner, u_inner,
                                       get_unsigned_normal_vector_3d(direction),
                                       x, t, Gradient(), equations_parabolic)
@@ -456,16 +456,16 @@ function calc_boundary_flux_by_direction_divergence!(surface_flux_values::Abstra
 
         for j in eachnode(dg), i in eachnode(dg)
             # Get viscous boundary fluxes
-            flux_ll, flux_rr = get_surface_node_vars(u, equations_parabolic, dg, i, j,
-                                                     boundary)
+            flux_ll, flux_rr = get_surface_node_vars(u, equations_parabolic, dg,
+                                                     i, j, boundary)
             if neighbor_sides[boundary] == 1 # Element is on the left, boundary on the right
                 flux_inner = flux_ll
             else # Element is on the right, boundary on the left
                 flux_inner = flux_rr
             end
 
-            x = get_node_coords(node_coordinates, equations_parabolic, dg, i, j,
-                                boundary)
+            x = get_node_coords(node_coordinates, equations_parabolic, dg,
+                                i, j, boundary)
 
             # TODO: add a field in `cache.boundaries` for gradient information. UPDATE THIS COMMENT
             # Here, we pass in `u_inner = nothing` since we overwrite cache.boundaries.u with gradient information.
@@ -773,8 +773,8 @@ end
                              u_interfaces, interface, orientation)
     for j in eachnode(dg), i in eachnode(dg)
         # Call pointwise two-point numerical flux function
-        u_ll, u_rr = get_surface_node_vars(u_interfaces, equations_parabolic, dg, i, j,
-                                           interface)
+        u_ll, u_rr = get_surface_node_vars(u_interfaces, equations_parabolic, dg,
+                                           i, j, interface)
 
         flux = flux_parabolic(u_ll, u_rr, gradient_or_divergence,
                               mesh, equations_parabolic, parabolic_scheme)
@@ -896,8 +896,8 @@ function calc_gradient_interface_flux!(surface_flux_values,
         for j in eachnode(dg), i in eachnode(dg)
             # Call pointwise Riemann solver
             u_ll, u_rr = get_surface_node_vars(cache_parabolic.interfaces.u,
-                                               equations, dg, i, j,
-                                               interface)
+                                               equations, dg,
+                                               i, j, interface)
 
             flux = flux_parabolic(u_ll, u_rr, Gradient(),
                                   mesh, equations, parabolic_scheme)
@@ -932,25 +932,25 @@ function calc_gradient!(gradients, u_transformed, t,
 
             # Calculate volume terms in one element
             for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-                u_node = get_node_vars(u_transformed, equations_parabolic, dg, i, j, k,
-                                       element)
+                u_node = get_node_vars(u_transformed, equations_parabolic, dg,
+                                       i, j, k, element)
 
                 for ii in eachnode(dg)
                     multiply_add_to_node_vars!(gradients_x, derivative_dhat[ii, i],
-                                               u_node, equations_parabolic, dg, ii, j,
-                                               k, element)
+                                               u_node, equations_parabolic, dg,
+                                               ii, j, k, element)
                 end
 
                 for jj in eachnode(dg)
                     multiply_add_to_node_vars!(gradients_y, derivative_dhat[jj, j],
-                                               u_node, equations_parabolic, dg, i, jj,
-                                               k, element)
+                                               u_node, equations_parabolic, dg,
+                                               i, jj, k, element)
                 end
 
                 for kk in eachnode(dg)
                     multiply_add_to_node_vars!(gradients_z, derivative_dhat[kk, k],
-                                               u_node, equations_parabolic, dg, i, j,
-                                               kk, element)
+                                               u_node, equations_parabolic, dg,
+                                               i, j, kk, element)
                 end
             end
         end

--- a/src/solvers/dgsem_unstructured/dg_2d.jl
+++ b/src/solvers/dgsem_unstructured/dg_2d.jl
@@ -110,25 +110,30 @@ function prolong2interfaces!(cache, u,
 
         if primary_side == 1
             for i in eachnode(dg), v in eachvariable(equations)
-                interfaces_u[1, v, i, interface] = u[v, i, 1, primary_element]
+                interfaces_u[1, v, i, interface] = u[v, i, 1,
+                                                     primary_element]
             end
         elseif primary_side == 2
             for i in eachnode(dg), v in eachvariable(equations)
-                interfaces_u[1, v, i, interface] = u[v, nnodes(dg), i, primary_element]
+                interfaces_u[1, v, i, interface] = u[v, nnodes(dg), i,
+                                                     primary_element]
             end
         elseif primary_side == 3
             for i in eachnode(dg), v in eachvariable(equations)
-                interfaces_u[1, v, i, interface] = u[v, i, nnodes(dg), primary_element]
+                interfaces_u[1, v, i, interface] = u[v, i, nnodes(dg),
+                                                     primary_element]
             end
         else # primary_side == 4
             for i in eachnode(dg), v in eachvariable(equations)
-                interfaces_u[1, v, i, interface] = u[v, 1, i, primary_element]
+                interfaces_u[1, v, i, interface] = u[v, 1, i,
+                                                     primary_element]
             end
         end
 
         if secondary_side == 1
             for i in eachnode(dg), v in eachvariable(equations)
-                interfaces_u[2, v, i, interface] = u[v, i, 1, secondary_element]
+                interfaces_u[2, v, i, interface] = u[v, i, 1,
+                                                     secondary_element]
             end
         elseif secondary_side == 2
             for i in eachnode(dg), v in eachvariable(equations)
@@ -142,7 +147,8 @@ function prolong2interfaces!(cache, u,
             end
         else # secondary_side == 4
             for i in eachnode(dg), v in eachvariable(equations)
-                interfaces_u[2, v, i, interface] = u[v, 1, i, secondary_element]
+                interfaces_u[2, v, i, interface] = u[v, 1, i,
+                                                     secondary_element]
             end
         end
     end
@@ -184,8 +190,7 @@ function calc_interface_flux!(surface_flux_values,
             #   Note! this assumes a conforming approximation, more must be done in terms of the normals
             #         for hanging nodes and other non-conforming approximation spaces
             outward_direction = get_surface_normal(normal_directions, primary_index,
-                                                   primary_side,
-                                                   primary_element)
+                                                   primary_side, primary_element)
 
             # Call pointwise numerical flux with rotation. Direction is normalized inside this function
             flux = surface_flux(u_ll, u_rr, outward_direction, equations)
@@ -238,8 +243,7 @@ function calc_interface_flux!(surface_flux_values,
             # Note! This assumes a conforming approximation, more must be done in terms
             # of the normals for hanging nodes and other non-conforming approximation spaces
             outward_direction = get_surface_normal(normal_directions, primary_index,
-                                                   primary_side,
-                                                   primary_element)
+                                                   primary_side, primary_element)
 
             # Calculate the conservative portion of the numerical flux
             # Call pointwise numerical flux with rotation. Direction is normalized


### PR DESCRIPTION
The main motivation for this PR is code like

https://github.com/trixi-framework/Trixi.jl/blob/4b7c029575fe027e0d43fefe209d138caee1c2d3/src/solvers/dgsem_p4est/dg_2d.jl#L334-L335

vs

https://github.com/trixi-framework/Trixi.jl/blob/4b7c029575fe027e0d43fefe209d138caee1c2d3/src/solvers/dgsem_p4est/dg_3d.jl#L396-L397

which really bothers me. I tried to make the line breaks more consistent across dimensions and, if possible, follow the semantics of the variables.

Some line breaks like 

https://github.com/trixi-framework/Trixi.jl/blob/4b7c029575fe027e0d43fefe209d138caee1c2d3/src/solvers/dgsem_p4est/dg_2d_parabolic.jl#L214-L216

are also clearly caused by the formatter and went through undetected.