### PR TITLE
Fix `vorticity` for `GradientVariablesEntropy()`

### DIFF
--- a/examples/tree_3d_dgsem/elixir_navierstokes_taylor_green_vortex.jl
+++ b/examples/tree_3d_dgsem/elixir_navierstokes_taylor_green_vortex.jl
@@ -9,7 +9,8 @@ mu = 6.25e-4 # equivalent to Re = 1600
 
 equations = CompressibleEulerEquations3D(1.4)
 equations_parabolic = CompressibleNavierStokesDiffusion3D(equations, mu = mu,
-                                                          Prandtl = prandtl_number())
+                                                          Prandtl = prandtl_number(),
+                                                          gradient_variables = GradientVariablesEntropy())
 
 """
     initial_condition_taylor_green_vortex(x, t, equations::CompressibleEulerEquations3D)

--- a/examples/tree_3d_dgsem/elixir_navierstokes_taylor_green_vortex.jl
+++ b/examples/tree_3d_dgsem/elixir_navierstokes_taylor_green_vortex.jl
@@ -10,7 +10,7 @@ mu = 6.25e-4 # equivalent to Re = 1600
 equations = CompressibleEulerEquations3D(1.4)
 equations_parabolic = CompressibleNavierStokesDiffusion3D(equations, mu = mu,
                                                           Prandtl = prandtl_number(),
-                                                          gradient_variables = GradientVariablesEntropy())
+                                                          gradient_variables = GradientVariablesPrimitive())
 
 """
     initial_condition_taylor_green_vortex(x, t, equations::CompressibleEulerEquations3D)

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -636,8 +636,7 @@ function analyze(quantity::typeof(enstrophy), du, u, t,
     # We do not apply `enstrophy` directly here because we might later have different `quantity`s
     # that we wish to integrate, which can share this routine.
     return analyze(quantity, du, u, t, mesh, equations, equations_parabolic, solver,
-                   cache,
-                   cache_parabolic)
+                   cache, cache_parabolic)
 end
 function analyze(quantity, du, u, t, mesh, equations, equations_parabolic, solver,
                  cache, cache_parabolic)
@@ -711,6 +710,5 @@ function analyze(quantity::AnalysisSurfaceIntegral{Variable},
     equations_parabolic = semi.equations_parabolic
     cache_parabolic = semi.cache_parabolic
     return analyze(quantity, du, u, t, mesh, equations, equations_parabolic, solver, cache,
-                   semi,
-                   cache_parabolic)
+                   semi, cache_parabolic)
 end

--- a/src/callbacks_step/analysis_surface_integral_2d.jl
+++ b/src/callbacks_step/analysis_surface_integral_2d.jl
@@ -135,6 +135,8 @@ end
 # This is required for drag and lift coefficients based on shear stress,
 # as well as for the non-integrated quantities such as
 # skin friction coefficient (to be added).
+# NOTE: This function is only valid for the compressible Navier-Stokes diffusion operator with
+# `gradient_variables = GradientVariablesPrimitive()`.
 function viscous_stress_tensor(u, normal_direction, equations_parabolic,
                                gradients_1, gradients_2)
     _, dv1dx, dv2dx, _ = convert_derivative_to_primitive(u, gradients_1,

--- a/src/equations/compressible_navier_stokes_2d.jl
+++ b/src/equations/compressible_navier_stokes_2d.jl
@@ -366,6 +366,18 @@ Computes the (node-wise) vorticity, defined in 2D as
     return dv2dx - dv1dy
 end
 
+@inline function vorticity(u, gradients,
+                           equations::CompressibleNavierStokesDiffusion2D{GradientVariablesEntropy})
+    # Need to convert to entropy variables first for `convert_derivative_to_primitive` to work correctly.
+    w = cons2entropy(u, equations)
+
+    # Ensure that we have velocity `gradients` by way of the `convert_gradient_variables` function.
+    _, _, dv2dx, _ = convert_derivative_to_primitive(w, gradients[1], equations)
+    _, dv1dy, _, _ = convert_derivative_to_primitive(w, gradients[2], equations)
+
+    return dv2dx - dv1dy
+end
+
 @inline function (boundary_condition::BoundaryConditionNavierStokesWall{<:NoSlip,
                                                                         <:Adiabatic})(flux_inner,
                                                                                       u_inner,

--- a/src/equations/compressible_navier_stokes_3d.jl
+++ b/src/equations/compressible_navier_stokes_3d.jl
@@ -402,6 +402,19 @@ Computes the (node-wise) vorticity, defined in 3D as
     return SVector(dv3dy - dv2dz, dv1dz - dv3dx, dv2dx - dv1dy)
 end
 
+@inline function vorticity(u, gradients,
+                           equations::CompressibleNavierStokesDiffusion3D{GradientVariablesEntropy})
+    # Need to convert to entropy variables first for `convert_derivative_to_primitive` to work correctly.
+    w = cons2entropy(u, equations)
+
+    # Ensure that we have velocity `gradients` by way of the `convert_gradient_variables` function.
+    _, _, dv2dx, dv3dx, _ = convert_derivative_to_primitive(w, gradients[1], equations)
+    _, dv1dy, _, dv3dy, _ = convert_derivative_to_primitive(w, gradients[2], equations)
+    _, dv1dz, dv2dz, _, _ = convert_derivative_to_primitive(w, gradients[3], equations)
+
+    return SVector(dv3dy - dv2dz, dv1dz - dv3dx, dv2dx - dv1dy)
+end
+
 @inline function (boundary_condition::BoundaryConditionNavierStokesWall{<:NoSlip,
                                                                         <:Adiabatic})(flux_inner,
                                                                                       u_inner,

--- a/test/test_parabolic_2d.jl
+++ b/test/test_parabolic_2d.jl
@@ -1219,6 +1219,29 @@ end
     @test_allocations(Trixi.rhs_parabolic!, semi, sol, 1000)
 end
 
+@trixi_testset "elixir_navierstokes_vortex_street.jl (GradientVariablesEntropy)" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
+                                 "elixir_navierstokes_vortex_street.jl"),
+                        gradient_variables=GradientVariablesEntropy(),
+                        l2=[
+                            0.01242797973116292,
+                            0.02892502142448505,
+                            0.0230829131666028,
+                            0.11323126134096527
+                        ],
+                        linf=[
+                            0.4544189333202735,
+                            1.269315313304855,
+                            0.7082067255956892,
+                            3.6951068269010645
+                        ],
+                        tspan=(0.0, 1.0))
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    @test_allocations(Trixi.rhs!, semi, sol, 1000)
+    @test_allocations(Trixi.rhs_parabolic!, semi, sol, 1000)
+end
+
 @trixi_testset "elixir_navierstokes_poiseuille_flow.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_poiseuille_flow.jl"),

