### PR TITLE
Update Coveralls action in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,8 @@ jobs:
       #     github-token: ${{ secrets.GITHUB_TOKEN }}
       #     flag-name: run-${{ matrix.trixi_test }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-${{ github.run_id }}
       #     parallel: true
-      #     path-to-lcov: ./lcov.info
+      #     file: ./lcov.info
+      #     format: lcov
       # Instead, we use a more tedious approach:
       # - Store all individual coverage files as artifacts (directly below)
       # - Download and merge individual coverage reports in another step
@@ -209,7 +210,9 @@ jobs:
       - uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./lcov.info
+          file: ./lcov.info
+          format: lcov
+          debug: true
       # Upload merged coverage data as artifact for debugging
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
As mentioned by @DanielDoehring in https://github.com/trixi-framework/Trixi.jl/pull/3084#issuecomment-4701068399, the coveralls GitHub action did not report results in many recent runs (including PRs). The latest CI run on `main` where it shows up successfully is https://github.com/trixi-framework/Trixi.jl/commit/42b5759e9cd676b91c8d86e415052605d7a600b3 with coveralls results https://coveralls.io/builds/79945251.

Here, I updated some settings to avoid deprecated functionality. It looks like this helps - at least in this PR.

Closes #3085.