### PR TITLE
Improve plotting for 1D BlockFV

### DIFF
--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -694,6 +694,7 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
                     slice = :x, point = (0.0, 0.0, 0.0), curve = nothing,
                     variable_names = nothing) where {Basis <: UniformFiniteVolumeBasis}
 
+    friendly_slice = (slice === :xy) ? :x : slice
 
     solution_variables_ = Trixi.digest_solution_variables(equations, solution_variables)
     variable_names_ = Trixi.digest_variable_names(solution_variables_, equations, variable_names)
@@ -709,10 +710,8 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
 
     left_boundary = mesh.tree.center_level_0[1] - mesh.tree.length_level_0 / 2;
 
-    @show ndims(mesh), curve, slice #what is wrong with the slice?
-    slice = :x
-    @show ndims(mesh), curve, slice
-    if ndims(mesh) == 1 && curve == nothing && slice == :x
+    @show ndims(mesh), curve, friendly_slice #what is wrong with the slice?
+    if ndims(mesh) == 1 && curve == nothing && friendly_slice == :x
         orientation_x = 1;
 
         for i in 1:n_elements #the loop over the cells

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -701,66 +701,66 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
     unstructured_data = Trixi.get_unstructured_data(u, solution_variables_, mesh,
                                                     equations, solver, cache)
 
-    n_nodes = size(unstructured_data, 1);  # number of subcells per cell
-    n_elements = nelements(solver, cache); # number of cells
-    total_plot_points = 2 * n_nodes * n_elements; # The total array size we need
+    n_nodes = size(unstructured_data, 1)  # number of subcells per cell
+    n_elements = nelements(solver, cache) # number of cells
+    total_plot_points = 2 * n_nodes * n_elements # The total array size we need
 
-    x = Vector{Float64}(undef, total_plot_points);
-    data = Array{Float64}(undef, total_plot_points, length(variable_names_));
-    mesh_vertices_x = Vector{Float64}(undef, n_elements + 1);
+    x = Vector{Float64}(undef, total_plot_points)
+    data = Array{Float64}(undef, total_plot_points, length(variable_names_))
+    mesh_vertices_x = Vector{Float64}(undef, n_elements + 1)
 
-    left_boundary = mesh.tree.center_level_0[1] - mesh.tree.length_level_0 / 2;
+    left_boundary = mesh.tree.center_level_0[1] - mesh.tree.length_level_0 / 2
 
     @show ndims(mesh), curve, friendly_slice #what is wrong with the slice?
     if ndims(mesh) == 1 && curve == nothing && friendly_slice == :x
-        orientation_x = 1;
+        orientation_x = 1
 
         for i in 1:n_elements #the loop over the cells
             #element_width = cache.elements.dx[i];
             #element_width = Trixi.get_element_length(i, cache)
             element_width = 2.0 / cache.elements.inverse_jacobian[i]
-            sub_cell_width = element_width / n_nodes;
+            sub_cell_width = element_width / n_nodes
 
             for j in 1:n_nodes #the loop over the subscells
-                idx_left = (i - 1) * (2 * n_nodes) + 2 * j - 1; #slot number in the list x for the left side of this subcell
-                idx_right = (i - 1) * (2 * n_nodes) + 2 * j; #slot number in the list x for the right side of this subcell
+                idx_left = (i - 1) * (2 * n_nodes) + 2 * j - 1 #slot number in the list x for the left side of this subcell
+                idx_right = (i - 1) * (2 * n_nodes) + 2 * j #slot number in the list x for the right side of this subcell
 
-                x[idx_left] = left_boundary + (j - 1) * sub_cell_width; #coordinate for the left edge of the subcell
-                x[idx_right] = left_boundary + j * sub_cell_width; #coordinate for the right edge of the subcell
+                x[idx_left] = left_boundary + (j - 1) * sub_cell_width #coordinate for the left edge of the subcell
+                x[idx_right] = left_boundary + j * sub_cell_width #coordinate for the right edge of the subcell
 
                 for v in 1:length(variable_names_) #loop over the values
-                    data[idx_left, v] = unstructured_data[j, i, v]; #value for quantity v at left edge of subcell
-                    data[idx_right, v] = unstructured_data[j, i, v]; #value for quantity v at right edge of subcell
+                    data[idx_left, v] = unstructured_data[j, i, v] #value for quantity v at left edge of subcell
+                    data[idx_right, v] = unstructured_data[j, i, v] #value for quantity v at right edge of subcell
                 end
             end
 
-            mesh_vertices_x[i] = left_boundary; #write left boundary of the cell under consideration into the i'th entry of mesh_vertices_x 
-            left_boundary += element_width; #go to the left boundary of the next cell
+            mesh_vertices_x[i] = left_boundary #write left boundary of the cell under consideration into the i'th entry of mesh_vertices_x 
+            left_boundary += element_width #go to the left boundary of the next cell
         end
-        mesh_vertices_x[end] = left_boundary; #this is the right boundary. We do that by going out of the cell. In that case its the left boundary
+        mesh_vertices_x[end] = left_boundary #this is the right boundary. We do that by going out of the cell. In that case its the left boundary
 
     else
-        error("BlockFV is not yet supported for 2D, 3D, curves.");
+        error("BlockFV is not yet supported for 2D, 3D, curves.")
     end
