### PR TITLE
check boxes

### DIFF
--- a/.github/workflows/CheckForBoxes.yml
+++ b/.github/workflows/CheckForBoxes.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'AUTHORS.md'
+      - 'CITATION.bib'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE.md'
+      - 'NEWS.md'
+      - 'README.md'
+      - '.zenodo.json'
+      - '.github/workflows/benchmark.yml'
+      - '.github/workflows/CompatHelper.yml'
+      - '.github/workflows/TagBot.yml'
+      - 'benchmark/**'
+      - 'docs/**'
+      - 'utils/**'
+  pull_request:
+    paths-ignore:
+      - 'AUTHORS.md'
+      - 'CITATION.bib'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE.md'
+      - 'NEWS.md'
+      - 'README.md'
+      - '.zenodo.json'
+      - '.github/workflows/benchmark.yml'
+      - '.github/workflows/CompatHelper.yml'
+      - '.github/workflows/TagBot.yml'
+      - 'benchmark/**'
+      - 'docs/**'
+      - 'utils/**'
+  workflow_dispatch:
+
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
+# Cancel redundant CI tests automatically
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    name: Check for Boxes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.12'
+          arch: x64
+      - run: julia -e 'using InteractiveUtils; versioninfo(verbose = true)'
+      - uses: julia-actions/cache@v2
+        with:
+          include-matrix: false
+      - uses: julia-actions/julia-buildpkg@v1
+        env:
+          PYTHON: ''
+      - run: julia --project=. -e 'include("test/test_boxes.jl")'

