### PR TITLE
increase allowed allocations for some GPU tests

### DIFF
--- a/test/test_amdgpu_2d.jl
+++ b/test/test_amdgpu_2d.jl
@@ -118,7 +118,7 @@ end
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     semi = ode.p # `semidiscretize` adapts the semi, so we need to obtain it from the ODE problem.
-    @test_allocations(Trixi.rhs!, semi, sol, 100_000)
+    @test_allocations(Trixi.rhs!, semi, sol, 600_000)
     @test real(semi.solver) == Float32
     @test real(semi.solver.basis) == Float32
     @test real(semi.solver.mortar) == Float32

--- a/test/test_amdgpu_3d.jl
+++ b/test/test_amdgpu_3d.jl
@@ -125,7 +125,7 @@ end
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     semi = ode.p # `semidiscretize` adapts the semi, so we need to obtain it from the ODE problem.
-    @test_allocations(Trixi.rhs!, semi, sol, 100_000)
+    @test_allocations(Trixi.rhs!, semi, sol, 600_000)
     @test real(semi.solver) == Float32
     @test real(semi.solver.basis) == Float32
     @test real(semi.solver.mortar) == Float32

--- a/test/test_cuda_2d.jl
+++ b/test/test_cuda_2d.jl
@@ -118,7 +118,7 @@ end
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     semi = ode.p # `semidiscretize` adapts the semi, so we need to obtain it from the ODE problem.
-    @test_allocations(Trixi.rhs!, semi, sol, 100_000)
+    @test_allocations(Trixi.rhs!, semi, sol, 600_000)
     @test real(semi.solver) == Float32
     @test real(semi.solver.basis) == Float32
     @test real(semi.solver.mortar) == Float32

--- a/test/test_cuda_3d.jl
+++ b/test/test_cuda_3d.jl
@@ -125,7 +125,7 @@ end
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     semi = ode.p # `semidiscretize` adapts the semi, so we need to obtain it from the ODE problem.
-    @test_allocations(Trixi.rhs!, semi, sol, 100_000)
+    @test_allocations(Trixi.rhs!, semi, sol, 600_000)
     @test real(semi.solver) == Float32
     @test real(semi.solver.basis) == Float32
     @test real(semi.solver.mortar) == Float32

--- a/test/test_kernelabstractions.jl
+++ b/test/test_kernelabstractions.jl
@@ -79,7 +79,7 @@ end
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     semi = ode.p # `semidiscretize` adapts the semi, so we need to obtain it from the ODE problem.
-    @test_allocations(Trixi.rhs!, semi, sol, 100_000)
+    @test_allocations(Trixi.rhs!, semi, sol, 600_000)
 end
 end
 
@@ -153,7 +153,7 @@ end
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     semi = ode.p # `semidiscretize` adapts the semi, so we need to obtain it from the ODE problem.
-    @test_allocations(Trixi.rhs!, semi, sol, 400_000)
+    @test_allocations(Trixi.rhs!, semi, sol, 600_000)
 end
 
 @trixi_testset "elixir_euler_source_terms_nonperiodic.jl native" begin


### PR DESCRIPTION
Some GPU CI runs failed recently since the number of allocations was higher for these recently introduced tests, e.g., https://buildkite.com/julialang/trixi-dot-jl/builds/7149/list?jid=019e8241-6c5d-4703-9c86-22cd4115fa48&tab=output. I increased the allowed number to make CI more reliable. It's interesting that we did not always get the same numbers (depending liekly on the hardware/setup of the GPU CI runners).