-    return PlotData1D(x, data, variable_names_, mesh_vertices_x, orientation_x);
+    return PlotData1D(x, data, variable_names_, mesh_vertices_x, orientation_x)
 end
 #end new thing
 
 # unwrap u if it is VectorOfArray
 PlotData1D(u::VectorOfArray, mesh, equations, dg::DGMulti{1}, cache;
-           kwargs...) = PlotData1D(parent(u),
-                                   mesh,
-                                   equations,
-                                   dg,
-                                   cache;
-                                   kwargs...)
+kwargs...) = PlotData1D(parent(u),
+                        mesh,
+                        equations,
+                        dg,
+                        cache;
+                        kwargs...)
 PlotData2D(u::VectorOfArray, mesh, equations, dg::DGMulti{2}, cache;
-           kwargs...) = PlotData2D(parent(u),
-                                   mesh,
-                                   equations,
-                                   dg,
-                                   cache;
-                                   kwargs...)
+kwargs...) = PlotData2D(parent(u),
+                        mesh,
+                        equations,
+                        dg,
+                        cache;
+                        kwargs...)
 
 function PlotData1D(u, mesh, equations, solver, cache;
                     solution_variables = nothing, nvisnodes = nothing,

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -715,9 +715,12 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
         orientation_x = 1;
 
         for i in 1:n_elements #the loop over the cells
-            element_width = cache.elements.dx[i];
+            #element_width = cache.elements.dx[i];
+            #element_width = Trixi.get_element_length(i, cache)
+            element_width = 2.0 / cache.elements.inverse_jacobian[i]
             sub_cell_width = element_width / n_nodes;
-
+ 
+            
             for j in 1:n_nodes #thr loop over the subscells
                 idx_left  = (i - 1) * (2 * n_nodes) + 2 * j - 1; #slot number in the list x for the left side of this subcell
                 idx_right = (i - 1) * (2 * n_nodes) + 2 * j; #slot number in the list x for the right side of this subcell

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -743,17 +743,17 @@ end
 
 # unwrap u if it is VectorOfArray
 PlotData1D(u::VectorOfArray, mesh, equations, dg::DGMulti{1}, cache; kwargs...) = PlotData1D(parent(u),
-                                                                                            mesh,
-                                                                                            equations,
-                                                                                            dg,
-                                                                                            cache;
-                                                                                            kwargs...)
+                                                                                             mesh,
+                                                                                             equations,
+                                                                                             dg,
+                                                                                             cache;
+                                                                                             kwargs...)
 PlotData2D(u::VectorOfArray, mesh, equations, dg::DGMulti{2}, cache; kwargs...) = PlotData2D(parent(u),
-                                                                                            mesh,
-                                                                                            equations,
-                                                                                            dg,
-                                                                                            cache;
-                                                                                            kwargs...)
+                                                                                             mesh,
+                                                                                             equations,
+                                                                                             dg,
+                                                                                             cache;
+                                                                                             kwargs...)
 
 function PlotData1D(u, mesh, equations, solver, cache;
                     solution_variables = nothing, nvisnodes = nothing,

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -687,7 +687,6 @@ function PlotData1D(u, mesh::TreeMesh, equations, solver, cache;
                       orientation_x)
 end
 
-#new thing
 function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
                     solution_variables = nothing, nvisnodes = nothing,
                     reinterpolate = default_reinterpolate(solver),
@@ -711,13 +710,10 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
 
     left_boundary = mesh.tree.center_level_0[1] - mesh.tree.length_level_0 / 2
 
-    @show ndims(mesh), curve, friendly_slice #what is wrong with the slice?
     if ndims(mesh) == 1 && curve == nothing && friendly_slice == :x
         orientation_x = 1
 
         for i in 1:n_elements #the loop over the cells
-            #element_width = cache.elements.dx[i];
-            #element_width = Trixi.get_element_length(i, cache)
             element_width = 2.0 / cache.elements.inverse_jacobian[i]
             sub_cell_width = element_width / n_nodes
 
@@ -744,7 +740,6 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
     end
     return PlotData1D(x, data, variable_names_, mesh_vertices_x, orientation_x)
 end
-#end new thing
 
 # unwrap u if it is VectorOfArray
 PlotData1D(u::VectorOfArray, mesh, equations, dg::DGMulti{1}, cache;

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -742,20 +742,18 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
 end
 
 # unwrap u if it is VectorOfArray
-PlotData1D(u::VectorOfArray, mesh, equations, dg::DGMulti{1}, cache;
-kwargs...) = PlotData1D(parent(u),
-                        mesh,
-                        equations,
-                        dg,
-                        cache;
-                        kwargs...)
-PlotData2D(u::VectorOfArray, mesh, equations, dg::DGMulti{2}, cache;
-kwargs...) = PlotData2D(parent(u),
-                        mesh,
-                        equations,
-                        dg,
-                        cache;
-                        kwargs...)
+PlotData1D(u::VectorOfArray, mesh, equations, dg::DGMulti{1}, cache; kwargs...) = PlotData1D(parent(u),
+                                                                                            mesh,
+                                                                                            equations,
+                                                                                            dg,
+                                                                                            cache;
+                                                                                            kwargs...)
+PlotData2D(u::VectorOfArray, mesh, equations, dg::DGMulti{2}, cache; kwargs...) = PlotData2D(parent(u),
+                                                                                            mesh,
+                                                                                            equations,
+                                                                                            dg,
+                                                                                            cache;
+                                                                                            kwargs...)
 
 function PlotData1D(u, mesh, equations, solver, cache;
                     solution_variables = nothing, nvisnodes = nothing,

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -721,7 +721,7 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
             sub_cell_width = element_width / n_nodes;
  
             
-            for j in 1:n_nodes #thr loop over the subscells
+            for j in 1:n_nodes #the loop over the subscells
                 idx_left  = (i - 1) * (2 * n_nodes) + 2 * j - 1; #slot number in the list x for the left side of this subcell
                 idx_right = (i - 1) * (2 * n_nodes) + 2 * j; #slot number in the list x for the right side of this subcell
 

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -692,13 +692,11 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
                     reinterpolate = default_reinterpolate(solver),
                     slice = :x, point = (0.0, 0.0, 0.0), curve = nothing,
                     variable_names = nothing) where {Basis <: UniformFiniteVolumeBasis}
-    friendly_slice = (slice === :xy) ? :x : slice
-
-    solution_variables_ = Trixi.digest_solution_variables(equations, solution_variables)
-    variable_names_ = Trixi.digest_variable_names(solution_variables_, equations,
-                                                  variable_names)
-    unstructured_data = Trixi.get_unstructured_data(u, solution_variables_, mesh,
-                                                    equations, solver, cache)
+    solution_variables_ = digest_solution_variables(equations, solution_variables)
+    variable_names_ = digest_variable_names(solution_variables_, equations,
+                                            variable_names)
+    unstructured_data = get_unstructured_data(u, solution_variables_, mesh,
+                                              equations, solver, cache)
 
     n_nodes = size(unstructured_data, 1)  # number of subcells per cell
     n_elements = nelements(solver, cache) # number of cells
@@ -710,7 +708,7 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
 
     left_boundary = mesh.tree.center_level_0[1] - mesh.tree.length_level_0 / 2
 
-    if ndims(mesh) == 1 && curve == nothing && friendly_slice == :x
+    if ndims(mesh) === 1
         orientation_x = 1
 
         for i in 1:n_elements #the loop over the cells
@@ -736,7 +734,7 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
         mesh_vertices_x[end] = left_boundary #this is the right boundary. We do that by going out of the cell. In that case its the left boundary
 
     else
-        error("BlockFV is not yet supported for 2D, 3D, curves.")
+        error("BlockFV is not yet supported for 2D and 3D.")
     end
     return PlotData1D(x, data, variable_names_, mesh_vertices_x, orientation_x)
 end

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -693,12 +693,13 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
                     reinterpolate = default_reinterpolate(solver),
                     slice = :x, point = (0.0, 0.0, 0.0), curve = nothing,
                     variable_names = nothing) where {Basis <: UniformFiniteVolumeBasis}
-
     friendly_slice = (slice === :xy) ? :x : slice
 
     solution_variables_ = Trixi.digest_solution_variables(equations, solution_variables)
-    variable_names_ = Trixi.digest_variable_names(solution_variables_, equations, variable_names)
-    unstructured_data = Trixi.get_unstructured_data(u, solution_variables_, mesh, equations, solver, cache)
+    variable_names_ = Trixi.digest_variable_names(solution_variables_, equations,
+                                                  variable_names)
+    unstructured_data = Trixi.get_unstructured_data(u, solution_variables_, mesh,
+                                                    equations, solver, cache)
 
     n_nodes = size(unstructured_data, 1);  # number of subcells per cell
     n_elements = nelements(solver, cache); # number of cells
@@ -719,17 +720,16 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
             #element_width = Trixi.get_element_length(i, cache)
             element_width = 2.0 / cache.elements.inverse_jacobian[i]
             sub_cell_width = element_width / n_nodes;
- 
-            
+
             for j in 1:n_nodes #the loop over the subscells
-                idx_left  = (i - 1) * (2 * n_nodes) + 2 * j - 1; #slot number in the list x for the left side of this subcell
+                idx_left = (i - 1) * (2 * n_nodes) + 2 * j - 1; #slot number in the list x for the left side of this subcell
                 idx_right = (i - 1) * (2 * n_nodes) + 2 * j; #slot number in the list x for the right side of this subcell
 
-                x[idx_left]  = left_boundary + (j - 1) * sub_cell_width; #coordinate for the left edge of the subcell
+                x[idx_left] = left_boundary + (j - 1) * sub_cell_width; #coordinate for the left edge of the subcell
                 x[idx_right] = left_boundary + j * sub_cell_width; #coordinate for the right edge of the subcell
 
                 for v in 1:length(variable_names_) #loop over the values
-                    data[idx_left, v]  = unstructured_data[j, i, v]; #value for quantity v at left edge of subcell
+                    data[idx_left, v] = unstructured_data[j, i, v]; #value for quantity v at left edge of subcell
                     data[idx_right, v] = unstructured_data[j, i, v]; #value for quantity v at right edge of subcell
                 end
             end
@@ -738,28 +738,29 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
             left_boundary += element_width; #go to the left boundary of the next cell
         end
         mesh_vertices_x[end] = left_boundary; #this is the right boundary. We do that by going out of the cell. In that case its the left boundary
-        
-    else 
+
+    else
         error("BlockFV is not yet supported for 2D, 3D, curves.");
     end
     return PlotData1D(x, data, variable_names_, mesh_vertices_x, orientation_x);
-
 end
 #end new thing
 
 # unwrap u if it is VectorOfArray
-PlotData1D(u::VectorOfArray, mesh, equations, dg::DGMulti{1}, cache; kwargs...) = PlotData1D(parent(u),
-                                                                                             mesh,
-                                                                                             equations,
-                                                                                             dg,
-                                                                                             cache;
-                                                                                             kwargs...)
-PlotData2D(u::VectorOfArray, mesh, equations, dg::DGMulti{2}, cache; kwargs...) = PlotData2D(parent(u),
-                                                                                             mesh,
-                                                                                             equations,
-                                                                                             dg,
-                                                                                             cache;
-                                                                                             kwargs...)
+PlotData1D(u::VectorOfArray, mesh, equations, dg::DGMulti{1}, cache;
+           kwargs...) = PlotData1D(parent(u),
+                                   mesh,
+                                   equations,
+                                   dg,
+                                   cache;
+                                   kwargs...)
+PlotData2D(u::VectorOfArray, mesh, equations, dg::DGMulti{2}, cache;
+           kwargs...) = PlotData2D(parent(u),
+                                   mesh,
+                                   equations,
+                                   dg,
+                                   cache;
+                                   kwargs...)
 
 function PlotData1D(u, mesh, equations, solver, cache;
                     solution_variables = nothing, nvisnodes = nothing,

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -687,6 +687,59 @@ function PlotData1D(u, mesh::TreeMesh, equations, solver, cache;
                       orientation_x)
 end
 
+function PlotData1D(u, mesh::TreeMesh, equations, solver::DG{Basis}, cache;
+                    solution_variables = nothing, nvisnodes = nothing,
+                    reinterpolate = default_reinterpolate(solver),
+                    slice = :x, point = (0.0, 0.0, 0.0), curve = nothing,
+                    variable_names = nothing) where {Basis <: UniformFiniteVolumeBasis}
+
+
+    solution_variables_ = Trixi.digest_solution_variables(equations, solution_variables)
+    variable_names_ = Trixi.digest_variable_names(solution_variables_, equations, variable_names)
+    unstructured_data = Trixi.get_unstructured_data(u, solution_variables_, mesh, equations, solver, cache)
+
+    n_nodes = size(unstructured_data, 1);  # number of subcells per cell
+    n_elements = nelements(solver, cache); # number of cells
+    total_plot_points = 2 * n_nodes * n_elements; # The total array size we need
+
+    x = Vector{Float64}(undef, total_plot_points);
+    data = Array{Float64}(undef, total_plot_points, length(variable_names_));
+    mesh_vertices_x = Vector{Float64}(undef, n_elements + 1);
+
+    left_boundary = mesh.tree.center_level_0[1] - mesh.tree.length_level_0 / 2;
+
+    if ndims(mesh) == 1 && curve == nothing && slice == :x
+        orientation_x = 1;
+
+        for i in 1:n_elements #the loop over the cells
+            element_width = cache.elements.dx[i];
+            sub_cell_width = element_width / n_nodes;
+
+            for j in 1:n_nodes #thr loop over the subscells
+                idx_left  = (i - 1) * (2 * n_nodes) + 2 * j - 1; #slot number in the list x for the left side of this subcell
+                idx_right = (i - 1) * (2 * n_nodes) + 2 * j; #slot number in the list x for the right side of this subcell
+
+                x[idx_left]  = left_boundary + (j - 1) * sub_cell_width; #coordinate for the left edge of the subcell
+                x[idx_right] = left_boundary + j * sub_cell_width; #coordinate for the right edge of the subcell
+
+                for v in 1:length(variable_names_) #loop over the values
+                    data[idx_left, v]  = unstructured_data[j, i, v]; #value for quantity v at left edge of subcell
+                    data[idx_right, v] = unstructured_data[j, i, v]; #value for quantity v at right edge of subcell
+                end
+            end
+
+            mesh_vertices_x[i] = left_boundary; #write left boundary of the cell under consideration into the i'th entry of mesh_vertices_x 
+            left_boundary += element_width; #go to the left boundary of the next cell
+        end
+        mesh_vertices_x[end] = left_boundary; #this is the right boundary. We do that by going out of the cell. In that case its the left boundary
+        
+    else 
+        error("BlockFV is not yet supported for 2D, 3D, curves.");
+    end
+    return PlotData1D(x, data, variable_names_, mesh_vertices_x, orientation_x);
+
+end
+
 # unwrap u if it is VectorOfArray
 PlotData1D(u::VectorOfArray, mesh, equations, dg::DGMulti{1}, cache; kwargs...) = PlotData1D(parent(u),
                                                                                              mesh,

--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -687,7 +687,8 @@ function PlotData1D(u, mesh::TreeMesh, equations, solver, cache;
                       orientation_x)
 end
 
-function PlotData1D(u, mesh::TreeMesh, equations, solver::DG{Basis}, cache;
+#new thing
+function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
                     solution_variables = nothing, nvisnodes = nothing,
                     reinterpolate = default_reinterpolate(solver),
                     slice = :x, point = (0.0, 0.0, 0.0), curve = nothing,
@@ -708,6 +709,9 @@ function PlotData1D(u, mesh::TreeMesh, equations, solver::DG{Basis}, cache;
 
     left_boundary = mesh.tree.center_level_0[1] - mesh.tree.length_level_0 / 2;
 
+    @show ndims(mesh), curve, slice #what is wrong with the slice?
+    slice = :x
+    @show ndims(mesh), curve, slice
     if ndims(mesh) == 1 && curve == nothing && slice == :x
         orientation_x = 1;
 
@@ -739,6 +743,7 @@ function PlotData1D(u, mesh::TreeMesh, equations, solver::DG{Basis}, cache;
     return PlotData1D(x, data, variable_names_, mesh_vertices_x, orientation_x);
 
 end
+#end new thing
 
 # unwrap u if it is VectorOfArray
 PlotData1D(u::VectorOfArray, mesh, equations, dg::DGMulti{1}, cache; kwargs...) = PlotData1D(parent(u),

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -240,21 +240,22 @@ end
 
     @testset "BlockFV 1D Visualization" begin
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
-                                     "elixir_advection_basic.jl"), m=workspace)
+                                     "elixir_advection_basic.jl"))
+        let
+            u_fv = sol.u[end]
+            mesh_fv = semi.mesh
+            equations_fv = semi.equations
+            solver_fv = semi.solver
+            cache_fv = semi.cache
 
-        u_fv = workspace.sol.u[end]
-        mesh_fv = workspace.semi.mesh
-        equations_fv = workspace.semi.equations
-        solver_fv = workspace.semi.solver
-        cache_fv = workspace.semi.cache
+            pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv,
+                                        cache_fv)
+            @test pd_fv_explicit isa PlotData1D
 
-        pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
-        @test pd_fv_explicit isa PlotData1D
-
-        pd_fv_wrapped = PlotData1D(sol)
-        @test pd_fv_wrapped isa PlotData1D
+            pd_fv_wrapped = PlotData1D(sol)
+            @test pd_fv_wrapped isa PlotData1D
+        end
     end
-
     @testset "1D plot recipes" begin
         pd = PlotData1D(sol)
 

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -240,13 +240,13 @@ end
 
     @testset "BlockFV 1D Visualization" begin
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
-                                     "elixir_advection_basic.jl"), m=Module())
+                                     "elixir_advection_basic.jl"), m=workspace)
 
