### PR TITLE
Fix allocations when (subcell) limit multiple nonlinear variables

### DIFF
--- a/src/solvers/dgsem_tree/subcell_limiters.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters.jl
@@ -258,23 +258,13 @@ end
 
 @inline function idp_positivity!(alpha, limiter, u, dt, semi)
     # Conservative variables
-    for variable in limiter.positivity_variables_cons
-        @trixi_timeit timer() "conservative variables" idp_positivity_conservative!(alpha,
-                                                                                    limiter,
-                                                                                    u,
-                                                                                    dt,
-                                                                                    semi,
-                                                                                    variable)
+    @trixi_timeit timer() "conservative variables" for variable in limiter.positivity_variables_cons
+        idp_positivity_conservative!(alpha, limiter, u, dt, semi, variable)
     end
 
     # Nonlinear variables
-    for variable in limiter.positivity_variables_nonlinear
-        @trixi_timeit timer() "nonlinear variables" idp_positivity_nonlinear!(alpha,
-                                                                              limiter,
-                                                                              u,
-                                                                              dt,
-                                                                              semi,
-                                                                              variable)
+    @trixi_timeit timer() "nonlinear variables" for variable in limiter.positivity_variables_nonlinear
+        idp_positivity_nonlinear!(alpha, limiter, u, dt, semi, variable)
     end
 
     return nothing
@@ -284,8 +274,8 @@ end
 # Newton-bisection method
 
 @inline function newton_loop!(alpha, bound, u, indices, variable, min_or_max,
-                              initial_check, final_check, equations, dt, limiter,
-                              antidiffusive_flux)
+                              initial_check, final_check,
+                              equations, dt, limiter, antidiffusive_flux)
     newton_reltol, newton_abstol = limiter.newton_tolerances
 
     beta = 1 - alpha[indices...]

