### PR TITLE
Debug Coveralls action in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,9 @@ jobs:
       - uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./lcov.info
+          file: ./lcov.info
+          format: lcov
+          debug: true
       # Upload merged coverage data as artifact for debugging
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Recently, the coveralls GitHub action does not report results anymore. The latest CI run on `main` where it shows up successfully is https://github.com/trixi-framework/Trixi.jl/commit/42b5759e9cd676b91c8d86e415052605d7a600b3 with coveralls results https://coveralls.io/builds/79945251.