### PR TITLE
Use non-deprecated form of mpiexec

### DIFF
--- a/docs/src/parallelization.md
+++ b/docs/src/parallelization.md
@@ -143,9 +143,7 @@ To start Trixi.jl in parallel with MPI, there are three options:
    ```julia
    julia> using MPI
 
-   julia> mpiexec() do cmd
-            run(`$cmd -n 3 $(Base.julia_cmd()) --threads=1 --project=@. -e 'using Trixi; trixi_include(default_example())'`)
-          end
+   julia> run(`$(mpiexec()) -n 3 $(Base.julia_cmd()) --threads=1 --project=@. -e 'using Trixi; trixi_include(default_example())'`)
    ```
    The parameter `-n 3` specifies that Trixi.jl should run with three processes (or
    *ranks* in MPI parlance) and should be adapted to your available

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,10 +22,7 @@ const TRIXI_NTHREADS = clamp(Sys.CPU_THREADS, 2, 3)
         @test true
 
         # We provide a `--heap-size-hint` to avoid/reduce out-of-memory errors during CI testing
-        mpiexec() do cmd
-            run(`$cmd -n $TRIXI_MPI_NPROCS $(Base.julia_cmd()) --threads=1 --check-bounds=yes --heap-size-hint=0.5G $(joinpath(@__DIR__, "test_mpi.jl"))`)
-            return nothing
-        end
+        run(`$(mpiexec()) -n $TRIXI_MPI_NPROCS $(Base.julia_cmd()) --threads=1 --check-bounds=yes --heap-size-hint=0.5G $(joinpath(@__DIR__, "test_mpi.jl"))`)
     end
 
     @time if TRIXI_TEST == "all" || TRIXI_TEST == "threaded" ||


### PR DESCRIPTION
JLLs have depreacted the `mpiexec ... do` form for a while and it is recommended to use direct interpolation.
