### PR TITLE
Elixir with constant subsonic state and boundary treatment

### DIFF
--- a/examples/p4est_2d_dgsem/elixir_euler_subsonic_constant.jl
+++ b/examples/p4est_2d_dgsem/elixir_euler_subsonic_constant.jl
@@ -72,7 +72,6 @@ coordinates_max = (1.0, 1.0)
 
 trees_per_dimension = (1, 1)
 
-
 mesh = P4estMesh(trees_per_dimension, polydeg = 3,
                  coordinates_min = coordinates_min, coordinates_max = coordinates_max,
                  initial_refinement_level = 3,

--- a/examples/p4est_2d_dgsem/elixir_euler_subsonic_constant.jl
+++ b/examples/p4est_2d_dgsem/elixir_euler_subsonic_constant.jl
@@ -1,6 +1,6 @@
 using OrdinaryDiffEqSSPRK
 using Trixi
-using Trixi: norm
+using LinearAlgebra: norm
 
 ###############################################################################
 ## Semidiscretization of the compressible Euler equations

--- a/examples/p4est_2d_dgsem/elixir_euler_subsonic_constant.jl
+++ b/examples/p4est_2d_dgsem/elixir_euler_subsonic_constant.jl
@@ -1,0 +1,126 @@
+using OrdinaryDiffEqSSPRK
+using Trixi
+using Trixi: norm
+
+###############################################################################
+## Semidiscretization of the compressible Euler equations
+
+equations = CompressibleEulerEquations2D(1.4)
+
+@inline function initial_condition_subsonic(x_, t, equations::CompressibleEulerEquations2D)
+    rho, v1, v2, p = (0.5313, 0.0, 0.0, 0.4)
+
+    prim = SVector(rho, v1, v2, p)
+    return prim2cons(prim, equations)
+end
+
+initial_condition = initial_condition_subsonic
+
+# Calculate the boundary flux from the inner state while using the pressure from the outer state
+# when the flow is subsonic (which is always the case in this example).
+
+# If the naive approach of only using the inner state is used, the errors increase with the
+# increase of refinement level, see https://github.com/trixi-framework/Trixi.jl/issues/2530
+# These errors arise from the corner points in this test.
+
+# See the reference below for a discussion on inflow/outflow boundary conditions. The subsonic
+# outflow boundary conditions are discussed in Section 2.3.
+#
+# - Jan-Reneé Carlson (2011)
+#   Inflow/Outflow Boundary Conditions with Application to FUN3D.
+#   [NASA TM 20110022658](https://ntrs.nasa.gov/citations/20110022658)
+@inline function boundary_condition_outflow_general(u_inner,
+                                                    normal_direction::AbstractVector, x, t,
+                                                    surface_flux_function,
+                                                    equations::CompressibleEulerEquations2D)
+
+    # This would be for the general case where we need to check the magnitude of the local Mach number
+    norm_ = norm(normal_direction)
+    # Normalize the vector without using `normalize` since we need to multiply by the `norm_` later
+    normal = normal_direction / norm_
+
+    # Rotate the internal solution state
+    u_local = Trixi.rotate_to_x(u_inner, normal, equations)
+
+    # Compute the primitive variables
+    rho_local, v_normal, v_tangent, p_local = cons2prim(u_local, equations)
+
+    # Compute local Mach number
+    a_local = sqrt(equations.gamma * p_local / rho_local)
+    Mach_local = abs(v_normal / a_local)
+    if Mach_local <= 1.0 # The `if` is not needed in this elixir but kept for generality
+        # In general, `p_local` need not be available from the initial condition
+        p_local = pressure(initial_condition_subsonic(x, t, equations), equations)
+    end
+
+    # Create the `u_surface` solution state where the local pressure is possibly set from an external value
+    prim = SVector(rho_local, v_normal, v_tangent, p_local)
+    u_boundary = prim2cons(prim, equations)
+    u_surface = Trixi.rotate_from_x(u_boundary, normal, equations)
+
+    # Compute the flux using the appropriate mixture of internal / external solution states
+    return flux(u_surface, normal_direction, equations)
+end
+
+boundary_conditions = Dict(:x_neg => boundary_condition_outflow_general,
+                           :x_pos => boundary_condition_outflow_general,
+                           :y_neg => boundary_condition_outflow_general,
+                           :y_pos => boundary_condition_outflow_general)
+
+coordinates_min = (0.0, 0.0)
+coordinates_max = (1.0, 1.0)
+
+trees_per_dimension = (1, 1)
+
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 6,
+                periodicity = false, n_cells_max = 512^2 * 16)
+
+mesh = P4estMesh(trees_per_dimension, polydeg = 3,
+                 coordinates_min = coordinates_min, coordinates_max = coordinates_max,
+                 initial_refinement_level = 3,
+                 periodicity = false)
+
+surface_flux = flux_lax_friedrichs
+
+polydeg = 3
+basis = LobattoLegendreBasis(polydeg)
+
+volume_integral = VolumeIntegralWeakForm()
+
+solver = DGSEM(polydeg = polydeg, surface_flux = surface_flux,
+               volume_integral = volume_integral)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                    boundary_conditions = boundary_conditions)
+
+###############################################################################
+## ODE solvers, callbacks etc.
+
+tspan = (0.0, 0.25)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 1000
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval = 100)
+
+save_solution = SaveSolutionCallback(interval = 100,
+                                     save_initial_solution = true,
+                                     save_final_solution = true,
+                                     solution_variables = cons2prim)
+
+stepsize_callback = StepsizeCallback(cfl = 0.5)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        save_solution,
+                        stepsize_callback)
+
+###############################################################################
+## Run the simulation
+sol = solve(ode, SSPRK54();
+            dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep = false, callback = callbacks);

