### PR TITLE
Add wave equation 1D 2D symmetric first order system

### DIFF
--- a/examples/tree_1d_dgsem/elixir_wave_convergence.jl
+++ b/examples/tree_1d_dgsem/elixir_wave_convergence.jl
@@ -1,0 +1,57 @@
+using OrdinaryDiffEqLowStorageRK
+using Trixi
+
+###############################################################################
+# semidiscretization of the wave equations
+
+equations = WaveEquations1D(1.0)
+
+initial_condition = initial_condition_gauss
+
+# Create DG solver with polynomial degree = 3 and (local) Lax-Friedrichs/Rusanov flux as surface flux
+solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
+
+coordinates_min = (-1.0)
+coordinates_max = (1.0)
+
+# Create a uniformly refined mesh with periodic boundaries
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 4,
+                n_cells_max = 30_000, periodicity = false)
+
+# A semidiscretization collects data structures and functions for the spatial discretization
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver;
+                                    boundary_conditions = boundary_condition_wall)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 4.0)
+ode = semidiscretize(semi, tspan)
+
+# At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
+# and resets the timers
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+
+# The AnalysisCallback allows to analyse the solution in regular intervals and prints the results
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
+
+# The AliveCallback prints short status information in regular intervals
+alive_callback = AliveCallback(analysis_interval = analysis_interval)
+
+# The StepsizeCallback handles the re-calculation of the maximum Δt after each time step
+stepsize_callback = StepsizeCallback(cfl = 0.8)
+
+# Create a CallbackSet to collect all callbacks such that they can be passed to the ODE solver
+callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback,
+                        stepsize_callback)
+
+###############################################################################
+# run the simulation
+
+# OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition = false);
+            dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            ode_default_options()..., callback = callbacks);

--- a/examples/tree_1d_dgsem/elixir_wave_convergence.jl
+++ b/examples/tree_1d_dgsem/elixir_wave_convergence.jl
@@ -12,7 +12,6 @@ solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
 
 coordinates_min = (-1.0)
 coordinates_max = (1.0)
-
 mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 4,
                 n_cells_max = 30_000, periodicity = false)

--- a/examples/tree_1d_dgsem/elixir_wave_convergence.jl
+++ b/examples/tree_1d_dgsem/elixir_wave_convergence.jl
@@ -29,7 +29,6 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 
 analysis_interval = 100
-
 analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 
 alive_callback = AliveCallback(analysis_interval = analysis_interval)

--- a/examples/tree_1d_dgsem/elixir_wave_convergence.jl
+++ b/examples/tree_1d_dgsem/elixir_wave_convergence.jl
@@ -4,11 +4,8 @@ using Trixi
 ###############################################################################
 # semidiscretization of the wave equations
 
-# implements the wave equation as a first order hyperbolic system 
-# with an auxiliary variable for the wave flux
 equations = WaveEquations1D(1.0)
 
-# this is a Gaussian Bump in both amplitude and wave flux.
 initial_condition = initial_condition_gauss
 
 solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
@@ -37,7 +34,7 @@ analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 
 alive_callback = AliveCallback(analysis_interval = analysis_interval)
 
-stepsize_callback = StepsizeCallback(cfl = 0.8)
+stepsize_callback = StepsizeCallback(cfl = 1.5)
 
 callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback,
                         stepsize_callback)

--- a/examples/tree_1d_dgsem/elixir_wave_convergence.jl
+++ b/examples/tree_1d_dgsem/elixir_wave_convergence.jl
@@ -4,22 +4,22 @@ using Trixi
 ###############################################################################
 # semidiscretization of the wave equations
 
+# implements the wave equation as a first order hyperbolic system 
+# with an auxiliary variable for the wave flux
 equations = WaveEquations1D(1.0)
 
+# this is a Gaussian Bump in both amplitude and wave flux.
 initial_condition = initial_condition_gauss
 
-# Create DG solver with polynomial degree = 3 and (local) Lax-Friedrichs/Rusanov flux as surface flux
 solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
 
 coordinates_min = (-1.0)
 coordinates_max = (1.0)
 
-# Create a uniformly refined mesh with periodic boundaries
 mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 4,
                 n_cells_max = 30_000, periodicity = false)
 
-# A semidiscretization collects data structures and functions for the spatial discretization
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver;
                                     boundary_conditions = boundary_condition_wall)
 
@@ -29,29 +29,21 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver;
 tspan = (0.0, 4.0)
 ode = semidiscretize(semi, tspan)
 
-# At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
-# and resets the timers
 summary_callback = SummaryCallback()
 
 analysis_interval = 100
 
-# The AnalysisCallback allows to analyse the solution in regular intervals and prints the results
 analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 
-# The AliveCallback prints short status information in regular intervals
 alive_callback = AliveCallback(analysis_interval = analysis_interval)
 
-# The StepsizeCallback handles the re-calculation of the maximum Δt after each time step
 stepsize_callback = StepsizeCallback(cfl = 0.8)
 
