### PR TITLE
[Preferences] Fix use of symbol for _PREFERENCE_THREADING

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -18,7 +18,7 @@ module Trixi
 using Preferences: @load_preference, set_preferences!
 const _PREFERENCE_SQRT = @load_preference("sqrt", "sqrt_Trixi_NaN")
 const _PREFERENCE_LOG = @load_preference("log", "log_Trixi_NaN")
-const _PREFERENCE_THREADING = @load_preference("backend", :polyester)
+const _PREFERENCE_THREADING = Symbol(@load_preference("backend", "polyester"))
 const _PREFERENCE_LOOPVECTORIZATION = @load_preference("loop_vectorization", true)
 
 # Include other packages that are used in Trixi.jl

--- a/src/auxiliary/math.jl
+++ b/src/auxiliary/math.jl
@@ -27,7 +27,7 @@ function set_threading_backend!(backend::Symbol = :polyester; force = true)
     if !(backend in valid_backends)
         throw(ArgumentError("Invalid threading backend: $(backend). Current options are: $(join(valid_backends, ", "))"))
     end
-    set_preferences!(TRIXI_UUID, "backend" => backend, force = force)
+    set_preferences!(TRIXI_UUID, "backend" => string(backend), force = force)
     @info "Please restart Julia and reload Trixi.jl for the `backend` change to take effect"
 end
 


### PR DESCRIPTION
Fixes a mistake in #2476 where we can't store symbols in LocalPreferences.toml and thus have to do the conversion on either side.