-        u_fv = sol.u[end]
-        mesh_fv = semi.mesh
-        equations_fv = semi.equations
-        solver_fv = semi.solver
-        cache_fv = semi.cache
+        u_fv = workspace.sol.u[end]
+        mesh_fv = workspace.semi.mesh
+        equations_fv = workspace.semi.equations
+        solver_fv = workspace.semi.solver
+        cache_fv = workspace.semi.cache
 
         pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
         @test pd_fv_explicit isa PlotData1D

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -242,7 +242,7 @@ end
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_fv",
                                      "elixir_advection_basic,jl"), tspan=(0.0, 0.0))
 
-        u_fv = compute_coefficients(0.0, semi_fv)
+        u_fv = sol.u[end]
         mesh_fv = semi.mesh
         equations_fv = semi.equations
         solver_fv = semi.solver
@@ -253,8 +253,6 @@ end
 
         pd_fv_wrapped = PlotData1D(sol)
         @test pd_fv_wrapped isa PlotData1D
-
-        @trixi_test_nowarn Plots.plot(pd_fv_wrapped)
     end
 
     @testset "1D plot recipes" begin

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -275,7 +275,8 @@ end
 @timed_testset "FV testsets" begin
     @trixi_testset "BlockFV 1D Visualization" begin
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
-                                     "elixir_advection_basic.jl"), n_nodes=4,
+                                     "elixir_advection_basic.jl"),
+                            n_nodes=4,
                             initial_refinement_level=3)
 
         pd_fv_wrapped = @test_nowarn PlotData1D(sol)
