### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,8 +14,7 @@ steps:
     env:
       TRIXI_TEST: "CUDA"
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     if: build.message !~ /\[skip ci\]/
     timeout_in_minutes: 60
     soft_fail:
@@ -33,8 +32,7 @@ steps:
     env:
       TRIXI_TEST: "AMDGPU"
     agents:
-      queue: "juliagpu"
-      rocm: "*"
+      queue: "rocm"
       rocmgpu: "gfx1100" # see https://github.com/trixi-framework/Trixi.jl/pull/2939
     if: build.message !~ /\[skip ci\]/
     timeout_in_minutes: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,6 @@ steps:
       TRIXI_TEST: "AMDGPU"
     agents:
       queue: "rocm"
-      rocmgpu: "gfx1100" # see https://github.com/trixi-framework/Trixi.jl/pull/2939
     if: build.message !~ /\[skip ci\]/
     timeout_in_minutes: 60
     soft_fail:


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"`, `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm`/`intel` tag.

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)