### PR TITLE
Refactor: Shorten package extension names (Fixes #2543)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -62,11 +62,11 @@ NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 
 [extensions]
-TrixiCUDAExt = "CUDA"
-TrixiConvexECOSExt = ["Convex", "ECOS"]
-TrixiMakieExt = "Makie"
-TrixiNLsolveExt = "NLsolve"
-TrixiSparseConnectivityTracerExt = "SparseConnectivityTracer"
+CUDAExt = "CUDA"
+ConvexECOSExt = ["Convex", "ECOS"]
+MakieExt = "Makie"
+NLsolveExt = "NLsolve"
+SparseConnectivityTracerExt = "SparseConnectivityTracer"
 
 [compat]
 Accessors = "0.1.36"

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -1,5 +1,5 @@
 # Package extension for adding CUDA-based features to Trixi.jl
-module TrixiCUDAExt
+module CUDAExt
 
 import CUDA: CuArray
 import Trixi

--- a/ext/ConvexECOSExt.jl
+++ b/ext/ConvexECOSExt.jl
@@ -1,5 +1,5 @@
 # Package extension for adding Convex-based features to Trixi.jl
-module TrixiConvexECOSExt
+module ConvexECOSExt
 
 # Required for coefficient optimization in PERK scheme integrators
 using Convex: MOI, solve!, Variable, minimize, evaluate

--- a/ext/MakieExt.jl
+++ b/ext/MakieExt.jl
@@ -1,5 +1,5 @@
 # Package extension for adding Makie-based features to Trixi.jl
-module TrixiMakieExt
+module MakieExt
 
 # Required for visualization code
 using Makie: Makie, GeometryBasics

--- a/ext/NLsolveExt.jl
+++ b/ext/NLsolveExt.jl
@@ -1,5 +1,5 @@
 # Package extension for adding NLsolve-based features to Trixi.jl
-module TrixiNLsolveExt
+module NLsolveExt
 
 # Required for finding coefficients in Butcher tableau in the third order of
 # PERK scheme integrators

--- a/ext/SparseConnectivityTracerExt.jl
+++ b/ext/SparseConnectivityTracerExt.jl
@@ -1,5 +1,5 @@
 # Package extension for overloading of branching (if-clauses) base functions such as sqrt, log, etc.
-module TrixiSparseConnectivityTracerExt
+module SparseConnectivityTracerExt
 
 import Trixi
 import SparseConnectivityTracer: AbstractTracer


### PR DESCRIPTION
Refactors package extension names by removing the redundant 'Trixi' prefix, aligning with Pkg.jl documentation recommendations.

**Changes:**
* Renamed files in `ext/` (e.g., `TrixiSparseConnectivityTracerExt.jl` -> `SparseConnectivityTracerExt.jl`).
* Updated `Project.toml` extension keys to match the new filenames.
* Updated module names in the extension files to remove the `Trixi` prefix.

**Testing:**
* Instantiated the environment and verified that dependencies load correctly using `using Trixi`.