--- a/examples/p4est_2d_dgsem/elixir_euler_subsonic_constant.jl
+++ b/examples/p4est_2d_dgsem/elixir_euler_subsonic_constant.jl
@@ -72,9 +72,6 @@ coordinates_max = (1.0, 1.0)
 
 trees_per_dimension = (1, 1)
 
-mesh = TreeMesh(coordinates_min, coordinates_max,
-                initial_refinement_level = 6,
-                periodicity = false, n_cells_max = 512^2 * 16)
 
 mesh = P4estMesh(trees_per_dimension, polydeg = 3,
                  coordinates_min = coordinates_min, coordinates_max = coordinates_max,
@@ -86,10 +83,7 @@ surface_flux = flux_lax_friedrichs
 polydeg = 3
 basis = LobattoLegendreBasis(polydeg)
 
-volume_integral = VolumeIntegralWeakForm()
-
-solver = DGSEM(polydeg = polydeg, surface_flux = surface_flux,
-               volume_integral = volume_integral)
+solver = DGSEM(polydeg = polydeg, surface_flux = surface_flux)
 
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
                                     boundary_conditions = boundary_conditions)

--- a/examples/p4est_2d_dgsem/elixir_euler_subsonic_constant.jl
+++ b/examples/p4est_2d_dgsem/elixir_euler_subsonic_constant.jl
@@ -8,6 +8,7 @@ using LinearAlgebra: norm
 equations = CompressibleEulerEquations2D(1.4)
 polydeg = 3
 solver = DGSEM(polydeg = polydeg, surface_flux = flux_lax_friedrichs)
+
 @inline function initial_condition_subsonic(x_, t, equations::CompressibleEulerEquations2D)
     rho, v1, v2, p = (0.5313, 0.0, 0.0, 0.4)
 

--- a/examples/p4est_2d_dgsem/elixir_euler_subsonic_constant.jl
+++ b/examples/p4est_2d_dgsem/elixir_euler_subsonic_constant.jl
@@ -6,7 +6,8 @@ using LinearAlgebra: norm
 ## Semidiscretization of the compressible Euler equations
 
 equations = CompressibleEulerEquations2D(1.4)
-
+polydeg = 3
+solver = DGSEM(polydeg = polydeg, surface_flux = flux_lax_friedrichs)
 @inline function initial_condition_subsonic(x_, t, equations::CompressibleEulerEquations2D)
     rho, v1, v2, p = (0.5313, 0.0, 0.0, 0.4)
 
@@ -72,17 +73,11 @@ coordinates_max = (1.0, 1.0)
 
 trees_per_dimension = (1, 1)
 
-mesh = P4estMesh(trees_per_dimension, polydeg = 3,
+mesh = P4estMesh(trees_per_dimension, polydeg = polydeg,
                  coordinates_min = coordinates_min, coordinates_max = coordinates_max,
                  initial_refinement_level = 3,
                  periodicity = false)
 
-surface_flux = flux_lax_friedrichs
-
-polydeg = 3
-basis = LobattoLegendreBasis(polydeg)
-
-solver = DGSEM(polydeg = polydeg, surface_flux = surface_flux)
 
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
                                     boundary_conditions = boundary_conditions)

--- a/examples/p4est_2d_dgsem/elixir_euler_subsonic_constant.jl
+++ b/examples/p4est_2d_dgsem/elixir_euler_subsonic_constant.jl
@@ -79,7 +79,6 @@ mesh = P4estMesh(trees_per_dimension, polydeg = polydeg,
                  initial_refinement_level = 3,
                  periodicity = false)
 
-
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
                                     boundary_conditions = boundary_conditions)
 

--- a/test/test_p4est_2d.jl
+++ b/test/test_p4est_2d.jl
@@ -187,6 +187,33 @@ end
     end
 end
 
+@trixi_testset "elixir_euler_subsonic_constant.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR,
+                                 "elixir_euler_subsonic_constant.jl"),
+                        l2=[
+                            9.268884363640194e-14,
+                            1.0689589615395477e-13,
+                            1.0408994850535984e-13,
+                            1.7032684855598177e-13
+                        ],
+                        linf=[
+                            1.6986412276764895e-13,
+                            2.2503592098759465e-12,
+                            1.7696906239744284e-12,
+                            3.623767952376511e-13
+                        ],
+                        initial_refinement_level=7,
+                        tspan=(0.0, 0.1))
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    let
+        t = sol.t[end]
+        u_ode = sol.u[end]
+        du_ode = similar(u_ode)
+        @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) < 1000
+    end
+end
+
 @trixi_testset "elixir_euler_source_terms_nonconforming_unstructured_flag.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "elixir_euler_source_terms_nonconforming_unstructured_flag.jl"),

--- a/test/test_tree_2d_euler.jl
+++ b/test/test_tree_2d_euler.jl
@@ -1094,7 +1094,7 @@ end
                             8.515583343047957e-14, 2.0472512574087887e-13
                         ],
                         initial_refinement_level=7,
-                        tspan=(0.0, 0.1)) # this test is sensitive to the CFL factor
+                        tspan=(0.0, 0.1))
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     let


### PR DESCRIPTION
This adds exactly the same elixir as in https://github.com/trixi-framework/Trixi.jl/pull/2560 for `P4estMesh`, resolving https://github.com/trixi-framework/Trixi.jl/issues/2530 where large errors were seen when initializing a constant subsonic state with outflow boundary condition. The added elixir has good subsonic outflow boundary treatment, and thus doesn't suffer from those large errors.

Also removes a potentially redundant comment added in the testing script in https://github.com/trixi-framework/Trixi.jl/pull/2560.