### PR TITLE
`SparseConnectivityTracer` ready mean functions

### DIFF
--- a/ext/TrixiSparseConnectivityTracerExt.jl
+++ b/ext/TrixiSparseConnectivityTracerExt.jl
@@ -10,4 +10,21 @@ import SparseConnectivityTracer: AbstractTracer
 # we switch back to the Base implementation here which does not contain an if-clause.
 Trixi.sqrt(x::AbstractTracer) = Base.sqrt(x)
 
+# if-clause free (i.e., non-optimized) implementations of some helper functions
+# that compute specialized mean values used in advanced flux functions
+
+@inline function Trixi.ln_mean(x::AbstractTracer, y::AbstractTracer)
+    return (y - x) / log(y / x)
+end
+
+@inline function Trixi.inv_ln_mean(x::AbstractTracer, y::AbstractTracer)
+    return log(y / x) / (y - x)
+end
+
+@inline function Trixi.stolarsky_mean(x::AbstractTracer, y::AbstractTracer, gamma::Real)
+    yg = exp((gamma - 1) * log(y)) # equivalent to y^(gamma - 1) but faster for non-integers
+    xg = exp((gamma - 1) * log(x)) # equivalent to x^(gamma - 1) but faster for non-integers
+    return (gamma - 1) * (yg * y - xg * x) / (gamma * (yg - xg))
+end
+
 end

--- a/src/auxiliary/math.jl
+++ b/src/auxiliary/math.jl
@@ -434,8 +434,8 @@ Given ε = 1.0e-4, we use the following algorithm.
             yg = y^(gamma - 1)
             xg = x^(gamma - 1)
         else
-            yg = exp((gamma - 1) * log(y)) # equivalent to y^gamma but faster for non-integers
-            xg = exp((gamma - 1) * log(x)) # equivalent to x^gamma but faster for non-integers
+            yg = exp((gamma - 1) * log(y)) # equivalent to y^(gamma - 1) but faster for non-integers
+            xg = exp((gamma - 1) * log(x)) # equivalent to x^(gamma - 1) but faster for non-integers
         end
         return (gamma - 1) * (yg * y - xg * x) / (gamma * (yg - xg))
     end

--- a/test/test_structured_2d.jl
+++ b/test/test_structured_2d.jl
@@ -258,6 +258,29 @@ end
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 
+@trixi_testset "elixir_euler_convergence_implicit_sparse_jacobian.jl with flux_ranocha" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR,
+                                 "elixir_euler_convergence_implicit_sparse_jacobian.jl"),
+                        solver=DGSEM(polydeg = 3, surface_flux = surface_flux,
+                                     volume_integral = VolumeIntegralFluxDifferencing(flux_ranocha)),
+                        tspan=(0.0, 1.0),
+                        l2=[
+                            0.002488034310310255,
+                            0.002537347299714133,
+                            0.002533529761212216,
+                            0.0030150881617191675
+                        ],
+                        linf=[
+                            0.005844630331331979,
+                            0.005507186931414498,
+                            0.005377359689946237,
+                            0.00631648929531492
+                        ])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    @test_allocations(Trixi.rhs!, semi, sol, 1000)
+end
+
 @trixi_testset "elixir_eulermulti_convergence_ec.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_eulermulti_convergence_ec.jl"),
                         l2=[
@@ -706,6 +729,45 @@ end
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
+end
+
+@trixi_testset "elixir_eulerpolytropic_convergence.jl sparsity detection" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR,
+                                 "elixir_eulerpolytropic_convergence.jl"),
+                        surface_flux=flux_lax_friedrichs,
+                        tspan=(0.0, 0.0))
+
+    import SparseConnectivityTracer: TracerSparsityDetector,
+                                     jacobian_eltype,
+                                     jacobian_sparsity
+
+    jac_detector = TracerSparsityDetector()
+    # We need to construct the semidiscretization with the correct
+    # sparsity-detection ready datatype, which is retrieved here
+    jac_eltype = jacobian_eltype(real(solver), jac_detector)
+
+    # Semidiscretization for sparsity pattern detection
+    semi_jac_type = SemidiscretizationHyperbolic(mesh, equations,
+                                                 initial_condition,
+                                                 solver,
+                                                 source_terms = source_terms_convergence_test,
+                                                 uEltype = jac_eltype) # Need to supply Jacobian element type
+
+    # Call `semidiscretize` to create the ODE problem to have access to the
+    # initial condition based on which the sparsity pattern is computed
+    ode_jac_type = semidiscretize(semi_jac_type, tspan)
+    u0_ode = ode_jac_type.u0
+    du_ode = similar(u0_ode)
+
+    ###############################################################################
+    ### Compute the Jacobian sparsity pattern ###
+
+    # Wrap the `Trixi.rhs!` function to match the signature `f!(du, u)`, see
+    # https://adrianhill.de/SparseConnectivityTracer.jl/stable/user/api/#ADTypes.jacobian_sparsity
+    rhs_wrapped! = (du_ode, u0_ode) -> Trixi.rhs!(du_ode, u0_ode, semi_jac_type,
+                                                  tspan[1])
+
+    @test_nowarn jacobian_sparsity(rhs_wrapped!, du_ode, u0_ode, jac_detector)
 end
 
 @trixi_testset "elixir_eulerpolytropic_ec.jl" begin


### PR DESCRIPTION
`SparseConnectivityTracer` does not like `if` clauses. Since in these functions the `if` clauses are for performance purposes only, one can add valid `if`-free alternatives.

I waited with this PR for #2274