--- a/src/meshes/p4est_mesh_view.jl
+++ b/src/meshes/p4est_mesh_view.jl
@@ -132,9 +132,10 @@ function save_mesh_file(mesh::P4estMeshView, output_directory, timestep,
         attributes(file)["cell_ids"] = mesh.cell_ids
 
         file["tree_node_coordinates"] = mesh.parent.tree_node_coordinates
-        file["nodes"] = Vector(mesh.parent.nodes) # the mesh uses `SVector`s for the nodes
-        # to increase the runtime performance
-        # but HDF5 can only handle plain arrays
+        # The mesh uses `SVector`s for the nodes to increase the
+        # runtime performance but HDF5 can only handle plain arrays.
+        # Thus, we convert the nodes to a Vector here.
+        file["nodes"] = Vector(mesh.parent.nodes)
         file["boundary_names"] = mesh.parent.boundary_names .|> String
         return nothing
     end

--- a/test/test_boxes.jl
+++ b/test/test_boxes.jl
@@ -94,7 +94,7 @@ function scan_method!(lines, m::Method, modules)
     end
 end
 
-function check_no_boxes(modules = Set(["Trixi"]))
+function number_of_boxes(modules = Set(["Trixi"]))
     format = "markdown"
     lines = Vector{NamedTuple}()
     Base.visit(Core.methodtable) do m
@@ -130,12 +130,16 @@ function check_no_boxes(modules = Set(["Trixi"]))
         end
     end
 
-    return isempty(lines)
+    return length(lines)
 end
 
 ################################################################################
 
 @testset "No Core.Box" begin
     # Too complicated to adapt to v1.11-, skip it in that case.
-    @test check_no_boxes() skip=(VERSION < v"1.12")
+    if VERSION < v"1.12"
+        @info "Skipping Core.Box check on Julia versions < 1.12"
+        return
+    end
+    @test number_of_boxes() == 33
 end

--- a/test/test_boxes.jl
+++ b/test/test_boxes.jl
@@ -1,0 +1,141 @@
+using Test
+using Trixi
+
+# Code for detecting `Core.Box`es adapted from
+# <https://github.com/JuliaLang/julia/pull/60478> and
+# <https://github.com/NumericalEarth/Breeze.jl/pull/400>.
+# There's a chance this will be eventually integrated into
+# Test or Aqua.jl; for the time being we vendor the code here.
+
+function is_box_call(expr)
+    if !(expr isa Expr)
+        return false
+    end
+    if expr.head === :call
+        callee = expr.args[1]
+        return callee === Core.Box || (callee isa GlobalRef && callee.mod === Core && callee.name === :Box)
+    elseif expr.head === :new
+        callee = expr.args[1]
+        return callee === Core.Box || (callee isa GlobalRef && callee.mod === Core && callee.name === :Box)
+    end
+    return false
+end
+
+function slot_name(ci, slot)
+    if slot isa Core.SlotNumber
+        idx = Int(slot.id)
+        if 1 <= idx <= length(ci.slotnames)
+            return string(ci.slotnames[idx])
+        end
+    end
+    return string(slot)
+end
+
+function method_location(m::Method)
+    file = m.file
+    line = m.line
+    file_str = file isa Symbol ? String(file) : string(file)
+    if file_str == "none" || line == 0
+        return ("", 0)
+    end
+    return (file_str, line)
+end
+
+function root_module(mod::Module)
+    while true
+        parent = parentmodule(mod)
+        if parent === mod || parent === Main || parent === Core
+            return mod
+        end
+        mod = parent
+    end
+end
+
+function format_box_fields(var, m::Method)
+    file, line = method_location(m)
+    location = isempty(file) ? "" : string(file, ":", line)
+    return (
+        mod = string(root_module(m.module)),
+        var = string(var),
+        func = string(m.name),
+        sig = string(m.sig),
+        location = location,
+    )
+end
+
+function escape_md(s)
+    return replace(string(s), "|" => "\\|")
+end
+
+function md_code(s)
+    return "`" * replace(string(s), "`" => "``") * "`"
+end
+
+function scan_method!(lines, m::Method, modules)
+    root = string(root_module(m.module))
+    if !isempty(modules) && !(root in modules)
+        return
+    end
+    ci = try
+        Base.uncompressed_ast(m)
+    catch
+        return
+    end
+    for stmt in ci.code
+        if stmt isa Expr && stmt.head === :(=)
+            lhs = stmt.args[1]
+            rhs = stmt.args[2]
+            if is_box_call(rhs)
+                push!(lines, format_box_fields(slot_name(ci, lhs), m))
+            end
+        elseif is_box_call(stmt)
+            push!(lines, format_box_fields("<unknown>", m))
+        end
+    end
+end
+
+function check_no_boxes(modules = Set(["Trixi"]))
+    format = "markdown"
+    lines = Vector{NamedTuple}()
+    Base.visit(Core.methodtable) do m
+        scan_method!(lines, m, modules)
+    end
+    sort!(lines, by = entry -> (entry.mod, entry.func, entry.var))
+    if format == "plain"
+        for entry in lines
+            println("mod=", entry.mod,
+                    "\tvar=", entry.var,
+                    "\tfunc=", entry.func,
+                    "\tsig=", entry.sig,
+                    "\tlocation=", entry.location)
+        end
+    else
+        # treat "markdown" and "markdown-table" as table output
+        last_mod = ""
+        for entry in lines
+            if entry.mod != last_mod
+                if !isempty(last_mod)
+                    println()
+                end
+                println("## $(length(lines)) `Core.Box`es detected in module `", entry.mod, "`")
+                println("| var | func | sig | location |")
+                println("| --- | --- | --- | --- |")
+                last_mod = entry.mod
+            end
+            println("| ", md_code(escape_md(entry.var)),
+                    " | ", md_code(escape_md(entry.func)),
+                    " | ", md_code(escape_md(entry.sig)),
+                    " | ", md_code(escape_md(entry.location)),
+                    " |")
+        end
+    end
+
+    return isempty(lines)
+end
+
+################################################################################
+
+@testset "No Core.Box" begin
+    # Too complicated to adapt to v1.11-, skip it in that case.
+    @test check_no_boxes() skip=(VERSION < v"1.12")
+end


### PR DESCRIPTION
As discussed briefly on Slack, there has been some work to check for `Core.Box`es in https://github.com/JuliaLang/julia/pull/60478. I followed https://github.com/NumericalEarth/Breeze.jl/pull/400 and implemented a simple check here. Currently, we get

## 33 `Core.Box`es detected in module `Trixi`
| var | func | sig | location |
| --- | --- | --- | --- |
| `num_plotting_points` | `#PlotData2D#1279` | `Tuple{Trixi.var"##PlotData2D#1279", Any, Any, typeof(PlotData2D), StructArray, Any, Any, DGMulti{NDIMS, ElemType, ApproxType} where {NDIMS, ElemType, ApproxType}, Any}` | `~/.julia/dev/Trixi/src/visualization/types.jl:331` |
| `mapping` | `#T8codeMesh#250` | `Tuple{Trixi.var"##T8codeMesh#250", Any, Any, Any, Any, Any, Any, Any, Any, Type{T8codeMesh}, Any}` | `~/.julia/dev/Trixi/src/meshes/t8code_mesh.jl:428` |
| `ghost_remote_first_elem` | `#fill_mesh_info!#279` | `Tuple{Trixi.var"##fill_mesh_info!#279", Any, typeof(Trixi.fill_mesh_info!), T8codeMesh, Vararg{Any, 4}}` | `~/.julia/dev/Trixi/src/meshes/t8code_mesh.jl:1192` |
| `remotes` | `#fill_mesh_info!#279` | `Tuple{Trixi.var"##fill_mesh_info!#279", Any, typeof(Trixi.fill_mesh_info!), T8codeMesh, Vararg{Any, 4}}` | `~/.julia/dev/Trixi/src/meshes/t8code_mesh.jl:1192` |
| `ndims` | `#load_mesh_serial#310` | `Tuple{Trixi.var"##load_mesh_serial#310", Any, Any, typeof(Trixi.load_mesh_serial), AbstractString}` | `~/.julia/dev/Trixi/src/meshes/mesh_io.jl:407` |
| `data` | `#save_solution_file#1128` | `Tuple{Trixi.var"##save_solution_file#1128", Any, typeof(Trixi.save_solution_file), Any, Any, Any, Any, Union{P4estMesh{NDIMS, <:Any, <:Real, <:Static.False} where NDIMS, P4estMeshView, StructuredMesh, StructuredMeshView, T8codeMesh{NDIMS, <:Real, <:Static.False} where NDIMS, TreeMesh{NDIMS, <:Trixi.SerialTree{NDIMS}} where NDIMS, UnstructuredMesh2D}, Any, DG, Vararg{Any, 4}}` | `~/.julia/dev/Trixi/src/callbacks_step/save_solution_dg.jl:8` |
| `n_vars` | `#save_solution_file#1128` | `Tuple{Trixi.var"##save_solution_file#1128", Any, typeof(Trixi.save_solution_file), Any, Any, Any, Any, Union{P4estMesh{NDIMS, <:Any, <:Real, <:Static.False} where NDIMS, P4estMeshView, StructuredMesh, StructuredMeshView, T8codeMesh{NDIMS, <:Real, <:Static.False} where NDIMS, TreeMesh{NDIMS, <:Trixi.SerialTree{NDIMS}} where NDIMS, UnstructuredMesh2D}, Any, DG, Vararg{Any, 4}}` | `~/.julia/dev/Trixi/src/callbacks_step/save_solution_dg.jl:8` |
| `data` | `#save_solution_file#1130` | `Tuple{Trixi.var"##save_solution_file#1130", Any, typeof(Trixi.save_solution_file), Any, Any, Any, Any, DGMultiMesh, Any, DG, Vararg{Any, 4}}` | `~/.julia/dev/Trixi/src/callbacks_step/save_solution_dg.jl:94` |
| `n_vars` | `#save_solution_file#1130` | `Tuple{Trixi.var"##save_solution_file#1130", Any, typeof(Trixi.save_solution_file), Any, Any, Any, Any, DGMultiMesh, Any, DG, Vararg{Any, 4}}` | `~/.julia/dev/Trixi/src/callbacks_step/save_solution_dg.jl:94` |
| `global_element_id` | `T8codeMesh` | `Tuple{Type{T8codeMesh}, Vararg{Any, 13}}` | `~/.julia/dev/Trixi/src/meshes/t8code_mesh.jl:138` |
| `mesh_file` | `get_restart_mesh_filename` | `Tuple{typeof(Trixi.get_restart_mesh_filename), Any, Static.False}` | `~/.julia/dev/Trixi/src/meshes/tree_mesh.jl:233` |
| `mesh_file` | `get_restart_mesh_filename` | `Tuple{typeof(Trixi.get_restart_mesh_filename), Any, Static.True}` | `~/.julia/dev/Trixi/src/meshes/parallel_tree_mesh.jl:83` |
| `hanging_side` | `init_mpi_mortars_iter_face_inner` | `Tuple{typeof(Trixi.init_mpi_mortars_iter_face_inner), Any, Any, Any}` | `~/.julia/dev/Trixi/src/solvers/dgsem_p4est/containers_parallel.jl:496` |
| `ghost_id` | `init_neighbor_rank_connectivity_iter_face_inner` | `Tuple{typeof(Trixi.init_neighbor_rank_connectivity_iter_face_inner), Any, Any}` | `~/.julia/dev/Trixi/src/solvers/dgsem_p4est/dg_parallel.jl:404` |
| `hanging_side` | `init_neighbor_rank_connectivity_iter_face_inner` | `Tuple{typeof(Trixi.init_neighbor_rank_connectivity_iter_face_inner), Any, Any}` | `~/.julia/dev/Trixi/src/solvers/dgsem_p4est/dg_parallel.jl:404` |
| `proc_offsets` | `init_neighbor_rank_connectivity_iter_face_inner` | `Tuple{typeof(Trixi.init_neighbor_rank_connectivity_iter_face_inner), Any, Any}` | `~/.julia/dev/Trixi/src/solvers/dgsem_p4est/dg_parallel.jl:404` |
| `rho` | `initial_condition_weak_blast_wave` | `Tuple{typeof(initial_condition_weak_blast_wave), Any, Any, IdealGlmMhdMulticomponentEquations1D}` | `~/.julia/dev/Trixi/src/equations/ideal_glm_mhd_multicomponent_1d.jl:157` |
| `n_cells` | `load_mesh!` | `Tuple{typeof(Trixi.load_mesh!), TreeMesh{NDIMS, <:Trixi.ParallelTree{NDIMS}} where NDIMS, AbstractString}` | `~/.julia/dev/Trixi/src/meshes/mesh_io.jl:725` |
| `nodes` | `p4est_connectivity_from_standard_abaqus` | `Tuple{typeof(Trixi.p4est_connectivity_from_standard_abaqus), Vararg{Any, 6}}` | `~/.julia/dev/Trixi/src/meshes/p4est_mesh.jl:713` |
| `el_list_follows` | `parse_elements` | `Tuple{typeof(Trixi.parse_elements), Vararg{Any, 5}}` | `~/.julia/dev/Trixi/src/meshes/p4est_mesh.jl:855` |
| `tree_id` | `parse_elements` | `Tuple{typeof(Trixi.parse_elements), Vararg{Any, 5}}` | `~/.julia/dev/Trixi/src/meshes/p4est_mesh.jl:855` |
| `current_nodes` | `parse_node_sets` | `Tuple{typeof(Trixi.parse_node_sets), Any, Any}` | `~/.julia/dev/Trixi/src/meshes/p4est_mesh.jl:889` |
| `current_symbol` | `parse_node_sets` | `Tuple{typeof(Trixi.parse_node_sets), Any, Any}` | `~/.julia/dev/Trixi/src/meshes/p4est_mesh.jl:889` |
| `element_index` | `preprocess_standard_abaqus` | `Tuple{typeof(Trixi.preprocess_standard_abaqus), Vararg{Any, 6}}` | `~/.julia/dev/Trixi/src/meshes/p4est_mesh.jl:508` |
| `elements_begin_idx` | `preprocess_standard_abaqus` | `Tuple{typeof(Trixi.preprocess_standard_abaqus), Vararg{Any, 6}}` | `~/.julia/dev/Trixi/src/meshes/p4est_mesh.jl:508` |
| `preproc_element_section_lines` | `preprocess_standard_abaqus` | `Tuple{typeof(Trixi.preprocess_standard_abaqus), Vararg{Any, 6}}` | `~/.julia/dev/Trixi/src/meshes/p4est_mesh.jl:508` |
| `sets_begin_idx` | `preprocess_standard_abaqus` | `Tuple{typeof(Trixi.preprocess_standard_abaqus), Vararg{Any, 6}}` | `~/.julia/dev/Trixi/src/meshes/p4est_mesh.jl:508` |
| `current_element_type` | `preprocess_standard_abaqus_for_p4est` | `Tuple{typeof(Trixi.preprocess_standard_abaqus_for_p4est), Vararg{Any, 7}}` | `~/.julia/dev/Trixi/src/meshes/p4est_mesh.jl:607` |
| `new_line` | `preprocess_standard_abaqus_for_p4est` | `Tuple{typeof(Trixi.preprocess_standard_abaqus_for_p4est), Vararg{Any, 7}}` | `~/.julia/dev/Trixi/src/meshes/p4est_mesh.jl:607` |
| `order` | `preprocess_standard_abaqus_for_p4est` | `Tuple{typeof(Trixi.preprocess_standard_abaqus_for_p4est), Vararg{Any, 7}}` | `~/.julia/dev/Trixi/src/meshes/p4est_mesh.jl:607` |
| `node_section` | `read_nodes_standard_abaqus` | `Tuple{typeof(Trixi.read_nodes_standard_abaqus), Vararg{Any, 4}}` | `~/.julia/dev/Trixi/src/meshes/p4est_mesh.jl:680` |
| `levels` | `save_mesh_file` | `Tuple{typeof(Trixi.save_mesh_file), T8codeMesh, Any, Any, Union{Static.False, Static.True}}` | `~/.julia/dev/Trixi/src/meshes/mesh_io.jl:239` |
| `p4est_filename` | `save_mesh_file` | `Tuple{typeof(Trixi.save_mesh_file), P4estMeshView, Any, Any, Static.False}` | `~/.julia/dev/Trixi/src/meshes/p4est_mesh_view.jl:107` |


As you can see, they are mostly in initialization/saving etc. I do not think it is worth fixing them right now, since they are not critical for performance, and allocations happen anyway.

However, I added a regression test that checks the number of boxes, so we are informed if new ones are introduced (but we could always increase the number of allowed boxes). If you agree this is reasonable, we could also move the code that counts boxes to TrixiTest.jl.