@@ -284,13 +285,15 @@ end
 
     @trixi_testset "DGSEM vs BlockFV 1D Visualization" begin
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_dgsem",
-                                     "elixir_advection_finite_volume.jl"), polydeg=0,
+                                     "elixir_advection_finite_volume.jl"),
+                            polydeg=0,
                             initial_refinement_level=5)
 
         pd_dgsem_polydeg0 = @test_nowarn PlotData1D(sol)
 
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
-                                     "elixir_advection_basic.jl"), n_nodes=4,
+                                     "elixir_advection_basic.jl"),
+                            n_nodes=4,
                             initial_refinement_level=3)
 
         pd_blockfv = @test_nowarn PlotData1D(sol)
@@ -302,10 +305,20 @@ end
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
                                      "elixir_euler_source_term_nonperiodic.jl"),
                             n_nodes=4,
-                            initial_refinement_level=3)
+                            initial_refinement_level=3,
+                            initial_condition=initial_condition_constant,
+                            tspan=(0.0, 0.0))
 
-        pd_fv_constant_ic = @test_nowarn PlotData1D(sol)
-        @test pd_fv_constant_ic isa PlotData1D
+        pd = @test_nowarn PlotData1D(sol)
+        @test pd isa PlotData1D
+
+        ref_cons = initial_condition_constant(SVector(0.0), 0.0,
+                                              semi.equations)
+        ref_prim = cons2prim(ref_cons, semi.equations)
+
+        @test all(x -> isapprox(x, ref_prim[1]), pd.data[:, 1]) # rho
+        @test all(x -> isapprox(x, ref_prim[2]), pd.data[:, 2]) # v1
+        @test all(x -> isapprox(x, ref_prim[3]), pd.data[:, 3]) # p
     end
 end
 
