### PR TITLE
OrdinaryDiffEqLowStorageRK in developer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ cd Trixi.jl
 mkdir run
 cd run
 julia --project=. -e 'using Pkg; Pkg.develop(PackageSpec(path=".."))' # Install local Trixi.jl clone
-julia --project=. -e 'using Pkg; Pkg.add(["OrdinaryDiffEq", "Trixi2Vtk", "Plots"])' # Install additional packages
+julia --project=. -e 'using Pkg; Pkg.add(["OrdinaryDiffEqLowStorageRK", "OrdinaryDiffEqSSPRK",
+                                          "Trixi2Vtk", "Plots"])' # Install additional packages
 ```
 Note that the postprocessing tools Trixi2Vtk.jl and Plots.jl are optional and
 can be omitted.


### PR DESCRIPTION
While "For users" had already been adapted, "For developers" still listed "OrdinaryDiffEq".