### PR TITLE
replace zero(real(mesh)) for type stability

### DIFF
--- a/src/callbacks_step/analysis_dg1d.jl
+++ b/src/callbacks_step/analysis_dg1d.jl
@@ -196,6 +196,7 @@ function integrate_via_indices(func::Func, u,
                                mesh::StructuredMesh{1}, equations, dg::DGSEM, cache,
                                args...; normalize = true) where {Func}
     @unpack weights = dg.basis
+    @unpack inverse_jacobian = cache.elements
 
     # Initialize integral with zeros of the right shape
     integral = zero(func(u, 1, 1, equations, dg, args...))
@@ -205,7 +206,7 @@ function integrate_via_indices(func::Func, u,
     @batch reduction=((+, integral), (+, total_volume)) for element in eachelement(dg,
                                                                                    cache)
         for i in eachnode(dg)
-            jacobian_volume = abs(inv(cache.elements.inverse_jacobian[i, element]))
+            jacobian_volume = abs(inv(inverse_jacobian[i, element]))
             integral += jacobian_volume * weights[i] *
                         func(u, i, element, equations, dg, args...)
             total_volume += jacobian_volume * weights[i]

--- a/src/callbacks_step/analysis_dg1d.jl
+++ b/src/callbacks_step/analysis_dg1d.jl
@@ -87,7 +87,7 @@ function calc_error_norms(func, u, t, analyzer,
     # Set up data structures
     l2_error = zero(func(get_node_vars(u, equations, dg, 1, 1), equations))
     linf_error = copy(l2_error)
-    total_volume = zero(real(mesh))
+    total_volume = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
 
     # Iterate over all elements for error calculations
     for element in eachelement(dg, cache)
@@ -199,7 +199,7 @@ function integrate_via_indices(func::Func, u,
 
     # Initialize integral with zeros of the right shape
     integral = zero(func(u, 1, 1, equations, dg, args...))
-    total_volume = zero(real(mesh))
+    total_volume = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
 
     # Use quadrature to numerically integrate over entire domain
     @batch reduction=((+, integral), (+, total_volume)) for element in eachelement(dg,

--- a/src/callbacks_step/analysis_dg2d.jl
+++ b/src/callbacks_step/analysis_dg2d.jl
@@ -159,7 +159,7 @@ function calc_error_norms(func, u, t, analyzer,
     # Set up data structures
     l2_error = zero(func(get_node_vars(u, equations, dg, 1, 1, 1), equations))
     linf_error = copy(l2_error)
-    total_volume = zero(real(mesh))
+    total_volume = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
 
     # Iterate over all elements for error calculations
     for element in eachelement(dg, cache)
@@ -358,7 +358,7 @@ function integrate_via_indices(func::Func, ::Nothing, u,
 
     # Initialize integral with zeros of the right shape
     integral = zero(func(u, 1, 1, 1, equations, dg, args...))
-    total_volume = zero(real(mesh))
+    total_volume = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
 
     # Use quadrature to numerically integrate over entire domain
     @batch reduction=((+, integral), (+, total_volume)) for element in eachelement(dg,
@@ -398,7 +398,8 @@ function integrate_via_indices(func::Func, backend::Backend, u,
     # TODO: Technically we need device_promote_op here that "infers" the function within the context of the GPU.
     integral0 = zero(Base.promote_op(func, typeof(u), Int, Int, Int, typeof(equations),
                                      typeof(dg), map(typeof, args)...))
-    init = neutral = (integral0, zero(real(mesh)))
+    volume0 = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
+    init = neutral = (integral0, volume0)
 
     # Use quadrature to numerically integrate over entire domain
     num_elements = nelements(dg, cache)

--- a/src/callbacks_step/analysis_dg2d_parallel.jl
+++ b/src/callbacks_step/analysis_dg2d_parallel.jl
@@ -101,7 +101,7 @@ function calc_error_norms(func, u, t, analyzer,
     # Set up data structures
     l2_error = zero(func(get_node_vars(u, equations, dg, 1, 1, 1), equations))
     linf_error = copy(l2_error)
-    volume = zero(real(mesh))
+    volume = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
 
     # Iterate over all elements for error calculations
     for element in eachelement(dg, cache)
@@ -186,7 +186,7 @@ function integrate_via_indices(func::Func, u,
     # https://github.com/trixi-framework/Trixi.jl/pull/2126/files/7cbc57cfcba93e67353566e10fce1f3edac27330#r1814483243.
     integral = zero(func(zeros(eltype(u), nvariables(equations), nnodes(dg), nnodes(dg),
                                1), 1, 1, 1, equations, dg, args...))
-    volume = zero(real(mesh))
+    volume = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
 
     # Use quadrature to numerically integrate over entire domain
     @batch reduction=((+, integral), (+, volume)) for element in eachelement(dg, cache)

--- a/src/callbacks_step/analysis_dg2d_parallel.jl
+++ b/src/callbacks_step/analysis_dg2d_parallel.jl
@@ -178,6 +178,7 @@ function integrate_via_indices(func::Func, u,
                                equations,
                                dg::DGSEM, cache, args...; normalize = true) where {Func}
     @unpack weights = dg.basis
+    @unpack inverse_jacobian = cache.elements
 
     # Initialize integral with zeros of the right shape
     # Pass `zeros(eltype(u), nvariables(equations), nnodes(dg), nnodes(dg), 1)`
@@ -191,7 +192,7 @@ function integrate_via_indices(func::Func, u,
     # Use quadrature to numerically integrate over entire domain
     @batch reduction=((+, integral), (+, volume)) for element in eachelement(dg, cache)
         for j in eachnode(dg), i in eachnode(dg)
-            volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, element]))
+            volume_jacobian = abs(inv(inverse_jacobian[i, j, element]))
             integral += volume_jacobian * weights[i] * weights[j] *
                         func(u, i, j, element, equations, dg, args...)
             volume += volume_jacobian * weights[i] * weights[j]

--- a/src/callbacks_step/analysis_dg3d.jl
+++ b/src/callbacks_step/analysis_dg3d.jl
@@ -179,7 +179,7 @@ function calc_error_norms(func, u, t, analyzer,
     # Set up data structures
     l2_error = zero(func(get_node_vars(u, equations, dg, 1, 1, 1, 1), equations))
     linf_error = copy(l2_error)
-    total_volume = zero(real(mesh))
+    total_volume = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
 
     # Iterate over all elements for error calculations
     for element in eachelement(dg, cache)
@@ -405,7 +405,7 @@ function integrate_via_indices(func::Func, ::Nothing, u,
 
     # Initialize integral with zeros of the right shape
     integral = zero(func(u, 1, 1, 1, 1, equations, dg, args...))
-    total_volume = zero(real(mesh))
+    total_volume = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
 
     # Use quadrature to numerically integrate over entire domain
     @batch reduction=((+, integral), (+, total_volume)) for element in eachelement(dg,
@@ -444,7 +444,8 @@ function integrate_via_indices(func::Func, backend::Backend, u,
     integral0 = zero(Base.promote_op(func, typeof(u), Int, Int, Int, Int,
                                      typeof(equations), typeof(dg),
                                      map(typeof, args)...))
-    init = neutral = (integral0, zero(real(mesh)))
+    volume0 = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
+    init = neutral = (integral0, volume0)
 
     # Use quadrature to numerically integrate over entire domain
     num_elements = nelements(dg, cache)

--- a/src/callbacks_step/analysis_dg3d_parallel.jl
+++ b/src/callbacks_step/analysis_dg3d_parallel.jl
@@ -71,6 +71,7 @@ function integrate_via_indices(func::Func, u,
                                equations,
                                dg::DGSEM, cache, args...; normalize = true) where {Func}
     @unpack weights = dg.basis
+    @unpack inverse_jacobian = cache.elements
 
     # Initialize integral with zeros of the right shape
     # Pass `zeros(eltype(u), nvariables(equations), nnodes(dg), nnodes(dg), nnodes(dg), 1)`
@@ -84,7 +85,7 @@ function integrate_via_indices(func::Func, u,
     # Use quadrature to numerically integrate over entire domain
     @batch reduction=((+, integral), (+, volume)) for element in eachelement(dg, cache)
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-            volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, k, element]))
+            volume_jacobian = abs(inv(inverse_jacobian[i, j, k, element]))
             integral += volume_jacobian * weights[i] * weights[j] * weights[k] *
                         func(u, i, j, k, element, equations, dg, args...)
             volume += volume_jacobian * weights[i] * weights[j] * weights[k]

--- a/src/callbacks_step/analysis_dg3d_parallel.jl
+++ b/src/callbacks_step/analysis_dg3d_parallel.jl
@@ -16,7 +16,7 @@ function calc_error_norms(func, u, t, analyzer,
     # Set up data structures
     l2_error = zero(func(get_node_vars(u, equations, dg, 1, 1, 1, 1), equations))
     linf_error = copy(l2_error)
-    volume = zero(real(mesh))
+    volume = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
 
     # Iterate over all elements for error calculations
     for element in eachelement(dg, cache)
@@ -79,7 +79,7 @@ function integrate_via_indices(func::Func, u,
     # https://github.com/trixi-framework/Trixi.jl/pull/2126/files/7cbc57cfcba93e67353566e10fce1f3edac27330#r1814483243.
     integral = zero(func(zeros(eltype(u), nvariables(equations), nnodes(dg), nnodes(dg),
                                nnodes(dg), 1), 1, 1, 1, 1, equations, dg, args...))
-    volume = zero(real(mesh))
+    volume = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
 
     # Use quadrature to numerically integrate over entire domain
     @batch reduction=((+, integral), (+, volume)) for element in eachelement(dg, cache)

--- a/src/solvers/dgsem/compute_u_mean.jl
+++ b/src/solvers/dgsem/compute_u_mean.jl
@@ -28,7 +28,7 @@ end
     @unpack weights = dg.basis
     @unpack inverse_jacobian = cache.elements
 
-    node_volume = zero(real(mesh))
+    node_volume = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
     total_volume = zero(node_volume)
 
     u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
@@ -49,7 +49,7 @@ end
     @unpack weights = dg.basis
     @unpack inverse_jacobian = cache.elements
 
-    node_volume = zero(real(mesh))
+    node_volume = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
     total_volume = zero(node_volume)
 
     u_mean = zero(get_node_vars(u, equations, dg, 1, 1, 1, element))

--- a/src/solvers/fdsbp_unstructured/fdsbp_2d.jl
+++ b/src/solvers/fdsbp_unstructured/fdsbp_2d.jl
@@ -242,6 +242,7 @@ function integrate_via_indices(func::Func, u,
                                dg::FDSBP, cache, args...; normalize = true) where {Func}
     # TODO: FD. This is rather inefficient right now and allocates...
     weights = diag(SummationByPartsOperators.mass_matrix(dg.basis))
+    @unpack inverse_jacobian = cache.elements
 
     # Initialize integral with zeros of the right shape
     integral = zero(func(u, 1, 1, 1, equations, dg, args...))
@@ -251,7 +252,7 @@ function integrate_via_indices(func::Func, u,
     @batch reduction=((+, integral), (+, total_volume)) for element in eachelement(dg,
                                                                                    cache)
         for j in eachnode(dg), i in eachnode(dg)
-            volume_jacobian = abs(inv(cache.elements.inverse_jacobian[i, j, element]))
+            volume_jacobian = abs(inv(inverse_jacobian[i, j, element]))
             integral += volume_jacobian * weights[i] * weights[j] *
                         func(u, i, j, element, equations, dg, args...)
             total_volume += volume_jacobian * weights[i] * weights[j]

--- a/src/solvers/fdsbp_unstructured/fdsbp_2d.jl
+++ b/src/solvers/fdsbp_unstructured/fdsbp_2d.jl
@@ -245,7 +245,7 @@ function integrate_via_indices(func::Func, u,
 
     # Initialize integral with zeros of the right shape
     integral = zero(func(u, 1, 1, 1, equations, dg, args...))
-    total_volume = zero(real(mesh))
+    total_volume = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
 
     # Use quadrature to numerically integrate over entire domain
     @batch reduction=((+, integral), (+, total_volume)) for element in eachelement(dg,
@@ -276,7 +276,7 @@ function calc_error_norms(func, u, t, analyzer,
     # Set up data structures
     l2_error = zero(func(get_node_vars(u, equations, dg, 1, 1, 1), equations))
     linf_error = copy(l2_error)
-    total_volume = zero(real(mesh))
+    total_volume = zero(eltype(weights)) * zero(eltype(inverse_jacobian))
 
     # Iterate over all elements for error calculations
     for element in eachelement(dg, cache)


### PR DESCRIPTION
The issue was found by @vchuravy when working on #2833. I made the fix everywhere where we used `zero(real(mesh))` before.