### PR TITLE
Refactor  `calc_bounds_two/onesided`

### DIFF
--- a/src/solvers/dgsem_p4est/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_p4est/subcell_limiters_2d.jl
@@ -5,8 +5,8 @@
 @muladd begin
 #! format: noindent
 
-function calc_bounds_twosided_interface!(var_min, var_max, variable,
-                                         u, semi, mesh::P4estMesh{2})
+function calc_bounds_twosided_interface!(var_min, var_max, variable, u,
+                                         semi, mesh::P4estMesh{2}, equations)
     _, _, dg, cache = mesh_equations_solver_cache(semi)
 
     (; neighbor_ids, node_indices) = cache.interfaces
@@ -126,8 +126,8 @@ end
     return nothing
 end
 
-function calc_bounds_onesided_interface!(var_minmax, minmax, variable,
-                                         u, semi, mesh::P4estMesh{2})
+function calc_bounds_onesided_interface!(var_minmax, minmax, variable, u,
+                                         semi, mesh::P4estMesh{2})
     _, equations, dg, cache = mesh_equations_solver_cache(semi)
 
     (; neighbor_ids, node_indices) = cache.interfaces

--- a/src/solvers/dgsem_p4est/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_p4est/subcell_limiters_2d.jl
@@ -6,13 +6,12 @@
 #! format: noindent
 
 function calc_bounds_twosided_interface!(var_min, var_max, variable,
-                                         u, t, semi, mesh::P4estMesh{2}, equations)
+                                         u, semi, mesh::P4estMesh{2})
     _, _, dg, cache = mesh_equations_solver_cache(semi)
 
     (; neighbor_ids, node_indices) = cache.interfaces
     index_range = eachnode(dg)
 
-    # Calc bounds at interfaces and periodic boundaries
     for interface in eachinterface(dg, cache)
         # Get element and side index information on the primary element
         primary_element = neighbor_ids[1, interface]
@@ -127,14 +126,13 @@ end
     return nothing
 end
 
-function calc_bounds_onesided_interface!(var_minmax, minmax, variable, u, t, semi,
-                                         mesh::P4estMesh{2})
+function calc_bounds_onesided_interface!(var_minmax, minmax, variable,
+                                         u, semi, mesh::P4estMesh{2})
     _, equations, dg, cache = mesh_equations_solver_cache(semi)
 
     (; neighbor_ids, node_indices) = cache.interfaces
     index_range = eachnode(dg)
 
-    # Calc bounds at interfaces and periodic boundaries
     for interface in eachinterface(dg, cache)
         # Get element and side index information on the primary element
         primary_element = neighbor_ids[1, interface]
@@ -182,12 +180,6 @@ function calc_bounds_onesided_interface!(var_minmax, minmax, variable, u, t, sem
             j_secondary += j_secondary_step
         end
     end
-
-    # Calc bounds at physical boundaries
-    (; boundary_conditions) = semi
-    calc_bounds_onesided_boundary!(var_minmax, minmax, variable, u, t,
-                                   boundary_conditions,
-                                   mesh, equations, dg, cache)
 
     return nothing
 end

--- a/src/solvers/dgsem_p4est/subcell_limiters_3d.jl
+++ b/src/solvers/dgsem_p4est/subcell_limiters_3d.jl
@@ -6,13 +6,12 @@
 #! format: noindent
 
 function calc_bounds_twosided_interface!(var_min, var_max, variable,
-                                         u, t, semi, mesh::P4estMesh{3}, equations)
+                                         u, semi, mesh::P4estMesh{3})
     _, _, dg, cache = mesh_equations_solver_cache(semi)
 
     (; neighbor_ids, node_indices) = cache.interfaces
     index_range = eachnode(dg)
 
-    # Calc bounds at interfaces and periodic boundaries
     for interface in eachinterface(dg, cache)
         # Get element and side index information on the primary element
         primary_element = neighbor_ids[1, interface]
@@ -171,14 +170,13 @@ end
     return nothing
 end
 
