### PR TITLE
reorder dependency loading in elixi_advection_diffusion_implicit_sparse_jacobian

### DIFF
--- a/examples/tree_1d_dgsem/elixir_advection_diffusion_implicit_sparse_jacobian.jl
+++ b/examples/tree_1d_dgsem/elixir_advection_diffusion_implicit_sparse_jacobian.jl
@@ -1,7 +1,8 @@
 using Trixi
+using OrdinaryDiffEqBDF
 using SparseConnectivityTracer # For obtaining the Jacobian sparsity pattern
 using SparseMatrixColorings # For obtaining the coloring vector
-using OrdinaryDiffEqBDF, ADTypes
+using ADTypes # To access the types choosing how to evaluate Jacobian-vector products
 
 ###############################################################################
 # semidiscretization of the linear advection-diffusion equation


### PR DESCRIPTION
Potential fix for #2885

First I observed that it seems to reliably only be this recipe,
that triggered the error (perhaps lacking some insulation in our test environment).

The additional debug logging in #2889 showed:

```
┌ Debug: Loading cache file /home/runner/.julia/compiled/v1.10/SparseConnectivityTracer/AGPkv_0L6SR.ji for SparseConnectivityTracer [9f842d2f-2579-4b1d-911e-f412cf18a3f5]
└ @ Base loading.jl:1122
...
┌ Debug: Rejecting cache file /home/runner/.julia/compiled/v1.10/OrdinaryDiffEqSDIRK/gKeQT_n54Kk.ji because module DiffEqBaseSparseArraysExt [4131c53f-b1d6-5635-a7a3-57f6f930b644] is already loaded and incompatible.
└ @ Base loading.jl:3164
...
 Debug: Precompiling OrdinaryDiffEqSDIRK [2d112036-d095-4a1e-ab9a-08536f3ecdbf]
└ @ Base loading.jl:2432
```

I don't understand why/how we are creating `DiffEqBaseSparseArraysExt` in an incompatible manner, but let's first load the DiffEq package after loading Trixi
and then the rest and see if we see a difference.

