### PR TITLE
Add tests for serial and static backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           - threaded
           - kernelabstractions
           - serial
-          - threads
+          - base_threads
         include:
           - version: '1.11'
             os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
           - mpi
           - threaded
           - kernelabstractions
+          - serial
+          - threads
         include:
           - version: '1.11'
             os: ubuntu-latest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,7 +163,7 @@ const TRIXI_NTHREADS = clamp(Sys.CPU_THREADS, 2, 3)
         previous_backend = Trixi._PREFERENCE_THREADING
         Trixi.set_threading_backend!(:static)
         try
-            run(`$(Base.julia_cmd()) --threads=$TRIXI_NTHREADS --check-bounds=yes $(abspath("test_threads.jl"))`)
+            run(`$(Base.julia_cmd()) --threads=$TRIXI_NTHREADS --check-bounds=yes $(abspath("test_base_threads.jl"))`)
         finally
             Trixi.set_threading_backend!(Symbol(previous_backend))
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -159,7 +159,7 @@ const TRIXI_NTHREADS = clamp(Sys.CPU_THREADS, 2, 3)
         end
     end
 
-    @time if TRIXI_TEST == "all" || TRIXI_TEST == "threads"
+    @time if TRIXI_TEST == "all" || TRIXI_TEST == "base_threads"
         previous_backend = Trixi._PREFERENCE_THREADING
         Trixi.set_threading_backend!(:static)
         try

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,4 +148,24 @@ const TRIXI_NTHREADS = clamp(Sys.CPU_THREADS, 2, 3)
             Trixi.set_threading_backend!(Symbol(previous_backend))
         end
     end
+
+    @time if TRIXI_TEST == "all" || TRIXI_TEST == "serial"
+        previous_backend = Trixi._PREFERENCE_THREADING
+        Trixi.set_threading_backend!(:serial)
+        try
+            run(`$(Base.julia_cmd()) --threads=$TRIXI_NTHREADS --check-bounds=yes $(abspath("test_serial.jl"))`)
+        finally
+            Trixi.set_threading_backend!(Symbol(previous_backend))
+        end
+    end
+
+    @time if TRIXI_TEST == "all" || TRIXI_TEST == "threads"
+        previous_backend = Trixi._PREFERENCE_THREADING
+        Trixi.set_threading_backend!(:static)
+        try
+            run(`$(Base.julia_cmd()) --threads=$TRIXI_NTHREADS --check-bounds=yes $(abspath("test_threads.jl"))`)
+        finally
+            Trixi.set_threading_backend!(Symbol(previous_backend))
+        end
+    end
 end

--- a/test/test_base_threads.jl
+++ b/test/test_base_threads.jl
@@ -1,4 +1,4 @@
-module TestExamplesThreads
+module TestExamplesBaseThreads
 
 using Test
 using Trixi
@@ -51,7 +51,6 @@ end
     # Threads.@threads :static has more overhead than Polyester's @batch
     @test_allocations(Trixi.rhs!, semi, sol, 50_000)
 end
-
 end # testset
 
 # Clean up afterwards: delete Trixi.jl output directory

--- a/test/test_serial.jl
+++ b/test/test_serial.jl
@@ -1,0 +1,58 @@
+module TestExamplesSerial
+
+using Test
+using Trixi
+
+include("test_trixi.jl")
+
+EXAMPLES_DIR = examples_dir()
+
+# Start with a clean environment: remove Trixi.jl output directory if it exists
+outdir = "out"
+Trixi.mpi_isroot() && isdir(outdir) && rm(outdir, recursive = true)
+Trixi.MPI.Barrier(Trixi.mpi_comm())
+
+@testset "basic" begin
+    @test Trixi._PREFERENCE_THREADING == :serial
+end
+
+@testset "Serial 2D" begin
+#! format: noindent
+
+@trixi_testset "elixir_advection_amr_refine_twice.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_2d_dgsem",
+                                 "elixir_advection_amr_refine_twice.jl"),
+                        l2=[0.00020547512522578292],
+                        linf=[0.007831753383083506])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    @test_allocations(Trixi.rhs!, semi, sol, 5000)
+end
+
+@trixi_testset "elixir_euler_source_terms_nonperiodic.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_2d_dgsem",
+                                 "elixir_euler_source_terms_nonperiodic.jl"),
+                        l2=[
+                            2.259440511766445e-6,
+                            2.318888155713922e-6,
+                            2.3188881557894307e-6,
+                            6.3327863238858925e-6
+                        ],
+                        linf=[
+                            1.498738264560373e-5,
+                            1.9182011928187137e-5,
+                            1.918201192685487e-5,
+                            6.0526717141407005e-5
+                        ])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    @test_allocations(Trixi.rhs!, semi, sol, 5000)
+end
+
+end # testset
+
+# Clean up afterwards: delete Trixi.jl output directory
+Trixi.mpi_isroot() && isdir(outdir) && @test_nowarn rm(outdir, recursive = true)
+Trixi.MPI.Barrier(Trixi.mpi_comm())
+
+end # module

