### PR TITLE
Revert `StructuredMesh2D` interface flux calculations

### DIFF
--- a/src/solvers/dgsem_structured/dg_2d.jl
+++ b/src/solvers/dgsem_structured/dg_2d.jl
@@ -542,24 +542,6 @@ end
                                                   StructuredMeshView{2}},
                                       have_nonconservative_terms::True, equations,
                                       surface_integral, dg::DG, cache)
-    calc_interface_flux!(surface_flux_values, left_element, right_element, orientation,
-                         u, mesh, have_nonconservative_terms,
-                         combine_conservative_and_nonconservative_fluxes(surface_integral.surface_flux,
-                                                                         equations),
-                         equations, surface_integral,
-                         dg, cache)
-    return nothing
-end
-
-@inline function calc_interface_flux!(surface_flux_values, left_element, right_element,
-                                      orientation, u,
-                                      mesh::Union{StructuredMesh{2},
-                                                  StructuredMeshView{2}},
-                                      have_nonconservative_terms::True,
-                                      combine_conservative_and_nonconservative_fluxes::False,
-                                      equations,
-                                      surface_integral, dg::DG, cache)
-
     # See comment on `calc_interface_flux!` with `have_nonconservative_terms::False`
     if left_element <= 0 # left_element = 0 at boundaries
         return nothing


### PR DESCRIPTION
Working on the 3D implementation of the optimized kernel for nonconservative fluxes, I realized there was this part of the `StructuredMesh` that has to be deleted, since we are not enabling the support of this performance specialization for that type of mesh.