### PR TITLE
hotfix saving restart files using GPUs

### DIFF
--- a/src/callbacks_step/save_restart.jl
+++ b/src/callbacks_step/save_restart.jl
@@ -107,6 +107,11 @@ end
 
 @inline function save_restart_file(u_ode, t, dt, iter,
                                    semi::AbstractSemidiscretization, restart_callback)
+    # TODO GPU currently on CPU
+    backend = trixi_backend(u_ode)
+    if backend !== nothing
+        u_ode = Array(u_ode)
+    end
     mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
     u = wrap_array_native(u_ode, mesh, equations, solver, cache)
     return save_restart_file(u, t, dt, iter, mesh, equations, solver, cache,


### PR DESCRIPTION
It looks like we were not careful enough in #3025, since `examples/p4est_3d_dgsem/elixir_advection_basic.jl` has a restart callback but `examples/p4est_3d_dgsem/elixir_advection_basic_gpu.jl` did not. This should at least fix the immediate error (without implementing a nicer interface for loading restart files on GPUs, which is tracked in https://github.com/trixi-framework/Trixi.jl/issues/2822).