-function calc_bounds_onesided_interface!(var_minmax, minmax, variable, u, t, semi,
-                                         mesh::P4estMesh{3})
+function calc_bounds_onesided_interface!(var_minmax, minmax, variable,
+                                         u, semi, mesh::P4estMesh{3})
     _, equations, dg, cache = mesh_equations_solver_cache(semi)
 
     (; neighbor_ids, node_indices) = cache.interfaces
     index_range = eachnode(dg)
 
-    # Calc bounds at interfaces and periodic boundaries
     for interface in eachinterface(dg, cache)
         # Get element and side index information on the primary element
         primary_element = neighbor_ids[1, interface]
@@ -251,12 +249,6 @@ function calc_bounds_onesided_interface!(var_minmax, minmax, variable, u, t, sem
             k_secondary += k_secondary_step_j
         end
     end
-
-    # Calc bounds at physical boundaries
-    (; boundary_conditions) = semi
-    calc_bounds_onesided_boundary!(var_minmax, minmax, variable, u, t,
-                                   boundary_conditions,
-                                   mesh, equations, dg, cache)
 
     return nothing
 end

--- a/src/solvers/dgsem_p4est/subcell_limiters_3d.jl
+++ b/src/solvers/dgsem_p4est/subcell_limiters_3d.jl
@@ -5,8 +5,8 @@
 @muladd begin
 #! format: noindent
 
-function calc_bounds_twosided_interface!(var_min, var_max, variable,
-                                         u, semi, mesh::P4estMesh{3})
+function calc_bounds_twosided_interface!(var_min, var_max, variable, u,
+                                         semi, mesh::P4estMesh{3})
     _, _, dg, cache = mesh_equations_solver_cache(semi)
 
     (; neighbor_ids, node_indices) = cache.interfaces
@@ -170,8 +170,8 @@ end
     return nothing
 end
 
-function calc_bounds_onesided_interface!(var_minmax, minmax, variable,
-                                         u, semi, mesh::P4estMesh{3})
+function calc_bounds_onesided_interface!(var_minmax, minmax, variable, u,
+                                         semi, mesh::P4estMesh{3})
     _, equations, dg, cache = mesh_equations_solver_cache(semi)
 
     (; neighbor_ids, node_indices) = cache.interfaces

--- a/src/solvers/dgsem_p4est/subcell_limiters_3d.jl
+++ b/src/solvers/dgsem_p4est/subcell_limiters_3d.jl
@@ -6,7 +6,7 @@
 #! format: noindent
 
 function calc_bounds_twosided_interface!(var_min, var_max, variable, u,
-                                         semi, mesh::P4estMesh{3})
+                                         semi, mesh::P4estMesh{3}, equations)
     _, _, dg, cache = mesh_equations_solver_cache(semi)
 
     (; neighbor_ids, node_indices) = cache.interfaces

--- a/src/solvers/dgsem_structured/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_structured/subcell_limiters_2d.jl
@@ -6,10 +6,9 @@
 #! format: noindent
 
 function calc_bounds_twosided_interface!(var_min, var_max, variable,
-                                         u, t, semi, mesh::StructuredMesh{2}, equations)
+                                         u, semi, mesh::StructuredMesh{2})
     _, _, dg, cache = mesh_equations_solver_cache(semi)
 
-    # Calc bounds at interfaces and periodic boundaries
     for element in eachelement(dg, cache)
         # Get neighboring element ids
         left = cache.elements.left_neighbors[1, element]
@@ -138,11 +137,10 @@ end
     return nothing
 end
 
-function calc_bounds_onesided_interface!(var_minmax, minmax, variable, u, t, semi,
-                                         mesh::StructuredMesh{2})
+function calc_bounds_onesided_interface!(var_minmax, minmax, variable,
+                                         u, semi, mesh::StructuredMesh{2})
     _, equations, dg, cache = mesh_equations_solver_cache(semi)
 
-    # Calc bounds at interfaces and periodic boundaries
     for element in eachelement(dg, cache)
         # Get neighboring element ids
         left = cache.elements.left_neighbors[1, element]
