### PR TITLE
Reduce `DGMulti` parabolic allocs

### DIFF
--- a/src/solvers/dgmulti/dg_parabolic.jl
+++ b/src/solvers/dgmulti/dg_parabolic.jl
@@ -236,8 +236,25 @@ function calc_boundary_flux!(flux, u, t, operator_type, ::BoundaryConditionPerio
     return nothing
 end
 
-# "lispy tuple programming" instead of for loop for type stability
-function calc_boundary_flux!(flux, u, t, operator_type, boundary_conditions,
+# Unroll over `NamedTuple` boundary tags at compile time to avoid runtime allocations from
+# `first(keys(...))`, `first(...)`, and `Base.tail` during recursive peeling.
+@generated function calc_boundary_flux!(flux, u, t, operator_type,
+                                        bc::NamedTuple{Names, Types},
+                                        mesh, equations, dg::DGMulti, cache,
+                                        cache_parabolic) where {Names, Types}
+    stmts = Expr[]
+    for i in 1:length(Names)
+        push!(stmts,
+              :(calc_single_boundary_flux!(flux, u, t, operator_type, getfield(bc, $i),
+                                           $(QuoteNode(Names[i])), mesh, equations, dg,
+                                           cache, cache_parabolic)))
+    end
+    push!(stmts, :(return nothing))
+    return Expr(:block, stmts...)
+end
+
+# "lispy tuple programming" instead of for loop for type stability (plain `Tuple` BC lists)
+function calc_boundary_flux!(flux, u, t, operator_type, boundary_conditions::Tuple,
                              mesh, equations, dg::DGMulti, cache, cache_parabolic)
 
     # peel off first boundary condition
@@ -252,9 +269,8 @@ function calc_boundary_flux!(flux, u, t, operator_type, boundary_conditions,
     return nothing
 end
 
-# terminate recursion
-function calc_boundary_flux!(flux, u, t, operator_type,
-                             boundary_conditions::NamedTuple{(), Tuple{}},
+# terminate tuple recursion (e.g., `(periodic, periodic)` after peeling both entries)
+function calc_boundary_flux!(flux, u, t, operator_type, ::Tuple{},
                              mesh, equations, dg::DGMulti, cache, cache_parabolic)
     return nothing
 end

--- a/src/solvers/dgmulti/dg_parabolic.jl
+++ b/src/solvers/dgmulti/dg_parabolic.jl
@@ -276,8 +276,9 @@ function calc_single_boundary_flux!(flux_face_values, u_face_values, t,
             e = ((f - 1) ÷ num_faces) + 1
             fid = i + ((f - 1) % num_faces) * num_pts_per_face
 
-            face_normal = SVector{NDIMS}(getindex.(nxyz, fid, e))
-            face_coordinates = SVector{NDIMS}(getindex.(xyzf, fid, e))
+            face_normal = SVector(ntuple(j -> @inbounds(nxyz[j][fid, e]), Val(NDIMS)))
+            face_coordinates = SVector(ntuple(j -> @inbounds(xyzf[j][fid, e]),
+                                              Val(NDIMS)))
 
             # for both the gradient and the divergence, the boundary flux is scalar valued.
             # for the gradient, it is the solution; for divergence, it is the normal flux.
@@ -298,9 +299,10 @@ function calc_single_boundary_flux!(flux_face_values, u_face_values, t,
     return nothing
 end
 
-function calc_parabolic_fluxes!(flux_parabolic, u, gradients, mesh::DGMultiMesh,
+function calc_parabolic_fluxes!(flux_parabolic, u, gradients,
+                                mesh::DGMultiMesh{NDIMS},
                                 equations::AbstractEquationsParabolic,
-                                dg::DGMulti, cache, cache_parabolic)
+                                dg::DGMulti, cache, cache_parabolic) where {NDIMS}
     for dim in eachdim(mesh)
         set_zero!(flux_parabolic[dim], dg)
     end
@@ -318,7 +320,8 @@ function calc_parabolic_fluxes!(flux_parabolic, u, gradients, mesh::DGMultiMesh,
         # compute parabolic flux at quad points
         for i in eachindex(local_u_values)
             u_i = local_u_values[i]
-            gradients_i = getindex.(gradients, i, e)
+            gradients_i = SVector(ntuple(d -> @inbounds(gradients[d][i, e]),
+                                         Val(NDIMS)))
             for dim in eachdim(mesh)
                 flux_parabolic_i = flux(u_i, gradients_i, dim, equations)
                 setindex!(flux_parabolic[dim], flux_parabolic_i, i, e)

--- a/test/test_parabolic_2d.jl
+++ b/test/test_parabolic_2d.jl
@@ -92,17 +92,7 @@ end
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
-    # TODO: We would like to call
-    # @test_allocations(Trixi.rhs_parabolic!, semi, sol, 1000)
-    # However, we currently observe allocations that shall we
-    # investigate and fix in a future PR.
-    let
-        t = sol.t[end]
-        u_ode = copy(sol.u[end])
-        du_ode = similar(u_ode)
-        Trixi.rhs_parabolic!(du_ode, u_ode, semi, t)
-        @test_broken (@allocated Trixi.rhs_parabolic!(du_ode, u_ode, semi, t) < 1000)
-    end
+    @test_allocations(Trixi.rhs_parabolic!, semi, sol, 1000)
 end
 
 @trixi_testset "DGMulti: elixir_advection_diffusion_periodic.jl" begin


### PR DESCRIPTION
Attempt at addressing #2729. Currently a draft PR to experiment with different approaches.

On `main`, running `trixi_include(joinpath(examples_dir(), "dgmulti_2d", "elixir_advection_diffusion.jl"))` and then `@test_allocations(Trixi.rhs_parabolic!, semi, sol, 1000)` yields `Evaluated: 1728 < 1000`.