### PR TITLE
Fix docstring `flux_parabolic`

### DIFF
--- a/src/solvers/solvers_parabolic.jl
+++ b/src/solvers/solvers_parabolic.jl
@@ -20,8 +20,8 @@ In the latter case, the [`ViscousFormulationLocalDG`](@ref) scheme is recommende
 struct ViscousFormulationBassiRebay1 end
 
 """
-  flux_parabolic(u_ll, u_rr, gradient_or_divergence, mesh, equations,
-                 parabolic_scheme::ViscousFormulationBassiRebay1)
+    flux_parabolic(u_ll, u_rr, gradient_or_divergence, mesh, equations,
+                   parabolic_scheme::ViscousFormulationBassiRebay1)
 
 This computes the classical BR1 flux. Since the interface flux for both the 
 DG gradient and DG divergence under BR1 are identical, this function does 
@@ -66,11 +66,11 @@ Cockburn and Dong proved that this scheme is still stable despite the zero penal
 ViscousFormulationLocalDG() = ViscousFormulationLocalDG(nothing)
 
 """
-  flux_parabolic(u_ll, u_rr, ::Gradient, mesh::TreeMesh, equations,
-                 parabolic_scheme::ViscousFormulationLocalDG)
-
-  flux_parabolic(u_ll, u_rr, ::Divergence, mesh::TreeMesh, equations,
-                 parabolic_scheme::ViscousFormulationLocalDG)
+    flux_parabolic(u_ll, u_rr, ::Gradient, mesh::TreeMesh, equations,
+                   parabolic_scheme::ViscousFormulationLocalDG)
+  
+    flux_parabolic(u_ll, u_rr, ::Divergence, mesh::TreeMesh, equations,
+                   parabolic_scheme::ViscousFormulationLocalDG)
 
 These fluxes computes the gradient and divergence interface fluxes for the 
 local DG method. The local DG method uses an "upwind/downwind" flux for the 

--- a/src/solvers/solvers_parabolic.jl
+++ b/src/solvers/solvers_parabolic.jl
@@ -68,7 +68,6 @@ ViscousFormulationLocalDG() = ViscousFormulationLocalDG(nothing)
 """
     flux_parabolic(u_ll, u_rr, ::Gradient, mesh::TreeMesh, equations,
                    parabolic_scheme::ViscousFormulationLocalDG)
-  
     flux_parabolic(u_ll, u_rr, ::Divergence, mesh::TreeMesh, equations,
                    parabolic_scheme::ViscousFormulationLocalDG)
 

--- a/src/solvers/solvers_parabolic.jl
+++ b/src/solvers/solvers_parabolic.jl
@@ -68,6 +68,7 @@ ViscousFormulationLocalDG() = ViscousFormulationLocalDG(nothing)
 """
     flux_parabolic(u_ll, u_rr, ::Gradient, mesh::TreeMesh, equations,
                    parabolic_scheme::ViscousFormulationLocalDG)
+
     flux_parabolic(u_ll, u_rr, ::Divergence, mesh::TreeMesh, equations,
                    parabolic_scheme::ViscousFormulationLocalDG)
 


### PR DESCRIPTION
Did not get rendered correctly, see:

![Screenshot from 2025-06-24 09-33-23](https://github.com/user-attachments/assets/d8e99c3a-d258-45e4-9b71-fc045280df27)
