### PR TITLE
Fix indentation error and wrong output in tutorials

### DIFF
--- a/docs/literate/src/files/adding_new_scalar_equations.jl
+++ b/docs/literate/src/files/adding_new_scalar_equations.jl
@@ -95,7 +95,7 @@ plot(sol)
 ## A new setup with dissipation
 semi = remake(semi, solver = DGSEM(3, flux_godunov))
 ode = semidiscretize(semi, tspan)
-sol = solve(ode, SSPRK43(); ode_default_options()...)
+sol = solve(ode, SSPRK43(); ode_default_options()...);
 plot!(sol)
 
 # You can see that there are fewer oscillations, in particular around steep edges.
@@ -105,7 +105,7 @@ plot!(sol)
 semi = remake(semi,
               mesh = TreeMesh(-1.0, 1.0, initial_refinement_level = 8, n_cells_max = 10^5))
 ode = semidiscretize(semi, (0.0, 0.5)) # set tspan to (0.0, 0.5)
-sol = solve(ode, SSPRK43(); ode_default_options()...)
+sol = solve(ode, SSPRK43(); ode_default_options()...);
 plot(sol)
 
 # You can observe that nonclassical shocks develop and are stable under grid refinement,
@@ -195,27 +195,27 @@ tspan = (0.0, 0.1)
 ode = semidiscretize(semi, tspan)
 
 ## OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
-sol = solve(ode, SSPRK43(); ode_default_options()...)
+sol = solve(ode, SSPRK43(); ode_default_options()...);
 plot(sol)
 
 ## A new setup with dissipation
 semi = remake(semi, solver = DGSEM(3, flux_godunov))
 ode = semidiscretize(semi, tspan)
-sol = solve(ode, SSPRK43(); ode_default_options()...)
+sol = solve(ode, SSPRK43(); ode_default_options()...);
 plot!(sol)
 
 ## A larger final time: Nonclassical shocks develop (you can even increase the refinement to 12)
 semi = remake(semi,
               mesh = TreeMesh(-1.0, 1.0, initial_refinement_level = 8, n_cells_max = 10^5))
 ode = semidiscretize(semi, (0.0, 0.5))
-sol = solve(ode, SSPRK43(); ode_default_options()...)
+sol = solve(ode, SSPRK43(); ode_default_options()...);
 plot(sol)
 
 ## Let's use a provably entropy-dissipative semidiscretization
 semi = remake(semi,
               solver = DGSEM(3, flux_godunov, VolumeIntegralFluxDifferencing(flux_ec)))
 ode = semidiscretize(semi, (0.0, 0.5))
-sol = solve(ode, SSPRK43(); ode_default_options()...)
+sol = solve(ode, SSPRK43(); ode_default_options()...);
 plot(sol)
 
 # ## Package versions

--- a/docs/literate/src/files/adding_nonconservative_equation.jl
+++ b/docs/literate/src/files/adding_nonconservative_equation.jl
@@ -132,7 +132,7 @@ callbacks = CallbackSet(summary_callback, analysis_callback)
 ## OrdinaryDiffEq's `solve` method evolves the solution in time and executes
 ## the passed callbacks
 sol = solve(ode, Tsit5(), abstol = 1.0e-6, reltol = 1.0e-6;
-            ode_default_options()..., callback = callbacks)
+            ode_default_options()..., callback = callbacks);
 
 ## Plot the numerical solution at the final time
 using Plots: plot

--- a/docs/literate/src/files/custom_semidiscretization.jl
+++ b/docs/literate/src/files/custom_semidiscretization.jl
@@ -98,7 +98,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition,
 tspan = (0.0, 3.0)
 ode = semidiscretize(semi, tspan)
 
-sol = solve(ode, RDPK3SpFSAL49(); ode_default_options()...)
+sol = solve(ode, RDPK3SpFSAL49(); ode_default_options()...);
 
 plot(sol; label = "numerical sol.", legend = :topright)
 
@@ -129,7 +129,7 @@ callbacks = CallbackSet(summary_callback,
                         alive_callback)
 
 sol = solve(ode, RDPK3SpFSAL49();
-            ode_default_options()..., callback = callbacks)
+            ode_default_options()..., callback = callbacks);
 
 # ## Using a custom ODE right-hand side function
 
@@ -160,7 +160,7 @@ ode_source_custom = ODEProblem(rhs_source_custom!,
                                ode.tspan,
                                ode.p) # semi
 sol_source_custom = solve(ode_source_custom, RDPK3SpFSAL49();
-                          ode_default_options()...)
+                          ode_default_options()...);
 
 plot(sol_source_custom; label = "numerical sol.")
 let
