### PR TITLE
Remove Trixi from docs/Project.toml

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -22,7 +22,6 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 Trixi2Vtk = "bc1476a1-1ca6-4cc3-950b-c312b255ff95"
 TrixiBase = "9a0f1c46-06d5-4909-a5a3-ce25d3fa3284"
 
@@ -52,6 +51,3 @@ SparseMatrixColorings = "0.4.21"
 Test = "1"
 Trixi2Vtk = "0.3.16"
 TrixiBase = "0.1.1"
-
-[sources.Trixi]
-path = ".."


### PR DESCRIPTION
Currently, it is a bit annoying that dependabot wants to add a compat bound for Trixi.jl in docs/Project.toml and thus creates unnecessarily many PRs. It's also annoying that new compat updates we actually want are grouped with this. We do not want a compat entry in docs/Project.toml because it should use development version (that's why we have it in `sources`). I don't think there is a perfect option to tell dependabot to ignore exactly this kind of update (i.e., ignore a specific package in a specific directory).
Alternatives I can think of:
- keep it as it is and live with noise in dependabot PRs
- exclude Trixi completely via `exclude-patterns` as in https://github.com/trixi-framework/P4est.jl/blob/288b56bd4f3a8ce49b4fecb6b48f78f34c5fad6c/.github/dependabot.yml#L29, but that would also not allow for dependabot updates of Trixi.jl in benchmark/
- exclude Trixi via `exclude-patterns` (as above) and create another entry in dependabot.yaml like
	```yaml
	  - package-ecosystem: "julia"
	    directories: # Location of Julia projects
	      - "/benchmark"
	    schedule:
	      interval: "daily"
	    groups:
	      trixi-benchmark:
	        patterns:
	          - "Trixi"
	```
    this would create a separate PR for updating the Trixi compat in benchmark/, when we create a breaking release
- create two groups: one for updates of Trixi and one for the rest like
	```yaml
	groups:
	      trixi:
	        patterns:
	          - "Trixi"
	      all-julia-packages-except-trixi:
	        patterns:
	          - "*"
	        exclude-patterns:
	          - "Trixi"
	```
    but then we always have a stale PR by dependabot, which tries to add a compat bound Trixi in docs/Project.toml similar to #2794 and if we create a breaking change we will get a PR including compat bound updates for Trixi in docs/ and benchmark/, where the benchmark/ one is wanted, but the docs/ one not
- completely remove Trixi.jl from docs/Project.toml, which is how we do it in most other repos and how we did it before already in Trixi.jl. This has the disadvantage that when locally building the documentation Trixi has to be added to the docs project explicitly and  you have to remember to remove the `Trixi` entry again from docs/Project.toml before committing.

I now opted for the last option because it is consistent with other repos and keeps the setup simple, but I could see the third option as a viable solution as well. But probably I'm overthinking this :sweat_smile: 

See also https://github.com/trixi-framework/TrixiBottomTopography.jl/pull/104#issuecomment-4524880794.

cc @vchuravy since you introduced the `[sources]` section in #2212.