### PR TITLE
specialize max_dt for BlockFV

### DIFF
--- a/src/solvers/blockfv/blockfv_2d.jl
+++ b/src/solvers/blockfv/blockfv_2d.jl
@@ -186,6 +186,33 @@ function calc_error_norms(func, u, t, analyzer,
     return l2_error, linf_error
 end
 
+# Required for the StepsizeCallback. The difference to the default implementation of `max_dt`
+# used for DGSEM is that we compute the maximum of the sum of the wave speeds instead of the
+# maximum of the wave speeds in each direction separately. The default implementation would
+# make the result depend on the number of FV cells per macro-cell, which is not desirable.
+function max_dt(u, t, mesh::TreeMesh{2},
+                constant_speed::False, equations, dg::BlockFV, cache)
+    # Avoid division by zero if the speed vanishes everywhere,
+    # e.g. for steady-state linear advection
+    max_scaled_speed = nextfloat(zero(t))
+
+    @batch reduction=(max, max_scaled_speed) for element in eachelement(dg, cache)
+        max_lambda_sum = zero(max_scaled_speed)
+        for j in eachnode(dg), i in eachnode(dg)
+            u_node = get_node_vars(u, equations, dg, i, j, element)
+            lambda1, lambda2 = max_abs_speeds(u_node, equations)
+            max_lambda_sum = Base.max(max_lambda_sum, lambda1 + lambda2)
+        end
+        inv_jacobian = cache.elements.inverse_jacobian[element]
+        # Use `Base.max` to prevent silent failures, as `max` from `@fastmath` doesn't propagate
+        # `NaN`s properly. See https://github.com/trixi-framework/Trixi.jl/pull/2445#discussion_r2336812323
+        max_scaled_speed = Base.max(max_scaled_speed,
+                                    inv_jacobian * max_lambda_sum)
+    end
+
+    return 2 / (nnodes(dg) * max_scaled_speed)
+end
+
 @inline function element_solutions_to_mortars!(mortars,
                                                mortar_l2::UniformFiniteVolumeBasis,
                                                leftright,

--- a/test/test_tree_2d_blockfv.jl
+++ b/test/test_tree_2d_blockfv.jl
@@ -58,15 +58,19 @@ end # Linear scalar advection
 @trixi_testset "elixir_euler_density_wave.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "elixir_euler_density_wave.jl"),
-                        l2=[0.031233316749041267,
-                            0.003123331674903803,
-                            0.006246663349808052,
-                            0.0007808329187371395],
-                        linf=[0.044169344994492266,
-                            0.0044169344994492215,
-                            0.008833868998898514,
-                            0.0011042336248863194],
-                        tspan=(0.0, 0.5))
+                        l2=[
+                            0.003190908142060662,
+                            0.00031909081420601837,
+                            0.0006381816284120868,
+                            7.977270355347174e-5
+                        ],
+                        linf=[
+                            0.0045107823283880855,
+                            0.00045107823283929704,
+                            0.000902156465677928,
+                            0.00011276955822125956
+                        ],
+                        tspan=(0.0, 0.05))
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
@@ -75,14 +79,18 @@ end
 @trixi_testset "elixir_euler_vortex.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "elixir_euler_vortex.jl"),
-                        l2=[0.0009462760556996494,
-                            0.034845346890640956,
-                            0.0349234255730328,
-                            0.09387847561186147],
-                        linf=[0.01522697023057773,
-                            0.40428197961893275,
-                            0.39638850053862995,
-                            1.628539546658537],
+                        l2=[
+                            0.0009463095855559644,
+                            0.034840444590943494,
+                            0.03491933775722927,
+                            0.09388027508058767
+                        ],
+                        linf=[
+                            0.015226079023008654,
+                            0.40423179950815646,
+                            0.3963363807671082,
+                            1.628386806835067
+                        ],
                         tspan=(0.0, 1.0))
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
@@ -92,14 +100,18 @@ end
 @trixi_testset "elixir_euler_convergence.jl" begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "elixir_euler_convergence.jl"),
-                        l2=[0.003798391701194144,
-                            0.009489467813506548,
-                            0.00948946781350655,
-                            0.02704154630948781],
-                        linf=[0.005743846316061285,
-                            0.013649501767585503,
+                        l2=[
+                            0.003798391701194131,
+                            0.0094894678135065,
+                            0.009489467813506488,
+                            0.027041546309487817
+                        ],
+                        linf=[
+                            0.005743846316061063,
                             0.013649501767585726,
-                            0.03876289859195037],
+                            0.013649501767585726,
+                            0.03876289859195037
+                        ],
                         tspan=(0.0, 0.5))
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
@@ -110,16 +122,16 @@ end
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "elixir_euler_source_term_nonperiodic.jl"),
                         l2=[
-                            0.0013980788738505803,
-                            0.0027151896203078626,
-                            0.0027151896203078817,
-                            0.008307485477336464
+                            0.0013980802560727824,
+                            0.0027151888286537657,
+                            0.002715188828653762,
+                            0.008307473062557628
                         ],
                         linf=[
-                            0.0028249606444796793,
-                            0.005820266937670571,
-                            0.005820266937670571,
-                            0.016196092853339117
+                            0.002824953578837608,
+                            0.0058202665506430495,
+                            0.0058202665506430495,
+                            0.0161960768546221
                         ],
                         tspan=(0.0, 0.5))
     # Ensure that we do not have excessive memory allocations
@@ -127,21 +139,13 @@ end
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 
-@trixi_testset "elixir_euler_vortex_mortar.jl with blockfv vs with dgsem with polydeg=0" begin
-    # We explicitly pass a time step size `dt` and set the `stepsize_callback` to `nothing`
-    # to avoid subtle differences coming from different time step size evaluations in the
-    # two runs: The `DGSEM` solver computes the wave speeds in all directions and takes the
-    # maximum over all cells, while the `BlockFV` solver first takes a maximum of the wave speeds
-    # separately in each macro-cell before combining them, leading to slightly different results.
-
+@trixi_testset "elixir_euler_vortex_mortar.jl, BlockFV vs DGSEM with polydeg=0" begin
     # Compute with BlockFV solver.
     trixi_include(@__MODULE__,
                   joinpath(EXAMPLES_DIR, "elixir_euler_vortex_mortar.jl"),
                   n_nodes = 4,
                   initial_refinement_level = 5,
-                  tspan = (0.0, 0.5),
-                  dt = 2.0e-3,
-                  stepsize_callback = nothing)
+                  tspan = (0.0, 0.5))
     res1 = @inferred analysis_callback(sol)
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
@@ -152,9 +156,7 @@ end
                   joinpath(EXAMPLES_DIR, "elixir_euler_vortex_mortar.jl"),
                   solver = DGSEM(polydeg = 0, surface_flux = flux_hllc),
                   initial_refinement_level = 7,
-                  tspan = (0.0, 0.5),
-                  dt = 2.0e-3,
-                  stepsize_callback = nothing)
+                  tspan = (0.0, 0.5))
     res2 = @inferred analysis_callback(sol)
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)


### PR DESCRIPTION
This removes an inconsistency of the computed time step size obtained for different numbers of FV cells per macro cell of the mesh. It fixes an open issue listed in https://github.com/trixi-framework/Trixi.jl/issues/3068.
