### PR TITLE
Implement IDP mortars with limiting

### DIFF
--- a/examples/tree_2d_dgsem/elixir_euler_kelvin_helmholtz_instability_amr_sc_subcell.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_kelvin_helmholtz_instability_amr_sc_subcell.jl
@@ -1,0 +1,106 @@
+using Trixi
+
+###############################################################################
+# semidiscretization of the compressible Euler equations
+gamma = 1.4
+equations = CompressibleEulerEquations2D(gamma)
+
+"""
+    initial_condition_kelvin_helmholtz_instability(x, t, equations::CompressibleEulerEquations2D)
+
+A version of the classical Kelvin-Helmholtz instability based on
+- Andrés M. Rueda-Ramírez, Gregor J. Gassner (2021)
+  A Subcell Finite Volume Positivity-Preserving Limiter for DGSEM Discretizations
+  of the Euler Equations
+  [arXiv: 2102.06017](https://arxiv.org/abs/2102.06017)
+"""
+function initial_condition_kelvin_helmholtz_instability(x, t,
+                                                        equations::CompressibleEulerEquations2D)
+    # change discontinuity to tanh
+    # typical resolution 128^2, 256^2
+    # domain size is [-1,+1]^2
+    RealT = eltype(x)
+    slope = 15
+    B = tanh(slope * x[2] + 7.5f0) - tanh(slope * x[2] - 7.5f0)
+    rho = 0.5f0 + 0.75f0 * B
+    v1 = 0.5f0 * (B - 1)
+    v2 = convert(RealT, 0.1) * sinpi(2 * x[1])
+    p = 1
+    return prim2cons(SVector(rho, v1, v2, p), equations)
+end
+initial_condition = initial_condition_kelvin_helmholtz_instability
+
+surface_flux = flux_lax_friedrichs
+volume_flux = flux_ranocha
+polydeg = 3
+basis = LobattoLegendreBasis(polydeg)
+
+limiter_idp = SubcellLimiterIDP(equations, basis;
+                                positivity_variables_cons = ["rho"],
+                                positivity_variables_nonlinear = [pressure])
+volume_integral = VolumeIntegralSubcellLimiting(limiter_idp;
+                                                volume_flux_dg = volume_flux,
+                                                volume_flux_fv = surface_flux)
+mortar = MortarIDP(basis; positivity_variables_cons = [1])
+solver = DGSEM(basis, surface_flux, volume_integral, mortar)
+
+coordinates_min = (-1.0, -1.0)
+coordinates_max = (1.0, 1.0)
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 5,
+                n_cells_max = 100_000)
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 3.7)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval = analysis_interval)
+
+save_solution = SaveSolutionCallback(interval = 100,
+                                     save_initial_solution = true,
+                                     save_final_solution = true,
+                                     solution_variables = cons2prim,
+                                     extra_node_variables = (:limiting_coefficient,))
+
+save_restart = SaveRestartCallback(interval = 1000,
+                                   save_final_restart = true)
+
+amr_indicator = IndicatorHennemannGassner(semi,
+                                          alpha_max = 1.0,
+                                          alpha_min = 0.0001,
+                                          alpha_smooth = false,
+                                          variable = Trixi.density)
+amr_controller = ControllerThreeLevel(semi, amr_indicator,
+                                      base_level = 4,
+                                      med_level = 0, med_threshold = 0.0003,
+                                      max_level = 6, max_threshold = 0.003)
+amr_callback = AMRCallback(semi, amr_controller,
+                           interval = 1,
+                           adapt_initial_condition = true,
+                           adapt_initial_condition_only_refine = true)
+
+stepsize_callback = StepsizeCallback(cfl = 0.3)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        save_solution, save_restart,
+                        amr_callback,
+                        stepsize_callback)
+
+###############################################################################
+# run the simulation
+
+stage_callbacks = (SubcellLimiterIDPCorrection(), BoundsCheckCallback())
+
+sol = Trixi.solve(ode, Trixi.SimpleSSPRK33(stage_callbacks = stage_callbacks);
+                  dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+                  ode_default_options()...,
+                  callback = callbacks);

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -263,7 +263,7 @@ export DG,
        VolumeIntegralUpwind,
        SurfaceIntegralWeakForm, SurfaceIntegralStrongForm,
        SurfaceIntegralUpwind,
-       MortarL2
+       MortarL2, MortarIDP
 
 export VolumeIntegralSubcellLimiting, BoundsCheckCallback,
        SubcellLimiterIDP, SubcellLimiterIDPCorrection