-# Create a CallbackSet to collect all callbacks such that they can be passed to the ODE solver
 callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback,
                         stepsize_callback)
 
 ###############################################################################
 # run the simulation
 
-# OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition = false);
-            dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition = false); dt = 1.0,
             ode_default_options()..., callback = callbacks);

--- a/examples/tree_2d_dgsem/elixir_wave_convergence.jl
+++ b/examples/tree_2d_dgsem/elixir_wave_convergence.jl
@@ -9,7 +9,7 @@ equations = WaveEquations2D(2 * sqrt(2 / 5))
 # initial condition for a standing wave
 initial_condition = function (x, t, equations::WaveEquations2D)
     c = equations.c
-    p = cospi(3*x[1] / 2) * cospi(x[2] / 2) * cospi(sqrt(5 / 2) * c * t)
+    p = cospi(3 * x[1] / 2) * cospi(x[2] / 2) * cospi(sqrt(5 / 2) * c * t)
     vx = 3 / sqrt(10) * sinpi(3 * x[1] / 2) * cospi(x[2] / 2) * sinpi(sqrt(5 / 2) * c * t)
     vy = 1 / sqrt(10) * cospi(3 * x[1] / 2) * sinpi(x[2] / 2) * sinpi(sqrt(5 / 2) * c * t)
     return SVector(p, vx, vy)
@@ -44,7 +44,7 @@ semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver;
 ###############################################################################
 # ODE solvers, callbacks etc.
 
-tspan = (0.0, 0.5)
+tspan = (0.0, 1.0)
 ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
@@ -54,7 +54,7 @@ analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 
 alive_callback = AliveCallback(analysis_interval = analysis_interval)
 
-stepsize_callback = StepsizeCallback(cfl = 0.8)
+stepsize_callback = StepsizeCallback(cfl = 1.5)
 
 callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback,
                         stepsize_callback)

--- a/examples/tree_2d_dgsem/elixir_wave_convergence.jl
+++ b/examples/tree_2d_dgsem/elixir_wave_convergence.jl
@@ -9,9 +9,9 @@ equations = WaveEquations2D(2 * sqrt(2 / 5))
 # initial condition for a standing wave
 initial_condition = function (x, t, equations::WaveEquations2D)
     c = equations.c
-    p = cospi(3x[1] / 2) * cospi(x[2] / 2) * cospi(sqrt(5 / 2) * c * t)
-    vx = 3 / sqrt(10) * sinpi(3x[1] / 2) * cospi(x[2] / 2) * sinpi(sqrt(5 / 2) * c * t)
-    vy = 1 / sqrt(10) * cospi(3x[1] / 2) * sinpi(x[2] / 2) * sinpi(sqrt(5 / 2) * c * t)
+    p = cospi(3*x[1] / 2) * cospi(x[2] / 2) * cospi(sqrt(5 / 2) * c * t)
+    vx = 3 / sqrt(10) * sinpi(3 * x[1] / 2) * cospi(x[2] / 2) * sinpi(sqrt(5 / 2) * c * t)
+    vy = 1 / sqrt(10) * cospi(3 * x[1] / 2) * sinpi(x[2] / 2) * sinpi(sqrt(5 / 2) * c * t)
     return SVector(p, vx, vy)
 end
 
@@ -29,55 +29,38 @@ boundary_condition = function (u_inner, orientation, direction, x, t,
     return flux
 end
 
-# Create DG solver with polynomial degree = 3 and (local) Lax-Friedrichs/Rusanov flux as surface flux
 solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
 
-coordinates_min = (-1.0, -1.0) # minimum coordinates (min(x), min(y))
-coordinates_max = (1.0, 1.0) # maximum coordinates (max(x), max(y))
+coordinates_min = (-1.0, -1.0)
+coordinates_max = (1.0, 1.0)
 
-# Create a uniformly refined mesh with periodic boundaries
 mesh = TreeMesh(coordinates_min, coordinates_max,
-                initial_refinement_level = 4,
+                initial_refinement_level = 3,
                 n_cells_max = 30_000, periodicity = false)
 
-# A semidiscretization collects data structures and functions for the spatial discretization
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver;
                                     boundary_conditions = boundary_condition)
 
 ###############################################################################
 # ODE solvers, callbacks etc.
 
-# Create ODE problem with time span from 0.0 to 1.0
-tspan = (0.0, 1.0)
+tspan = (0.0, 0.5)
 ode = semidiscretize(semi, tspan)
 
-# At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
-# and resets the timers
 summary_callback = SummaryCallback()
 
 analysis_interval = 100
-
-# The AnalysisCallback allows to analyse the solution in regular intervals and prints the results
 analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 
-# The SaveSolutionCallback allows to save the solution to a file in regular intervals
-save_solution = SaveSolutionCallback(interval = analysis_interval,
-                                     solution_variables = cons2prim)
-
-# The AliveCallback prints short status information in regular intervals
 alive_callback = AliveCallback(analysis_interval = analysis_interval)
 
-# The StepsizeCallback handles the re-calculation of the maximum Δt after each time step
 stepsize_callback = StepsizeCallback(cfl = 0.8)
 
