### PR TITLE
Add support for multiple source terms

### DIFF
--- a/examples/tree_1d_dgsem/elixir_euler_source_terms_tuple.jl
+++ b/examples/tree_1d_dgsem/elixir_euler_source_terms_tuple.jl
@@ -1,0 +1,87 @@
+using OrdinaryDiffEqLowStorageRK
+using Trixi
+
+###############################################################################
+# semidiscretization of the compressible Euler equations to test convergence with a source term 
+# provided as a tuple.
+
+equations = CompressibleEulerEquations1D(1.4)
+
+initial_condition = initial_condition_convergence_test
+
+# Note that the expected EOC of 5 is not reached with this flux.
+# Using `flux_hll` instead yields the expected EOC.
+
+# Up to version 0.13.0, `max_abs_speed_naive` was used as the default wave speed estimate of
+# `const flux_lax_friedrichs = FluxLaxFriedrichs(), i.e., `FluxLaxFriedrichs(max_abs_speed = max_abs_speed_naive)`.
+# In the `StepsizeCallback`, though, the less diffusive `max_abs_speeds` is employed which is consistent with `max_abs_speed`.
+# Thus, we exchanged in PR#2458 the default wave speed used in the LLF flux to `max_abs_speed`.
+# To ensure that every example still runs we specify explicitly `FluxLaxFriedrichs(max_abs_speed_naive)`.
+# We remark, however, that the now default `max_abs_speed` is in general recommended due to compliance with the
+# `StepsizeCallback` (CFL-Condition) and less diffusion.
+solver = DGSEM(polydeg = 4, surface_flux = FluxLaxFriedrichs(max_abs_speed_naive))
+
+coordinates_min = 0.0
+coordinates_max = 2.0
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 4,
+                n_cells_max = 10_000, periodicity = true)
+
+# For testing purposes, the MMS source term is split into three separate source terms, 
+# that are passed as a tuple to the semidiscretization.
+function source_terms_convergence_test_1(u, x, t,
+                                         equations::CompressibleEulerEquations1D)
+    return SVector(source_terms_convergence_test(u, x, t, equations)[1], 0, 0)
+end
+
+function source_terms_convergence_test_2(u, x, t,
+                                         equations::CompressibleEulerEquations1D)
+    return SVector(0, source_terms_convergence_test(u, x, t, equations)[2], 0)
+end
+
+function source_terms_convergence_test_3(u, x, t,
+                                         equations::CompressibleEulerEquations1D)
+    return SVector(0, 0, source_terms_convergence_test(u, x, t, equations)[3])
+end
+
+source_terms_convergence_test_tuple = (source_terms_convergence_test_1,
+                                       source_terms_convergence_test_2,
+                                       source_terms_convergence_test_3)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver;
+                                    source_terms = source_terms_convergence_test_tuple,
+                                    boundary_conditions = boundary_condition_periodic)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 2.0)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval,
+                                     extra_analysis_errors = (:l2_error_primitive,
+                                                              :linf_error_primitive))
+
+alive_callback = AliveCallback(analysis_interval = analysis_interval)
+
+save_solution = SaveSolutionCallback(interval = 100,
+                                     save_initial_solution = true,
+                                     save_final_solution = true,
+                                     solution_variables = cons2prim)
+
+stepsize_callback = StepsizeCallback(cfl = 0.8)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        save_solution,
+                        stepsize_callback)
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition = false);
+            dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            ode_default_options()..., callback = callbacks);