@@ -174,12 +172,6 @@ function calc_bounds_onesided_interface!(var_minmax, minmax, variable, u, t, sem
             end
         end
     end
-
-    # Calc bounds at physical boundaries
-    (; boundary_conditions) = semi
-    calc_bounds_onesided_boundary!(var_minmax, minmax, variable, u, t,
-                                   boundary_conditions,
-                                   mesh, equations, dg, cache)
 
     return nothing
 end

--- a/src/solvers/dgsem_structured/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_structured/subcell_limiters_2d.jl
@@ -5,8 +5,8 @@
 @muladd begin
 #! format: noindent
 
-function calc_bounds_twosided_interface!(var_min, var_max, variable,
-                                         u, semi, mesh::StructuredMesh{2})
+function calc_bounds_twosided_interface!(var_min, var_max, variable, u,
+                                         semi, mesh::StructuredMesh{2}, equations)
     _, _, dg, cache = mesh_equations_solver_cache(semi)
 
     for element in eachelement(dg, cache)
@@ -137,8 +137,8 @@ end
     return nothing
 end
 
-function calc_bounds_onesided_interface!(var_minmax, minmax, variable,
-                                         u, semi, mesh::StructuredMesh{2})
+function calc_bounds_onesided_interface!(var_minmax, minmax, variable, u,
+                                         semi, mesh::StructuredMesh{2})
     _, equations, dg, cache = mesh_equations_solver_cache(semi)
 
     for element in eachelement(dg, cache)

--- a/src/solvers/dgsem_tree/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_2d.jl
@@ -337,8 +337,8 @@ end
 ##############################################################################
 # Local minimum or maximum limiting of nonlinear variables
 
-@inline function idp_local_onesided!(alpha, limiter, u::AbstractArray{<:Real, 4}, t, dt,
-                                     semi, variable, min_or_max)
+@inline function idp_local_onesided!(alpha, limiter, u::AbstractArray{<:Real, 4},
+                                     t, dt, semi, variable, min_or_max)
     mesh, equations, dg, cache = mesh_equations_solver_cache(semi)
     (; variable_bounds) = limiter.cache.subcell_limiter_coefficients
     var_minmax = variable_bounds[Symbol(string(variable), "_", string(min_or_max))]

--- a/src/solvers/dgsem_tree/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_2d.jl
@@ -13,9 +13,9 @@
 # Calculation of local bounds using low-order FV solution
 
 @inline function calc_bounds_twosided!(var_min, var_max, variable,
-                                       u::AbstractArray{<:Any, 4},
-                                       t, semi)
-    mesh, equations, dg, cache = mesh_equations_solver_cache(semi)
+                                       u::AbstractArray{<:Any, 4}, t,
+                                       semi, equations)
+    mesh, _, dg, cache = mesh_equations_solver_cache(semi)
     # Calc bounds inside elements
     @threaded for element in eachelement(dg, cache)
         # Calculate bounds at Gauss-Lobatto nodes
@@ -49,8 +49,8 @@
     end
 
     # Calc bounds at element interfaces and periodic boundaries
-    calc_bounds_twosided_interface!(var_min, var_max, variable,
-                                    u, semi, mesh)
+    calc_bounds_twosided_interface!(var_min, var_max, variable, u,
+                                    semi, mesh, equations)
 
     # Calc bounds at physical boundaries
     (; boundary_conditions) = semi
@@ -60,8 +60,8 @@
     return nothing
 end
 
-@inline function calc_bounds_twosided_interface!(var_min, var_max, variable,
-                                                 u, semi, mesh::TreeMesh2D)
+@inline function calc_bounds_twosided_interface!(var_min, var_max, variable, u,
+                                                 semi, mesh::TreeMesh2D, equations)
     _, _, dg, cache = mesh_equations_solver_cache(semi)
 
     for interface in eachinterface(dg, cache)
@@ -140,8 +140,8 @@ end
 end
 
 @inline function calc_bounds_onesided!(var_minmax, min_or_max, variable,
-                                       u::AbstractArray{<:Any, 4},
-                                       t, semi)
+                                       u::AbstractArray{<:Any, 4}, t,
+                                       semi)
     mesh, equations, dg, cache = mesh_equations_solver_cache(semi)
 
     # The approach used in `calc_bounds_twosided!` is not used here because it requires more
