### PR TITLE
move tolerances in Krylov solver example

### DIFF
--- a/examples/tree_2d_dgsem/elixir_diffusion_steady_state_linear_map.jl
+++ b/examples/tree_2d_dgsem/elixir_diffusion_steady_state_linear_map.jl
@@ -66,15 +66,12 @@ u_ls = A_matrix \ b
 # Iterative solve, works directly on the linear map, no explicit matrix construction required!
 using Krylov
 
-atol = 1e-11
-rtol = 1e-10
-
 # This solves the Laplace equation (i.e., steady-state diffusion/heat equation).
 # Note that we do not use CG since the operator `A_map` itself is only
 # symmetric and positive definite with respect to the inner product induced by
 # the DGSEM quadrature, not the standard Euclidean inner product. Standard CG
 # would require multiplying the result of `A_map * u` (and `b`) by the mass matrix.
-u_ls, stats = gmres(A_map, b, atol = atol, rtol = rtol)
+u_ls, stats = gmres(A_map, b, atol = 1.0e-11, rtol = 1.0e-10)
 
 ###############################################################################
 


### PR DESCRIPTION
The tolerances introduced in https://github.com/trixi-framework/Trixi.jl/pull/2625 were separated by a big comment from the place where they are used. Moreover, we can still override them with `trixi_include` when they are supplied as keyword arguments directly.