--- a/src/semidiscretization/semidiscretization_hyperbolic.jl
+++ b/src/semidiscretization/semidiscretization_hyperbolic.jl
@@ -480,7 +480,14 @@ function Base.show(io::IO, ::MIME"text/plain", semi::SemidiscretizationHyperboli
 
         print_boundary_conditions(io, semi)
 
-        summary_line(io, "source terms", semi.source_terms)
+        if semi.source_terms isa Tuple
+            summary_line(io, "#source_terms", length(semi.source_terms))
+            for (i, source_term) in enumerate(semi.source_terms)
+                summary_line(increment_indent(io), "source_term $i", source_term)
+            end
+        else
+            summary_line(io, "source terms", semi.source_terms)
+        end
         summary_line(io, "solver", semi.solver |> typeof |> nameof)
         summary_line(io, "total #DOFs per field", ndofsglobal(semi))
         summary_footer(io)

--- a/src/semidiscretization/semidiscretization_hyperbolic_parabolic.jl
+++ b/src/semidiscretization/semidiscretization_hyperbolic_parabolic.jl
@@ -193,7 +193,14 @@ function Base.show(io::IO, ::MIME"text/plain",
 
         # print_boundary_conditions(io, semi)
 
-        summary_line(io, "source terms", semi.source_terms)
+        if semi.source_terms isa Tuple
+            summary_line(io, "#source_terms", length(semi.source_terms))
+            for (i, source_term) in enumerate(semi.source_terms)
+                summary_line(increment_indent(io), "source_term $i", source_term)
+            end
+        else
+            summary_line(io, "source terms", semi.source_terms)
+        end
         summary_line(io, "source terms parabolic", semi.source_terms_parabolic)
         summary_line(io, "solver", semi.solver |> typeof |> nameof)
         summary_line(io, "parabolic solver", semi.solver_parabolic |> typeof |> nameof)

--- a/src/solvers/dgmulti/dg.jl
+++ b/src/solvers/dgmulti/dg.jl
@@ -785,6 +785,24 @@ function calc_sources!(du, u, t, source_terms,
     return nothing
 end
 
+# Iterate over a tuple with multiple source terms in a type-stable way using "lispy tuple programming",
+# similar to https://stackoverflow.com/a/55849398
+function calc_sources!(du, u, t, source_terms::NTuple{N, Any},
+                       mesh, equations, dg::Union{DGMulti, DGMultiFluxDiffSBP},
+                       cache) where {N}
+    source_term = first(source_terms)
+    remaining_source_terms = Base.tail(source_terms)
+
+    calc_sources!(du, u, t, source_term, mesh, equations, dg, cache)
+    calc_sources!(du, u, t, remaining_source_terms, mesh, equations, dg, cache)
+end
+
+# Terminate the type-stable iteration over tuples
+function calc_sources!(du, u, t, source_terms::Tuple{},
+                       mesh, equations, dg::Union{DGMulti, DGMultiFluxDiffSBP}, cache)
+    return nothing
+end
+
 function rhs!(du, u, t, mesh, equations,
               boundary_conditions::BC, source_terms::Source,
               dg::DGMulti, cache) where {BC, Source}

--- a/src/solvers/dgsem_tree/dg_1d.jl
+++ b/src/solvers/dgsem_tree/dg_1d.jl
@@ -786,4 +786,21 @@ function calc_sources!(du, u, t, source_terms,
 
     return nothing
 end
+
+# Iterate over a tuple with multiple source terms in a type-stable way using "lispy tuple programming",
+# similar to https://stackoverflow.com/a/55849398
+function calc_sources!(du, u, t, source_terms::NTuple{N, Any},
+                       equations::AbstractEquations{1}, dg::DG, cache) where {N}
+    source_term = first(source_terms)
+    remaining_source_terms = Base.tail(source_terms)
+
+    calc_sources!(du, u, t, source_term, equations, dg, cache)
+    calc_sources!(du, u, t, remaining_source_terms, equations, dg, cache)
+end
+
+# Terminate the type-stable iteration over tuples
+function calc_sources!(du, u, t, source_terms::Tuple{},
+                       equations::AbstractEquations{1}, dg::DG, cache)
+    return nothing
+end
 end # @muladd

--- a/src/solvers/dgsem_tree/dg_2d.jl
+++ b/src/solvers/dgsem_tree/dg_2d.jl
@@ -1380,4 +1380,21 @@ function calc_sources!(du, u, t, source_terms,
 
     return nothing
 end
+
+# Iterate over a tuple with multiple source terms in a type-stable way using "lispy tuple programming",
+# similar to https://stackoverflow.com/a/55849398
+function calc_sources!(du, u, t, source_terms::NTuple{N, Any},
+                       equations::AbstractEquations{2}, dg::DG, cache) where {N}
+    source_term = first(source_terms)
+    remaining_source_terms = Base.tail(source_terms)
+
+    calc_sources!(du, u, t, source_term, equations, dg, cache)
+    calc_sources!(du, u, t, remaining_source_terms, equations, dg, cache)
+end
+
+# Terminate the type-stable iteration over tuples
+function calc_sources!(du, u, t, source_terms::Tuple{},
+                       equations::AbstractEquations{2}, dg::DG, cache)
+    return nothing
+end
 end # @muladd

--- a/src/solvers/dgsem_tree/dg_3d.jl
+++ b/src/solvers/dgsem_tree/dg_3d.jl
@@ -1443,4 +1443,21 @@ function calc_sources!(du, u, t, source_terms,
 
     return nothing
 end
+
+# Iterate over a tuple with multiple source terms in a type-stable way using "lispy tuple programming",
+# similar to https://stackoverflow.com/a/55849398
+function calc_sources!(du, u, t, source_terms::NTuple{N, Any},
+                       equations::AbstractEquations{3}, dg::DG, cache) where {N}
+    source_term = first(source_terms)
+    remaining_source_terms = Base.tail(source_terms)
+
+    calc_sources!(du, u, t, source_term, equations, dg, cache)
+    calc_sources!(du, u, t, remaining_source_terms, equations, dg, cache)
+end
+
+# Terminate the type-stable iteration over tuples
+function calc_sources!(du, u, t, source_terms::Tuple{},
+                       equations::AbstractEquations{3}, dg::DG, cache)
+    return nothing
+end
 end # @muladd

--- a/test/test_parabolic_1d.jl
+++ b/test/test_parabolic_1d.jl
@@ -459,6 +459,26 @@ end
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 
+# Same test as above, but the source term is passed as a tuple
+@trixi_testset "DGMulti: elixir_navierstokes_convergence_periodic.jl (source tuple)" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "dgmulti_1d",
+                                 "elixir_navierstokes_convergence_periodic.jl"),
+                        l2=[
+                            3.7943372542675425e-5,
+                            4.078766566292102e-5,
+                            0.00024524952267207235
+                        ],
+                        linf=[
+                            0.00010969455084941515,
+                            9.183113730193426e-5,
+                            0.0005450421812014383
+                        ],
+                        source_terms=(source_terms_navier_stokes_convergence_test,))
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    @test_allocations(Trixi.rhs!, semi, sol, 1000)
+end
+
 @trixi_testset "DGMulti: elixir_navierstokes_convergence_periodic.jl (Diff. CFL)" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "dgmulti_1d",
                                  "elixir_navierstokes_convergence_periodic.jl"),

--- a/test/test_tree_1d_euler.jl
+++ b/test/test_tree_1d_euler.jl
@@ -38,6 +38,22 @@ EXAMPLES_DIR = joinpath(examples_dir(), "tree_1d_dgsem")
     @test point_data ≈ ref_data
 end
 
+@trixi_testset "elixir_euler_source_terms_tuple.jl" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms_tuple.jl"),
+                        l2=[
+                            2.2527950196212703e-8,
+                            1.8187357193835156e-8,
+                            7.705669939973104e-8],
+                        linf=[
+                            1.6205433861493646e-7,
+                            1.465427772462391e-7,
+                            5.372255111879554e-7
+                        ])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    @test_allocations(Trixi.rhs!, semi, sol, 1000)
+end
+
 @trixi_testset "elixir_euler_convergence_pure_fv.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_convergence_pure_fv.jl"),
                         l2=[

--- a/test/test_tree_2d_euler.jl
+++ b/test/test_tree_2d_euler.jl
@@ -29,6 +29,27 @@ EXAMPLES_DIR = joinpath(examples_dir(), "tree_2d_dgsem")
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 
+# Same test as above, but the source term is passed as a tuple
+@trixi_testset "elixir_euler_source_terms.jl (source tuple)" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms.jl"),
+                        l2=[
+                            9.321181253186009e-7,
+                            1.4181210743438511e-6,
+                            1.4181210743487851e-6,
+                            4.824553091276693e-6
+                        ],
+                        linf=[
+                            9.577246529612893e-6,
+                            1.1707525976012434e-5,
+                            1.1707525976456523e-5,
+                            4.8869615580926506e-5
+                        ],
+                        source_terms=(source_terms_convergence_test,))
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    @test_allocations(Trixi.rhs!, semi, sol, 1000)
+end
+
 @trixi_testset "elixir_euler_convergence_pure_fv.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_convergence_pure_fv.jl"),
                         l2=[

--- a/test/test_tree_3d_euler.jl
+++ b/test/test_tree_3d_euler.jl
@@ -63,6 +63,29 @@ EXAMPLES_DIR = joinpath(examples_dir(), "tree_3d_dgsem")
     @test point_data ≈ ref_data
 end
 
+# Same test as above, but the source term is passed as a tuple
+@trixi_testset "elixir_euler_source_terms.jl (source tuple)" begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_source_terms.jl"),
+                        l2=[
+                            0.010385936842224346,
+                            0.009776048833895767,
+                            0.00977604883389591,
+                            0.009776048833895733,
+                            0.01506687097416608
+                        ],
+                        linf=[
+                            0.03285848350791731,
+                            0.0321792316408982,
+                            0.032179231640894645,
+                            0.032179231640895534,
+                            0.0655408023333299
+                        ],
+                        source_terms=(source_terms_convergence_test,))
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    @test_allocations(Trixi.rhs!, semi, sol, 1000)
+end
+
 @trixi_testset "elixir_euler_convergence_pure_fv.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_convergence_pure_fv.jl"),
                         l2=[


### PR DESCRIPTION
This PR adds the option to include multiple source terms in a semidiscretization. This can be done by passing them as a tuple:

```source_terms = (source_term_1, source_term_2, ..., source_term_n)```