@@ -1134,7 +1147,7 @@ end
     pd = @inferred PlotData2D(sol)
     @trixi_test_nowarn Makie.plot(pd["rho"])
     @trixi_test_nowarn Makie.plot(pd["rho"], colormap = :blues)
-    # plot_mesh = true 
+    # plot_mesh = true
     @trixi_test_nowarn Makie.plot(pd["rho"], plot_mesh = true)
 
     # explicit PlotMesh overlay (works for all PlotData2DTriangulated meshes)

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -313,7 +313,8 @@ end
 
     @trixi_testset "Constant IC" begin
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
-                                     "elixir_euler_source_term_nonperiodic.jl"), n_nodes=4,
+                                     "elixir_euler_source_term_nonperiodic.jl"),
+                            n_nodes=4,
                             initial_refinement_level=3)
 
         u_fv = sol.u[end]

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -239,8 +239,8 @@ end
     @test size(pd2.data) == (128, 3)
 
     @testset "BlockFV 1D Visualization" begin
-        @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_fv",
-                                     "elixir_advection_basic,jl"), tspan=(0.0, 0.0))
+        @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
+                                     "elixir_advection_basic.jl"), tspan=(0.0, 0.0))
 
         u_fv = sol.u[end]
         mesh_fv = semi.mesh

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -238,26 +238,6 @@ end
     pd2 = PlotData1D(sol, nvisnodes = 2)
     @test size(pd2.data) == (128, 3)
 
