### PR TITLE
Mention Solver Source Code Logic in Docs

### DIFF
--- a/docs/src/conventions.md
+++ b/docs/src/conventions.md
@@ -76,6 +76,24 @@ set via the keywords
   documented with a docstring (but maybe with comments using `#`).
 
 
+## Structure of the `solver` directory
+
+If some functionality is shared by multiple combinations of meshes/solvers,
+it is defined in the directory of the most basic mesh and solver type.
+An example for this is the `rhs!` function which lays out the sequence of functions 
+which compose the overall right-hand-side function fed to the ODE integrator.
+Since this general "recipe" can be unified for different meshes of a certain dimension,
+a shared implementation is used to minimize code duplication.
+
+The most basic (in the sense that it is most tested and developed) solver type in Trixi.jl is
+[`DGSEM`](@ref) due to historic reasons and background of the main contributors.
+We consider the [`TreeMesh`](@ref) to be the most basic mesh type since it is Cartesian
+and was the first mesh in Trixi.jl.
+Thus, shared implementations for more advanced meshes such as the [`P4estMesh`](@ref) can be found in
+the `src/solvers/dgsem_tree` directory, while only necessary specifics are actually placed in
+`src/solvers/dgsem_p4est`.
+
+
 ## Array types and wrapping
 
 To allow adaptive mesh refinement efficiently when using time integrators from

--- a/docs/src/conventions.md
+++ b/docs/src/conventions.md
@@ -90,8 +90,8 @@ The most basic (in the sense that it is most tested and developed) solver type i
 We consider the [`TreeMesh`](@ref) to be the most basic mesh type since it is Cartesian
 and was the first mesh in Trixi.jl.
 Thus, shared implementations for more advanced meshes such as the [`P4estMesh`](@ref) can be found in
-the `src/solvers/dgsem_tree` directory, while only necessary specifics are actually placed in
-`src/solvers/dgsem_p4est`.
+the `src/solvers/dgsem_tree/` directory, while only necessary specifics are actually placed in
+`src/solvers/dgsem_p4est/`.
 
 
 ## Array types and wrapping

--- a/docs/src/conventions.md
+++ b/docs/src/conventions.md
@@ -80,8 +80,8 @@ set via the keywords
 
 If some functionality is shared by multiple combinations of meshes/solvers,
 it is defined in the directory of the most basic mesh and solver type.
-An example for this is the `rhs!` function which lays out the sequence of functions 
-which compose the overall right-hand-side function fed to the ODE integrator.
+An example for this is the `rhs!` function, which lays out the sequence of functions 
+that compose the overall right-hand-side function provided to the ODE integrator.
 Since this general "recipe" can be unified for different meshes of a certain dimension,
 a shared implementation is used to minimize code duplication.
 

--- a/src/solvers/dg.jl
+++ b/src/solvers/dg.jl
@@ -828,13 +828,14 @@ function compute_coefficients!(backend::Nothing, u, func, t, mesh::AbstractMesh{
 end
 
 # Discretizations specific to each mesh type of Trixi.jl
+
 # If some functionality is shared by multiple combinations of meshes/solvers,
 # it is defined in the directory of the most basic mesh and solver type.
 # The most basic solver type in Trixi.jl is DGSEM (historic reasons and background
 # of the main contributors).
 # We consider the `TreeMesh` to be the most basic mesh type since it is Cartesian
-# and was the first mesh in Trixi.jl. The order of the other mesh types is the same
-# as the include order below.
+# and was the first mesh in Trixi.jl.
+# The order of the other mesh types is the same as the include order below.
 include("dgsem_tree/dg.jl")
 include("dgsem_structured/dg.jl")
 include("dgsem_unstructured/dg.jl")


### PR DESCRIPTION
See https://github.com/trixi-framework/Trixi.jl/pull/2488#issuecomment-3173648694

>  I was just last week talking to a Trixi.jl newcomer, who wants to contribute to Trixi.jl and was confused about seeing code relevant for the `P4estMesh` in the `TreeMesh` folder and therefore didn't find the relevant code. If we want to keep the current structure, I would at least highlight this structure more prominently in the docs, e.g., in the development section.

Mostly copied from 

https://github.com/trixi-framework/Trixi.jl/blob/531ee91d0dbe93e8fb8bf9f675b34f7982b9077e/src/solvers/dg.jl#L830-L837