### PR TITLE
Fix native Julia visualization for SBP triangles

### DIFF
--- a/src/visualization/utilities.jl
+++ b/src/visualization/utilities.jl
@@ -241,7 +241,7 @@ function mesh_plotting_wireframe(u::ScalarData, mesh, equations, dg::DGMulti, ca
     @unpack N, Fmask = rd
 
     # number of points on a single face, assuming all faces have the same number of points
-    # note that since ScalarPlotData2D is restricted to Tri and Quad types, this should always be true.
+    # note that since `ScalarPlotData2D` is restricted to Tri and Quad types, this should always be true.
     num_face_points = size(Fmask, 1) ÷ num_faces(rd.element_type)
 
     # extract a set of interpolation nodes for the face nodes. For Polynomial approximations, 

--- a/src/visualization/utilities.jl
+++ b/src/visualization/utilities.jl
@@ -222,6 +222,7 @@ end
 function extract_face_nodes_1D(basis::DGMultiBasis{<:Any, <:Tri})
     # this assumes that the nodes of the first face on the reference element correspond to a face where
     # s = constant, so that the `r` coordinates on this face can be used to construct a nodal basis. 
+    @assert length(basis.Fmask) % num_faces(basis.element_type)==0 "The number of face nodes must be the same for all faces."
     return reshape(basis.r[basis.Fmask[:, 1]], :, num_faces(basis.element_type))[:, 1]
 end
 
@@ -229,6 +230,7 @@ function extract_face_nodes_1D(basis::DGMultiBasis{<:Any, <:Quad})
     # this assumes that the nodes of the first face on the reference element correspond to a face where
     # r = constant, so that the `s` coordinates on this face can be used to construct a nodal basis. 
     # For quadrilateral elements, this is true since the faces are ordered r = ±1, s = ±1.
+    @assert length(basis.Fmask) % num_faces(basis.element_type)==0 "The number of face nodes must be the same for all faces."
     return reshape(basis.s[basis.Fmask[:, 1]], :, num_faces(basis.element_type))[:, 1]
 end
 

--- a/src/visualization/utilities.jl
+++ b/src/visualization/utilities.jl
@@ -222,7 +222,7 @@ end
 function extract_face_nodes_1D(basis::DGMultiBasis{<:Any, <:Tri})
     # this assumes that the nodes of the first face on the reference element correspond to a face where
     # s = constant, so that the `r` coordinates on this face can be used to construct a nodal basis. 
-    @assert length(basis.Fmask) % num_faces(basis.element_type) == 0 "The number of face nodes must be the same for all faces."
+    @assert length(basis.Fmask) % num_faces(basis.element_type)==0 "The number of face nodes must be the same for all faces."
     return reshape(basis.r[basis.Fmask[:, 1]], :, num_faces(basis.element_type))[:, 1]
 end
 
@@ -230,7 +230,7 @@ function extract_face_nodes_1D(basis::DGMultiBasis{<:Any, <:Quad})
     # this assumes that the nodes of the first face on the reference element correspond to a face where
     # r = constant, so that the `s` coordinates on this face can be used to construct a nodal basis. 
     # For quadrilateral elements, this is true since the faces are ordered r = ±1, s = ±1.
-    @assert length(basis.Fmask) % num_faces(basis.element_type) == 0 "The number of face nodes must be the same for all faces."
+    @assert length(basis.Fmask) % num_faces(basis.element_type)==0 "The number of face nodes must be the same for all faces."
     return reshape(basis.s[basis.Fmask[:, 1]], :, num_faces(basis.element_type))[:, 1]
 end
 

--- a/src/visualization/utilities.jl
+++ b/src/visualization/utilities.jl
@@ -222,7 +222,7 @@ end
 function extract_face_nodes_1D(basis::DGMultiBasis{<:Any, <:Tri})
     # this assumes that the nodes of the first face on the reference element correspond to a face where
     # s = constant, so that the `r` coordinates on this face can be used to construct a nodal basis. 
-    @assert length(basis.Fmask) % num_faces(basis.element_type)==0 "The number of face nodes must be the same for all faces."
+    @assert length(basis.Fmask) % num_faces(basis.element_type) == 0 "The number of face nodes must be the same for all faces."
     return reshape(basis.r[basis.Fmask[:, 1]], :, num_faces(basis.element_type))[:, 1]
 end
 
@@ -230,7 +230,7 @@ function extract_face_nodes_1D(basis::DGMultiBasis{<:Any, <:Quad})
     # this assumes that the nodes of the first face on the reference element correspond to a face where
     # r = constant, so that the `s` coordinates on this face can be used to construct a nodal basis. 
     # For quadrilateral elements, this is true since the faces are ordered r = ±1, s = ±1.
-    @assert length(basis.Fmask) % num_faces(basis.element_type)==0 "The number of face nodes must be the same for all faces."
+    @assert length(basis.Fmask) % num_faces(basis.element_type) == 0 "The number of face nodes must be the same for all faces."
     return reshape(basis.s[basis.Fmask[:, 1]], :, num_faces(basis.element_type))[:, 1]
 end
 

--- a/src/visualization/utilities.jl
+++ b/src/visualization/utilities.jl
@@ -223,14 +223,22 @@ function mesh_plotting_wireframe(u::ScalarData, mesh, equations, dg::DGMulti, ca
                                  nvisnodes = 2 * nnodes(dg))
     @unpack md = mesh
     rd = dg.basis
-
-    # Construct 1D plotting interpolation matrix `Vp1D` for a single face
     @unpack N, Fmask = rd
-    vandermonde_matrix_1D = StartUpDG.vandermonde(Line(), N, StartUpDG.nodes(Line(), N))
+
+    # number of points on a single face, assuming all faces have the same number of points
+    # note that since ScalarPlotData2D is restricted to Tri and Quad types, this should always be true.
+    num_face_points = size(Fmask, 1) ÷ num_faces(rd.element_type)
+
+    # this assumes that the nodes of the first face on the reference element correspond to a face where
+    # s = constant, so that the `r` coordinates on this face can be used to construct a nodal basis. 
+    face_nodes_1D = rd.r[reshape(rd.Fmask, :, num_faces(rd.element_type))[:, 1]]
+
+    # Construct 1D plotting interpolation matrix `Vp1D` for a single face. 
+    # Since num_face_points may be larger than N+1, this is doing a least squares projection
+    vandermonde_matrix_1D = StartUpDG.vandermonde(Line(), N, face_nodes_1D)
     rplot = LinRange(-1, 1, nvisnodes)
     Vp1D = StartUpDG.vandermonde(Line(), N, rplot) / vandermonde_matrix_1D
 
-    num_face_points = N + 1
     num_faces_total = num_faces(rd.element_type) * md.num_elements
     xf, yf, uf = map(x -> reshape(view(x, Fmask, :), num_face_points, num_faces_total),
                      (md.xyz..., u.data))

--- a/src/visualization/utilities.jl
+++ b/src/visualization/utilities.jl
@@ -219,6 +219,19 @@ function mesh_plotting_wireframe(u::ScalarData, mesh, equations,
     return xfp, yfp, ufp
 end
 
+function extract_face_nodes_1D(basis::DGMultiBasis{<:Any, <:Tri})
+    # this assumes that the nodes of the first face on the reference element correspond to a face where
+    # s = constant, so that the `r` coordinates on this face can be used to construct a nodal basis. 
+    return reshape(basis.r[basis.Fmask[:, 1]], :, num_faces(basis.element_type))[:, 1]
+end
+
+function extract_face_nodes_1D(basis::DGMultiBasis{<:Any, <:Quad})
+    # this assumes that the nodes of the first face on the reference element correspond to a face where
+    # r = constant, so that the `s` coordinates on this face can be used to construct a nodal basis. 
+    # For quadrilateral elements, this is true since the faces are ordered r = ±1, s = ±1.
+    return reshape(basis.s[basis.Fmask[:, 1]], :, num_faces(basis.element_type))[:, 1]
+end
+
 function mesh_plotting_wireframe(u::ScalarData, mesh, equations, dg::DGMulti, cache;
                                  nvisnodes = 2 * nnodes(dg))
     @unpack md = mesh
@@ -229,9 +242,10 @@ function mesh_plotting_wireframe(u::ScalarData, mesh, equations, dg::DGMulti, ca
     # note that since ScalarPlotData2D is restricted to Tri and Quad types, this should always be true.
     num_face_points = size(Fmask, 1) ÷ num_faces(rd.element_type)
 
-    # this assumes that the nodes of the first face on the reference element correspond to a face where
-    # s = constant, so that the `r` coordinates on this face can be used to construct a nodal basis. 
-    face_nodes_1D = rd.r[reshape(rd.Fmask, :, num_faces(rd.element_type))[:, 1]]
+    # extract a set of interpolation nodes for the face nodes. For Polynomial approximations, 
+    # these are usually just (N+1) Gauss-Lobatto nodes. For SBP approximation types, these can 
+    # be more general, with length(face_nodes_1D) ≥ N+1 for certain configurations. 
+    face_nodes_1D = extract_face_nodes_1D(dg.basis)
 
     # Construct 1D plotting interpolation matrix `Vp1D` for a single face. 
     # Since num_face_points may be larger than N+1, this is doing a least squares projection

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -174,6 +174,19 @@ test_examples_2d = Dict("TreeMesh" => ("tree_2d_dgsem",
     end
 end
 
+# check that ScalarPlotData2D works for Quad elements
+@timed_testset "ScalarPlotData2D with DGMulti Quad elements" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "dgmulti_2d",
+                                 "elixir_euler_weakform.jl"),
+                        tspan=(0.0, 0.0),
+                        element_type=Quad(),
+                        cells_per_dimension=(2, 2))
+    semi = sol.prob.p
+    u = parent(sol.u[end])
+    scalar_data = StructArrays.component(u, 1)
+    @trixi_test_nowarn Plots.plot(ScalarPlotData2D(scalar_data, semi))
+end
+
 @timed_testset "PlotData1D, PlotDataSeries, PlotMesh" begin
     # Run Trixi.jl
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_dgsem",

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -631,6 +631,23 @@ end
     @trixi_test_nowarn Plots.plot((x, equations) -> x, semi)
 end
 
+@timed_testset "PlotData2D (DGMulti Tri SBP)" begin
+    # Regression test for plotting with SBP on triangular elements (reference triangulation of rstp).
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "dgmulti_2d",
+                                 "elixir_euler_weakform.jl"),
+                        cells_per_dimension=(4, 4),
+                        approximation_type=SBP(),
+                        surface_integral=SurfaceIntegralWeakForm(FluxHLL(min_max_speed_naive)),
+                        tspan=(0.0, 0.0))
+
+    pd = PlotData2D(sol)
+    @test pd isa Trixi.PlotData2DTriangulated
+    @test size(pd.t, 1) > 0
+
+    @trixi_test_nowarn Plots.plot(pd)
+    @trixi_test_nowarn Plots.plot(pd["rho"])
+end
+
 @timed_testset "1D plot recipes (StructuredMesh)" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "structured_1d_dgsem",
                                  "elixir_euler_source_terms.jl"),


### PR DESCRIPTION
Native Julia visualization currently assumes `Polynomial` approximation types, or `SBP` approximation types that are equivalent to a polynomial basis (e.g., DGSEM). 

This PR extends visualization to `SBP` triangles, where face interpolation operators are not naturally defined and the number of face nodes can be unrelated to the polynomial degree. 

This is spun off from #2872