### PR TITLE
Remove doubled saving of subcell limiting factors

### DIFF
--- a/src/callbacks_stage/subcell_limiter_idp_correction_2d.jl
+++ b/src/callbacks_stage/subcell_limiter_idp_correction_2d.jl
@@ -11,7 +11,7 @@ function perform_idp_correction!(u, dt,
                                  equations, dg, cache)
     @unpack inverse_weights = dg.basis
     @unpack antidiffusive_flux1_L, antidiffusive_flux2_L, antidiffusive_flux1_R, antidiffusive_flux2_R = cache.antidiffusive_fluxes
-    @unpack alpha1, alpha2 = dg.volume_integral.limiter.cache.subcell_limiter_coefficients
+    @unpack alpha = dg.volume_integral.limiter.cache.subcell_limiter_coefficients
 
     @threaded for element in eachelement(dg, cache)
         for j in eachnode(dg), i in eachnode(dg)
@@ -19,19 +19,40 @@ function perform_idp_correction!(u, dt,
             inverse_jacobian = -get_inverse_jacobian(cache.elements.inverse_jacobian,
                                                      mesh, i, j, element)
 
-            # Note: antidiffusive_flux1[v, i, xi, element] = antidiffusive_flux2[v, xi, i, element] = 0 for all i in 1:nnodes and xi in {1, nnodes+1}
-            alpha_flux1 = (1 - alpha1[i, j, element]) *
-                          get_node_vars(antidiffusive_flux1_R, equations, dg,
-                                        i, j, element)
-            alpha_flux1_ip1 = (1 - alpha1[i + 1, j, element]) *
-                              get_node_vars(antidiffusive_flux1_L, equations, dg,
-                                            i + 1, j, element)
-            alpha_flux2 = (1 - alpha2[i, j, element]) *
-                          get_node_vars(antidiffusive_flux2_R, equations, dg,
-                                        i, j, element)
-            alpha_flux2_jp1 = (1 - alpha2[i, j + 1, element]) *
-                              get_node_vars(antidiffusive_flux2_L, equations, dg,
-                                            i, j + 1, element)
+            # Note: For LGL nodes, the high-order and low-order fluxes at element interfaces are equal.
+            # Therefore, we only need to consider the inner updates and setting the outer fluxes to zero.
+            if i > 1
+                alpha1 = max(alpha[i - 1, j, element], alpha[i, j, element])
+                alpha_flux1 = (1 - alpha1) *
+                              get_node_vars(antidiffusive_flux1_R, equations, dg,
+                                            i, j, element)
+            else
+                alpha_flux1 = zero(SVector{nvariables(equations), eltype(u)})
+            end
+            if i < nnodes(dg)
+                alpha1_ip1 = max(alpha[i, j, element], alpha[i + 1, j, element])
+                alpha_flux1_ip1 = (1 - alpha1_ip1) *
+                                  get_node_vars(antidiffusive_flux1_L, equations, dg,
+                                                i + 1, j, element)
+            else
+                alpha_flux1_ip1 = zero(SVector{nvariables(equations), eltype(u)})
+            end
+            if j > 1
+                alpha2 = max(alpha[i, j - 1, element], alpha[i, j, element])
+                alpha_flux2 = (1 - alpha2) *
+                              get_node_vars(antidiffusive_flux2_R, equations, dg,
+                                            i, j, element)
+            else
+                alpha_flux2 = zero(SVector{nvariables(equations), eltype(u)})
+            end
+            if j < nnodes(dg)
+                alpha2_jp1 = max(alpha[i, j, element], alpha[i, j + 1, element])
+                alpha_flux2_jp1 = (1 - alpha2_jp1) *
+                                  get_node_vars(antidiffusive_flux2_L, equations, dg,
+                                                i, j + 1, element)
+            else
+                alpha_flux2_jp1 = zero(SVector{nvariables(equations), eltype(u)})
+            end
 
             for v in eachvariable(equations)
                 u[v, i, j, element] += dt * inverse_jacobian *

--- a/src/solvers/dgsem_tree/containers_2d.jl
+++ b/src/solvers/dgsem_tree/containers_2d.jl
@@ -1354,14 +1354,10 @@ end
 
 # Container data structure (structure-of-arrays style) for variables used for IDP limiting
 mutable struct ContainerSubcellLimiterIDP2D{uEltype <: Real}
-    alpha::Array{uEltype, 3}                  # [i, j, element]
-    alpha1::Array{uEltype, 3}
-    alpha2::Array{uEltype, 3}
+    alpha::Array{uEltype, 3} # [i, j, element]
     variable_bounds::Dict{Symbol, Array{uEltype, 3}}
     # internal `resize!`able storage
     _alpha::Vector{uEltype}
-    _alpha1::Vector{uEltype}
-    _alpha2::Vector{uEltype}
     _variable_bounds::Dict{Symbol, Vector{uEltype}}
 end
 
@@ -1372,10 +1368,6 @@ function ContainerSubcellLimiterIDP2D{uEltype}(capacity::Integer, n_nodes,
     # Initialize fields with defaults
     _alpha = fill(nan_uEltype, n_nodes * n_nodes * capacity)
     alpha = unsafe_wrap(Array, pointer(_alpha), (n_nodes, n_nodes, capacity))
-    _alpha1 = fill(nan_uEltype, (n_nodes + 1) * n_nodes * capacity)
-    alpha1 = unsafe_wrap(Array, pointer(_alpha1), (n_nodes + 1, n_nodes, capacity))
-    _alpha2 = fill(nan_uEltype, n_nodes * (n_nodes + 1) * capacity)
-    alpha2 = unsafe_wrap(Array, pointer(_alpha2), (n_nodes, n_nodes + 1, capacity))
 
     _variable_bounds = Dict{Symbol, Vector{uEltype}}()
     variable_bounds = Dict{Symbol, Array{uEltype, 3}}()
@@ -1385,10 +1377,8 @@ function ContainerSubcellLimiterIDP2D{uEltype}(capacity::Integer, n_nodes,
                                            (n_nodes, n_nodes, capacity))
     end
 
-    return ContainerSubcellLimiterIDP2D{uEltype}(alpha, alpha1, alpha2,
-                                                 variable_bounds,
-                                                 _alpha, _alpha1, _alpha2,
-                                                 _variable_bounds)
+    return ContainerSubcellLimiterIDP2D{uEltype}(alpha, variable_bounds,
+                                                 _alpha, _variable_bounds)
 end
 
 nnodes(container::ContainerSubcellLimiterIDP2D) = size(container.alpha, 1)
@@ -1401,16 +1391,10 @@ nnodes(container::ContainerSubcellLimiterIDP2D) = size(container.alpha, 1)
 function Base.resize!(container::ContainerSubcellLimiterIDP2D, capacity)
     n_nodes = nnodes(container)
 
-    (; _alpha, _alpha1, _alpha2) = container
+    (; _alpha) = container
     resize!(_alpha, n_nodes * n_nodes * capacity)
     container.alpha = unsafe_wrap(Array, pointer(_alpha), (n_nodes, n_nodes, capacity))
     container.alpha .= convert(eltype(container.alpha), NaN)
-    resize!(_alpha1, (n_nodes + 1) * n_nodes * capacity)
-    container.alpha1 = unsafe_wrap(Array, pointer(_alpha1),
-                                   (n_nodes + 1, n_nodes, capacity))
-    resize!(_alpha2, n_nodes * (n_nodes + 1) * capacity)
-    container.alpha2 = unsafe_wrap(Array, pointer(_alpha2),
-                                   (n_nodes, n_nodes + 1, capacity))
 
     (; _variable_bounds) = container
     for (key, _) in _variable_bounds

--- a/src/solvers/dgsem_tree/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_2d.jl
@@ -30,8 +30,8 @@ function create_cache(limiter::Type{SubcellLimiterIDP}, equations::AbstractEquat
             idp_bounds_delta_global)
 end
 
-function (limiter::SubcellLimiterIDP)(u::AbstractArray{<:Any, 4},
-                                      semi, equations, dg::DGSEM,
+# dimension agnostic
+function (limiter::SubcellLimiterIDP)(u, semi, equations, dg::DGSEM,
                                       t, dt;
                                       kwargs...)
     @unpack alpha = limiter.cache.subcell_limiter_coefficients
@@ -48,21 +48,6 @@ function (limiter::SubcellLimiterIDP)(u::AbstractArray{<:Any, 4},
     if limiter.local_onesided
         @trixi_timeit timer() "local onesided" idp_local_onesided!(alpha, limiter,
                                                                    u, t, dt, semi)
-    end
-
-    # Calculate alpha1 and alpha2
-    @unpack alpha1, alpha2 = limiter.cache.subcell_limiter_coefficients
-    @threaded for element in eachelement(dg, semi.cache)
-        for j in eachnode(dg), i in 2:nnodes(dg)
-            alpha1[i, j, element] = max(alpha[i - 1, j, element], alpha[i, j, element])
-        end
-        for j in 2:nnodes(dg), i in eachnode(dg)
-            alpha2[i, j, element] = max(alpha[i, j - 1, element], alpha[i, j, element])
-        end
-        alpha1[1, :, element] .= zero(eltype(alpha1))
-        alpha1[nnodes(dg) + 1, :, element] .= zero(eltype(alpha1))
-        alpha2[:, 1, element] .= zero(eltype(alpha2))
-        alpha2[:, nnodes(dg) + 1, element] .= zero(eltype(alpha2))
     end
 
     return nothing


### PR DESCRIPTION
In `alpha1` and `alpha2`, basically, only the maximum factor between two nodes were saved.
```
alpha1[i, j, element] = max(alpha[i - 1, j, element], alpha[i, j, element])
alpha2[i, j, element] = max(alpha[i, j - 1, element], alpha[i, j, element])
```
This was convenient since we didn't need any `if` clause later in the correction stage.

Moreover, to keep the nice update of