@@ -183,7 +183,8 @@ end
     end
 
     # Calc bounds at element interfaces and periodic boundaries
-    calc_bounds_onesided_interface!(var_minmax, min_or_max, variable, u, semi, mesh)
+    calc_bounds_onesided_interface!(var_minmax, min_or_max, variable, u,
+                                    semi, mesh)
 
     # Calc bounds at physical boundaries
     (; boundary_conditions) = semi
@@ -194,8 +195,8 @@ end
     return nothing
 end
 
-@inline function calc_bounds_onesided_interface!(var_minmax, min_or_max, variable,
-                                                 u, semi, mesh::TreeMesh2D)
+@inline function calc_bounds_onesided_interface!(var_minmax, min_or_max, variable, u,
+                                                 semi, mesh::TreeMesh2D)
     _, equations, dg, cache = mesh_equations_solver_cache(semi)
 
     for interface in eachinterface(dg, cache)
@@ -276,7 +277,7 @@ end
 
 @inline function idp_local_twosided!(alpha, limiter, u::AbstractArray{<:Any, 4},
                                      t, dt, semi, variable)
-    mesh, _, dg, cache = mesh_equations_solver_cache(semi)
+    mesh, equations, dg, cache = mesh_equations_solver_cache(semi)
     (; antidiffusive_flux1_L, antidiffusive_flux2_L, antidiffusive_flux1_R, antidiffusive_flux2_R) = cache.antidiffusive_fluxes
     (; inverse_weights) = dg.basis # Plays role of inverse DG-subcell sizes
 
@@ -284,7 +285,7 @@ end
     variable_string = string(variable)
     var_min = variable_bounds[Symbol(variable_string, "_min")]
     var_max = variable_bounds[Symbol(variable_string, "_max")]
-    calc_bounds_twosided!(var_min, var_max, variable, u, t, semi)
+    calc_bounds_twosided!(var_min, var_max, variable, u, t, semi, equations)
 
     @threaded for element in eachelement(dg, semi.cache)
         for j in eachnode(dg), i in eachnode(dg)

--- a/src/solvers/dgsem_tree/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_2d.jl
@@ -13,8 +13,9 @@
 # Calculation of local bounds using low-order FV solution
 
 @inline function calc_bounds_twosided!(var_min, var_max, variable,
-                                       u::AbstractArray{<:Any, 4}, t, semi, equations)
-    mesh, _, dg, cache = mesh_equations_solver_cache(semi)
+                                       u::AbstractArray{<:Any, 4},
+                                       t, semi)
+    mesh, equations, dg, cache = mesh_equations_solver_cache(semi)
     # Calc bounds inside elements
     @threaded for element in eachelement(dg, cache)
         # Calculate bounds at Gauss-Lobatto nodes
@@ -47,9 +48,9 @@
         end
     end
 
-    # Values at element interfaces
+    # Calc bounds at element interfaces and periodic boundaries
     calc_bounds_twosided_interface!(var_min, var_max, variable,
-                                    u, t, semi, mesh, equations)
+                                    u, semi, mesh)
 
     # Calc bounds at physical boundaries
     (; boundary_conditions) = semi
@@ -60,11 +61,9 @@
 end
 
 @inline function calc_bounds_twosided_interface!(var_min, var_max, variable,
-                                                 u, t, semi, mesh::TreeMesh2D,
-                                                 equations)
+                                                 u, semi, mesh::TreeMesh2D)
     _, _, dg, cache = mesh_equations_solver_cache(semi)
 
-    # Calc bounds at interfaces and periodic boundaries
     for interface in eachinterface(dg, cache)
         # Get neighboring element ids
         left_element = cache.interfaces.neighbor_ids[1, interface]
@@ -141,7 +140,8 @@ end
 end
 
 @inline function calc_bounds_onesided!(var_minmax, min_or_max, variable,
-                                       u::AbstractArray{<:Any, 4}, t, semi)
+                                       u::AbstractArray{<:Any, 4},
+                                       t, semi)
     mesh, equations, dg, cache = mesh_equations_solver_cache(semi)
 
     # The approach used in `calc_bounds_twosided!` is not used here because it requires more
