### PR TITLE
Replace deprecated `destats` by `stats`

### DIFF
--- a/docs/literate/src/files/adding_new_parabolic_terms.jl
+++ b/docs/literate/src/files/adding_new_parabolic_terms.jl
@@ -170,7 +170,7 @@ callbacks = CallbackSet(SummaryCallback())
 time_int_tol = 1.0e-6
 sol = solve(ode, RDPK3SpFSAL49(); abstol = time_int_tol, reltol = time_int_tol,
             ode_default_options()..., callback = callbacks);
-println("Number of timesteps: ", sol.destats.naccept)
+println("Number of timesteps: ", sol.stats.naccept)
 
 using Plots
 plot(sol)
@@ -179,9 +179,9 @@ plot(sol)
 
 # In the example above, we used an adaptive timestep based on truncation error estimates.
 # Alternatively, we can also use a CFL-based timestep control, cf. [`StepsizeCallback`](@ref).
-# To be able to do so, we need to define [`max_diffusivity`](@ref) and 
+# To be able to do so, we need to define [`max_diffusivity`](@ref) and
 # [`have_constant_diffusivity`](@ref) for the new parabolic terms.
-# In Trixi.jl, currently only the standard Laplace Diffusion and Compressible Navier-Stokes-Fourier 
+# In Trixi.jl, currently only the standard Laplace Diffusion and Compressible Navier-Stokes-Fourier
 # parabolic terms are implemented.
 # Since these equations have **isotropic** diffusivity, i.e., direction-independent coefficients,
 # [`max_diffusivity`](@ref) is expected to return a scalar value.
@@ -198,7 +198,7 @@ lambda_max() = maximum(abs.(eigvals(diffusivity)))
     return Trixi.True()
 end
 
-# Return the estimated maximum diffusivity for CFL calculations based on 
+# Return the estimated maximum diffusivity for CFL calculations based on
 # the spectral radius of the diffusivity matrix computed above
 @inline function Trixi.max_diffusivity(equations_parabolic::ConstantAnisotropicDiffusion2D)
     return lambda_max()
@@ -216,7 +216,7 @@ callbacks = CallbackSet(SummaryCallback(), stepsize_callback);
 sol = solve(ode, RDPK3SpFSAL49();
             adaptive = false, dt = stepsize_callback(ode),
             ode_default_options()..., callback = callbacks);
-println("Number of timesteps: ", sol.destats.naccept)
+println("Number of timesteps: ", sol.stats.naccept)
 
 plot(sol)
 


### PR DESCRIPTION
Split out of #2910. Will be necessary to update to the new SciML package versions. Was probably missed in #1372.