### PR TITLE
remove macos-15-intel MPI tests from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,6 @@ jobs:
             arch: x64
             trixi_test: threaded_legacy
           - version: '1.10'
-            os: macos-15-intel
-            arch: x64
-            trixi_test: mpi
-          - version: '1.10'
             os: macos-latest
             arch: aarch64
             trixi_test: threaded


### PR DESCRIPTION
MPI does not work properly on Apple Silicon (M series), see https://github.com/trixi-framework/Trixi.jl/issues/1922. Thus, we need to test MPI on old Apple hardware. However, GitHub removed the old macos-13 runners so that we had to switch to macos-15-intel in https://github.com/trixi-framework/Trixi.jl/pull/2596 (knowing that they will be the last Intel versions for MacOS from GitHub).
However, I observed that the macos-15-intel tests are dominating our CI time: they take roughly 40 minutes to one hour compared to about 30 minutes or less for the other CI jobs. See for example https://github.com/trixi-framework/Trixi.jl/actions/runs/19529363653

Edit: macos-15-intel took even 56 minutes in https://github.com/trixi-framework/Trixi.jl/actions/runs/19645505901/job/56259640584

Thus, I would like to test whether removing this job influences our test coverage. Please note that the threaded CI tests on macos-latest are still included.