@@ -182,17 +182,22 @@ end
         end
     end
 
-    # Values at element boundary
-    calc_bounds_onesided_interface!(var_minmax, min_or_max, variable, u, t, semi, mesh)
+    # Calc bounds at element interfaces and periodic boundaries
+    calc_bounds_onesided_interface!(var_minmax, min_or_max, variable, u, semi, mesh)
+
+    # Calc bounds at physical boundaries
+    (; boundary_conditions) = semi
+    calc_bounds_onesided_boundary!(var_minmax, min_or_max, variable, u, t,
+                                   boundary_conditions,
+                                   mesh, equations, dg, cache)
 
     return nothing
 end
 
-@inline function calc_bounds_onesided_interface!(var_minmax, min_or_max, variable, u, t,
-                                                 semi, mesh::TreeMesh2D)
+@inline function calc_bounds_onesided_interface!(var_minmax, min_or_max, variable,
+                                                 u, semi, mesh::TreeMesh2D)
     _, equations, dg, cache = mesh_equations_solver_cache(semi)
 
-    # Calc bounds at interfaces and periodic boundaries
     for interface in eachinterface(dg, cache)
         # Get neighboring element ids
         left_element = cache.interfaces.neighbor_ids[1, interface]
@@ -224,12 +229,6 @@ end
                                                                  var_right)
         end
     end
-
-    # Calc bounds at physical boundaries
-    (; boundary_conditions) = semi
-    calc_bounds_onesided_boundary!(var_minmax, min_or_max, variable, u, t,
-                                   boundary_conditions,
-                                   mesh, equations, dg, cache)
 
     return nothing
 end
@@ -275,9 +274,9 @@ end
 ###############################################################################
 # Local minimum and maximum limiting of conservative variables
 
-@inline function idp_local_twosided!(alpha, limiter, u::AbstractArray{<:Any, 4}, t, dt,
-                                     semi, variable)
-    mesh, equations, dg, cache = mesh_equations_solver_cache(semi)
+@inline function idp_local_twosided!(alpha, limiter, u::AbstractArray{<:Any, 4},
+                                     t, dt, semi, variable)
+    mesh, _, dg, cache = mesh_equations_solver_cache(semi)
     (; antidiffusive_flux1_L, antidiffusive_flux2_L, antidiffusive_flux1_R, antidiffusive_flux2_R) = cache.antidiffusive_fluxes
     (; inverse_weights) = dg.basis # Plays role of inverse DG-subcell sizes
 
@@ -285,7 +284,7 @@ end
     variable_string = string(variable)
     var_min = variable_bounds[Symbol(variable_string, "_min")]
     var_max = variable_bounds[Symbol(variable_string, "_max")]
-    calc_bounds_twosided!(var_min, var_max, variable, u, t, semi, equations)
+    calc_bounds_twosided!(var_min, var_max, variable, u, t, semi)
 
     @threaded for element in eachelement(dg, semi.cache)
         for j in eachnode(dg), i in eachnode(dg)

--- a/src/solvers/dgsem_tree/subcell_limiters_3d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_3d.jl
@@ -343,7 +343,7 @@ end
     variable_string = string(variable)
     var_min = variable_bounds[Symbol(variable_string, "_min")]
     var_max = variable_bounds[Symbol(variable_string, "_max")]
-    calc_bounds_twosided!(var_min, var_max, variable, u, t, semi)
+    calc_bounds_twosided!(var_min, var_max, variable, u, t, semi, equations)
 
     @threaded for element in eachelement(dg, semi.cache)
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)

--- a/src/solvers/dgsem_tree/subcell_limiters_3d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_3d.jl
@@ -14,8 +14,9 @@
 
 @inline function calc_bounds_twosided!(var_min, var_max, variable,
                                        u::AbstractArray{<:Any, 5}, t,
-                                       semi)
-    mesh, equations, dg, cache = mesh_equations_solver_cache(semi)
+                                       semi, equations)
+    mesh, _, dg, cache = mesh_equations_solver_cache(semi)
+
     # Calc bounds inside elements
     @threaded for element in eachelement(dg, cache)
         # Calculate bounds at Gauss-Lobatto nodes
