### PR TITLE
merge performance specialization CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,7 @@ jobs:
           - paper_self_gravitating_gas_dynamics
           - misc_part1
           - misc_part2
-          - performance_specializations_part1
-          - performance_specializations_part2
+          - performance_specializations
           - mpi
           - threaded
         include:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -99,10 +99,8 @@ const TRIXI_NTHREADS = clamp(Sys.CPU_THREADS, 2, 3)
         include("test_aqua.jl")
     end
 
-    @time if TRIXI_TEST == "all" || TRIXI_TEST == "performance_specializations_part1"
+    @time if TRIXI_TEST == "all" || TRIXI_TEST == "performance_specializations"
         include("test_performance_specializations_2d.jl")
-    end
-    @time if TRIXI_TEST == "all" || TRIXI_TEST == "performance_specializations_part2"
         include("test_performance_specializations_3d.jl")
     end
 


### PR DESCRIPTION
The two performance specialization CI jobs just take a few minutes (5 minutes and 6 minutes in the last runs). Thus, we can free one CI runner and use the capacity for other CI jobs.