### PR TITLE
moving out `OneTo` in `DGMulti` shock capturing

### DIFF
--- a/src/solvers/dgmulti/shock_capturing.jl
+++ b/src/solvers/dgmulti/shock_capturing.jl
@@ -94,8 +94,8 @@ function (indicator_hg::IndicatorHennemannGassner)(u, mesh::DGMultiMesh,
         clip_1_ranges = ntuple(Returns(to_N), NDIMS)
         clip_2_ranges = ntuple(Returns(to_N_minus_one), NDIMS)
         # These splattings do not seem to allocate as of Julia 1.9.0?
-        total_energy_clip1 = sum(square, view(modal, clip_1_ranges...))
-        total_energy_clip2 = sum(square, view(modal, clip_2_ranges...))
+        total_energy_clip1 = sum(abs2, view(modal, clip_1_ranges...))
+        total_energy_clip2 = sum(abs2, view(modal, clip_2_ranges...))
 
         # Calculate energy in higher modes
         if !(iszero(total_energy))

--- a/src/solvers/dgmulti/shock_capturing.jl
+++ b/src/solvers/dgmulti/shock_capturing.jl
@@ -85,8 +85,7 @@ function (indicator_hg::IndicatorHennemannGassner)(u, mesh::DGMultiMesh,
         # Here, we reshape modal coefficients to expose the tensor product structure.
         to_N_minus_one = Base.OneTo(dg.basis.N - 1)
         to_N = Base.OneTo(dg.basis.N)
-        to_N_plus_one = Base.OneTo(dg.basis.N + 1)
-        modal = Base.ReshapedArray(modal_, ntuple(Returns(to_N_plus_one), NDIMS), ())
+        modal = Base.ReshapedArray(modal_, ntuple(Returns(dg.basis.N + 1), NDIMS), ())
 
         # Calculate total energies for all modes, all modes minus the highest mode, and
         # all modes without the two highest modes

--- a/src/solvers/dgmulti/shock_capturing.jl
+++ b/src/solvers/dgmulti/shock_capturing.jl
@@ -89,8 +89,7 @@ function (indicator_hg::IndicatorHennemannGassner)(u, mesh::DGMultiMesh,
 
         # Calculate total energies for all modes, all modes minus the highest mode, and
         # all modes without the two highest modes
-        square = x -> x^2
-        total_energy = sum(square, modal)
+        total_energy = sum(abs2, modal)
         clip_1_ranges = ntuple(Returns(to_N), NDIMS)
         clip_2_ranges = ntuple(Returns(to_N_minus_one), NDIMS)
         # These splattings do not seem to allocate as of Julia 1.9.0?

--- a/src/solvers/dgmulti/shock_capturing.jl
+++ b/src/solvers/dgmulti/shock_capturing.jl
@@ -79,19 +79,24 @@ function (indicator_hg::IndicatorHennemannGassner)(u, mesh::DGMultiMesh,
         # multiply by invVDM::SimpleKronecker
         LinearAlgebra.mul!(modal_, inverse_vandermonde, indicator)
 
+        # Create Returns functors to return the constructor args (e.g., Base.OneTo(dg.basis.N)) no matter what
+        # Returns(Base.OneTo(dg.basis.N)) equiv to _ -> Base.OneTo(dg.basis.N), with possibly fewer allocs
+        return_N_plus_one = Returns(dg.basis.N + 1)
+        return_to_N_minus_one = Returns(Base.OneTo(dg.basis.N - 1))
+        return_to_N = Returns(Base.OneTo(dg.basis.N))
+
         # As of Julia 1.9, Base.ReshapedArray does not produce allocations when setting values.
         # Thus, Base.ReshapedArray should be used if you are setting values in the array.
         # `reshape` is fine if you are only accessing values.
         # Here, we reshape modal coefficients to expose the tensor product structure.
-        to_N_minus_one = Base.OneTo(dg.basis.N - 1)
-        to_N = Base.OneTo(dg.basis.N)
-        modal = Base.ReshapedArray(modal_, ntuple(Returns(dg.basis.N + 1), NDIMS), ())
+
+        modal = Base.ReshapedArray(modal_, ntuple(return_N_plus_one, NDIMS), ())
 
         # Calculate total energies for all modes, all modes minus the highest mode, and
         # all modes without the two highest modes
         total_energy = sum(abs2, modal)
-        clip_1_ranges = ntuple(Returns(to_N), NDIMS)
-        clip_2_ranges = ntuple(Returns(to_N_minus_one), NDIMS)
+        clip_1_ranges = ntuple(return_to_N, NDIMS)
+        clip_2_ranges = ntuple(return_to_N_minus_one, NDIMS)
         # These splattings do not seem to allocate as of Julia 1.9.0?
         total_energy_clip1 = sum(abs2, view(modal, clip_1_ranges...))
         total_energy_clip2 = sum(abs2, view(modal, clip_2_ranges...))


### PR DESCRIPTION
I was getting significant lag in my simulations because the compiler couldn't optimize the anonymous functions the way that these were written. Since all of the objects I move around are not mutated in the code, this shouldn't change any logic.