### PR TITLE
Avoid hang in Trixi.download when download fails

### DIFF
--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -357,12 +357,9 @@ function download(src_url, file_path)
             end
             try
                 Downloads.download(src_url, file_path; headers)
-            catch
-                # Otherwise the other processes will wait indefinitely at the barrier below.
-                if mpi_isparallel()
-                    MPI.Abort(mpi_comm(), 1)
-                end
-                rethrow()
+            catch exc
+                # Turn exception into something a warning, otherwise the other ranks will wait indefinitely at the barrier below.
+                @error "Failed to download $src_url to $file_path" exception = exc
             end
         end
     end

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -360,7 +360,7 @@ function download(src_url, file_path)
             catch
                 # Otherwise the other processes will wait indefinitely at the barrier below.
                 if mpi_isparallel()
-                    MPI.Barrier(mpi_comm())
+                    MPI.Abort(mpi_comm(), 1)
                 end
                 rethrow()
             end

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -358,7 +358,8 @@ function download(src_url, file_path)
             try
                 Downloads.download(src_url, file_path; headers)
             catch exc
-                # Turn exception into something a warning, otherwise the other ranks will wait indefinitely at the barrier below.
+                # Turn exception into something like a warning;
+                # otherwise the other ranks will wait indefinitely at the barrier below.
                 @error "Failed to download $src_url to $file_path" exception=exc
             end
         end

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -359,7 +359,7 @@ function download(src_url, file_path)
                 Downloads.download(src_url, file_path; headers)
             catch exc
                 # Turn exception into something a warning, otherwise the other ranks will wait indefinitely at the barrier below.
-                @error "Failed to download $src_url to $file_path" exception = exc
+                @error "Failed to download $src_url to $file_path" exception=exc
             end
         end
     end

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -355,7 +355,15 @@ function download(src_url, file_path)
             if token !== nothing
                 push!(headers, "authorization" => "Bearer $token")
             end
-            Downloads.download(src_url, file_path; headers)
+            try
+                Downloads.download(src_url, file_path; headers)
+            catch
+                # Otherwise the other processes will wait indefinitely at the barrier below.
+                if mpi_isparallel()
+                    MPI.Barrier(mpi_comm())
+                end
+                rethrow()
+            end
         end
     end
 