@@ -61,7 +62,7 @@
 
     # Calc bounds at element interfaces and periodic boundaries
     calc_bounds_twosided_interface!(var_min, var_max, variable, u,
-                                    semi, mesh)
+                                    semi, mesh, equations)
 
     # Calc bounds at physical boundaries
     (; boundary_conditions) = semi
@@ -72,7 +73,7 @@
 end
 
 @inline function calc_bounds_twosided_interface!(var_min, var_max, variable, u,
-                                                 semi, mesh::TreeMesh3D)
+                                                 semi, mesh::TreeMesh3D, equations)
     _, _, dg, cache = mesh_equations_solver_cache(semi)
 
     for interface in eachinterface(dg, cache)

--- a/src/solvers/dgsem_tree/subcell_limiters_3d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_3d.jl
@@ -13,8 +13,8 @@
 # Calculation of local bounds using low-order FV solution
 
 @inline function calc_bounds_twosided!(var_min, var_max, variable,
-                                       u::AbstractArray{<:Any, 5},
-                                       t, semi)
+                                       u::AbstractArray{<:Any, 5}, t,
+                                       semi)
     mesh, equations, dg, cache = mesh_equations_solver_cache(semi)
     # Calc bounds inside elements
     @threaded for element in eachelement(dg, cache)
@@ -60,8 +60,8 @@
     end
 
     # Calc bounds at element interfaces and periodic boundaries
-    calc_bounds_twosided_interface!(var_min, var_max, variable,
-                                    u, semi, mesh)
+    calc_bounds_twosided_interface!(var_min, var_max, variable, u,
+                                    semi, mesh)
 
     # Calc bounds at physical boundaries
     (; boundary_conditions) = semi
@@ -71,8 +71,8 @@
     return nothing
 end
 
-@inline function calc_bounds_twosided_interface!(var_min, var_max, variable,
-                                                 u, semi, mesh::TreeMesh3D)
+@inline function calc_bounds_twosided_interface!(var_min, var_max, variable, u,
+                                                 semi, mesh::TreeMesh3D)
     _, _, dg, cache = mesh_equations_solver_cache(semi)
 
     for interface in eachinterface(dg, cache)
@@ -170,13 +170,14 @@ end
 end
 
 @inline function calc_bounds_onesided!(var_minmax, min_or_max, variable,
-                                       u::AbstractArray{<:Any, 5}, t, semi)
+                                       u::AbstractArray{<:Any, 5}, t,
+                                       semi)
     mesh, equations, dg, cache = mesh_equations_solver_cache(semi)
-    # Calc bounds inside elements
 
     # The approach used in `calc_bounds_twosided!` is not used here because it requires more
     # evaluations of the variable and is therefore slower.
 
+    # Calc bounds inside elements
     @threaded for element in eachelement(dg, cache)
         # Reset bounds
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
@@ -220,7 +221,8 @@ end
     end
 
     # Calc bounds at element interfaces and periodic boundaries
-    calc_bounds_onesided_interface!(var_minmax, min_or_max, variable, u, semi, mesh)
+    calc_bounds_onesided_interface!(var_minmax, min_or_max, variable, u,
+                                    semi, mesh)
 
     # Calc bounds at physical boundaries
     (; boundary_conditions) = semi
@@ -231,8 +233,8 @@ end
     return nothing
 end
 
-@inline function calc_bounds_onesided_interface!(var_minmax, min_or_max, variable,
-                                                 u, semi, mesh::TreeMesh{3})
+@inline function calc_bounds_onesided_interface!(var_minmax, min_or_max, variable, u,
+                                                 semi, mesh::TreeMesh{3})
     _, equations, dg, cache = mesh_equations_solver_cache(semi)
 
     for interface in eachinterface(dg, cache)

