### PR TITLE
Jacobian via ForwardDiff for parabolic part only

### DIFF
--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -309,7 +309,9 @@ export trixi_include, examples_dir, get_examples, default_example,
 
 export ode_norm, ode_unstable_check
 
-export convergence_test, jacobian_fd, jacobian_ad_forward, linear_structure
+export convergence_test,
+       jacobian_fd, jacobian_ad_forward, jacobian_ad_forward_parabolic,
+       linear_structure
 
 export DGMulti, DGMultiBasis, estimate_dt, DGMultiMesh, GaussSBP
 

--- a/src/semidiscretization/semidiscretization.jl
+++ b/src/semidiscretization/semidiscretization.jl
@@ -220,7 +220,7 @@ end
 
 Uses the right-hand side operator of the semidiscretization `semi`
 and simple second order finite difference to compute the Jacobian `J`
-of the semidiscretization `semi` at state `u0_ode`.
+of the semidiscretization `semi` at state `u0_ode` and time `t0`.
 """
 function jacobian_fd(semi::AbstractSemidiscretization;
                      t0 = zero(real(semi)),
@@ -267,7 +267,7 @@ end
 
 Uses the right-hand side operator of the semidiscretization `semi`
 and forward mode automatic differentiation to compute the Jacobian `J`
-of the semidiscretization `semi` at state `u0_ode`.
+of the semidiscretization `semi` at state `u0_ode` and time `t0`.
 """
 function jacobian_ad_forward(semi::AbstractSemidiscretization;
                              t0 = zero(real(semi)),

--- a/src/semidiscretization/semidiscretization.jl
+++ b/src/semidiscretization/semidiscretization.jl
@@ -220,7 +220,7 @@ end
 
 Uses the right-hand side operator of the semidiscretization `semi`
 and simple second order finite difference to compute the Jacobian `J`
-of the semidiscretization `semi` at state `u0_ode` and time `t0`.
+of the semidiscretization `semi` at time `t0` and state `u0_ode`.
 """
 function jacobian_fd(semi::AbstractSemidiscretization;
                      t0 = zero(real(semi)),
@@ -267,7 +267,7 @@ end
 
 Uses the right-hand side operator of the semidiscretization `semi`
 and forward mode automatic differentiation to compute the Jacobian `J`
-of the semidiscretization `semi` at state `u0_ode` and time `t0`.
+of the semidiscretization `semi` at time `t0` and state `u0_ode`.
 """
 function jacobian_ad_forward(semi::AbstractSemidiscretization;
                              t0 = zero(real(semi)),

--- a/src/semidiscretization/semidiscretization_hyperbolic_parabolic.jl
+++ b/src/semidiscretization/semidiscretization_hyperbolic_parabolic.jl
@@ -383,7 +383,7 @@ end
 
 Uses the *parabolic part* of the right-hand side operator of the [`SemidiscretizationHyperbolicParabolic`](@ref) `semi`
 and forward mode automatic differentiation to compute the Jacobian `J` of the 
-parabolic/diffusive contribution only at state `u0_ode` and time `t0`.
+parabolic/diffusive contribution only at time `t0` and state `u0_ode`.
 
 This might be useful for operator-splitting methods, e.g., the construction of optimized 
 time integrators which optimize different methods for the hyperbolic and parabolic part separately.

--- a/test/test_special_elixirs.jl
+++ b/test/test_special_elixirs.jl
@@ -138,6 +138,12 @@ end
         J = jacobian_ad_forward(semi)
         λ = eigvals(J)
         @test maximum(real, λ) < 10 * sqrt(eps(real(semi)))
+
+        J_parabolic = jacobian_ad_forward_parabolic(semi)
+        λ_parabolic = eigvals(J_parabolic)
+        # Parabolic spectrum is real and negative
+        @test maximum(real, λ_parabolic) < 0
+        @test maximum(imag, λ_parabolic) < 10^(-14)
     end
 
     @timed_testset "Compressible Euler equations" begin
@@ -219,6 +225,12 @@ end
         J = jacobian_ad_forward(semi)
         λ = eigvals(J)
         @test maximum(real, λ) < 0.2
+
+        J_parabolic = jacobian_ad_forward_parabolic(semi)
+        λ_parabolic = eigvals(J_parabolic)
+        # Parabolic spectrum is real and negative
+        @test maximum(real, λ_parabolic) < 10^(-16)
+        @test maximum(imag, λ_parabolic) < 10^(-15)
     end
 
     @timed_testset "MHD" begin

--- a/test/test_special_elixirs.jl
+++ b/test/test_special_elixirs.jl
@@ -142,7 +142,7 @@ end
         J_parabolic = jacobian_ad_forward_parabolic(semi)
         λ_parabolic = eigvals(J_parabolic)
         # Parabolic spectrum is real and negative
-        @test maximum(real, λ_parabolic) < 0
+        @test maximum(real, λ_parabolic) < 10^(-14)
         @test maximum(imag, λ_parabolic) < 10^(-14)
     end
 


### PR DESCRIPTION
This might be useful for operator-splitting methods, e.g., the construction of optimized  time integrators which optimize different methods for the hyperbolic and parabolic part separately.