### PR TITLE
ignore warnings from OrdinaryDiffEqSDIRK.jl/OrdinaryDiffEqDifferentiation.jl

### DIFF
--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -13,7 +13,9 @@ macro test_trixi_include(expr, args...)
         r"┌ Warning: Problem status ALMOST_OPTIMAL; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n",
         # Warnings for higher-precision floating data types
         r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:118 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n",
-        r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:136 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n"
+        r"┌ Warning: #= /home/runner/work/Trixi.jl/Trixi.jl/src/solvers/dgsem/interpolation.jl:136 =#:\n│ `LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.\n│ Use `warn_check_args=false`, e.g. `@turbo warn_check_args=false ...`, to disable this warning.\n└ @ Trixi ~/.julia/packages/LoopVectorization/.*\n",
+        # Warnings for upstream problems in OrdinaryDiffEqSDIRK.jl/OrdinaryDiffEqDifferentiation.jl
+        r"┌ Warning: The call to compilecache failed to create a usable precompiled cache file for OrdinaryDiffEqSDIRK \[2d112036-d095-4a1e-ab9a-08536f3ecdbf\]\n│   exception = Required dependency OrdinaryDiffEqDifferentiation \[4302a76b-040a-498a-8c04-15b101fed76b\] failed to load from a cache file.\n└ @ Base loading.jl:.+\n"
     ]
     # if `maxiters` is set in tests, it is usually set to a small number to
     # run only a few steps - ignore possible warnings coming from that


### PR DESCRIPTION
This is just a workaround, but it fixes https://github.com/trixi-framework/Trixi.jl/issues/2885 for us.

@vchuravy Please feel free to have fun debugging the upstream issue and the problems with the caches. However, I would like to proceed with passing CI so that we can continue to merge PRs here.