### PR TITLE
Dispatch AMR indicators over AbstractMesh{NDIMS} instead of u

### DIFF
--- a/examples/p4est_2d_dgsem/elixir_advection_amr_solution_independent.jl
+++ b/examples/p4est_2d_dgsem/elixir_advection_amr_solution_independent.jl
@@ -17,8 +17,9 @@ function IndicatorSolutionIndependent(semi)
     return IndicatorSolutionIndependent{typeof(cache)}(cache)
 end
 
-function (indicator::IndicatorSolutionIndependent)(u::AbstractArray{<:Any, 4},
-                                                   mesh, equations, dg, cache;
+function (indicator::IndicatorSolutionIndependent)(u::AbstractArray{<:Any},
+                                                   mesh::Trixi.AbstractMesh{2}, equations,
+                                                   dg, cache;
                                                    t, kwargs...)
     mesh = indicator.cache.mesh
     alpha = indicator.cache.alpha

--- a/examples/p4est_3d_dgsem/elixir_euler_circular_wind_nonconforming.jl
+++ b/examples/p4est_3d_dgsem/elixir_euler_circular_wind_nonconforming.jl
@@ -39,8 +39,8 @@ end
     return SVector(du1, du2, du3, du4, du5)
 end
 
-function indicator_test(u::AbstractArray{<:Any, 5},
-                        mesh, equations, dg::DGSEM, cache;
+function indicator_test(u::AbstractArray{<:Any},
+                        mesh::Trixi.AbstractMesh{3}, equations, dg::DGSEM, cache;
                         kwargs...)
     alpha = zeros(Int, nelements(dg, cache))
 

--- a/examples/p4est_3d_dgsem/elixir_euler_source_terms_nonconforming_earth.jl
+++ b/examples/p4est_3d_dgsem/elixir_euler_source_terms_nonconforming_earth.jl
@@ -27,8 +27,8 @@ end
     return source_terms_convergence_test(u, x_scaled, t_scaled, equations) / 6.371229e6
 end
 
-function indicator_test(u::AbstractArray{<:Any, 5},
-                        mesh, equations, dg::DGSEM, cache;
+function indicator_test(u::AbstractArray{<:Any},
+                        mesh::Trixi.AbstractMesh{3}, equations, dg::DGSEM, cache;
                         kwargs...)
     alpha = zeros(Int, nelements(dg, cache))
 

--- a/examples/t8code_2d_dgsem/elixir_advection_amr_solution_independent.jl
+++ b/examples/t8code_2d_dgsem/elixir_advection_amr_solution_independent.jl
@@ -17,8 +17,9 @@ function IndicatorSolutionIndependent(semi)
     return IndicatorSolutionIndependent{typeof(cache)}(cache)
 end
 
-function (indicator::IndicatorSolutionIndependent)(u::AbstractArray{<:Any, 4},
-                                                   mesh, equations, dg, cache;
+function (indicator::IndicatorSolutionIndependent)(u::AbstractArray{<:Any},
+                                                   mesh::Trixi.AbstractMesh{2}, equations,
+                                                   dg, cache;
                                                    t, kwargs...)
     mesh = indicator.cache.mesh
     alpha = indicator.cache.alpha

--- a/examples/tree_2d_dgsem/elixir_advection_amr_coarsen_twice.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_amr_coarsen_twice.jl
@@ -22,8 +22,9 @@ function IndicatorAlwaysCoarsen(semi)
     return IndicatorAlwaysCoarsen{typeof(cache)}(cache)
 end
 
-function (indicator::IndicatorAlwaysCoarsen)(u::AbstractArray{<:Any, 4},
-                                             mesh, equations, dg, cache;
+function (indicator::IndicatorAlwaysCoarsen)(u::AbstractArray{<:Any},
+                                             mesh::Trixi.AbstractMesh{2}, equations, dg,
+                                             cache;
                                              t, kwargs...)
     alpha = indicator.cache.alpha
     resize!(alpha, nelements(dg, cache))

--- a/examples/tree_2d_dgsem/elixir_advection_amr_refine_twice.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_amr_refine_twice.jl
@@ -22,8 +22,9 @@ function IndicatorAlwaysRefine(semi)
     return IndicatorAlwaysRefine{typeof(cache)}(cache)
 end
 
-function (indicator::IndicatorAlwaysRefine)(u::AbstractArray{<:Any, 4},
-                                            mesh, equations, dg, cache;
+function (indicator::IndicatorAlwaysRefine)(u::AbstractArray{<:Any},
+                                            mesh::Trixi.AbstractMesh{2}, equations, dg,
+                                            cache;
                                             t, kwargs...)
     alpha = indicator.cache.alpha
     resize!(alpha, nelements(dg, cache))

--- a/examples/tree_2d_dgsem/elixir_advection_amr_solution_independent.jl
+++ b/examples/tree_2d_dgsem/elixir_advection_amr_solution_independent.jl
@@ -15,8 +15,9 @@ function IndicatorSolutionIndependent(semi)
     cache = (; semi.mesh, alpha)
     return IndicatorSolutionIndependent{typeof(cache)}(cache)
 end
-function (indicator::IndicatorSolutionIndependent)(u::AbstractArray{<:Any, 4},
-                                                   mesh, equations, dg, cache;
+function (indicator::IndicatorSolutionIndependent)(u::AbstractArray{<:Any},
+                                                   mesh::Trixi.AbstractMesh{2}, equations,
+                                                   dg, cache;
                                                    t, kwargs...)
     RealT = eltype(u)
     mesh = indicator.cache.mesh

--- a/examples/tree_2d_dgsem/elixir_euler_source_terms_amr_refine_coarsen.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_source_terms_amr_refine_coarsen.jl
@@ -22,8 +22,9 @@ function IndicatorRefineCoarsen(semi)
     return IndicatorRefineCoarsen{typeof(cache)}(cache)
 end
 
-function (indicator::IndicatorRefineCoarsen)(u::AbstractArray{<:Any, 4},
-                                             mesh, equations, dg, cache;
+function (indicator::IndicatorRefineCoarsen)(u::AbstractArray{<:Any},
+                                             mesh::Trixi.AbstractMesh{2}, equations, dg,
+                                             cache;
                                              t, kwargs...)
     RealT = eltype(u)
     alpha = indicator.cache.alpha

--- a/examples/tree_2d_dgsem/elixir_euler_vortex_amr.jl
+++ b/examples/tree_2d_dgsem/elixir_euler_vortex_amr.jl
@@ -21,8 +21,9 @@ function IndicatorVortex(semi)
     return IndicatorVortex{typeof(cache)}(cache)
 end
 
-function (indicator_vortex::IndicatorVortex)(u::AbstractArray{<:Any, 4},
-                                             mesh, equations, dg, cache;
+function (indicator_vortex::IndicatorVortex)(u::AbstractArray{<:Any},
+                                             mesh::Trixi.AbstractMesh{2}, equations, dg,
+                                             cache;
                                              t, kwargs...)
     mesh = indicator_vortex.cache.mesh
     alpha = indicator_vortex.cache.alpha

--- a/src/solvers/dgsem_tree/indicators_1d.jl
+++ b/src/solvers/dgsem_tree/indicators_1d.jl
@@ -125,8 +125,8 @@ function create_cache(typ::Union{Type{IndicatorLöhner}, Type{IndicatorMax}},
     return create_cache(typ, equations, dg.basis)
 end
 
-function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any, 3},
-                                   mesh, equations, dg::DGSEM, cache;
+function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any},
+                                   mesh::AbstractMesh{1}, equations, dg::DGSEM, cache;
                                    kwargs...)
     @assert nnodes(dg)>=3 "IndicatorLöhner only works for nnodes >= 3 (polydeg > 1)"
     @unpack alpha, indicator_threaded = löhner.cache
@@ -158,8 +158,9 @@ function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any, 3},
     return alpha
 end
 
-function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any, 3},
-                                       mesh, equations, dg::DGSEM, cache;
+function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any},
+                                       mesh::AbstractMesh{1}, equations, dg::DGSEM,
+                                       cache;
                                        kwargs...)
     @unpack alpha, indicator_threaded = indicator_max.cache
     resize!(alpha, nelements(dg, cache))

--- a/src/solvers/dgsem_tree/indicators_2d.jl
+++ b/src/solvers/dgsem_tree/indicators_2d.jl
@@ -148,8 +148,8 @@ function create_cache(::Union{Type{IndicatorLöhner}, Type{IndicatorMax}},
     return (; alpha, indicator_threaded)
 end
 
-function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any, 4},
-                                   mesh, equations, dg::DGSEM, cache;
+function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any},
+                                   mesh::AbstractMesh{2}, equations, dg::DGSEM, cache;
                                    kwargs...)
     @assert nnodes(dg)>=3 "IndicatorLöhner only works for nnodes >= 3 (polydeg > 1)"
     @unpack alpha, indicator_threaded = löhner.cache
@@ -189,8 +189,9 @@ function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any, 4},
     return alpha
 end
 