-# Create a CallbackSet to collect all callbacks such that they can be passed to the ODE solver
-callbacks = CallbackSet(summary_callback, analysis_callback, save_solution, alive_callback,
+callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback,
                         stepsize_callback)
 
 ###############################################################################
 # run the simulation
 
-# OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
-sol = solve(ode, CarpenterKennedy2N54(williamson_condition = false);
-            dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition = false); dt = 1.0,
             ode_default_options()..., callback = callbacks);

--- a/examples/tree_2d_dgsem/elixir_wave_convergence.jl
+++ b/examples/tree_2d_dgsem/elixir_wave_convergence.jl
@@ -7,27 +7,14 @@ using Trixi
 equations = WaveEquations2D(2 * sqrt(2 / 5))
 
 # initial condition for a standing wave
-initial_condition = function (x, t, equations::WaveEquations2D)
+function initial_condition_standing_wave(x, t, equations::WaveEquations2D)
     c = equations.c
     p = cospi(3 * x[1] / 2) * cospi(x[2] / 2) * cospi(sqrt(5 / 2) * c * t)
     vx = 3 / sqrt(10) * sinpi(3 * x[1] / 2) * cospi(x[2] / 2) * sinpi(sqrt(5 / 2) * c * t)
     vy = 1 / sqrt(10) * cospi(3 * x[1] / 2) * sinpi(x[2] / 2) * sinpi(sqrt(5 / 2) * c * t)
     return SVector(p, vx, vy)
 end
-
-# corresponding boundary condition for the standing wave
-boundary_condition = function (u_inner, orientation, direction, x, t,
-                               surface_flux_function,
-                               equations::WaveEquations2D)
-    u_boundary = initial_condition(x, t, equations)
-    # Calculate boundary flux
-    if direction in (2, 4)  # u_inner is "left" of boundary, u_boundary is "right" of boundary
-        flux = surface_flux_function(u_inner, u_boundary, orientation, equations)
-    else # u_boundary is "left" of boundary, u_inner is "right" of boundary
-        flux = surface_flux_function(u_boundary, u_inner, orientation, equations)
-    end
-    return flux
-end
+initial_condition = initial_condition_standing_wave
 
 solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
 
@@ -38,8 +25,9 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 4,
                 n_cells_max = 30_000, periodicity = false)
 
+boundary_condition_standing_wave = BoundaryConditionDirichlet(initial_condition)
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver;
-                                    boundary_conditions = boundary_condition)
+                                    boundary_conditions = boundary_condition_standing_wave)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/tree_2d_dgsem/elixir_wave_convergence.jl
+++ b/examples/tree_2d_dgsem/elixir_wave_convergence.jl
@@ -4,21 +4,21 @@ using Trixi
 ###############################################################################
 # semidiscretization of the wave equations
 
-equations = WaveEquations2D(2*sqrt(2/5))
+equations = WaveEquations2D(2 * sqrt(2 / 5))
 
 # initial condition for a standing wave
-initial_condition = function(x, t, equations::WaveEquations2D)
+initial_condition = function (x, t, equations::WaveEquations2D)
     c = equations.c
-    p = cospi(3x[1]/2)*cospi(x[2]/2)*cospi(sqrt(5/2)*c*t)
-    vx = 3/sqrt(10)*sinpi(3x[1]/2)*cospi(x[2]/2)*sinpi(sqrt(5/2)*c*t)
-    vy = 1/sqrt(10)*cospi(3x[1]/2)*sinpi(x[2]/2)*sinpi(sqrt(5/2)*c*t)
+    p = cospi(3x[1] / 2) * cospi(x[2] / 2) * cospi(sqrt(5 / 2) * c * t)
+    vx = 3 / sqrt(10) * sinpi(3x[1] / 2) * cospi(x[2] / 2) * sinpi(sqrt(5 / 2) * c * t)
+    vy = 1 / sqrt(10) * cospi(3x[1] / 2) * sinpi(x[2] / 2) * sinpi(sqrt(5 / 2) * c * t)
     return SVector(p, vx, vy)
 end
 
 # corresponding boundary condition for the standing wave
-boundary_condition = function(u_inner, orientation, direction, x, t,
-                                 surface_flux_function,
-                                 equations::WaveEquations2D)
+boundary_condition = function (u_inner, orientation, direction, x, t,
+                               surface_flux_function,
+                               equations::WaveEquations2D)
     u_boundary = initial_condition(x, t, equations)
     # Calculate boundary flux
     if direction in (2, 4)  # u_inner is "left" of boundary, u_boundary is "right" of boundary

--- a/examples/tree_2d_dgsem/elixir_wave_convergence.jl
+++ b/examples/tree_2d_dgsem/elixir_wave_convergence.jl
@@ -35,7 +35,7 @@ coordinates_min = (-1.0, -1.0)
 coordinates_max = (1.0, 1.0)
 
 mesh = TreeMesh(coordinates_min, coordinates_max,
-                initial_refinement_level = 3,
+                initial_refinement_level = 4,
                 n_cells_max = 30_000, periodicity = false)
 
 semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver;