@@ -181,7 +181,7 @@ callbacks = CallbackSet(summary_callback,
                         alive_callback)
 
 sol = solve(ode_source_custom, RDPK3SpFSAL49();
-            ode_default_options()..., callback = callbacks)
+            ode_default_options()..., callback = callbacks);
 
 # ## Setting up a custom semidiscretization
 
@@ -232,7 +232,7 @@ ode_semi_custom = ODEProblem(rhs_semi_custom!,
                              ode.tspan,
                              semi_custom)
 sol_semi_custom = solve(ode_semi_custom, RDPK3SpFSAL49();
-                        ode_default_options()...)
+                        ode_default_options()...);
 
 # If we want to make use of additional functionality provided by
 # Trixi.jl, e.g., for plotting, we need to implement a few additional
@@ -296,7 +296,7 @@ callbacks = CallbackSet(summary_callback,
                         alive_callback)
 
 sol = solve(ode_semi_custom, RDPK3SpFSAL49();
-            ode_default_options()..., callback = callbacks)
+            ode_default_options()..., callback = callbacks);
 
 # For even more advanced usage of custom semidiscretizations, you
 # may look at the source code of the ones contained in Trixi.jl, e.g.,

--- a/docs/literate/src/files/differentiable_programming.jl
+++ b/docs/literate/src/files/differentiable_programming.jl
@@ -230,7 +230,7 @@ function energy_at_final_time(k) # k is the wave number of the initial condition
     semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
                                         uEltype = typeof(k))
     ode = semidiscretize(semi, (0.0, 1.0))
-    sol = solve(ode, BS3(); ode_default_options()...)
+    sol = solve(ode, BS3(); ode_default_options()...);
     Trixi.integrate(energy_total, sol.u[end], semi)
 end
 
@@ -280,7 +280,7 @@ function energy_at_final_time(k) # k is the wave number of the initial condition
     semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
                                         uEltype = typeof(k))
     ode = semidiscretize(semi, (0.0, 1.0))
-    sol = solve(ode, BS3(); ode_default_options()...)
+    sol = solve(ode, BS3(); ode_default_options()...);
     Trixi.integrate(energy_total, sol.u[end], semi)
 end
 
@@ -330,7 +330,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
 # does. This is basically the only part where you need to modify your standard Trixi.jl
 # code to enable automatic differentiation. From there on, the remaining steps
 ode = semidiscretize(semi, (0.0, 1.0))
-sol = solve(ode, BS3(); ode_default_options()...)
+sol = solve(ode, BS3(); ode_default_options()...);
 round(Trixi.integrate(energy_total, sol.u[end], semi), sigdigits = 5)
 @test round(Trixi.integrate(energy_total, sol.u[end], semi), sigdigits = 5) == 0.24986 #src
 
@@ -411,7 +411,7 @@ relative_difference = norm(J_fd - J_ad) / size(J_fd, 1)
 # [Trixi.jl](https://github.com/trixi-framework/Trixi.jl) supports efficient Jacobian computations by leveraging the
 # [SparseConnectivityTracer.jl](https://github.com/adrhill/SparseConnectivityTracer.jl)
 # and [SparseMatrixColorings.jl](https://github.com/gdalle/SparseMatrixColorings.jl) packages.
-# These tools allow to detect the sparsity pattern of the Jacobian and compute the 
+# These tools allow to detect the sparsity pattern of the Jacobian and compute the
 # optional coloring vector for efficient Jacobian evaluations.
 # These are then handed over to the ODE solver from [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl).
 
@@ -441,7 +441,7 @@ jac_detector = TracerSparsityDetector()
 # [`jacobian_eltype`](https://adrianhill.de/SparseConnectivityTracer.jl/stable/user/api/#SparseConnectivityTracer.jacobian_eltype).
 jac_eltype = jacobian_eltype(float_type, jac_detector)
 
