### PR TITLE
Fix `jacobian_fd` if state is (almost) zero

### DIFF
--- a/src/semidiscretization/semidiscretization.jl
+++ b/src/semidiscretization/semidiscretization.jl
@@ -121,7 +121,7 @@ function semidiscretize(semi::AbstractSemidiscretization, tspan;
 end
 
 """
-    semidiscretize(semi::AbstractSemidiscretization, tspan, 
+    semidiscretize(semi::AbstractSemidiscretization, tspan,
                    restart_file::AbstractString)
 
 Wrap the semidiscretization `semi` as an ODE problem in the time interval `tspan`
@@ -240,7 +240,7 @@ function jacobian_fd(semi::AbstractSemidiscretization;
     # use second order finite difference to estimate Jacobian matrix
     for idx in eachindex(u0_ode)
         # determine size of fluctuation
-        epsilon = sqrt(eps(u0_ode[idx]))
+        epsilon = sqrt(eps(typeof(u0_ode[idx])))
 
         # plus fluctuation
         u_ode[idx] = u0_ode[idx] + epsilon
@@ -250,7 +250,7 @@ function jacobian_fd(semi::AbstractSemidiscretization;
         u_ode[idx] = u0_ode[idx] - epsilon
         rhs!(dum_ode, u_ode, semi, t0)
 
-        # restore linearisation state
+        # restore linearization state
         u_ode[idx] = u0_ode[idx]
 
         # central second order finite difference
@@ -288,7 +288,7 @@ end
 function _jacobian_ad_forward(semi, t0, u0_ode, du_ode, config)
     new_semi = remake(semi, uEltype = eltype(config))
     # Create anonymous function passed as first argument to `ForwardDiff.jacobian` to match
-    # `ForwardDiff.jacobian(f!, y::AbstractArray, x::AbstractArray, 
+    # `ForwardDiff.jacobian(f!, y::AbstractArray, x::AbstractArray,
     #                       cfg::JacobianConfig = JacobianConfig(f!, y, x), check=Val{true}())`
     J = ForwardDiff.jacobian(du_ode, u0_ode, config) do du_ode, u_ode
         Trixi.rhs!(du_ode, u_ode, new_semi, t0)
@@ -322,7 +322,7 @@ end
 function _jacobian_ad_forward_structarrays(semi, t0, u0_ode_plain, du_ode_plain, config)
     new_semi = remake(semi, uEltype = eltype(config))
     # Create anonymous function passed as first argument to `ForwardDiff.jacobian` to match
-    # `ForwardDiff.jacobian(f!, y::AbstractArray, x::AbstractArray, 
+    # `ForwardDiff.jacobian(f!, y::AbstractArray, x::AbstractArray,
     #                       cfg::JacobianConfig = JacobianConfig(f!, y, x), check=Val{true}())`
     J = ForwardDiff.jacobian(du_ode_plain, u0_ode_plain,
                              config) do du_ode_plain, u_ode_plain


### PR DESCRIPTION
This is an issue @andrewwinters5000 and I noticed. For the FD based Jacobian computation, we choose `epsilon` depending on `eps(u0_ode[idx])`. If `u0_ode[idx]` is equal to zero (or very close), this returns a very small `epsilon`, which is not desired here:

```julia
julia> eps(0.0)
5.0e-324

julia> eps(1e-16)
1.232595164407831e-32
```

Instead, we usually want `eps(typeof(u0_ode[idx]))`. That this can lead to a completely different spectrum can be seen for example with the elixir examples/tree_1d_fdsbp/elixir_advection_upwind.jl, which has an initial condition with four (close to) zeros (at the left boundary, two nodes at an interface in the middle and at the right boundary).
Before this PR:
<img width="600" height="400" alt="spectrum_wrong" src="https://github.com/user-attachments/assets/1ada3588-716e-4ce0-a2ac-aa71ef9dcf1a" />
After this PR:
<img width="600" height="400" alt="spectrum_correct" src="https://github.com/user-attachments/assets/4693823c-1dac-46ea-89fb-971c950c30d5" />

