### PR TITLE
Relocate resizing of subcell limiter cache

### DIFF
--- a/src/solvers/dgsem_tree/dg_2d_subcell_limiters.jl
+++ b/src/solvers/dgsem_tree/dg_2d_subcell_limiters.jl
@@ -51,6 +51,9 @@ function create_cache(mesh::Union{TreeMesh{2}, StructuredMesh{2}, P4estMesh{2}},
                  fhat_nonconservative_temp_threaded, phi_threaded)
     end
 
+    # The limiter cache was created with 0 elements
+    resize_subcell_limiter_cache!(dg.volume_integral.limiter, n_elements)
+
     return (; cache..., antidiffusive_fluxes,
             fhat1_L_threaded, fhat1_R_threaded,
             fhat2_L_threaded, fhat2_R_threaded,

--- a/src/solvers/dgsem_tree/dg_3d_subcell_limiters.jl
+++ b/src/solvers/dgsem_tree/dg_3d_subcell_limiters.jl
@@ -52,6 +52,9 @@ function create_cache(mesh::Union{TreeMesh{3}, P4estMesh{3}},
                  fhat_nonconservative_temp_threaded, phi_threaded)
     end
 
+    # The limiter cache was created with 0 elements
+    resize_subcell_limiter_cache!(dg.volume_integral.limiter, n_elements)
+
     return (; cache..., antidiffusive_fluxes,
             fhat1_L_threaded, fhat1_R_threaded,
             fhat2_L_threaded, fhat2_R_threaded,

--- a/src/solvers/dgsem_tree/subcell_limiters.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters.jl
@@ -7,8 +7,6 @@
 
 abstract type AbstractSubcellLimiter end
 
-resize_subcell_limiter_cache!(limiter::AbstractSubcellLimiter, new_size) = nothing
-
 function create_cache(typ::Type{LimiterType},
                       semi) where {LimiterType <: AbstractSubcellLimiter}
     return create_cache(typ, mesh_equations_solver_cache(semi)...)

--- a/src/solvers/dgsem_tree/subcell_limiters.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters.jl
@@ -7,6 +7,8 @@
 
 abstract type AbstractSubcellLimiter end
 
+resize_subcell_limiter_cache!(limiter::AbstractSubcellLimiter, new_size) = nothing
+
 function create_cache(typ::Type{LimiterType},
                       semi) where {LimiterType <: AbstractSubcellLimiter}
     return create_cache(typ, mesh_equations_solver_cache(semi)...)
@@ -247,6 +249,12 @@ function create_cache(limiter::Type{SubcellLimiterIDP},
 
     return (; subcell_limiter_coefficients, idp_bounds_delta_local,
             idp_bounds_delta_global)
+end
+
+function resize_subcell_limiter_cache!(limiter::SubcellLimiterIDP, new_size)
+    resize!(limiter.cache.subcell_limiter_coefficients, new_size)
+
+    return nothing
 end
 
 # While for the element-wise limiting with `VolumeIntegralShockCapturingHG` the indicator is

--- a/src/time_integration/methods_SSP.jl
+++ b/src/time_integration/methods_SSP.jl
@@ -132,14 +132,6 @@ function init(ode::ODEProblem, alg::SimpleAlgorithmSSP;
                                                                 kwargs...),
                                      false, true, false)
 
-    # Resize container of volume integral for subcell limiting
-    _, _, dg, cache = mesh_equations_solver_cache(integrator.p)
-    if dg.volume_integral isa VolumeIntegralSubcellLimiting
-        # `subcell_limiter_coefficients` was created with 0 elements
-        resize!(dg.volume_integral.limiter.cache.subcell_limiter_coefficients,
-                nelements(dg, cache))
-    end
-
     # Standard callbacks
     initialize_callbacks!(callback, integrator)
 


### PR DESCRIPTION
When creating the cache for the limiter, it is not known how many elements there will be. It's created with 0 elements. So, we need to resize it at some point.

Before, this was done in the initialization process of the time integrator, which was not very nice. This PR moves it to the creating of the volume integral cache.

Not an ideal solution, but I think the best we have.