### PR TITLE
Allow redefinition of host CPU features during test

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -83,3 +83,9 @@ SparseMatrixColorings = "0.4.21"
 StableRNGs = "1.0.2"
 Test = "1"
 TrixiTest = "0.2.1"
+
+[extras]
+HostCPUFeatures = "3e5b6fbb-0976-4d2c-9146-d79de83f2fb0"
+
+[preferences.HostCPUFeatures]
+allow_runtime_invalidation = true


### PR DESCRIPTION
We are seeing repeated failures during CI. This is due to some runners having avx512 and others not having that.
HostCPUFeatures is a little bit naughty and bakes the CPU architecture into the cache files.

This should allow us to use runtime redefinition (causing a full runtime cache invalidation...), to avoid the CI failures. 

Closes #2790.