### PR DESCRIPTION
Locally I observed a hang between [t8code finalizers](https://github.com/DLR-AMR/T8code.jl/issues/117) and the `Trixi.download` barrier.

The t8code issue is a real problem, but simultaneously we are gurantueed to create a hang when in `Trixi.download`
if the download fails for any reason. The root rank will exit the function early and all other ranks will be stuck in the barrier.

We could use `MPI.Abort` here, but most users of `Trix.download` use `ispath` to check their inputs.


```
P4estMesh2D: elixir_advection_diffusion_amr_inverted_index.jl: Error During Test at /home/vchuravy/.julia/packages/TrixiTest/6CVoC/src/macros.jl:196
  Got exception outside of a @test
  LoadError: RequestError: HTTP/2 404 while requesting https://gist.githubusercontent.com/andrewwinters5000/3e7dac35eeadc24739ea29619f78b8d2/raw/ecc29e82be69c656217dc878821917850c51e41d/mesh_wobbly_channel.inp
  Stacktrace:
    [1] #3
      @ ~/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/share/julia/stdlib/v1.10/Downloads/src/Downloads.jl:271 [inlined]
    [2] open(f::Downloads.var"#3#4"{Nothing, Vector{Pair{String, String}}, Float64, Nothing, Bool, Nothing, Nothing, String}, args::String; kwargs::@Kwargs{write::Bool, lock::Bool})
      @ Base ./io.jl:396
    [3] open_nolock
      @ ~/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/share/julia/stdlib/v1.10/ArgTools/src/ArgTools.jl:35 [inlined]
    [4] arg_write(f::Function, arg::String)
      @ ArgTools ~/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/share/julia/stdlib/v1.10/ArgTools/src/ArgTools.jl:103
    [5] #download#2
      @ ~/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/share/julia/stdlib/v1.10/Downloads/src/Downloads.jl:258 [inlined]
    [6] download
      @ ~/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/share/julia/stdlib/v1.10/Downloads/src/Downloads.jl:247 [inlined]
    [7] download(src_url::String, file_path::String)
      @ Trixi ~/src/Trixi/src/auxiliary/auxiliary.jl:358
    [8] top-level scope
      @ ~/src/Trixi/examples/p4est_2d_dgsem/elixir_advection_diffusion_amr_inverted_index.jl:40
    [9] include
      @ ./Base.jl:496 [inlined]
   [10] trixi_include(mapexpr::typeof(identity), mod::Module, elixir::String; enable_assignment_validation::Bool, replace_assignments_recursive::Bool, kwargs::@Kwargs{tspan::Expr})
      @ TrixiBase ~/.julia/packages/TrixiBase/MGeKl/src/trixi_include.jl:79
   [11] trixi_include
      @ ~/.julia/packages/TrixiBase/MGeKl/src/trixi_include.jl:49 [inlined]
   [12] #trixi_include#6
      @ ~/.julia/packages/TrixiBase/MGeKl/src/trixi_include.jl:86 [inlined]
   [13] (::Main.TestExamplesMPI.TestExamplesMPIP4estMesh2DParabolic.TrixiTestModule.var"#2#4")()
      @ Main.TestExamplesMPI.TestExamplesMPIP4estMesh2DParabolic.TrixiTestModule ~/.julia/packages/TrixiTest/6CVoC/src/macros.jl:15
   [14] (::Base.RedirectStdStream)(thunk::Main.TestExamplesMPI.TestExamplesMPIP4estMesh2DParabolic.TrixiTestModule.var"#2#4", stream::IOStream)
      @ Base ./stream.jl:1434
   [15] #1
      @ ~/.julia/packages/TrixiTest/6CVoC/src/macros.jl:14 [inlined]
   [16] open(::Main.TestExamplesMPI.TestExamplesMPIP4estMesh2DParabolic.TrixiTestModule.var"#1#3", ::String, ::Vararg{String}; kwargs::@Kwargs{})
      @ Base ./io.jl:396
   [17] open(::Function, ::String, ::String)
      @ Base ./io.jl:393
   [18] macro expansion
      @ ~/.julia/packages/TrixiTest/6CVoC/src/macros.jl:13 [inlined]
   [19] macro expansion
      @ ~/src/Trixi/test/test_trixi.jl:35 [inlined]
   [20] macro expansion
      @ ~/src/Trixi/test/test_mpi_p4est_parabolic_2d.jl:128 [inlined]
   [21] macro expansion
      @ ~/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/share/julia/stdlib/v1.10/Test/src/Test.jl:1582 [inlined]
   [22] macro expansion
      @ ~/src/Trixi/test/test_mpi_p4est_parabolic_2d.jl:128 [inlined]
   [23] top-level scope
      @ ~/.julia/packages/TrixiTest/6CVoC/src/macros.jl:196
   [24] eval(m::Module, e::Any)
      @ Core ./boot.jl:385
   [25] macro expansion
      @ ~/.julia/packages/TrixiTest/6CVoC/src/macros.jl:172 [inlined]
   [26] macro expansion
      @ ~/src/Trixi/test/test_mpi_p4est_parabolic_2d.jl:126 [inlined]
   [27] macro expansion
      @ ~/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/share/julia/stdlib/v1.10/Test/src/Test.jl:1582 [inlined]
   [28] top-level scope
      @ ~/src/Trixi/test/test_mpi_p4est_parabolic_2d.jl:11
   [29] include(mod::Module, _path::String)
      @ Base ./Base.jl:495
   [30] include(x::String)
      @ Main.TestExamplesMPI ~/src/Trixi/test/test_mpi.jl:1
   [31] macro expansion
      @ ~/src/Trixi/test/test_mpi.jl:29 [inlined]
   [32] macro expansion
      @ ~/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/share/julia/stdlib/v1.10/Test/src/Test.jl:1582 [inlined]
   [33] top-level scope
      @ ~/src/Trixi/test/test_mpi.jl:21
  in expression starting at
  ```
