### PR TITLE
Add missing `@test`

### DIFF
--- a/test/test_special_elixirs.jl
+++ b/test/test_special_elixirs.jl
@@ -454,7 +454,7 @@ end
             sol = solve(ode, SSPRK43(), callback = callbacks)
             return Trixi.integrate(entropy, sol.u[end], semi)
         end
-        ForwardDiff.derivative(entropy_at_final_time, 1.0) ≈ -0.4524664696235628
+        @test ForwardDiff.derivative(entropy_at_final_time, 1.0) ≈ -0.4524664696235628
     end
 
     @timed_testset "Linear advection 2D" begin
@@ -486,7 +486,7 @@ end
                         callback = callbacks)
             return Trixi.integrate(energy_total, sol.u[end], semi)
         end
-        ForwardDiff.derivative(energy_at_final_time, 1.0) ≈ 1.4388628342896945e-5
+        @test ForwardDiff.derivative(energy_at_final_time, 1.0) ≈ 1.1418127193865701e-5
     end
 
     @timed_testset "elixir_euler_ad.jl" begin


### PR DESCRIPTION
In #3096, I noticed two missing `@test`s, which means we did not actually tested if they pass. One of them still passes locally, while for the other one I needed to adapt the reference value slightly. I assume it just got stale over time (the values come from very early times of Trixi.jl more than 5 years ago).