### PR TITLE
Speed up calculation of subcell bounds

### DIFF
--- a/src/solvers/dgsem_tree/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_2d.jl
@@ -124,7 +124,7 @@ end
                                        u::AbstractArray{<:Any, 4}, t, semi)
     mesh, equations, dg, cache = mesh_equations_solver_cache(semi)
 
-    # The approach as in `calc_bounds_twosided!` is not used here, because it requires more
+    # The approach used in `calc_bounds_twosided!` is not used here because it requires more
     # evaluations of the variable and is therefore slower.
 
     # Calc bounds inside elements


### PR DESCRIPTION
Similar to https://github.com/trixi-framework/Trixi.jl/pull/2644, this PR refactors the computation of subcell bounds in `calc_bounds_twosided!`. Instead of going through all nodes and decide whether there is an available neighbor (`if i>1`, `if i<nnodes`, ...), we run over all subcell interfaces (`for i in 2:nnodes(dg)`, ...).
main
```
julia> @benchmark Trixi.calc_bounds_twosided!($var_min, $var_max, $variable, $u, $t, $semi, $equations)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  236.021 μs … 318.680 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     238.703 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   239.852 μs ±   3.522 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

        ▄▇█▆▄▅▅▅▃▂▂▂▁                         ▁                 ▂
  ▂▂▃▅▆██████████████████▇▇█▇▇█▇▇▆▇▆▆▆▇▆▅▆▇▆▆███▇▇▆▆▅▆▆▆▆▆▅▄▅▄▄ █
  236 μs        Histogram: log(frequency) by time        255 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

this PR
```
julia> @benchmark Trixi.calc_bounds_twosided!($var_min, $var_max, $variable, $u, $t, $semi, $equations)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  128.819 μs … 174.041 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     131.858 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   132.633 μs ±   2.932 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

     ▁▂▃▄▅▆▇██▇▇▆▅▅▄▄▃▂▂▁▁ ▁      ▁                             ▃
  ▄▆▇███████████████████████████████▇█▇████▆▇█▇▇█▇▇▇▇▆▆▇▇▆▆▆▆▆▆ █
  129 μs        Histogram: log(frequency) by time        145 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```


I tried the same for the computation of one-sided bounds (nonlinear variables), but it makes the routine slower due to more evaluations of `variable(..., equations)`.