-# Now we can construct the semidiscretization for sparsity detection with `jac_eltype` as the 
+# Now we can construct the semidiscretization for sparsity detection with `jac_eltype` as the
 # datatype for the working arrays and helper datastructures.
 semi_jac_type = SemidiscretizationHyperbolic(mesh, equation,
                                              initial_condition_convergence_test, solver,
@@ -487,7 +487,7 @@ ode_jac_sparse = semidiscretize(semi_float_type, tspan,
 # Currently we are bound to finite differencing here.
 using OrdinaryDiffEqSDIRK, ADTypes
 sol = solve(ode_jac_sparse, TRBDF2(; autodiff = AutoFiniteDiff()), dt = 0.1,
-            save_everystep = false)
+            save_everystep = false);
 
 # ## Linear systems
 

--- a/docs/literate/src/files/first_steps/getting_started.jl
+++ b/docs/literate/src/files/first_steps/getting_started.jl
@@ -141,7 +141,7 @@
 # trixi_include(joinpath(examples_dir(), "tree_2d_dgsem", "elixir_euler_ec.jl"))
 # ```
 using Trixi, OrdinaryDiffEqLowStorageRK #hide #md
-trixi_include(@__MODULE__, joinpath(examples_dir(), "tree_2d_dgsem", "elixir_euler_ec.jl")) #hide #md
+trixi_include(@__MODULE__, joinpath(examples_dir(), "tree_2d_dgsem", "elixir_euler_ec.jl")); #hide #md
 
 # The output contains a recap of the setup and various information about the course of the simulation.
 # For instance, the solution was approximated over the [`TreeMesh`](@ref) with 1024 effective cells using
@@ -216,7 +216,7 @@ nothing; #hide #md
 #   `elixir_euler_ec.jl` file that you just edited.
 #   ```julia
 #   using Trixi
-#   trixi_include(path/to/file)
+#   trixi_include(path/to/file);
 #   using Plots
 #   plot(sol)
 #   ```
@@ -224,7 +224,7 @@ nothing; #hide #md
 # condition.
 
 trixi_include(@__MODULE__, joinpath(examples_dir(), "tree_2d_dgsem", "elixir_euler_ec.jl"), #hide #md
-              initial_condition = initial_condition) #hide #md
+              initial_condition = initial_condition); #hide #md
 pd = PlotData2D(sol) #hide #md
 p1 = plot(pd["rho"]) #hide #md
 p2 = plot(pd["v1"], clim = (0.05, 0.15)) #hide #md

--- a/docs/literate/src/files/hohqmesh_tutorial.jl
+++ b/docs/literate/src/files/hohqmesh_tutorial.jl
@@ -37,7 +37,7 @@
 using Trixi
 rm("out", force = true, recursive = true) #hide #md
 redirect_stdio(stdout = devnull, stderr = devnull) do # code that prints annoying stuff we don't want to see here #hide #md
-    trixi_include(default_example_unstructured())
+trixi_include(default_example_unstructured());
 end #hide #md
 
 # This will compute a smooth, manufactured solution test case for the 2D compressible Euler equations
@@ -54,7 +54,7 @@ end #hide #md
 
 using Trixi2Vtk
 redirect_stdio(stdout = devnull, stderr = devnull) do # code that prints annoying stuff we don't want to see here #hide #md
-    trixi2vtk("out/solution_000000180.h5", output_directory = "out")
+trixi2vtk("out/solution_000000180.h5", output_directory = "out")
 end #hide #md
 
 # Note this step takes about 15-30 seconds as the package `Trixi2Vtk` must be precompiled and executed for the first time
@@ -64,7 +64,7 @@ end #hide #md
 # visualization nodes. For instance, if we want to use 12 uniformly spaced nodes for visualization we can execute
 
 redirect_stdio(stdout = devnull, stderr = devnull) do # code that prints annoying stuff we don't want to see here #hide #md
-    trixi2vtk("out/solution_000000180.h5", output_directory = "out", nvisnodes = 12)
+trixi2vtk("out/solution_000000180.h5", output_directory = "out", nvisnodes = 12)
 end #hide #md
 
 # By default `trixi2vtk` sets `nvisnodes` to be the same as the number of nodes specified in
@@ -73,7 +73,7 @@ end #hide #md
 # Finally, if you want to convert all the solution files to VTK execute
 
 redirect_stdio(stdout = devnull, stderr = devnull) do # code that prints annoying stuff we don't want to see here #hide #md
-    trixi2vtk("out/solution_000*.h5", output_directory = "out", nvisnodes = 12)
+trixi2vtk("out/solution_000*.h5", output_directory = "out", nvisnodes = 12)
 end #hide #md
 
 # then it is possible to open the `.pvd` file with ParaView and create a video of the simulation.
@@ -366,10 +366,10 @@ stepsize_callback = StepsizeCallback(cfl = 1.0)
 callbacks = CallbackSet(summary_callback, save_solution, stepsize_callback)
 
 redirect_stdio(stdout = devnull, stderr = devnull) do # code that prints annoying stuff we don't want to see here #hide #md
-    ## Evolve ODE problem in time using `solve` from OrdinaryDiffEq
-    sol = solve(ode, CarpenterKennedy2N54(williamson_condition = false);
-                dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-                ode_default_options()..., callback = callbacks)
+## Evolve ODE problem in time using `solve` from OrdinaryDiffEq
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition = false);
+            dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            ode_default_options()..., callback = callbacks);
 end #hide #md
 
 # Visualization of the solution is carried out in a similar way as above. That is, one converts the `.h5`