--- a/test/test_threads.jl
+++ b/test/test_threads.jl
@@ -1,0 +1,59 @@
+module TestExamplesThreads
+
+using Test
+using Trixi
+
+include("test_trixi.jl")
+
+EXAMPLES_DIR = examples_dir()
+
+# Start with a clean environment: remove Trixi.jl output directory if it exists
+outdir = "out"
+Trixi.mpi_isroot() && isdir(outdir) && rm(outdir, recursive = true)
+Trixi.MPI.Barrier(Trixi.mpi_comm())
+
+@testset "basic" begin
+    @test Trixi._PREFERENCE_THREADING == :static
+end
+
+@testset "Threads.@threads 2D" begin
+#! format: noindent
+
+@trixi_testset "elixir_advection_amr_refine_twice.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_2d_dgsem",
+                                 "elixir_advection_amr_refine_twice.jl"),
+                        l2=[0.00020547512522578292],
+                        linf=[0.007831753383083506])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    @test_allocations(Trixi.rhs!, semi, sol, 5000)
+end
+
+@trixi_testset "elixir_euler_source_terms_nonperiodic.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_2d_dgsem",
+                                 "elixir_euler_source_terms_nonperiodic.jl"),
+                        l2=[
+                            2.259440511766445e-6,
+                            2.318888155713922e-6,
+                            2.3188881557894307e-6,
+                            6.3327863238858925e-6
+                        ],
+                        linf=[
+                            1.498738264560373e-5,
+                            1.9182011928187137e-5,
+                            1.918201192685487e-5,
+                            6.0526717141407005e-5
+                        ],
+                        rtol=0.001)
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    @test_allocations(Trixi.rhs!, semi, sol, 5000)
+end
+
+end # testset
+
+# Clean up afterwards: delete Trixi.jl output directory
+Trixi.mpi_isroot() && isdir(outdir) && @test_nowarn rm(outdir, recursive = true)
+Trixi.MPI.Barrier(Trixi.mpi_comm())
+
+end # module

--- a/test/test_threads.jl
+++ b/test/test_threads.jl
@@ -26,7 +26,8 @@ end
                         linf=[0.007831753383083506])
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
-    @test_allocations(Trixi.rhs!, semi, sol, 5000)
+    # Threads.@threads :static has more overhead than Polyester's @batch
+    @test_allocations(Trixi.rhs!, semi, sol, 30_000)
 end
 
 @trixi_testset "elixir_euler_source_terms_nonperiodic.jl" begin
@@ -47,7 +48,8 @@ end
                         rtol=0.001)
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
-    @test_allocations(Trixi.rhs!, semi, sol, 5000)
+    # Threads.@threads :static has more overhead than Polyester's @batch
+    @test_allocations(Trixi.rhs!, semi, sol, 50_000)
 end
 
 end # testset


### PR DESCRIPTION
Given that we are adding some more backend specific behavior (as an example #3003),
we should have some smoke tests for the different backends


- **Add serial and Threads.@threads backend tests**
- **Add serial and threads CI jobs**
- **Fix test_serial and test_threads: mkpath outdir, higher alloc limits for static**
