### PR TITLE
Increase allowed allocations for some other GPU tests

### DIFF
--- a/test/test_amdgpu_2d.jl
+++ b/test/test_amdgpu_2d.jl
@@ -52,7 +52,7 @@ end
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     semi = ode.p # `semidiscretize` adapts the semi, so we need to obtain it from the ODE problem.
-    @test_allocations(Trixi.rhs!, semi, sol, 100_000)
+    @test_allocations(Trixi.rhs!, semi, sol, 600_000)
     @test real(ode.p.solver) == Float32
     @test real(ode.p.solver.basis) == Float32
     @test real(ode.p.solver.mortar) == Float32

--- a/test/test_amdgpu_3d.jl
+++ b/test/test_amdgpu_3d.jl
@@ -52,7 +52,7 @@ end
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     semi = ode.p # `semidiscretize` adapts the semi, so we need to obtain it from the ODE problem.
-    @test_allocations(Trixi.rhs!, semi, sol, 100_000)
+    @test_allocations(Trixi.rhs!, semi, sol, 1_700_000)
     @test real(ode.p.solver) == Float32
     @test real(ode.p.solver.basis) == Float32
     @test real(ode.p.solver.mortar) == Float32


### PR DESCRIPTION
Some GPU tests failed again https://buildkite.com/julialang/trixi-dot-jl/builds/7539/list?jid=019edee6-7327-4435-93b3-72f26cf34421&tab=output.

Now the allowed allocations for the AMD GPUs are aligned with the value we have for the NVIDIA devices.