### PR TITLE
`@unpack` `inverse_jacobian` consistently

### DIFF
--- a/src/callbacks_step/analysis_dg2d.jl
+++ b/src/callbacks_step/analysis_dg2d.jl
@@ -310,7 +310,7 @@ function analyze(::Val{:l2_divb}, du, u, t,
                  mesh::Union{StructuredMesh{2}, UnstructuredMesh2D, P4estMesh{2},
                              T8codeMesh{2}},
                  equations, dg::DGSEM, cache)
-    @unpack contravariant_vectors = cache.elements
+    @unpack contravariant_vectors, inverse_jacobian = cache.elements
     integrate_via_indices(u, mesh, equations, dg, cache, cache,
                           dg.basis.derivative_matrix) do u, i, j, element, equations,
                                                          dg, cache, derivative_matrix
@@ -331,7 +331,7 @@ function analyze(::Val{:l2_divb}, du, u, t,
                      derivative_matrix[j, k] *
                      (Ja21 * B1_ik + Ja22 * B2_ik))
         end
-        divb *= cache.elements.inverse_jacobian[i, j, element]
+        divb *= inverse_jacobian[i, j, element]
         return divb^2
     end |> sqrt
 end
@@ -369,7 +369,7 @@ function analyze(::Val{:linf_divb}, du, u, t,
                              T8codeMesh{2}},
                  equations, dg::DGSEM, cache)
     @unpack derivative_matrix, weights = dg.basis
-    @unpack contravariant_vectors = cache.elements
+    @unpack contravariant_vectors, inverse_jacobian = cache.elements
 
     # integrate over all elements to get the divergence-free condition errors
     linf_divb = zero(eltype(u))
@@ -394,7 +394,7 @@ function analyze(::Val{:linf_divb}, du, u, t,
                          derivative_matrix[j, k] *
                          (Ja21 * B1_ik + Ja22 * B2_ik))
             end
-            divb *= cache.elements.inverse_jacobian[i, j, element]
+            divb *= inverse_jacobian[i, j, element]
             linf_divb = max(linf_divb, abs(divb))
         end
     end

--- a/src/callbacks_step/analysis_dg3d.jl
+++ b/src/callbacks_step/analysis_dg3d.jl
@@ -337,7 +337,7 @@ function analyze(::Val{:l2_divb}, du, u, t,
                  mesh::Union{StructuredMesh{3}, P4estMesh{3}, T8codeMesh{3}},
                  equations,
                  dg::DGSEM, cache)
-    @unpack contravariant_vectors = cache.elements
+    @unpack contravariant_vectors, inverse_jacobian = cache.elements
     integrate_via_indices(u, mesh, equations, dg, cache, cache,
                           dg.basis.derivative_matrix) do u, i, j, k, element, equations,
                                                          dg, cache, derivative_matrix
@@ -366,7 +366,7 @@ function analyze(::Val{:l2_divb}, du, u, t,
                      derivative_matrix[k, l] *
                      (Ja31 * B_ijl[1] + Ja32 * B_ijl[2] + Ja33 * B_ijl[3]))
         end
-        divb *= cache.elements.inverse_jacobian[i, j, k, element]
+        divb *= inverse_jacobian[i, j, k, element]
         return divb^2
     end |> sqrt
 end
@@ -412,7 +412,7 @@ function analyze(::Val{:linf_divb}, du, u, t,
                  equations,
                  dg::DGSEM, cache)
     @unpack derivative_matrix, weights = dg.basis
-    @unpack contravariant_vectors = cache.elements
+    @unpack contravariant_vectors, inverse_jacobian = cache.elements
 
     # integrate over all elements to get the divergence-free condition errors
     linf_divb = zero(eltype(u))
@@ -443,7 +443,7 @@ function analyze(::Val{:linf_divb}, du, u, t,
                          derivative_matrix[k, l] * (Ja31 * B_ijl[1] +
                           Ja32 * B_ijl[2] + Ja33 * B_ijl[3]))
             end
-            divb *= cache.elements.inverse_jacobian[i, j, k, element]
+            divb *= inverse_jacobian[i, j, k, element]
             linf_divb = max(linf_divb, abs(divb))
         end
     end

--- a/src/callbacks_step/stepsize_dg3d.jl
+++ b/src/callbacks_step/stepsize_dg3d.jl
@@ -82,7 +82,7 @@ function max_dt(u, t, mesh::Union{StructuredMesh{3}, P4estMesh{3}, T8codeMesh{3}
     # e.g. for steady-state linear advection
     max_scaled_speed = nextfloat(zero(t))
 
-    @unpack contravariant_vectors = cache.elements
+    @unpack contravariant_vectors, inverse_jacobian = cache.elements
 
     @batch reduction=(max, max_scaled_speed) for element in eachelement(dg, cache)
         max_lambda1 = max_lambda2 = max_lambda3 = zero(max_scaled_speed)
@@ -100,7 +100,7 @@ function max_dt(u, t, mesh::Union{StructuredMesh{3}, P4estMesh{3}, T8codeMesh{3}
                                                         i, j, k, element)
             lambda3_transformed = abs(Ja31 * lambda1 + Ja32 * lambda2 + Ja33 * lambda3)
 
-            inv_jacobian = abs(cache.elements.inverse_jacobian[i, j, k, element])
+            inv_jacobian = abs(inverse_jacobian[i, j, k, element])
 
             max_lambda1 = Base.max(max_lambda1, inv_jacobian * lambda1_transformed)
             max_lambda2 = Base.max(max_lambda2, inv_jacobian * lambda2_transformed)
@@ -174,7 +174,7 @@ function max_dt(u, t, mesh::Union{StructuredMesh{3}, P4estMesh{3}, T8codeMesh{3}
     # e.g. for steady-state linear advection
     max_scaled_speed = nextfloat(zero(t))
 
-    @unpack contravariant_vectors = cache.elements
+    @unpack contravariant_vectors, inverse_jacobian = cache.elements
 
     max_lambda1, max_lambda2, max_lambda3 = max_abs_speeds(equations)
 
@@ -193,7 +193,7 @@ function max_dt(u, t, mesh::Union{StructuredMesh{3}, P4estMesh{3}, T8codeMesh{3}
             lambda3_transformed = abs(Ja31 * max_lambda1 + Ja32 * max_lambda2 +
                                       Ja33 * max_lambda3)
 
-            inv_jacobian = abs(cache.elements.inverse_jacobian[i, j, k, element])
+            inv_jacobian = abs(inverse_jacobian[i, j, k, element])
 
             # Use `Base.max` to prevent silent failures, as `max` from `@fastmath` doesn't propagate
             # `NaN`s properly. See https://github.com/trixi-framework/Trixi.jl/pull/2445#discussion_r2336812323


### PR DESCRIPTION
It looks strange to have `@unpack contravariant_vectors = cache.elements` and then access `cache.elements.inverse_jacobian`. Also, for stepsize in 2D this was already done:

https://github.com/trixi-framework/Trixi.jl/blob/d4f4d72d331957577a568bbef7f930be88c5b89e/src/callbacks_step/stepsize_dg2d.jl#L159