### PR TITLE
rm unused `Basis`

### DIFF
--- a/src/visualization/types.jl
+++ b/src/visualization/types.jl
@@ -691,7 +691,7 @@ function PlotData1D(u, mesh::TreeMesh1D, equations, solver::BlockFV, cache;
                     solution_variables = nothing, nvisnodes = nothing,
                     reinterpolate = default_reinterpolate(solver),
                     slice = :x, point = (0.0, 0.0, 0.0), curve = nothing,
-                    variable_names = nothing) where {Basis <: UniformFiniteVolumeBasis}
+                    variable_names = nothing)
     solution_variables_ = digest_solution_variables(equations, solution_variables)
     variable_names_ = digest_variable_names(solution_variables_, equations,
                                             variable_names)


### PR DESCRIPTION
```julia
Precompiling packages finished.
  170 dependencies successfully precompiled in 58 seconds. 88 already precompiled.
  2 dependencies had output during precompilation:
┌ MKL_jll
│   Downloading artifact: oneTBB
└  
┌ Trixi
│  WARNING: method definition for #PlotData1D#2121 at /home/daniel/git/Trixi.jl/src/visualization/types.jl:690 declares type variable Basis but does not use it.
└  
```

Slipped through in #3095 

@MagalieHeinrich I would request a review from you, but you are not yet part of the orga 