--- a/docs/literate/src/files/p4est_from_gmsh.jl
+++ b/docs/literate/src/files/p4est_from_gmsh.jl
@@ -17,8 +17,8 @@
 
 using Trixi
 redirect_stdio(stdout = devnull, stderr = devnull) do # code that prints annoying stuff we don't want to see here #hide #md
-    trixi_include(joinpath(examples_dir(), "p4est_2d_dgsem",
-                           "elixir_euler_NACA6412airfoil_mach2.jl"), tspan = (0.0, 0.5))
+trixi_include(joinpath(examples_dir(), "p4est_2d_dgsem",
+                       "elixir_euler_NACA6412airfoil_mach2.jl"), tspan = (0.0, 0.5));
 end #hide #md
 
 # Conveniently, we use the Plots package to have a first look at the results:

--- a/docs/literate/src/files/scalar_linear_advection_1d.jl
+++ b/docs/literate/src/files/scalar_linear_advection_1d.jl
@@ -344,7 +344,7 @@ tspan = (0.0, 2.0)
 ode = ODEProblem(rhs!, u0, tspan, x)
 
 sol = solve(ode, RDPK3SpFSAL49(); abstol = 1.0e-6, reltol = 1.0e-6,
-            ode_default_options()...)
+            ode_default_options()...);
 @test maximum(abs.(u0 - sol.u[end])) < 5e-5 #src
 
 plot(vec(x), vec(sol.u[end]), label = "solution at t=$(tspan[2])", legend = :topleft,
@@ -481,7 +481,7 @@ ode = ODEProblem(rhs!, u0, tspan, x)
 
 ## solve
 sol = solve(ode, RDPK3SpFSAL49(); abstol = 1.0e-6, reltol = 1.0e-6,
-            ode_default_options()...)
+            ode_default_options()...);
 @test maximum(abs.(vec(u0) - sol_trixi.u[end])) ≈ maximum(abs.(u0 - sol.u[end])) #src
 
 plot(vec(x), vec(sol.u[end]), label = "solution at t=$(tspan[2])", legend = :topleft,

--- a/docs/literate/src/files/subcell_shock_capturing.jl
+++ b/docs/literate/src/files/subcell_shock_capturing.jl
@@ -30,7 +30,7 @@
 # Therefore, subcell limiting with the IDP limiter requires the use of a Trixi-intern
 # time integration SSPRK method called with
 # ````julia
-# Trixi.solve(ode, method(stage_callbacks = stage_callbacks); ...)
+# Trixi.solve(ode, method(stage_callbacks = stage_callbacks); ...);
 # ````
 #-
 # Right now, only the canonical three-stage, third-order SSPRK method (Shu-Osher)

--- a/docs/literate/src/files/time_stepping.jl
+++ b/docs/literate/src/files/time_stepping.jl
@@ -6,7 +6,7 @@
 # The interface to these packages is the `solve(...)` function. It always requires an ODE problem and
 # a time integration algorithm as input parameters.
 # ````julia
-# solve(ode, alg; kwargs...)
+# solve(ode, alg; kwargs...);
 # ````
 # In Trixi.jl, the ODE problem is created by `semidiscretize(semi, tspan)` for a semidiscretization
 # `semi` and the time span `tspan`. In particular, [`semidiscretize`](@ref) returns an `ODEProblem`
@@ -69,7 +69,7 @@
 # alg = CarpenterKennedy2N54(williamson_condition=false)
 # solve(ode, alg;
 #       dt=1.0 # solve needs some value here but it will be overwritten by the stepsize_callback
-#       callback=callbacks)
+#       callback=callbacks);
 # ````
 
 # You can find simple examples with a CFL-based step size control for instance in the elixirs

--- a/examples/tree_2d_dgsem/elixir_acoustics_gauss_wall.jl
+++ b/examples/tree_2d_dgsem/elixir_acoustics_gauss_wall.jl
@@ -78,4 +78,4 @@ callbacks = CallbackSet(summary_callback, analysis_callback, save_solution,
 # OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition = false);
             dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
-            ode_default_options()..., callback = callbacks)
+            ode_default_options()..., callback = callbacks);


### PR DESCRIPTION
At some points of the tutorial section of the docs (especially the HOHQMesh tutorial), we had some indentation errors.
See:
<img width="1260" height="420" alt="Screenshot from 2025-09-08 16-26-15" src="https://github.com/user-attachments/assets/fc0a0c5d-89cc-470c-a6c6-7494ae956184" />

Moreover, sometimes in the docs unwanted output (see picture) was printed since we don't call the summary callback at the end. I added a `;` in those lines.
For consistency, I added `;` after every `solve` in the docs.