### PR TITLE
Use IController in implicit restart test for deterministic behavior

### DIFF
--- a/test/test_tree_2d_advection.jl
+++ b/test/test_tree_2d_advection.jl
@@ -42,7 +42,8 @@ end
 @trixi_testset "elixir_advection_implicit_sparse_jacobian_restart.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "elixir_advection_implicit_sparse_jacobian_restart.jl"),
-                        l2=[0.007964280656552015], linf=[0.011267546271397588])
+                        l2=[0.009816221102379877],
+                        linf=[0.013884832250496304])
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi_float_type, sol, 1000)
@@ -52,7 +53,8 @@ end
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "elixir_advection_implicit_sparse_jacobian_restart.jl"),
                         colorvec=nothing,
-                        l2=[0.007964280656552015], linf=[0.011267546271397588])
+                        l2=[0.009816221102379877],
+                        linf=[0.013884832250496304])
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi_float_type, sol, 1000)


### PR DESCRIPTION
## Summary

The implicit sparse Jacobian restart test (`elixir_advection_implicit_sparse_jacobian_restart.jl`) broke with OrdinaryDiffEqCore v3.10 because of a new first-step acceleration feature (https://github.com/SciML/OrdinaryDiffEq.jl/issues/3101).

The test was already fragile for two reasons:
1. **PIController has memory** (`qold`) — the previous error estimate ratio isn't saved/restored in checkpoints, so the restarted controller state differs from the continuous run. It only worked because the problem is trivial enough that the error estimate was near zero, making `qmax` the binding constraint and `qold` irrelevant.
2. **First-step acceleration** — OrdinaryDiffEqCore v3.10 added `qmax_first_step=10000` (matching Sundials CVODE behavior), which allows 10000x step growth on the first step. Since a restarted integrator has `success_iter=0`, it gets this acceleration, diverging from the continuous run.

### Fix

Switch the restart elixir's solver to use `NewIController(alg, qmax=10, qmax_first_step=10)`:
- **IController is memoryless** — no dependency on previous error estimates, so restart produces deterministic step sizes
- **`qmax_first_step = qmax`** — disables first-step acceleration so the restart behaves identically to a continuation

Reference values updated to match the new controller.

## Test plan

- [x] Both restart test variants (with and without colorvec) pass locally with updated reference values
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>