--- a/test/test_parabolic_3d.jl
+++ b/test/test_parabolic_3d.jl
@@ -274,6 +274,51 @@ end
                             0.07483494924031157,
                             0.150181591534448
                         ])
+
+    # For testing other solution functionals
+    u_ode = copy(sol.u[end])
+    du_ode = zero(u_ode)
+    u = Trixi.wrap_array(u_ode, semi)
+    du = Trixi.wrap_array(du_ode, semi)
+
+    enstrophy_ = Trixi.analyze(enstrophy, du, u, tspan[end], semi)
+    @test isapprox(enstrophy_, 0.3773381126096875, atol = 1e-13)
+
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    @test_allocations(Trixi.rhs!, semi, sol, 1000)
+    @test_allocations(Trixi.rhs_parabolic!, semi, sol, 1000)
+end
+
+@trixi_testset "TreeMesh3D: elixir_navierstokes_taylor_green_vortex.jl (GradientVariablesEntropy)" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
+                                 "elixir_navierstokes_taylor_green_vortex.jl"),
+                        initial_refinement_level=2, tspan=(0.0, 0.25),
+                        gradient_variables=GradientVariablesEntropy(),
+                        l2=[
+                            0.000241730983009407,
+                            0.015684271361255244,
+                            0.015684271361255223,
+                            0.021991915828078544,
+                            0.028253810752858436
+                        ],
+                        linf=[
+                            0.0008410544911241491,
+                            0.04740230181893817,
+                            0.047402301818937974,
+                            0.07483473947005896,
+                            0.15017808325123383
+                        ])
+
+    # For testing other solution functionals
+    u_ode = copy(sol.u[end])
+    du_ode = zero(u_ode)
+    u = Trixi.wrap_array(u_ode, semi)
+    du = Trixi.wrap_array(du_ode, semi)
+
+    enstrophy_ = Trixi.analyze(enstrophy, du, u, tspan[end], semi)
+    @test isapprox(enstrophy_, 0.37731523193564825, atol = 1e-13)
+
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)


### PR DESCRIPTION
Closes https://github.com/trixi-framework/Trixi.jl/issues/2307 

See also the recent report https://github.com/trixi-framework/Trixi.jl/issues/2954 and an old issue https://github.com/trixi-framework/Trixi.jl/issues/1347

As noted already here

https://github.com/trixi-framework/Trixi.jl/blob/bc7858adeca5c70830e40878ded5c54f0ae34d7c/src/equations/compressible_navier_stokes_2d.jl#L284-L291

the current procedure for the entropy variables is really not efficient, as I now convert to entropy variables and then back again.
The same more or less happens also in the `flux` computation 

https://github.com/trixi-framework/Trixi.jl/blob/bc7858adeca5c70830e40878ded5c54f0ae34d7c/src/equations/compressible_navier_stokes_2d.jl#L147-L155

which gives rise to the `TODO`. Definitely something to improve in the future - for the moment, I would like to fix this for the users reporting the issue.