### PR TITLE
Docstring Enstrophy, Export+Docstring Vorticity

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -233,9 +233,9 @@ export cons2cons, cons2prim, prim2cons, cons2macroscopic, cons2state, cons2mean,
        cons2entropy, entropy2cons
 export density, pressure, density_pressure, velocity, global_mean_vars,
        equilibrium_distribution, waterheight, waterheight_pressure
-export entropy, energy_total, energy_kinetic, energy_internal, energy_magnetic,
-       cross_helicity,
-       enstrophy, magnetic_field, divergence_cleaning_field
+export entropy, energy_total, energy_kinetic, energy_internal,
+       energy_magnetic, cross_helicity, magnetic_field, divergence_cleaning_field,
+       enstrophy, vorticity
 export lake_at_rest_error
 export ncomponents, eachcomponent
 

--- a/src/equations/compressible_navier_stokes_2d.jl
+++ b/src/equations/compressible_navier_stokes_2d.jl
@@ -295,8 +295,8 @@ Computes the (node-wise) enstrophy, defined as
 ```math
     \mathcal{E} = \frac{1}{2} \rho \omega \cdot \omega
 ```
-where ``\omega = \nabla \times \boldsymbol{v}`` is the [vorticity](@ref).
-In 2D, `\omega` is just a scalar.
+where ``\omega = \nabla \times \boldsymbol{v}`` is the [`vorticity`](@ref).
+In 2D,  ``\omega`` is just a scalar.
 """
 @inline function enstrophy(u, gradients, equations::CompressibleNavierStokesDiffusion2D)
     # Enstrophy is 0.5 rho ω⋅ω where ω = ∇ × v

--- a/src/equations/compressible_navier_stokes_2d.jl
+++ b/src/equations/compressible_navier_stokes_2d.jl
@@ -296,7 +296,7 @@ Computes the (node-wise) enstrophy, defined as
     \mathcal{E} = \frac{1}{2} \rho \omega \cdot \omega
 ```
 where ``\omega = \nabla \times \boldsymbol{v}`` is the [`vorticity`](@ref).
-In 2D,  ``\omega`` is just a scalar.
+In 2D, ``\omega`` is just a scalar.
 """
 @inline function enstrophy(u, gradients, equations::CompressibleNavierStokesDiffusion2D)
     # Enstrophy is 0.5 rho ω⋅ω where ω = ∇ × v

--- a/src/equations/compressible_navier_stokes_2d.jl
+++ b/src/equations/compressible_navier_stokes_2d.jl
@@ -288,6 +288,16 @@ end
     return SVector(v1, v2)
 end
 
+@doc raw"""
+    enstrophy(u, gradients, equations::CompressibleNavierStokesDiffusion2D)
+
+Computes the (node-wise) enstrophy, defined as
+```math
+    \mathcal{E} = \frac{1}{2} \rho \omega \cdot \omega
+```
+where ``\omega = \nabla \times \boldsymbol{v}`` is the [vorticity](@ref).
+In 2D, `\omega` is just a scalar.
+"""
 @inline function enstrophy(u, gradients, equations::CompressibleNavierStokesDiffusion2D)
     # Enstrophy is 0.5 rho ω⋅ω where ω = ∇ × v
 
@@ -295,10 +305,18 @@ end
     return 0.5f0 * u[1] * omega^2
 end
 
+@doc raw"""
+    vorticity(u, gradients, equations::CompressibleNavierStokesDiffusion2D)
+
+Computes the (node-wise) vorticity, defined in 2D as
+```math
+    \omega = \nabla \times \boldsymbol{v} = \frac{\partial v_2}{\partial x_1} - \frac{\partial v_1}{\partial x_2}
+```
+"""
 @inline function vorticity(u, gradients, equations::CompressibleNavierStokesDiffusion2D)
     # Ensure that we have velocity `gradients` by way of the `convert_gradient_variables` function.
-    _, dv1dx, dv2dx, _ = convert_derivative_to_primitive(u, gradients[1], equations)
-    _, dv1dy, dv2dy, _ = convert_derivative_to_primitive(u, gradients[2], equations)
+    _, _, dv2dx, _ = convert_derivative_to_primitive(u, gradients[1], equations)
+    _, dv1dy, _, _ = convert_derivative_to_primitive(u, gradients[2], equations)
 
     return dv2dx - dv1dy
 end

