### PR TITLE
Fix element print for `DGMulti`

### DIFF
--- a/src/callbacks_step/analysis_dgmulti.jl
+++ b/src/callbacks_step/analysis_dgmulti.jl
@@ -149,7 +149,7 @@ function nelementsglobal(mesh::DGMultiMesh, solver::DGMulti, cache)
     if mpi_isparallel()
         error("`nelementsglobal` is not implemented for `DGMultiMesh` when used in parallel with MPI")
     else
-        return ndofs(mesh, solver, cache)
+        return nelements(mesh, solver)
     end
 end
 function ndofsglobal(mesh::DGMultiMesh, solver::DGMulti, cache)


### PR DESCRIPTION
It's actually defined just above

https://github.com/trixi-framework/Trixi.jl/blob/95ba538693f490035c957406a2a60fd0f73fabf1/src/callbacks_step/analysis_dgmulti.jl#L147