--- a/src/solvers/dgsem_tree/subcell_limiters_3d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_3d.jl
@@ -13,8 +13,9 @@
 # Calculation of local bounds using low-order FV solution
 
 @inline function calc_bounds_twosided!(var_min, var_max, variable,
-                                       u::AbstractArray{<:Any, 5}, t, semi, equations)
-    mesh, _, dg, cache = mesh_equations_solver_cache(semi)
+                                       u::AbstractArray{<:Any, 5},
+                                       t, semi)
+    mesh, equations, dg, cache = mesh_equations_solver_cache(semi)
     # Calc bounds inside elements
     @threaded for element in eachelement(dg, cache)
         # Calculate bounds at Gauss-Lobatto nodes
@@ -58,9 +59,9 @@
         end
     end
 
-    # Values at element interfaces
+    # Calc bounds at element interfaces and periodic boundaries
     calc_bounds_twosided_interface!(var_min, var_max, variable,
-                                    u, t, semi, mesh, equations)
+                                    u, semi, mesh)
 
     # Calc bounds at physical boundaries
     (; boundary_conditions) = semi
@@ -71,11 +72,9 @@
 end
 
 @inline function calc_bounds_twosided_interface!(var_min, var_max, variable,
-                                                 u, t, semi, mesh::TreeMesh3D,
-                                                 equations)
+                                                 u, semi, mesh::TreeMesh3D)
     _, _, dg, cache = mesh_equations_solver_cache(semi)
 
-    # Calc bounds at interfaces and periodic boundaries
     for interface in eachinterface(dg, cache)
         # Get neighboring element ids
         left_element = cache.interfaces.neighbor_ids[1, interface]
@@ -220,17 +219,22 @@ end
         end
     end
 
-    # Values at element boundary
-    calc_bounds_onesided_interface!(var_minmax, min_or_max, variable, u, t, semi, mesh)
+    # Calc bounds at element interfaces and periodic boundaries
+    calc_bounds_onesided_interface!(var_minmax, min_or_max, variable, u, semi, mesh)
+
+    # Calc bounds at physical boundaries
+    (; boundary_conditions) = semi
+    calc_bounds_onesided_boundary!(var_minmax, min_or_max, variable, u, t,
+                                   boundary_conditions,
+                                   mesh, equations, dg, cache)
 
     return nothing
 end
 
-@inline function calc_bounds_onesided_interface!(var_minmax, min_or_max, variable, u, t,
-                                                 semi, mesh::TreeMesh{3})
+@inline function calc_bounds_onesided_interface!(var_minmax, min_or_max, variable,
+                                                 u, semi, mesh::TreeMesh{3})
     _, equations, dg, cache = mesh_equations_solver_cache(semi)
 
-    # Calc bounds at interfaces and periodic boundaries
     for interface in eachinterface(dg, cache)
         # Get neighboring element ids
         left_element = cache.interfaces.neighbor_ids[1, interface]
@@ -268,12 +272,6 @@ end
                                                                  var_right)
         end
     end
-
-    # Calc bounds at physical boundaries
-    (; boundary_conditions) = semi
-    calc_bounds_onesided_boundary!(var_minmax, min_or_max, variable, u, t,
-                                   boundary_conditions,
-                                   mesh, equations, dg, cache)
 
     return nothing
 end
@@ -342,7 +340,7 @@ end
     variable_string = string(variable)
     var_min = variable_bounds[Symbol(variable_string, "_min")]
     var_max = variable_bounds[Symbol(variable_string, "_max")]
-    calc_bounds_twosided!(var_min, var_max, variable, u, t, semi, equations)
+    calc_bounds_twosided!(var_min, var_max, variable, u, t, semi)
 
     @threaded for element in eachelement(dg, semi.cache)
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)


### PR DESCRIPTION
I forgot a few things in #2920 . This is now completed in this PR.
- remove not-needed `t` from `calc_bounds_twosided_interface!` and `calc_bounds_onesided_interface!`
- Do #2920 for `calc_bounds_onesided!`: Call `calc_bounds_onesided_boundary!` from within `calc_bounds_onesided!` and not `calc_bounds_onesided_interface!`