--- a/examples/tree_2d_dgsem/elixir_wave_convergence.jl
+++ b/examples/tree_2d_dgsem/elixir_wave_convergence.jl
@@ -1,0 +1,83 @@
+using OrdinaryDiffEqLowStorageRK
+using Trixi
+
+###############################################################################
+# semidiscretization of the wave equations
+
+equations = WaveEquations2D(2*sqrt(2/5))
+
+# initial condition for a standing wave
+initial_condition = function(x, t, equations::WaveEquations2D)
+    c = equations.c
+    p = cospi(3x[1]/2)*cospi(x[2]/2)*cospi(sqrt(5/2)*c*t)
+    vx = 3/sqrt(10)*sinpi(3x[1]/2)*cospi(x[2]/2)*sinpi(sqrt(5/2)*c*t)
+    vy = 1/sqrt(10)*cospi(3x[1]/2)*sinpi(x[2]/2)*sinpi(sqrt(5/2)*c*t)
+    return SVector(p, vx, vy)
+end
+
+# corresponding boundary condition for the standing wave
+boundary_condition = function(u_inner, orientation, direction, x, t,
+                                 surface_flux_function,
+                                 equations::WaveEquations2D)
+    u_boundary = initial_condition(x, t, equations)
+    # Calculate boundary flux
+    if direction in (2, 4)  # u_inner is "left" of boundary, u_boundary is "right" of boundary
+        flux = surface_flux_function(u_inner, u_boundary, orientation, equations)
+    else # u_boundary is "left" of boundary, u_inner is "right" of boundary
+        flux = surface_flux_function(u_boundary, u_inner, orientation, equations)
+    end
+    return flux
+end
+
+# Create DG solver with polynomial degree = 3 and (local) Lax-Friedrichs/Rusanov flux as surface flux
+solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
+
+coordinates_min = (-1.0, -1.0) # minimum coordinates (min(x), min(y))
+coordinates_max = (1.0, 1.0) # maximum coordinates (max(x), max(y))
+
+# Create a uniformly refined mesh with periodic boundaries
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 4,
+                n_cells_max = 30_000, periodicity = false)
+
+# A semidiscretization collects data structures and functions for the spatial discretization
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver;
+                                    boundary_conditions = boundary_condition)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+# Create ODE problem with time span from 0.0 to 1.0
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan)
+
+# At the beginning of the main loop, the SummaryCallback prints a summary of the simulation setup
+# and resets the timers
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+
+# The AnalysisCallback allows to analyse the solution in regular intervals and prints the results
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
+
+# The SaveSolutionCallback allows to save the solution to a file in regular intervals
+save_solution = SaveSolutionCallback(interval = analysis_interval,
+                                     solution_variables = cons2prim)
+
+# The AliveCallback prints short status information in regular intervals
+alive_callback = AliveCallback(analysis_interval = analysis_interval)
+
+# The StepsizeCallback handles the re-calculation of the maximum Δt after each time step
+stepsize_callback = StepsizeCallback(cfl = 0.8)
+
+# Create a CallbackSet to collect all callbacks such that they can be passed to the ODE solver
+callbacks = CallbackSet(summary_callback, analysis_callback, save_solution, alive_callback,
+                        stepsize_callback)
+
+###############################################################################
+# run the simulation
+
+# OrdinaryDiffEq's `solve` method evolves the solution in time and executes the passed callbacks
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition = false);
+            dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            ode_default_options()..., callback = callbacks);

--- a/examples/tree_2d_dgsem/elixir_wave_convergence.jl
+++ b/examples/tree_2d_dgsem/elixir_wave_convergence.jl
@@ -20,7 +20,6 @@ solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
 
 coordinates_min = (-1.0, -1.0)
 coordinates_max = (1.0, 1.0)
-
 mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 4,
                 n_cells_max = 30_000, periodicity = false)

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -182,7 +182,6 @@ export AcousticPerturbationEquations2D,
        PassiveTracerEquations,
        WaveEquations1D, WaveEquations2D
 
-
 export NonIdealCompressibleEulerEquations1D, NonIdealCompressibleEulerEquations2D
 export IdealGas, VanDerWaals, PengRobinson
 

--- a/src/Trixi.jl
+++ b/src/Trixi.jl
@@ -179,7 +179,9 @@ export AcousticPerturbationEquations2D,
        TrafficFlowLWREquations1D,
        MaxwellEquations1D,
        LinearElasticityEquations1D,
-       PassiveTracerEquations
+       PassiveTracerEquations,
+       WaveEquations1D, WaveEquations2D
+
 
 export NonIdealCompressibleEulerEquations1D, NonIdealCompressibleEulerEquations2D
 export IdealGas, VanDerWaals, PengRobinson

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -791,4 +791,9 @@ include("maxwell_1d.jl")
 abstract type AbstractLinearElasticityEquations{NDIMS, NVARS} <:
               AbstractEquations{NDIMS, NVARS} end
 include("linear_elasticity_1d.jl")