--- a/src/equations/compressible_navier_stokes_3d.jl
+++ b/src/equations/compressible_navier_stokes_3d.jl
@@ -317,6 +317,16 @@ end
     return SVector(v1, v2, v3)
 end
 
+@doc raw"""
+    enstrophy(u, gradients, equations::CompressibleNavierStokesDiffusion3D)
+
+Computes the (node-wise) enstrophy, defined as
+```math
+    \mathcal{E} = \frac{1}{2} \rho \boldsymbol{\omega} \cdot \boldsymbol{\omega}
+```
+where ``\boldsymbol{\omega} = \nabla \times \boldsymbol{v}`` is the [vorticity](@ref).
+In 3D, `\boldsymbol{\omega}` is a full three-component vector.
+"""
 @inline function enstrophy(u, gradients, equations::CompressibleNavierStokesDiffusion3D)
     # Enstrophy is 0.5 rho ω⋅ω where ω = ∇ × v
 
@@ -324,14 +334,24 @@ end
     return 0.5f0 * u[1] * (omega[1]^2 + omega[2]^2 + omega[3]^2)
 end
 
+@doc raw"""
+    vorticity(u, gradients, equations::CompressibleNavierStokesDiffusion3D)
+
+Computes the (node-wise) vorticity, defined in 3D as
+```math
+    \omega = \nabla \times \boldsymbol{v} =
+    \begin{pmatrix}
+        \frac{\partial v_3}{\partial y} - \frac{\partial v_2}{\partial z} \\
+        \frac{\partial v_1}{\partial z} - \frac{\partial v_3}{\partial x} \\
+        \frac{\partial v_2}{\partial x} - \frac{\partial v_1}{\partial y}
+    \end{pmatrix}
+```
+"""
 @inline function vorticity(u, gradients, equations::CompressibleNavierStokesDiffusion3D)
     # Ensure that we have velocity `gradients` by way of the `convert_gradient_variables` function.
-    _, dv1dx, dv2dx, dv3dx, _ = convert_derivative_to_primitive(u, gradients[1],
-                                                                equations)
-    _, dv1dy, dv2dy, dv3dy, _ = convert_derivative_to_primitive(u, gradients[2],
-                                                                equations)
-    _, dv1dz, dv2dz, dv3dz, _ = convert_derivative_to_primitive(u, gradients[3],
-                                                                equations)
+    _, _, dv2dx, dv3dx, _ = convert_derivative_to_primitive(u, gradients[1], equations)
+    _, dv1dy, _, dv3dy, _ = convert_derivative_to_primitive(u, gradients[2], equations)
+    _, dv1dz, dv2dz, _, _ = convert_derivative_to_primitive(u, gradients[3], equations)
 
     return SVector(dv3dy - dv2dz, dv1dz - dv3dx, dv2dx - dv1dy)
 end

--- a/src/equations/compressible_navier_stokes_3d.jl
+++ b/src/equations/compressible_navier_stokes_3d.jl
@@ -324,8 +324,8 @@ Computes the (node-wise) enstrophy, defined as
 ```math
     \mathcal{E} = \frac{1}{2} \rho \boldsymbol{\omega} \cdot \boldsymbol{\omega}
 ```
-where ``\boldsymbol{\omega} = \nabla \times \boldsymbol{v}`` is the [vorticity](@ref).
-In 3D, `\boldsymbol{\omega}` is a full three-component vector.
+where ``\boldsymbol{\omega} = \nabla \times \boldsymbol{v}`` is the [`vorticity`](@ref).
+In 3D, ``\boldsymbol{\omega}`` is a full three-component vector.
 """
 @inline function enstrophy(u, gradients, equations::CompressibleNavierStokesDiffusion3D)
     # Enstrophy is 0.5 rho ω⋅ω where ω = ∇ × v


### PR DESCRIPTION
`enstrophy` was exported
https://github.com/trixi-framework/Trixi.jl/blob/8c4cd808089534ca772da08339be58f6b988d801/src/Trixi.jl#L238
 but undocumented.

I chose to export `vorticity` now as well, as this is

1. Referenced in the new docstring
2. Will be used in the future, see https://github.com/trixi-framework/Trixi.jl/pull/2298