--- a/src/callbacks_stage/subcell_limiter_idp_correction.jl
+++ b/src/callbacks_stage/subcell_limiter_idp_correction.jl
@@ -56,6 +56,19 @@ function (limiter!::SubcellLimiterIDPCorrection)(u_ode, semi, t, dt,
 
     perform_idp_correction!(u, dt, mesh, equations, solver, cache)
 
+    if solver.mortar isa Trixi.LobattoLegendreMortarIDP
+        @trixi_timeit timer() "mortar blending factors" calc_mortar_limiting_factor!(u,
+                                                                                     semi,
+                                                                                     t,
+                                                                                     dt)
+
+        @trixi_timeit timer() "mortar correction" perform_idp_mortar_correction(u, dt,
+                                                                                mesh,
+                                                                                equations,
+                                                                                solver,
+                                                                                cache)
+    end
+
     return nothing
 end
 

--- a/src/solvers/dgsem_tree/containers_2d.jl
+++ b/src/solvers/dgsem_tree/containers_2d.jl
@@ -611,6 +611,138 @@ function init_mortars(cell_ids, mesh::TreeMesh2D,
     return mortars
 end
 
+# Container data structure (structure-of-arrays style) for DG mortars for IDP AMR
+# Positions/directions for orientations = 1, large_sides = 2:
+# mortar is orthogonal to x-axis, large side is in positive coordinate direction wrt mortar
+#           |    |
+# upper = 2 |    |
+#           |    |
+#                | 3 = large side
+#           |    |
+# lower = 1 |    |
+#           |    |
+mutable struct IDPMortarContainer2D{uEltype <: Real} <: AbstractContainer
+    u_upper::Array{uEltype, 4}  # [leftright, variables, i, mortars]
+    u_lower::Array{uEltype, 4}  # [leftright, variables, i, mortars]
+    u_large::Array{uEltype, 3}  # [variables, i, mortars]
+    neighbor_ids::Array{Int, 2} # [position, mortars]
+    # Large sides: left -> 1, right -> 2
+    large_sides::Vector{Int}  # [mortars]
+    orientations::Vector{Int} # [mortars]
+    limiting_factor::Vector{uEltype} # [mortars]
+    # internal `resize!`able storage
+    _u_upper::Vector{uEltype}
+    _u_lower::Vector{uEltype}
+    _u_large::Vector{uEltype}
+    _neighbor_ids::Vector{Int}
+end
+
+nvariables(mortars::IDPMortarContainer2D) = size(mortars.u_upper, 2)
+nnodes(mortars::IDPMortarContainer2D) = size(mortars.u_upper, 3)
+Base.eltype(mortars::IDPMortarContainer2D) = eltype(mortars.u_upper)
+
+# See explanation of Base.resize! for the element container
+function Base.resize!(mortars::IDPMortarContainer2D, capacity)
+    n_nodes = nnodes(mortars)
+    n_variables = nvariables(mortars)
+    @unpack _u_upper, _u_lower, _u_large, _neighbor_ids,
+    large_sides, orientations, limiting_factor = mortars
+
+    resize!(_u_upper, 2 * n_variables * n_nodes * capacity)
+    mortars.u_upper = unsafe_wrap(Array, pointer(_u_upper),
+                                  (2, n_variables, n_nodes, capacity))
+
+    resize!(_u_lower, 2 * n_variables * n_nodes * capacity)
+    mortars.u_lower = unsafe_wrap(Array, pointer(_u_lower),
+                                  (2, n_variables, n_nodes, capacity))
+
+    resize!(_u_large, n_variables * n_nodes * capacity)
+    mortars.u_large = unsafe_wrap(Array, pointer(_u_large),
+                                  (n_variables, n_nodes, capacity))
+
+    resize!(_neighbor_ids, 3 * capacity)
+    mortars.neighbor_ids = unsafe_wrap(Array, pointer(_neighbor_ids),
+                                       (3, capacity))
+
+    resize!(large_sides, capacity)
+
+    resize!(orientations, capacity)
+
+    resize!(limiting_factor, capacity)
+
+    return nothing
+end
+
+function IDPMortarContainer2D{uEltype}(capacity::Integer, n_variables,
+                                       n_nodes) where {uEltype <: Real}
+    nan = convert(uEltype, NaN)
+
+    # Initialize fields with defaults
+    _u_upper = fill(nan, 2 * n_variables * n_nodes * capacity)
+    u_upper = unsafe_wrap(Array, pointer(_u_upper),
+                          (2, n_variables, n_nodes, capacity))
+
+    _u_lower = fill(nan, 2 * n_variables * n_nodes * capacity)
+    u_lower = unsafe_wrap(Array, pointer(_u_lower),
+                          (2, n_variables, n_nodes, capacity))
+
+    _u_large = fill(nan, n_variables * n_nodes * capacity)
+    u_large = unsafe_wrap(Array, pointer(_u_large),
+                          (n_variables, n_nodes, capacity))
+
+    _neighbor_ids = fill(typemin(Int), 3 * capacity)
+    neighbor_ids = unsafe_wrap(Array, pointer(_neighbor_ids),
+                               (3, capacity))
+
+    large_sides = fill(typemin(Int), capacity)
+
+    orientations = fill(typemin(Int), capacity)
+
+    limiting_factor = fill(typemin(Int), capacity)
+
+    return IDPMortarContainer2D{uEltype}(u_upper, u_lower, u_large, neighbor_ids,
+                                         large_sides, orientations, limiting_factor,
+                                         _u_upper, _u_lower, _u_large, _neighbor_ids)
+end
+
+# Return number of IDP mortars
+@inline nmortars(l2mortars::IDPMortarContainer2D) = length(l2mortars.orientations)
+
+# Allow printing container contents
+function Base.show(io::IO, ::MIME"text/plain", c::IDPMortarContainer2D)
+    @nospecialize c # reduce precompilation time
+
+    println(io, '*'^20)
+    for idx in CartesianIndices(c.u_upper)
+        println(io, "c.u_upper[$idx] = $(c.u_upper[idx])")
+    end
+    for idx in CartesianIndices(c.u_lower)
+        println(io, "c.u_lower[$idx] = $(c.u_lower[idx])")
+    end
+    for idx in CartesianIndices(c.u_large)
+        println(io, "c.u_large[$idx] = $(c.u_large[idx])")
+    end
+    println(io, "transpose(c.neighbor_ids) = $(transpose(c.neighbor_ids))")
+    println(io, "c.large_sides = $(c.large_sides)")
+    println(io, "c.orientations = $(c.orientations)")
+    print(io, '*'^20)
+end
+
+# Create mortar container and initialize mortar data in `elements`.
+function init_mortars(cell_ids, mesh::TreeMesh2D,
+                      elements::ElementContainer2D,
+                      mortar::LobattoLegendreMortarIDP)
+    # Initialize containers
+    n_mortars = count_required_mortars(mesh, cell_ids)
+    mortars = IDPMortarContainer2D{eltype(elements)}(n_mortars,
+                                                     nvariables(elements),
+                                                     nnodes(elements))
+
+    # Connect elements with mortars
+    init_mortars!(mortars, elements, mesh)
+    return mortars
+end
+
 # Count the number of mortars that need to be created
 function count_required_mortars(mesh::TreeMesh2D, cell_ids)
     count = 0
@@ -1278,11 +1410,13 @@ mutable struct ContainerAntidiffusiveFlux2D{uEltype <: Real}
     antidiffusive_flux1_R::Array{uEltype, 4} # [variables, i, j, elements]
     antidiffusive_flux2_L::Array{uEltype, 4} # [variables, i, j, elements]
     antidiffusive_flux2_R::Array{uEltype, 4} # [variables, i, j, elements]
+    surface_flux_values_high_order::Array{uEltype, 4} # [variables, i, direction, elements]
     # internal `resize!`able storage
     _antidiffusive_flux1_L::Vector{uEltype}
     _antidiffusive_flux1_R::Vector{uEltype}
     _antidiffusive_flux2_L::Vector{uEltype}
     _antidiffusive_flux2_R::Vector{uEltype}
+    _surface_flux_values_high_order::Vector{uEltype}
 end
 
 function ContainerAntidiffusiveFlux2D{uEltype}(capacity::Integer, n_variables,
@@ -1308,14 +1442,23 @@ function ContainerAntidiffusiveFlux2D{uEltype}(capacity::Integer, n_variables,
     antidiffusive_flux2_R = unsafe_wrap(Array, pointer(_antidiffusive_flux2_R),
                                         (n_variables, n_nodes, n_nodes + 1, capacity))
 
+    _surface_flux_values_high_order = fill(nan_uEltype,
+                                           n_variables * n_nodes * 2 * 2 * capacity)
+    surface_flux_values_high_order = unsafe_wrap(Array,
+                                                 pointer(_surface_flux_values_high_order),
+                                                 (n_variables, n_nodes, 2 * 2,
+                                                  capacity))
+
     return ContainerAntidiffusiveFlux2D{uEltype}(antidiffusive_flux1_L,
                                                  antidiffusive_flux1_R,
                                                  antidiffusive_flux2_L,
                                                  antidiffusive_flux2_R,
+                                                 surface_flux_values_high_order,
                                                  _antidiffusive_flux1_L,
                                                  _antidiffusive_flux1_R,
                                                  _antidiffusive_flux2_L,
-                                                 _antidiffusive_flux2_R)
+                                                 _antidiffusive_flux2_R,
+                                                 _surface_flux_values_high_order)
 end
 
 nvariables(fluxes::ContainerAntidiffusiveFlux2D) = size(fluxes.antidiffusive_flux1_L, 1)
@@ -1330,7 +1473,7 @@ function Base.resize!(fluxes::ContainerAntidiffusiveFlux2D, capacity)
     n_nodes = nnodes(fluxes)
     n_variables = nvariables(fluxes)
 
-    @unpack _antidiffusive_flux1_L, _antidiffusive_flux2_L, _antidiffusive_flux1_R, _antidiffusive_flux2_R = fluxes
+    @unpack _antidiffusive_flux1_L, _antidiffusive_flux2_L, _antidiffusive_flux1_R, _antidiffusive_flux2_R, _surface_flux_values_high_order = fluxes
 
     resize!(_antidiffusive_flux1_L, n_variables * (n_nodes + 1) * n_nodes * capacity)
     fluxes.antidiffusive_flux1_L = unsafe_wrap(Array, pointer(_antidiffusive_flux1_L),
@@ -1348,6 +1491,12 @@ function Base.resize!(fluxes::ContainerAntidiffusiveFlux2D, capacity)
     fluxes.antidiffusive_flux2_R = unsafe_wrap(Array, pointer(_antidiffusive_flux2_R),
                                                (n_variables, n_nodes, n_nodes + 1,
                                                 capacity))
+
+    resize!(_surface_flux_values_high_order, n_variables * n_nodes * 2 * 2 * capacity)
+    fluxes.surface_flux_values_high_order = unsafe_wrap(Array,
+                                                        pointer(_surface_flux_values_high_order),
+                                                        (n_variables, n_nodes, 2 * 2,
+                                                         capacity))
 
     return nothing
 end

--- a/src/solvers/dgsem_tree/dg_2d.jl
+++ b/src/solvers/dgsem_tree/dg_2d.jl
@@ -90,7 +90,8 @@ end
 # The methods below are specialized on the mortar type
 # and called from the basic `create_cache` method at the top.
 function create_cache(mesh::TreeMesh{2}, equations,
-                      mortar_l2::LobattoLegendreMortarL2, uEltype)
+                      mortar_l2::Union{LobattoLegendreMortarL2,
+                                       LobattoLegendreMortarIDP}, uEltype)
     # TODO: Taal performance using different types
     MA2d = MArray{Tuple{nvariables(equations), nnodes(mortar_l2)},
                   uEltype, 2,

--- a/test/test_tree_2d_euler.jl
+++ b/test/test_tree_2d_euler.jl
@@ -690,6 +690,36 @@ end
     end
 end
 
+@trixi_testset "elixir_euler_kelvin_helmholtz_instability_amr_sc_subcell.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR,
+                                 "elixir_euler_kelvin_helmholtz_instability_amr_sc_subcell.jl"),
+                        l2=[
+                            0.055724454952595134,
+                            0.03312233274919345,
+                            0.05223955492824185,
+                            0.080116031615237
+                        ],
+                        linf=[
+                            0.2529113255620048,
+                            0.17296154306769038,
+                            0.1232191089800711,
+                            0.2691634973257111
+                        ],
+                        tspan=(0.0, 0.2))
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    let
+        t = sol.t[end]
+        u_ode = sol.u[end]
+        du_ode = similar(u_ode)
+        # Larger values for allowed allocations due to usage of custom
+        # integrator which are not *recorded* for the methods from
+        # OrdinaryDiffEq.jl
+        # Corresponding issue: https://github.com/trixi-framework/Trixi.jl/issues/1877
+        @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 15000
+    end
+end
+
 @trixi_testset "elixir_euler_colliding_flow.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_colliding_flow.jl"),
                         l2=[


### PR DESCRIPTION
Adds `MortarsIDP` within the high-order and a low-order surface flux are blended.
The low-order flux is computed by interpolating solution values from one side of the mortar to the other using nonnegative weights. As for the subcell IDP/FCT limiting, we first use the low-order variant and "correct" later in a _a-posteriori_ correction stage.
For now, the limiting only guarantees positivity of conservative variables.

https://github.com/user-attachments/assets/98a3d190-4b98-44fb-83d0-edae66d62ef3