+
+abstract type AbstractFirstOrderWaveEquations{NDIMS, NVARS} <:
+              AbstractEquations{NDIMS, NVARS} end
+include("wave_1d.jl")
+include("wave_2d.jl")
 end # @muladd

--- a/src/equations/wave_1d.jl
+++ b/src/equations/wave_1d.jl
@@ -47,7 +47,7 @@ end
     boundary_condition_wall(u_inner, orientation, direction, x, t, surface_flux_function,
                                 equations::WaveEquations1D)
 
-Boundary conditions for a solid wall, corresponding to zero amplitde at the wall.
+Boundary conditions for a solid wall, corresponding to zero amplitude at the wall.
 In some sense this is a mixed boundary condition, with Dirichlet zero for the amplitude and
 Neumann zero for the flux.
 """

--- a/src/equations/wave_1d.jl
+++ b/src/equations/wave_1d.jl
@@ -8,10 +8,16 @@
 @doc raw"""
     WaveEquations1D(c)
 
-The wave equations in one space dimension written as a first order system. The equations are given by
+The wave equation
+The wave equation
+```math
+u_{tt} - c^2 u_{xx} = 0
+```
+in one space dimension as a first order system.
+The equations are given by
 ```math
 \begin{alignat*}{2}
-    \partial_t p &+ c\nabla \cdot{} v &&= 0 \\
+    \partial_t p &+ c\nabla \cdot v &&= 0 \\
     \partial_t v &+ c\nabla p &&= 0
 \end{alignat*}
 The unknowns are the wave amplitude ``p`` and the wave flux ``v``. 

--- a/src/equations/wave_1d.jl
+++ b/src/equations/wave_1d.jl
@@ -32,6 +32,11 @@ function varnames(::Union{typeof(cons2cons), typeof(cons2prim)}, ::WaveEquations
     return ("u", "v")
 end
 
+"""
+    initial_condition_gauss(x, t, equations::WaveEquations1D)
+
+Gaussian bump in both amplitude and wave flux, centered at x=0.
+"""
 function initial_condition_gauss(x, t, ::WaveEquations1D)
     u = exp(-25 * x[1]^2)
     v = exp(-25 * x[1]^2)

--- a/src/equations/wave_1d.jl
+++ b/src/equations/wave_1d.jl
@@ -17,10 +17,10 @@ in one space dimension as a first order system.
 The equations are given by
 ```math
 \begin{alignat*}{2}
-    \partial_t p &+ c \partial_x v &&= 0 \\
-    \partial_t v &+ c\nabla p &&= 0
+    \partial_t u &+ c \partial_x v &&= 0 \\
+    \partial_t v &+ c \partial_x u &&= 0
 \end{alignat*}