-    @testset "BlockFV 1D Visualization" begin
-        bfv_workspace = Module(:BlockFVWorkspace)
-        Core.eval(bfv_workspace, :(using Trixi))
-
-        @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
-                                     "elixir_advection_basic.jl"), m=bfv_workspace,
-                            l2=nothing, linf=nothing)
-
-        u_fv = bfv_workspace.sol.u[end]
-        mesh_fv = bfv_workspace.semi.mesh
-        equations_fv = bfv_workspace.semi.equations
-        solver_fv = bfv_workspace.semi.solver
-        cache_fv = bfv_workspace.semi.cache
-
-        pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
-        @test pd_fv_explicit isa PlotData1D
-
-        pd_fv_wrapped = PlotData1D(bfv_workspace.sol)
-        @test pd_fv_wrapped isa PlotData1D
-    end
     @testset "1D plot recipes" begin
         pd = PlotData1D(sol)
 
@@ -291,6 +271,46 @@ end
         @trixi_test_nowarn Plots.plot(fake2d)
     end
 end
+
+#new thing
+
+@timed_testset "FV testsets" begin
+    @trixi_testset "BlockFV 1D Visualization" begin
+        @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
+                                     "elixir_advection_basic.jl"))
+
+        u_fv = sol.u[end]
+        mesh_fv = semi.mesh
+        equations_fv = semi.equations
+        solver_fv = semi.solver
+        cache_fv = semi.cache
+
+        pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
+        @test pd_fv_explicit isa PlotData1D
+
+        pd_fv_wrapped = PlotData1D(sol)
+        @test pd_fv_wrapped isa PlotData1D
+    end
+
+    @trixi_testset "Constant IC" begin
+        @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
+                                     "elixir_euler_source_term_nonperiodic"))
+
+        u_fv = sol.u[end]
+        mesh_fv = semi.mesh
+        equations_fv = semi.equations
+        solver_fv = semi.solver
+        cache_fv = semi.cache
+
+        pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
+        @test pd_fv_explicit isa PlotData1D
+
+        pd_fv_wrapped = PlotData1D(sol)
+        @test pd_fv_wrapped isa PlotData1D
+    end
+end
+
+#end new thing
 
 @timed_testset "1D plot from 2D solution" begin
     @trixi_testset "Create 1D plot along curve" begin

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -255,7 +255,7 @@ end
         pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
         @test pd_fv_explicit isa PlotData1D
 
-        pd_fv_wrapped = PlotData1D(sol)
+        pd_fv_wrapped = PlotData1D(bfv_workspace.sol)
         @test pd_fv_wrapped isa PlotData1D
     end
     @testset "1D plot recipes" begin

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -277,7 +277,8 @@ end
 @timed_testset "FV testsets" begin
     @trixi_testset "BlockFV 1D Visualization" begin
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
-                                     "elixir_advection_basic.jl"))
+                                     "elixir_advection_basic.jl"), n_nodes=4,
+                            initial_refinement_level=3)
 
         u_fv = sol.u[end]
         mesh_fv = semi.mesh
@@ -312,7 +313,8 @@ end
 
     @trixi_testset "Constant IC" begin
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
-                                     "elixir_euler_source_term_nonperiodic.jl"))
+                                     "elixir_euler_source_term_nonperiodic.jl"), n_nodes=4,
+                            initial_refinement_level=3)
 
         u_fv = sol.u[end]
         mesh_fv = semi.mesh

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -242,14 +242,16 @@ end
         equations_fv = LinearScalarAdvectionEquation1D(1.0)
         basis_fv = UniformFiniteVolumeBasis(3)
         solver_fv = BlockFV(basis_fv)
-        mesh_fv = TreeMesh((-1.0,), (-1.0,), initial_refinement_level = 2, n_cells_max = 100, periodicity = true)
-        semi_fv = SemidiscretizationHyperbolic(mesh_fv, equations_fv, initial_condition_constant, solver_fv)
+        mesh_fv = TreeMesh((-1.0,), (-1.0,), initial_refinement_level = 2,
+                           n_cells_max = 100, periodicity = true)
+        semi_fv = SemidiscretizationHyperbolic(mesh_fv, equations_fv,
+                                               initial_condition_constant, solver_fv)
         u_fv = compute_coefficients(0.0, semi_fv)
         cache_fv = semi_fv.cache
-        
+
         pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
         @test pd_fv_explicit isa PlotData1D
-        
+
         pd_fv_wrapped = PlotData1D(u_fv, semi_fv)
         @test pd_fv_wrapped isa PlotData1D
 

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -290,11 +290,29 @@ end
 
         pd_fv_wrapped = PlotData1D(sol)
         @test pd_fv_wrapped isa PlotData1D
+
+        @test pd_fv_explicit.data ≈ pd_fv_wrapped.data
+    end
+
+    @trixi_testset "DGSEM vs BlockFV 1D Visualization" begin
+        @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_dgsem",
+                                     "elixir_advection_finite_volume.jl"), polydeg=0,
+                            initial_refinement_level=5)
+
+        pd_dgsem_polydeg0 = PlotData1D(sol)
+
+        @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
+                                     "elixir_advection_basic.jl"), n_nodes=4,
+                            initial_refinement_level=3)
+
+        pd_blockfv = PlotData1D(sol)
+
+        @test pd_blockfv.data ≈ pd_dgsem_polydeg0.data
     end
 
     @trixi_testset "Constant IC" begin
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
-                                     "elixir_euler_source_term_nonperiodic"))
+                                     "elixir_euler_source_term_nonperiodic.jl"))
 
         u_fv = sol.u[end]
         mesh_fv = semi.mesh
@@ -307,6 +325,8 @@ end
 
         pd_fv_wrapped = PlotData1D(sol)
         @test pd_fv_wrapped isa PlotData1D
+
+        @test pd_fv_explicit.data ≈ pd_fv_wrapped.data
     end
 end
 

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -240,7 +240,7 @@ end
 
     @testset "BlockFV 1D Visualization" begin
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
-                                     "elixir_advection_basic.jl"), tspan=(0.0, 0.0))
+                                     "elixir_advection_basic.jl"))
 
         u_fv = sol.u[end]
         mesh_fv = semi.mesh

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -272,27 +272,14 @@ end
     end
 end
 
