### PR TITLE
Fix formatting of equations in Peng-Robinson model

### DIFF
--- a/src/equations/equation_of_state_peng_robinson.jl
+++ b/src/equations/equation_of_state_peng_robinson.jl
@@ -13,7 +13,7 @@ given by the pressure and internal energy relations
 ```math
 p = \frac{R T}{V - b} - \frac{a(T)}{V^2 + 2bV - b^2}, \quad e_{\text{internal}} = c_{v,0} T + K(a(T) - Ta'(T))
 ```
-where ``V = rho^{-1}`` and auxiliary expressions for ``a(T)`` and ``K`` are given by 
+where ``V = \rho^{-1}`` and auxiliary expressions for ``a(T)`` and ``K`` are given by 
 ```math
 a(T) = a_0\left(1 + \kappa \left(1 - \sqrt{\frac{T}{T_0}}\right)\right)^2, \quad 
 K = \frac{1}{b 2\sqrt{2}} \log\left( \frac{V + (1 - b \sqrt{2})}{V + (1 + b\sqrt{2})}\right).


### PR DESCRIPTION
Fixes formatting for https://trixi-framework.github.io/TrixiDocumentation/dev/reference-trixi/#Trixi.PengRobinson-Tuple{}

Current: <img width="830" height="567" alt="Screenshot 2026-02-16 at 2 23 53 PM" src="https://github.com/user-attachments/assets/9345e03b-2aac-4412-bfaf-89b6f6a5d1d4" />