-The unknowns are the wave amplitude ``p`` and the wave flux ``v``. 
+The unknowns are the wave amplitude ``u`` and the wave flux ``v``. 
 The parameter ``c`` is the wave speed.
 ```
 """
@@ -29,13 +29,13 @@ struct WaveEquations1D{RealT <: Real} <: AbstractFirstOrderWaveEquations{1, 2}
 end
 
 function varnames(::Union{typeof(cons2cons), typeof(cons2prim)}, ::WaveEquations1D)
-    return ("p", "v")
+    return ("u", "v")
 end
 
 function initial_condition_gauss(x, t, ::WaveEquations1D)
-    p = exp(-25 * x[1]^2)
+    u = exp(-25 * x[1]^2)
     v = exp(-25 * x[1]^2)
-    return SVector(p, v)
+    return SVector(u, v)
 end
 
 """
@@ -49,8 +49,8 @@ Neumann zero for the flux.
 function boundary_condition_wall(u_inner, orientation, direction, x, t,
                                  surface_flux_function,
                                  equations::WaveEquations1D)
-    p, v = u_inner
-    u_boundary = SVector(zero(p), v)
+    u, v = u_inner
+    u_boundary = SVector(zero(u), v)
 
     # Calculate boundary flux
     if direction == 2  # u_inner is "left" of boundary, u_boundary is "right" of boundary
@@ -64,12 +64,12 @@ end
 # Calculate 1D flux for a single point
 @inline function flux(u, orientation::Integer, equations::WaveEquations1D)
     @unpack c = equations
-    p, v = u
-    return SVector(c * v, c * p)
+    u, v = u
+    return SVector(c * v, c * u)
 end
 
 """
-    have_constant_speed(::WaveEquations1D)
+    have_constant_speed(::AbstractFirstOrderWaveEquations)
 
 Indicates whether the characteristic speeds are constant, i.e., independent of the solution.
 Queried in the timestep computation [`StepsizeCallback`](@ref) and [`linear_structure`](@ref).
@@ -77,7 +77,7 @@ Queried in the timestep computation [`StepsizeCallback`](@ref) and [`linear_stru
 # Returns
 - `True()`
 """
-@inline have_constant_speed(::WaveEquations1D) = True()
+@inline have_constant_speed(::AbstractFirstOrderWaveEquations) = True()
 
 @inline function max_abs_speeds(equations::WaveEquations1D)
     return equations.c

--- a/src/equations/wave_1d.jl
+++ b/src/equations/wave_1d.jl
@@ -27,8 +27,8 @@ function varnames(::Union{typeof(cons2cons), typeof(cons2prim)}, ::WaveEquations
 end
 
 function initial_condition_gauss(x, t, ::WaveEquations1D)
-    p = exp(-25*x[1]^2)
-    v = exp(-25*x[1]^2)
+    p = exp(-25 * x[1]^2)
+    v = exp(-25 * x[1]^2)
     return SVector(p, v)
 end
 
@@ -36,7 +36,9 @@ end
     boundary_condition_wall(u_inner, orientation, direction, x, t, surface_flux_function,
                                 equations::WaveEquations1D)
 
-Boundary conditions for a solid wall.
+Boundary conditions for a solid wall, corresponding to zero amplitde at the wall.
+In some sense this is a mixed boundary condition, with Dirichlet zero for the amplitude and
+Neumann zero for the flux.
 """
 function boundary_condition_wall(u_inner, orientation, direction, x, t,
                                  surface_flux_function,
@@ -57,7 +59,7 @@ end
 @inline function flux(u, orientation::Integer, equations::WaveEquations1D)
     @unpack c = equations
     p, v = u
-    return SVector(c*v, c*p)
+    return SVector(c * v, c * p)
 end
 
 """

--- a/src/equations/wave_1d.jl
+++ b/src/equations/wave_1d.jl
@@ -17,7 +17,7 @@ in one space dimension as a first order system.
 The equations are given by
 ```math
 \begin{alignat*}{2}
-    \partial_t p &+ c\nabla \cdot v &&= 0 \\
+    \partial_t p &+ c \partial_x v &&= 0 \\
     \partial_t v &+ c\nabla p &&= 0
 \end{alignat*}
 The unknowns are the wave amplitude ``p`` and the wave flux ``v``. 

--- a/src/equations/wave_1d.jl
+++ b/src/equations/wave_1d.jl
@@ -1,0 +1,86 @@
+# By default, Julia/LLVM does not use fused multiply-add operations (FMAs).
+# Since these FMAs can increase the performance of many numerical algorithms,
+# we need to opt-in explicitly.
+# See https://ranocha.de/blog/Optimizing_EC_Trixi for further details.
+@muladd begin
+#! format: noindent
+
+@doc raw"""
+    WaveEquations1D(c)
+
+The wave equations in one space dimension written as a first order system. The equations are given by
+```math
+\begin{alignat*}{2}
+    \partial_t p &+ c\nabla \cdot{} v &&= 0 \\
+    \partial_t v &+ c\nabla p &&= 0
+\end{alignat*}
+The unknowns are the wave amplitude ``p`` and the wave flux ``v``. 
+The parameter ``c`` is the wave speed.
+```
+"""
+struct WaveEquations1D{RealT <: Real} <: AbstractFirstOrderWaveEquations{1, 2}
+    c::RealT
+end
+
+function varnames(::Union{typeof(cons2cons), typeof(cons2prim)}, ::WaveEquations1D)
+    return ("p", "v")
+end
+
+function initial_condition_gauss(x, t, ::WaveEquations1D)
+    p = exp(-25*x[1]^2)
+    v = exp(-25*x[1]^2)
+    return SVector(p, v)
+end
+
+"""
+    boundary_condition_wall(u_inner, orientation, direction, x, t, surface_flux_function,
+                                equations::WaveEquations1D)
+
+Boundary conditions for a solid wall.
+"""
+function boundary_condition_wall(u_inner, orientation, direction, x, t,
+                                 surface_flux_function,
+                                 equations::WaveEquations1D)
+    p, v = u_inner
+    u_boundary = SVector(zero(p), v)
+
+    # Calculate boundary flux
+    if direction == 2  # u_inner is "left" of boundary, u_boundary is "right" of boundary
+        flux = surface_flux_function(u_inner, u_boundary, orientation, equations)
+    else # u_boundary is "left" of boundary, u_inner is "right" of boundary
+        flux = surface_flux_function(u_boundary, u_inner, orientation, equations)
+    end
+    return flux
+end
+
+# Calculate 1D flux for a single point
+@inline function flux(u, orientation::Integer, equations::WaveEquations1D)
+    @unpack c = equations
+    p, v = u
+    return SVector(c*v, c*p)
+end
+
+"""
+    have_constant_speed(::WaveEquations1D)
+
+Indicates whether the characteristic speeds are constant, i.e., independent of the solution.
+Queried in the timestep computation [`StepsizeCallback`](@ref) and [`linear_structure`](@ref).
+
+# Returns
+- `True()`
+"""
+@inline have_constant_speed(::WaveEquations1D) = True()
+
+@inline function max_abs_speeds(equations::WaveEquations1D)
+    return equations.c
+end
+
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation::Integer,
+                                     equations::WaveEquations1D)
+    return equations.c
+end
+
+# Convert conservative variables to primitive
+@inline cons2prim(u, ::WaveEquations1D) = u
+@inline cons2entropy(u, ::WaveEquations1D) = u
+end # muladd

--- a/src/equations/wave_2d.jl
+++ b/src/equations/wave_2d.jl
@@ -31,9 +31,9 @@ end
     @unpack c = equations
     u, vx, vy = u
     if orientation == 1
-        return SVector(c*vx, c*u, zero(vy))
+        return SVector(c * vx, c * u, zero(vy))
     else
-        return SVector(c*vy, zero(vx), c*u)
+        return SVector(c * vy, zero(vx), c * u)
     end
 end
 

--- a/src/equations/wave_2d.jl
+++ b/src/equations/wave_2d.jl
@@ -16,10 +16,10 @@ in two space dimension as a first order system.
 The equations are given by
 ```math
 \begin{alignat*}{2}
-    \partial_t p &+ c\nabla \cdot v &&= 0 \\
-    \partial_t v &+ c\nabla p &&= 0
+    \partial_t u              &+ c \nabla \cdot \boldsymbol{v} &&= 0 \\
+    \partial_t \boldsymbol{v} &+ c \nabla u                    &&= 0
 \end{alignat*}
-The unknowns are the wave amplitude ``p`` and the wave "flux" ``(v_x, v_y)^T``. 
+The unknowns are the wave amplitude ``u`` and the wave "flux" ``(v_x, v_y)^T``. 
 The parameter ``c`` is the wave speed.
 ```
 """
@@ -28,7 +28,7 @@ struct WaveEquations2D{RealT <: Real} <: AbstractFirstOrderWaveEquations{2, 3}
 end
 
 function varnames(::Union{typeof(cons2cons), typeof(cons2prim)}, ::WaveEquations2D)
-    return ("p", "vx", "vy")
+    return ("u", "vx", "vy")
 end
 
 # Calculate 1D flux for a single point
@@ -41,17 +41,6 @@ end
         return SVector(c * vy, zero(vx), c * u)
     end
 end
-
-"""
-    have_constant_speed(::WaveEquations2D)
-
-Indicates whether the characteristic speeds are constant, i.e., independent of the solution.
-Queried in the timestep computation [`StepsizeCallback`](@ref) and [`linear_structure`](@ref).
-
-# Returns
-- `True()`
-"""
-@inline have_constant_speed(::WaveEquations2D) = True()
 
 @inline function max_abs_speeds(equations::WaveEquations2D)
     return equations.c, equations.c

--- a/src/equations/wave_2d.jl
+++ b/src/equations/wave_2d.jl
@@ -1,0 +1,63 @@
+# By default, Julia/LLVM does not use fused multiply-add operations (FMAs).
+# Since these FMAs can increase the performance of many numerical algorithms,
+# we need to opt-in explicitly.
+# See https://ranocha.de/blog/Optimizing_EC_Trixi for further details.
+@muladd begin
+#! format: noindent
+
+@doc raw"""
+    WaveEquations2D(c)
+
+The wave equations in two space dimension written as a first order system. The equations are given by
+```math
+\begin{alignat*}{2}
+    \partial_t p &+ c\nabla \cdot{} v &&= 0 \\
+    \partial_t v &+ c\nabla p &&= 0
+\end{alignat*}
+The unknowns are the wave amplitude ``p`` and the wave "flux" ``(v_x, v_y)^T``. 
+The parameter ``c`` is the wave speed.
+```
+"""
+struct WaveEquations2D{RealT <: Real} <: AbstractFirstOrderWaveEquations{2, 3}
+    c::RealT
+end
+
+function varnames(::Union{typeof(cons2cons), typeof(cons2prim)}, ::WaveEquations2D)
+    return ("p", "vx", "vy")
+end
+
+# Calculate 1D flux for a single point
+@inline function flux(u, orientation::Integer, equations::WaveEquations2D)
+    @unpack c = equations
+    u, vx, vy = u
+    if orientation == 1
+        return SVector(c*vx, c*u, zero(vy))
+    else
+        return SVector(c*vy, zero(vx), c*u)
+    end
+end
+
+"""
+    have_constant_speed(::WaveEquations2D)
+
+Indicates whether the characteristic speeds are constant, i.e., independent of the solution.
+Queried in the timestep computation [`StepsizeCallback`](@ref) and [`linear_structure`](@ref).
+
+# Returns
+- `True()`
+"""
+@inline have_constant_speed(::WaveEquations2D) = True()
+
+@inline function max_abs_speeds(equations::WaveEquations2D)
+    return equations.c, equations.c
+end
+
+@inline function max_abs_speed_naive(u_ll, u_rr, orientation::Integer,
+                                     equations::WaveEquations2D)
+    return equations.c
+end
+
+# Convert conservative variables to primitive
+@inline cons2prim(u, ::WaveEquations2D) = u
+@inline cons2entropy(u, ::WaveEquations2D) = u
+end # muladd

--- a/src/equations/wave_2d.jl
+++ b/src/equations/wave_2d.jl
@@ -8,10 +8,15 @@
 @doc raw"""
     WaveEquations2D(c)
 
-The wave equations in two space dimension written as a first order system. The equations are given by
+The wave equation
+```math
+u_{tt} - c^2 \Delta u = 0
+```
+in two space dimension as a first order system.
+The equations are given by
 ```math
 \begin{alignat*}{2}
-    \partial_t p &+ c\nabla \cdot{} v &&= 0 \\
+    \partial_t p &+ c\nabla \cdot v &&= 0 \\
     \partial_t v &+ c\nabla p &&= 0
 \end{alignat*}
 The unknowns are the wave amplitude ``p`` and the wave "flux" ``(v_x, v_y)^T``. 

--- a/test/test_tree_1d.jl
+++ b/test/test_tree_1d.jl
@@ -57,6 +57,9 @@ isdir(outdir) && rm(outdir, recursive = true)
 
     # Passive tracers
     include("test_tree_1d_passive_tracers.jl")
+
+    # Wave equation
+    include("test_tree_1d_wave.jl")
 end
 
 # Coverage test for all initial conditions

--- a/test/test_tree_1d_wave.jl
+++ b/test/test_tree_1d_wave.jl
@@ -1,0 +1,20 @@
+
+using Test
+using Trixi
+
+include("test_trixi.jl")
+
+EXAMPLES_DIR = joinpath(examples_dir(), "tree_1d_dgsem")
+
+@testset "Wave Equations 1D" begin
+#! format: noindent
+
+@trixi_testset "elixir_wave_convergence.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_wave_convergence.jl"),
+                        l2=[0.0027356242067981735, 0.002735624132579398],
+                        linf=[0.010396415748525678, 0.01039641615909015])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    @test_allocations(Trixi.rhs!, semi, sol, 1000)
+end
+end

--- a/test/test_tree_2d_part3.jl
+++ b/test/test_tree_2d_part3.jl
@@ -28,6 +28,8 @@ isdir(outdir) && rm(outdir, recursive = true)
 
     # FDSBP methods on the TreeMesh
     include("test_tree_2d_fdsbp.jl")
+
+    include("test_tree_2d_wave.jl")
 end
 
 # Clean up afterwards: delete Trixi.jl output directory

--- a/test/test_tree_2d_part3.jl
+++ b/test/test_tree_2d_part3.jl
@@ -29,6 +29,7 @@ isdir(outdir) && rm(outdir, recursive = true)
     # FDSBP methods on the TreeMesh
     include("test_tree_2d_fdsbp.jl")
 
+    # Wave equation
     include("test_tree_2d_wave.jl")
 end
 

--- a/test/test_tree_2d_wave.jl
+++ b/test/test_tree_2d_wave.jl
@@ -12,14 +12,14 @@ EXAMPLES_DIR = joinpath(examples_dir(), "tree_2d_dgsem")
 @trixi_testset "elixir_wave_convergence.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_wave_convergence.jl"),
                         l2=[
-                            2.4292905839503593e-5,
-                            3.1433013845821566e-5,
-                            1.588526532948571e-5
+                            2.4495172317756833e-5,
+                            3.174909812221007e-5,
+                            2.9979271536156852e-6
                         ],
                         linf=[
-                            0.00016841204839490587,
-                            0.00016464766108787723,
-                            4.139321166533423e-5
+                            0.00016911867790070367,
+                            0.0001640678341614522,
+                            1.6269923975083337e-5
                         ])
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)

--- a/test/test_tree_2d_wave.jl
+++ b/test/test_tree_2d_wave.jl
@@ -1,0 +1,28 @@
+
+using Test
+using Trixi
+
+include("test_trixi.jl")
+
+EXAMPLES_DIR = joinpath(examples_dir(), "tree_2d_dgsem")
+
+@testset "Wave Equations 2D" begin
+#! format: noindent
+
+@trixi_testset "elixir_wave_convergence.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_wave_convergence.jl"),
+                        l2=[
+                            9.47185258e-05,
+                            6.92245498e-05,
+                            3.73189845e-05
+                        ],
+                        linf=[
+                            3.73557666e-04,
+                            2.92925075e-04,
+                            7.90116854e-05
+                        ])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    @test_allocations(Trixi.rhs!, semi, sol, 1000)
+end
+end

--- a/test/test_tree_2d_wave.jl
+++ b/test/test_tree_2d_wave.jl
@@ -12,14 +12,14 @@ EXAMPLES_DIR = joinpath(examples_dir(), "tree_2d_dgsem")
 @trixi_testset "elixir_wave_convergence.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_wave_convergence.jl"),
                         l2=[
-                            9.47185258e-05,
-                            6.92245498e-05,
-                            3.73189845e-05
+                            2.4292905839503593e-5,
+                            3.1433013845821566e-5,
+                            1.588526532948571e-5
                         ],
                         linf=[
-                            3.73557666e-04,
-                            2.92925075e-04,
-                            7.90116854e-05
+                            0.00016841204839490587,
+                            0.00016464766108787723,
+                            4.139321166533423e-5
                         ])
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)


### PR DESCRIPTION
Adds a first order for of the wave equations in 1D and 2D.
The 1D example implements a traveling wave (see the example on [wikipedia](https://en.wikipedia.org/wiki/Wave_equation))
The 2D example implements a standing wave on the square.