### PR TITLE
Exclude AMDGPU 2.4.0 from CI

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -45,7 +45,7 @@ TrixiTest = "0a316866-cbd0-4425-8bcb-08103b2c1f26"
 
 [compat]
 ADTypes = "1.14"
-AMDGPU = "2.2.1"
+AMDGPU = "~2.2.1, ~2.3"
 Accessors = "0.1.42"
 Adapt = "4.4"
 Aqua = "0.8"


### PR DESCRIPTION
@luraess and I think that https://github.com/JuliaGPU/AMDGPU.jl/pull/907 caused the failure on CI that we are seeing.

Potential fix in https://github.com/JuliaGPU/AMDGPU.jl/pull/924
