### PR TITLE
move `MeshT = typeof(mesh)` out of at-threaded loops

### DIFF
--- a/src/solvers/dgsem/calc_volume_integral.jl
+++ b/src/solvers/dgsem/calc_volume_integral.jl
@@ -180,8 +180,9 @@ end
 function calc_volume_integral!(backend::Nothing, du, u, mesh,
                                have_nonconservative_terms, equations,
                                volume_integral, dg::DGSEM, cache)
+    MeshT = typeof(mesh)
     @threaded for element in eachelement(dg, cache)
-        volume_integral_kernel!(du, u, element, typeof(mesh),
+        volume_integral_kernel!(du, u, element, MeshT,
                                 have_nonconservative_terms, equations,
                                 volume_integral, dg, cache)
     end
@@ -223,17 +224,18 @@ end
     # For `Float32`, this gives 1.1920929f-5
     RealT = eltype(alpha)
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
+    MeshT = typeof(mesh)
     @threaded for element in eachelement(dg, cache)
         alpha_element = alpha[element]
         # Clip blending factor for values close to zero (-> default volume integral)
         default_volume_integral = isapprox(alpha_element, 0, atol = atol)
 
         if default_volume_integral
-            volume_integral_kernel!(du, u, element, typeof(mesh),
+            volume_integral_kernel!(du, u, element, MeshT,
                                     have_nonconservative_terms, equations,
                                     volume_integral_default, dg, cache)
         else
-            volume_integral_kernel!(du, u, element, typeof(mesh),
+            volume_integral_kernel!(du, u, element, MeshT,
                                     have_nonconservative_terms, equations,
                                     volume_integral_stabilized, dg, cache)
         end
@@ -257,24 +259,25 @@ function calc_volume_integral!(backend::Nothing, du, u, mesh,
     # For `Float32`, this gives 1.1920929f-5
     RealT = eltype(alpha)
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
+    MeshT = typeof(mesh)
     @threaded for element in eachelement(dg, cache)
         alpha_element = alpha[element]
         # Clip blending factor for values close to zero (-> pure DG)
         dg_only = isapprox(alpha_element, 0, atol = atol)
 
         if dg_only
-            volume_integral_kernel!(du, u, element, typeof(mesh),
+            volume_integral_kernel!(du, u, element, MeshT,
                                     have_nonconservative_terms, equations,
                                     volume_integral_default, dg, cache)
         else
             # Calculate DG volume integral contribution
-            volume_integral_kernel!(du, u, element, typeof(mesh),
+            volume_integral_kernel!(du, u, element, MeshT,
                                     have_nonconservative_terms, equations,
                                     volume_integral_blend_high_order, dg, cache,
                                     1 - alpha_element)
 
             # Calculate FV volume integral contribution
-            volume_integral_kernel!(du, u, element, typeof(mesh),
+            volume_integral_kernel!(du, u, element, MeshT,
                                     have_nonconservative_terms, equations,
                                     volume_integral_blend_low_order, dg, cache,
                                     alpha_element)
@@ -301,32 +304,33 @@ function calc_volume_integral!(backend::Nothing, du, u, mesh,
                                                                                                dg,
                                                                                                cache)
 
+    MeshT = typeof(mesh)
     @threaded for element in eachelement(dg, cache)
-        # run default volume integral 
-        volume_integral_kernel!(du, u, element, typeof(mesh),
+        # run default volume integral
+        volume_integral_kernel!(du, u, element, MeshT,
                                 have_nonconservative_terms, equations,
                                 volume_integral_default, dg, cache)
 
-        # Check entropy production of "high order" volume integral. 
-        # 
+        # Check entropy production of "high order" volume integral.
+        #
         # Note that, for `TreeMesh`, both volume and surface integrals are calculated
-        # on the reference element. For other mesh types, because the volume integral 
-        # incorporates the scaled contravariant vectors, the surface integral should 
+        # on the reference element. For other mesh types, because the volume integral
+        # incorporates the scaled contravariant vectors, the surface integral should
         # be calculated on the physical element instead.
         #
         # Minus sign because of the flipped sign of the volume term in the DG RHS.
         # No scaling by inverse Jacobian here, as there is no Jacobian multiplication
         # in `integrate_reference_element`.
         dS_volume_integral = -entropy_change_reference_element(du, u, element,
-                                                               typeof(mesh), equations,
+                                                               MeshT, equations,
                                                                dg, cache)
 
         # Compute true entropy change given by surface integral of the entropy potential
         dS_true = surface_integral_reference_element(entropy_potential, u, element,
-                                                     typeof(mesh), equations, dg, cache)
+                                                     MeshT, equations, dg, cache)
 
-        # This quantity should be ≤ 0 for an entropy stable volume integral, and 
-        # exactly zero for an entropy conservative volume integral. 
+        # This quantity should be ≤ 0 for an entropy stable volume integral, and
+        # exactly zero for an entropy conservative volume integral.
         entropy_residual = dS_volume_integral - dS_true
 
         if entropy_residual > 0
@@ -334,19 +338,19 @@ function calc_volume_integral!(backend::Nothing, du, u, mesh,
             du_FD_element = du_element_threaded[Threads.threadid()]
             @views du_FD_element .= du[.., element]
 
-            # Reset pure flux-differencing volume integral 
+            # Reset pure flux-differencing volume integral
             # Note that this assumes that the volume terms are computed first,
             # before any surface terms are added.
             du[.., element] .= zero(eltype(du))
 
             # Calculate entropy stable volume integral contribution
-            volume_integral_kernel!(du, u, element, typeof(mesh),
+            volume_integral_kernel!(du, u, element, MeshT,
                                     have_nonconservative_terms, equations,
                                     volume_integral_stabilized, dg, cache)
 
             dS_volume_integral_stabilized = -entropy_change_reference_element(du, u,
                                                                               element,
-                                                                              typeof(mesh),
+                                                                              MeshT,
                                                                               equations,
                                                                               dg,
                                                                               cache)

--- a/src/solvers/dgsem_p4est/dg_2d.jl
+++ b/src/solvers/dgsem_p4est/dg_2d.jl
@@ -75,10 +75,11 @@ function prolong2interfaces!(backend::Nothing, cache, u,
     @unpack interfaces = cache
     @unpack neighbor_ids, node_indices = cache.interfaces
     index_range = eachnode(dg)
+    MeshT = typeof(mesh)
 
     @threaded for interface in eachinterface(dg, cache)
         prolong2interfaces_per_interface!(interfaces.u, u, interface,
-                                          typeof(mesh), equations,
+                                          MeshT, equations,
                                           neighbor_ids, node_indices, index_range)
     end
     return nothing
@@ -141,10 +142,11 @@ function prolong2interfaces!(backend::Nothing, cache, u,
     @unpack neighbor_ids, node_indices = cache.interfaces
     @unpack boundary_interpolation = dg.basis
     index_range = eachnode(dg)
+    MeshT = typeof(mesh)
 
     @threaded for interface in eachinterface(dg, cache)
         prolong2interfaces_per_interface!(interfaces.u, u, interface,
-                                          typeof(mesh), equations,
+                                          MeshT, equations,
                                           neighbor_ids, node_indices, index_range,
                                           boundary_interpolation)
     end
@@ -269,11 +271,13 @@ function calc_interface_flux!(backend::Nothing, surface_flux_values,
     # element data.
     @unpack contravariant_vectors = cache.elements
     index_range = eachnode(dg)
+    MeshT = typeof(mesh)
+    SolverT = typeof(dg)
 
     @threaded for interface in eachinterface(dg, cache)
-        calc_interface_flux_per_interface!(surface_flux_values, typeof(mesh),
+        calc_interface_flux_per_interface!(surface_flux_values, MeshT,
                                            have_nonconservative_terms,
-                                           equations, surface_integral, typeof(dg),
+                                           equations, surface_integral, SolverT,
                                            cache.interfaces.u, interface,
                                            neighbor_ids, node_indices,
                                            contravariant_vectors, index_range)
@@ -361,11 +365,13 @@ function calc_interface_flux!(backend::Nothing, surface_flux_values,
     # interface data.
     @unpack normal_directions = cache.interfaces
     index_range = eachnode(dg)
+    MeshT = typeof(mesh)
+    SolverT = typeof(dg)
 
     @threaded for interface in eachinterface(dg, cache)
-        calc_interface_flux_per_interface!(surface_flux_values, typeof(mesh),
+        calc_interface_flux_per_interface!(surface_flux_values, MeshT,
                                            have_nonconservative_terms,
-                                           equations, surface_integral, typeof(dg),
+                                           equations, surface_integral, SolverT,
                                            cache.interfaces.u, interface,
                                            neighbor_ids, node_indices,
                                            normal_directions, index_range)
@@ -1056,9 +1062,10 @@ function calc_surface_integral!(backend::Nothing, du, u,
                                 dg::DGSEM{<:LobattoLegendreBasis}, cache)
     @unpack inverse_weights = dg.basis
     @unpack surface_flux_values = cache.elements
+    MeshT = typeof(mesh)
 
     @threaded for element in eachelement(dg, cache)
-        calc_surface_integral_per_element!(du, typeof(mesh), equations,
+        calc_surface_integral_per_element!(du, MeshT, equations,
                                            surface_integral, dg, inverse_weights[1],
                                            surface_flux_values, element)
     end
@@ -1070,9 +1077,10 @@ function calc_surface_integral!(backend::Nothing, du, u,
                                 dg::DGSEM{<:GaussLegendreBasis}, cache)
     @unpack boundary_interpolation_inverse_weights = dg.basis
     @unpack surface_flux_values = cache.elements
+    MeshT = typeof(mesh)
 
     @threaded for element in eachelement(dg, cache)
-        calc_surface_integral_per_element!(du, typeof(mesh), equations,
+        calc_surface_integral_per_element!(du, MeshT, equations,
                                            surface_integral, dg,
                                            boundary_interpolation_inverse_weights,
                                            surface_flux_values, element)

--- a/src/solvers/dgsem_p4est/dg_3d.jl
+++ b/src/solvers/dgsem_p4est/dg_3d.jl
@@ -97,9 +97,10 @@ function prolong2interfaces!(backend::Nothing, cache, u,
     @unpack interfaces = cache
     @unpack neighbor_ids, node_indices = cache.interfaces
     index_range = eachnode(dg)
+    MeshT = typeof(mesh)
 
     @threaded for interface in eachinterface(dg, cache)
-        prolong2interfaces_per_interface!(interfaces.u, u, typeof(mesh), equations,
+        prolong2interfaces_per_interface!(interfaces.u, u, MeshT, equations,
                                           neighbor_ids, node_indices, index_range,
                                           interface)
     end
@@ -188,12 +189,14 @@ function calc_interface_flux!(backend::Nothing, surface_flux_values,
     @unpack neighbor_ids, node_indices = cache.interfaces
     @unpack contravariant_vectors = cache.elements
     index_range = eachnode(dg)
+    MeshT = typeof(mesh)
+    SolverT = typeof(dg)
 
     @threaded for interface in eachinterface(dg, cache)
         calc_interface_flux_per_interface!(surface_flux_values,
-                                           typeof(mesh),
+                                           MeshT,
                                            have_nonconservative_terms,
-                                           equations, surface_integral, typeof(dg),
+                                           equations, surface_integral, SolverT,
                                            cache.interfaces.u, neighbor_ids,
                                            node_indices,
                                            contravariant_vectors, index_range,
@@ -962,9 +965,10 @@ function calc_surface_integral!(backend::Nothing, du, u,
                                 dg::DGSEM, cache)
     @unpack inverse_weights = dg.basis
     @unpack surface_flux_values = cache.elements
+    MeshT = typeof(mesh)
 
     @threaded for element in eachelement(dg, cache)
-        calc_surface_integral_per_element!(du, typeof(mesh),
+        calc_surface_integral_per_element!(du, MeshT,
                                            equations, surface_integral,
                                            dg, inverse_weights[1],
                                            surface_flux_values,

--- a/src/solvers/dgsem_structured/dg_2d.jl
+++ b/src/solvers/dgsem_structured/dg_2d.jl
@@ -753,9 +753,10 @@ function apply_jacobian!(backend::Nothing, du,
                                      T8codeMesh{2}},
                          equations, dg::DG, cache)
     @unpack inverse_jacobian = cache.elements
+    MeshT = typeof(mesh)
     @threaded for element in eachelement(dg, cache)
         for j in eachnode(dg), i in eachnode(dg)
-            apply_jacobian_per_quadrature_node!(du, typeof(mesh), equations, dg,
+            apply_jacobian_per_quadrature_node!(du, MeshT, equations, dg,
                                                 inverse_jacobian,
                                                 i, j, element)
         end


### PR DESCRIPTION
This loop-invariant code motion performs slightly better and leads to less allocation with multiple threads, see https://github.com/trixi-framework/Trixi.jl/pull/3017#discussion_r3285997006.