--- a/src/solvers/dgsem_tree/subcell_limiters.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters.jl
@@ -108,6 +108,7 @@ function SubcellLimiterIDP(equations::AbstractEquations, basis;
         end
     end
     local_onesided_variables_nonlinear_ = Tuple(local_onesided_variables_nonlinear_)
+    positivity_variables_nonlinear = Tuple(positivity_variables_nonlinear)
 
     local_twosided_variables_cons_ = get_variable_index.(local_twosided_variables_cons,
                                                          equations)

--- a/src/solvers/dgsem_tree/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_2d.jl
@@ -482,43 +482,46 @@ end
 # Newton-bisection method
 
 # 2D version
-@inline function newton_loops_alpha!(alpha, bound, u, i, j, element, variable,
-                                     min_or_max, initial_check, final_check,
-                                     inverse_jacobian, dt, equations, dg, cache,
-                                     limiter)
+@inline function newton_loops_alpha!(alpha, bound, u, i, j, element,
+                                     variable, min_or_max,
+                                     initial_check, final_check,
+                                     inverse_jacobian, dt,
+                                     equations, dg, cache, limiter)
     (; inverse_weights) = dg.basis
     (; antidiffusive_flux1_L, antidiffusive_flux2_L, antidiffusive_flux1_R, antidiffusive_flux2_R) = cache.antidiffusive_fluxes
 
     (; gamma_constant_newton) = limiter
 
+    indices = (i, j, element)
+
     # negative xi direction
     antidiffusive_flux = gamma_constant_newton * inverse_jacobian * inverse_weights[i] *
-                         get_node_vars(antidiffusive_flux1_R, equations, dg, i, j,
-                                       element)
-    newton_loop!(alpha, bound, u, (i, j, element), variable, min_or_max, initial_check,
+                         get_node_vars(antidiffusive_flux1_R, equations, dg,
+                                       i, j, element)
+    newton_loop!(alpha, bound, u, indices, variable, min_or_max, initial_check,
                  final_check, equations, dt, limiter, antidiffusive_flux)
 
     # positive xi direction
     antidiffusive_flux = -gamma_constant_newton * inverse_jacobian *
                          inverse_weights[i] *
-                         get_node_vars(antidiffusive_flux1_L, equations, dg, i + 1, j,
-                                       element)
-    newton_loop!(alpha, bound, u, (i, j, element), variable, min_or_max, initial_check,
+                         get_node_vars(antidiffusive_flux1_L, equations, dg,
+                                       i + 1, j, element)
+    newton_loop!(alpha, bound, u, indices, variable, min_or_max, initial_check,
                  final_check, equations, dt, limiter, antidiffusive_flux)
 
     # negative eta direction
     antidiffusive_flux = gamma_constant_newton * inverse_jacobian * inverse_weights[j] *
-                         get_node_vars(antidiffusive_flux2_R, equations, dg, i, j,
-                                       element)
-    newton_loop!(alpha, bound, u, (i, j, element), variable, min_or_max, initial_check,
+                         get_node_vars(antidiffusive_flux2_R, equations, dg,
+                                       i, j, element)
+    newton_loop!(alpha, bound, u, indices, variable, min_or_max, initial_check,
                  final_check, equations, dt, limiter, antidiffusive_flux)
 
     # positive eta direction
     antidiffusive_flux = -gamma_constant_newton * inverse_jacobian *
                          inverse_weights[j] *
-                         get_node_vars(antidiffusive_flux2_L, equations, dg, i, j + 1,
-                                       element)
-    newton_loop!(alpha, bound, u, (i, j, element), variable, min_or_max, initial_check,
+                         get_node_vars(antidiffusive_flux2_L, equations, dg,
+                                       i, j + 1, element)
+    newton_loop!(alpha, bound, u, indices, variable, min_or_max, initial_check,
                  final_check, equations, dt, limiter, antidiffusive_flux)
 
     return nothing


### PR DESCRIPTION
@amrueda noticed some allocation when using multiple nonlinear variables in the subcell positivity limiting with `positivity_variables_nonlinear = [pressure1, pressure2]`:
```
───────────────────────────────────────────────────────────────────────────────────────────
                Trixi.jl                          Time                    Allocations      
                                         ───────────────────────   ────────────────────────
            Tot / % measured:                 71.5s / 100.0%           3.81GiB / 100.0%    

Section                          ncalls     time    %tot     avg     alloc    %tot      avg
───────────────────────────────────────────────────────────────────────────────────────────
...
  a posteriori limiter              636    33.3s   46.6%  52.4ms   1.88GiB   49.5%  3.03MiB
    blending factors                636    32.3s   45.2%  50.8ms   1.88GiB   49.5%  3.03MiB
      positivity                    636    32.3s   45.2%  50.7ms   1.88GiB   49.5%  3.03MiB
        nonlinear variables         636    31.7s   44.4%  49.8ms   1.88GiB   49.5%  3.03MiB
       ...
  check_bounds                      636    1.70s    2.4%  2.68ms   1.86GiB   49.0%  3.00MiB
  ...
───────────────────────────────────────────────────────────────────────────────────────────
```

I probably never simulated such a case and haven't noted the allocations which are occurring because the used vector contains elements of different types. Then, `for variable in positivity_variables_nonlinear` created allocations.

I fixed that by using a tuple instead. This is converted automatically such that tuple and vector are possible and not every elixir had to be changed.
```
───────────────────────────────────────────────────────────────────────────────────────────
                Trixi.jl                          Time                    Allocations      
                                         ───────────────────────   ────────────────────────
            Tot / % measured:                 45.4s / 100.0%           61.7MiB / 100.0%    

Section                          ncalls     time    %tot     avg     alloc    %tot      avg
───────────────────────────────────────────────────────────────────────────────────────────
...
  a posteriori limiter              636    8.69s   19.1%  13.7ms    380KiB    0.6%     612B
    blending factors                636    7.75s   17.1%  12.2ms    380KiB    0.6%     611B
      positivity                    636    7.69s   16.9%  12.1ms    379KiB    0.6%     610B
        nonlinear variables         636    7.14s   15.7%  11.2ms    278KiB    0.4%     448B
        ...
  check_bounds                      636    202ms    0.4%   318μs    378KiB    0.6%     608B
 ...
───────────────────────────────────────────────────────────────────────────────────────────