### PR TITLE
Add mailmap

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+2bc1cc68c4fed509a2a3e71d02b84e0be5c5565b

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,16 @@
+Hendrik Ranocha <mail@ranocha.de> <ranocha@users.noreply.github.com>
+Michael Schlottke-Lakemper <michael@sloede.com> <mschlott@math.uni-koeln.de>
+Jesse Chan <jchan985@gmail.com> <1156048+jlchan@users.noreply.github.com>
+Gregor Gassner <ggassner@uni-koeln.de>
+Gregor Gassner <ggassner@uni-koeln.de> <ggassner@math.uni-koeln.de>
+Erik Faulhaber <erik.faulhaber@web.de>
+Erik Faulhaber <erik.faulhaber@web.de> <44124897+efaulhaber@users.noreply.github.com>
+Erik Faulhaber <erik.faulhaber@web.de> <44124897+erik-f@users.noreply.github.com>
+Valentin Churavy <v.churavy@gmail.com> <vchuravy@users.noreply.github.com>
+Benjamin Bolm <74359358+bennibolm@users.noreply.github.com>
+Lars Christmann <lars@l12n.eu> <account-github@l12n.eu>
+Felipe Santillan <72009492+FelipeSantillan@users.noreply.github.com> <loko1@DESKTOP-MP2S0TM>
+Benedict Geihe <135045760+benegee@users.noreply.github.com>
+Benedict Geihe <135045760+benegee@users.noreply.github.com> <135045760+bgeihe@users.noreply.github.com>
+JuliaOd <JuleOdenthal@googlemail.com> <71124291+JuliaOd@users.noreply.github.com>
+


### PR DESCRIPTION
For tools like `git shortlog -nse` or `git-ship-of-theseus` it is very nice to have git collapse all commits by the same author.