-#new thing
-
 @timed_testset "FV testsets" begin
     @trixi_testset "BlockFV 1D Visualization" begin
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
                                      "elixir_advection_basic.jl"), n_nodes=4,
                             initial_refinement_level=3)
 
-        #u_fv = sol.u[end]
-        #mesh_fv = semi.mesh
-        #equations_fv = semi.equations
-        #solver_fv = semi.solver
-        #cache_fv = semi.cache
-
-        #pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
-        #@test pd_fv_explicit isa PlotData1D
-
-        pd_fv_wrapped = PlotData1D(sol)
+        pd_fv_wrapped = @test_nowarn PlotData1D(sol)
         @test pd_fv_wrapped isa PlotData1D
-
-        #@test pd_fv_explicit.data ≈ pd_fv_wrapped.data
     end
 
     @trixi_testset "DGSEM vs BlockFV 1D Visualization" begin
@@ -300,13 +287,13 @@ end
                                      "elixir_advection_finite_volume.jl"), polydeg=0,
                             initial_refinement_level=5)
 
-        pd_dgsem_polydeg0 = PlotData1D(sol)
+        pd_dgsem_polydeg0 = @test_nowarn PlotData1D(sol)
 
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
                                      "elixir_advection_basic.jl"), n_nodes=4,
                             initial_refinement_level=3)
 
-        pd_blockfv = PlotData1D(sol)
+        pd_blockfv = @test_nowarn PlotData1D(sol)
 
         @test pd_blockfv.data ≈ pd_dgsem_polydeg0.data
     end
@@ -317,23 +304,10 @@ end
                             n_nodes=4,
                             initial_refinement_level=3)
 
-        #u_fv = sol.u[end]
-        #mesh_fv = semi.mesh
-        #equations_fv = semi.equations
-        #solver_fv = semi.solver
-        #cache_fv = semi.cache
-
-        #pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
-        #@test pd_fv_explicit isa PlotData1D
-
-        pd_fv_wrapped = PlotData1D(sol)
-        @test pd_fv_wrapped isa PlotData1D
-
-        #@test pd_fv_explicit.data ≈ pd_fv_wrapped.data
+        pd_fv_constant_ic = @test_nowarn PlotData1D(sol)
+        @test pd_fv_constant_ic isa PlotData1D
     end
 end
-
-#end new thing
 
 @timed_testset "1D plot from 2D solution" begin
     @trixi_testset "Create 1D plot along curve" begin

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -280,17 +280,17 @@ end
                                      "elixir_advection_basic.jl"), n_nodes=4,
                             initial_refinement_level=3)
 
-        u_fv = sol.u[end]
-        mesh_fv = semi.mesh
-        equations_fv = semi.equations
-        solver_fv = semi.solver
-        cache_fv = semi.cache
+        #u_fv = sol.u[end]
+        #mesh_fv = semi.mesh
+        #equations_fv = semi.equations
+        #solver_fv = semi.solver
+        #cache_fv = semi.cache
 
-        pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
-        @test pd_fv_explicit isa PlotData1D
+        #pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
+        #@test pd_fv_explicit isa PlotData1D
 
-        #pd_fv_wrapped = PlotData1D(sol)
-        #@test pd_fv_wrapped isa PlotData1D
+        pd_fv_wrapped = PlotData1D(sol)
+        @test pd_fv_wrapped isa PlotData1D
 
         #@test pd_fv_explicit.data ≈ pd_fv_wrapped.data
     end
@@ -316,17 +316,17 @@ end
                                      "elixir_euler_source_term_nonperiodic.jl"), n_nodes=4,
                             initial_refinement_level=3)
 
-        u_fv = sol.u[end]
-        mesh_fv = semi.mesh
-        equations_fv = semi.equations
-        solver_fv = semi.solver
-        cache_fv = semi.cache
+        #u_fv = sol.u[end]
+        #mesh_fv = semi.mesh
+        #equations_fv = semi.equations
+        #solver_fv = semi.solver
+        #cache_fv = semi.cache
 
-        pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
-        @test pd_fv_explicit isa PlotData1D
+        #pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
+        #@test pd_fv_explicit isa PlotData1D
 
-        #pd_fv_wrapped = PlotData1D(sol)
-        #@test pd_fv_wrapped isa PlotData1D
+        pd_fv_wrapped = PlotData1D(sol)
+        @test pd_fv_wrapped isa PlotData1D
 
         #@test pd_fv_explicit.data ≈ pd_fv_wrapped.data
     end

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -239,22 +239,24 @@ end
     @test size(pd2.data) == (128, 3)
 
     @testset "BlockFV 1D Visualization" begin
+        bfv_workspace = Module(:BlockFVWorkspace)
+        Core.eval(bfv_workspace, :(using Trixi))
+
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
-                                     "elixir_advection_basic.jl"))
-        let
-            u_fv = sol.u[end]
-            mesh_fv = semi.mesh
-            equations_fv = semi.equations
-            solver_fv = semi.solver
-            cache_fv = semi.cache
+                                     "elixir_advection_basic.jl"), m=bfv_workspace,
+                            l2=nothing, linf=nothing)
 
-            pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv,
-                                        cache_fv)
-            @test pd_fv_explicit isa PlotData1D
+        u_fv = bfv_workspace.sol.u[end]
+        mesh_fv = bfv_workspace.semi.mesh
+        equations_fv = bfv_workspace.semi.equations
+        solver_fv = bfv_workspace.semi.solver
+        cache_fv = bfv_workspace.semi.cache
 