-function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any, 4},
-                                       mesh, equations, dg::DGSEM, cache;
+function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any},
+                                       mesh::AbstractMesh{2}, equations, dg::DGSEM,
+                                       cache;
                                        kwargs...)
     @unpack alpha, indicator_threaded = indicator_max.cache
     resize!(alpha, nelements(dg, cache))

--- a/src/solvers/dgsem_tree/indicators_3d.jl
+++ b/src/solvers/dgsem_tree/indicators_3d.jl
@@ -185,8 +185,8 @@ function create_cache(::Union{Type{IndicatorLöhner}, Type{IndicatorMax}},
     return (; alpha, indicator_threaded)
 end
 
-function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any, 5},
-                                   mesh, equations, dg::DGSEM, cache;
+function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any},
+                                   mesh::AbstractMesh{3}, equations, dg::DGSEM, cache;
                                    kwargs...)
     @assert nnodes(dg)>=3 "IndicatorLöhner only works for nnodes >= 3 (polydeg > 1)"
     @unpack alpha, indicator_threaded = löhner.cache
@@ -234,8 +234,9 @@ function (löhner::IndicatorLöhner)(u::AbstractArray{<:Any, 5},
     return alpha
 end
 
-function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any, 5},
-                                       mesh, equations, dg::DGSEM, cache;
+function (indicator_max::IndicatorMax)(u::AbstractArray{<:Any},
+                                       mesh::AbstractMesh{3}, equations, dg::DGSEM,
+                                       cache;
                                        kwargs...)
     @unpack alpha, indicator_threaded = indicator_max.cache
     resize!(alpha, nelements(dg, cache))


### PR DESCRIPTION
Thanks for the clarification in #1194 . This PR changes the dispatch of the AMR indicators to use the AbstractMesh{NDIMS} instead of the NVARS of u, making the indicators independent of the number of variables solved for. 

