### PR TITLE
improve summary output of GPU devices

### DIFF
--- a/ext/TrixiAMDGPUExt.jl
+++ b/ext/TrixiAMDGPUExt.jl
@@ -57,7 +57,9 @@ function Trixi.trixi_backend_info!(setup, ::ROCBackend)
         end
         str, arch, mem = query_amdgpu()
         push!(setup,
-              "  $i" => "$str ($arch, $(Base.format_bytes(mem.free)) / $(Base.format_bytes(mem.total)) available)")
+              "  $i" => "$str ($arch)")
+        push!(setup,
+              "  $i memory" => "$(Base.format_bytes(mem.free)) / $(Base.format_bytes(mem.total)) available")
     end
     return nothing
 end

--- a/ext/TrixiAMDGPUExt.jl
+++ b/ext/TrixiAMDGPUExt.jl
@@ -41,7 +41,7 @@ function Trixi.trixi_backend_info!(setup, ::ROCBackend)
     if isempty(devs)
         push!(setup, "AMDGPU devices" => "none")
     else
-        push!(setup, "AMDGPU devices:" => "")
+        push!(setup, "AMDGPU devices" => "")
     end
     for (i, dev) in enumerate(devs)
         # TODO implement NVML like optimization
@@ -57,9 +57,9 @@ function Trixi.trixi_backend_info!(setup, ::ROCBackend)
         end
         str, arch, mem = query_amdgpu()
         push!(setup,
-              "  $i" => "$str ($arch)")
+              "  $i (model)" => "$str ($arch)")
         push!(setup,
-              "  $i memory" => "$(Base.format_bytes(mem.free)) / $(Base.format_bytes(mem.total)) available")
+              "  $i (memory)" => "$(Base.format_bytes(mem.free)) / $(Base.format_bytes(mem.total)) available")
     end
     return nothing
 end

--- a/ext/TrixiCUDACoreExt.jl
+++ b/ext/TrixiCUDACoreExt.jl
@@ -52,7 +52,7 @@ function Trixi.trixi_backend_info!(setup, ::CUDABackend)
     if isempty(devs)
         push!(setup, "CUDA devices" => "none")
     else
-        push!(setup, "CUDA devices:" => "")
+        push!(setup, "CUDA devices" => "")
     end
     for (i, dev) in enumerate(devs)
         function query_cuda()
@@ -67,9 +67,9 @@ function Trixi.trixi_backend_info!(setup, ::CUDABackend)
         str, cap, mem = query_cuda()
 
         push!(setup,
-              "  $i" => "$str (sm_$(cap.major)$(cap.minor))")
+              "  $i (model)" => "$str (sm_$(cap.major)$(cap.minor))")
         push!(setup,
-              "  $i memory" => "$(Base.format_bytes(mem.free)) / $(Base.format_bytes(mem.total)) available")
+              "  $i (memory)" => "$(Base.format_bytes(mem.free)) / $(Base.format_bytes(mem.total)) available")
     end
 end
 

--- a/ext/TrixiCUDACoreExt.jl
+++ b/ext/TrixiCUDACoreExt.jl
@@ -67,7 +67,9 @@ function Trixi.trixi_backend_info!(setup, ::CUDABackend)
         str, cap, mem = query_cuda()
 
         push!(setup,
-              "  $i" => "$str (sm_$(cap.major)$(cap.minor), $(Base.format_bytes(mem.free)) / $(Base.format_bytes(mem.total)) available)")
+              "  $i" => "$str (sm_$(cap.major)$(cap.minor))")
+        push!(setup,
+              "  $i memory" => "$(Base.format_bytes(mem.free)) / $(Base.format_bytes(mem.total)) available")
     end
 end
 

--- a/src/callbacks_step/summary.jl
+++ b/src/callbacks_step/summary.jl
@@ -172,7 +172,7 @@ function initialize_summary_callback(cb::DiscreteCallback, u, t, integrator;
     io = stdout
     io_context = IOContext(io,
                            :compact => false,
-                           :key_width => 35,
+                           :key_width => 30,
                            :total_width => 100,
                            :indentation_level => 0)
 

--- a/src/callbacks_step/summary.jl
+++ b/src/callbacks_step/summary.jl
@@ -172,7 +172,7 @@ function initialize_summary_callback(cb::DiscreteCallback, u, t, integrator;
     io = stdout
     io_context = IOContext(io,
                            :compact => false,
-                           :key_width => 30,
+                           :key_width => 35,
                            :total_width => 100,
                            :indentation_level => 0)
 


### PR DESCRIPTION
Before, we had outputlike the following one:


```
┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Environment information                                                                          │
│ ═══════════════════════                                                                          │
│ #threads: …………………………………………………………………… 1                                                           │
│ threading backend: …………………………………………… polyester                                                   │
│ Backend: ……………………………………………………………………… KernelAbstractions CUDA                                     │
│ CUDA toolchain:: …………………………………………………                                                             │
│   - runtime: …………………………………………………………… 13.3.0                                                      │
│   - toolkit: …………………………………………………………… artifact installation                                       │
│   - driver: ……………………………………………………………… 13.3.0                                                      │
│   - compiler: ………………………………………………………… 13.3.33                                                     │
│ CUDA devices:: ………………………………………………………                                                             │
│   1: ………………………………………………………………………………… NVIDIA A100-PCIE-40GB MIG 1g.…96 GiB / 4.750 GiB available) │
└──────────────────────────────────────────────────────────────────────────────────────────────────┘

```

This is the new output in https://buildkite.com/julialang/trixi-dot-jl/builds/7461/list?jid=019ec157-a2fa-4b8c-a542-868a488548cb&tab=output#L1472:

```
┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Environment information                                                                          │
│ ═══════════════════════                                                                          │
│ #threads: …………………………………………………………………… 1                                                           │
│ threading backend: …………………………………………… polyester                                                   │
│ Backend: ……………………………………………………………………… KernelAbstractions CUDA                                     │
│ CUDA toolchain:: …………………………………………………                                                             │
│   - runtime: …………………………………………………………… 13.3.0                                                      │
│   - toolkit: …………………………………………………………… artifact installation                                       │
│   - driver: ……………………………………………………………… 13.3.0                                                      │
│   - compiler: ………………………………………………………… 13.3.33                                                     │
│ CUDA devices:: ………………………………………………………                                                             │
│   1: ………………………………………………………………………………… NVIDIA A100-PCIE-40GB MIG 1g.5gb (sm_80)                    │
│   1 memory: ……………………………………………………………… 4.596 GiB / 4.750 GiB available                             │
└──────────────────────────────────────────────────────────────────────────────────────────────────┘