-            pd_fv_wrapped = PlotData1D(sol)
-            @test pd_fv_wrapped isa PlotData1D
-        end
+        pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
+        @test pd_fv_explicit isa PlotData1D
+
+        pd_fv_wrapped = PlotData1D(sol)
+        @test pd_fv_wrapped isa PlotData1D
     end
     @testset "1D plot recipes" begin
         pd = PlotData1D(sol)

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -238,6 +238,24 @@ end
     pd2 = PlotData1D(sol, nvisnodes = 2)
     @test size(pd2.data) == (128, 3)
 
+    @testset "BlockFV 1D Visualization" begin
+        equations_fv = LinearScalarAdvectionEquation1D(1.0)
+        basis_fv = UniformFiniteVolumeBasis(3)
+        solver_fv = BlockFV(basis_fv)
+        mesh_fv = TreeMesh((-1.0,), (-1.0,), initial_refinement_level = 2, n_cells_max = 100, periodicity = true)
+        semi_fv = SemidiscretizationHyperbolic(mesh_fv, equations_fv, initial_condition_constant, solver_fv)
+        u_fv = compute_coefficients(0.0, semi_fv)
+        cache_fv = semi_fv.cache
+        
+        pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
+        @test pd_fv_explicit isa PlotData1D
+        
+        pd_fv_wrapped = PlotData1D(u_fv, semi_fv)
+        @test pd_fv_wrapped isa PlotData1D
+
+        @trixi_test_nowarn Plots.plot(pd_fv_wrapped)
+    end
+
     @testset "1D plot recipes" begin
         pd = PlotData1D(sol)
 

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -288,10 +288,10 @@ end
         pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
         @test pd_fv_explicit isa PlotData1D
 
-        pd_fv_wrapped = PlotData1D(sol)
-        @test pd_fv_wrapped isa PlotData1D
+        #pd_fv_wrapped = PlotData1D(sol)
+        #@test pd_fv_wrapped isa PlotData1D
 
-        @test pd_fv_explicit.data ≈ pd_fv_wrapped.data
+        #@test pd_fv_explicit.data ≈ pd_fv_wrapped.data
     end
 
     @trixi_testset "DGSEM vs BlockFV 1D Visualization" begin
@@ -323,10 +323,10 @@ end
         pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
         @test pd_fv_explicit isa PlotData1D
 
-        pd_fv_wrapped = PlotData1D(sol)
-        @test pd_fv_wrapped isa PlotData1D
+        #pd_fv_wrapped = PlotData1D(sol)
+        #@test pd_fv_wrapped isa PlotData1D
 
-        @test pd_fv_explicit.data ≈ pd_fv_wrapped.data
+        #@test pd_fv_explicit.data ≈ pd_fv_wrapped.data
     end
 end
 

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -239,20 +239,19 @@ end
     @test size(pd2.data) == (128, 3)
 
     @testset "BlockFV 1D Visualization" begin
-        equations_fv = LinearScalarAdvectionEquation1D(1.0)
-        basis_fv = UniformFiniteVolumeBasis(3)
-        solver_fv = BlockFV(basis_fv)
-        mesh_fv = TreeMesh((-1.0,), (-1.0,), initial_refinement_level = 2,
-                           n_cells_max = 100, periodicity = true)
-        semi_fv = SemidiscretizationHyperbolic(mesh_fv, equations_fv,
-                                               initial_condition_constant, solver_fv)
+        @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_fv",
+                                     "elixir_advection_basic,jl"), tspan=(0.0, 0.0))
+
         u_fv = compute_coefficients(0.0, semi_fv)
-        cache_fv = semi_fv.cache
+        mesh_fv = semi.mesh
+        equations_fv = semi.equations
+        solver_fv = semi.solver
+        cache_fv = semi.cache
 
         pd_fv_explicit = PlotData1D(u_fv, mesh_fv, equations_fv, solver_fv, cache_fv)
         @test pd_fv_explicit isa PlotData1D
 
-        pd_fv_wrapped = PlotData1D(u_fv, semi_fv)
+        pd_fv_wrapped = PlotData1D(sol)
         @test pd_fv_wrapped isa PlotData1D
 
         @trixi_test_nowarn Plots.plot(pd_fv_wrapped)

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -240,7 +240,7 @@ end
 
     @testset "BlockFV 1D Visualization" begin
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_blockfv",
-                                     "elixir_advection_basic.jl"))
+                                     "elixir_advection_basic.jl"), m=Module())
 
         u_fv = sol.u[end]
         mesh_fv = semi.mesh


### PR DESCRIPTION
Added method for plotting via Plots.jl/Makie.jl for TreeMesh1D if the solver is BlockFV.
This is described in issue #30687 (Block finite volume methods).

I tested the methof with 

trixi_include("../examples/tree_1d_blockfv/elixir_advection_basic.jl", n_nodes = 4, initial_refinement_level = 3); plot(sol)

which resulted in this graph

<img width="749" height="544" alt="bockfv" src="https://github.com/user-attachments/assets/16f9d3ad-5a2a-4384-9b88-bb21e39ad786" />

I also ran 

trixi_include("../examples/tree_1d_dgsem/elixir_advection_finite_volume.jl", polydeg = 0, initial_refinement_level = 5); plot(sol)

which resulted in this graph

<img width="744" height="536" alt="dgsem" src="https://github.com/user-attachments/assets/1e0c34e8-df66-4b2a-a211-4e4ff0d509e5" />

The idea behind comparing these is to verify the block finite volume method against the standard finite volume method at an identical global resolution. 

Case DGSEM: An initial refinement level of 5 yields 2^5=32 cells. 
Case BlockFV: The total resolution of a level 3 mesh (2^3=8 blocks) where each block is subdivided into 4 subcells is also 32 (8*4=32).