### PR TITLE
Use julia-downgrade-compat@v2

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -75,7 +75,7 @@ jobs:
           arch: ${{ matrix.arch }}
       - run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
       - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-downgrade-compat@v1
+      - uses: julia-actions/julia-downgrade-compat@v2
         with:
           skip: LinearAlgebra,Printf,SparseArrays,UUIDs,DelimitedFiles,Test,Downloads,Random
           projects: ., test
@@ -86,6 +86,7 @@ jobs:
         uses: julia-actions/julia-runtest@v1
         with:
           coverage: false
+          allow_reresolve: false
         env:
           PYTHON: ''
           TRIXI_TEST: ${{ matrix.trixi_test }}


### PR DESCRIPTION
With the new julia-downgrade-compat v2, the action switched to use [Resolver.jl](https://github.com/StefanKarpinski/Resolver.jl) to find minimal compatible versions. If everything works as intended, this makes it MUCH simpler to work with and debug the downgrade action because in case of incompatible lower bounds, you don't need to resolve the incompatibilities manually by finding out a set of working minimal bounds. This should now be done by Resolver.jl.