### PR TITLE
Put P4est.jl and T8code.jl in separate dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,17 @@ updates:
     schedule:
       interval: "daily"
     groups:
-      # Group all Julia package updates into a single PR:
-      all-julia-dependencies:
+      # Group updates for P4est.jl, T8code.jl, and all other julia packages into separate PRs
+      # because we usually want to update P4est.jl and T8code.jl separately.
+      p4est:
+        patterns:
+          - "P4est"
+      t8code:
+        patterns:
+          - "T8code"
+      all-julia-packages-except-p4est-t8code:
         patterns:
           - "*"
+        exclude-patterns:
+          - "P4est"
+          - "T8code"


### PR DESCRIPTION
As discussed in https://github.com/trixi-framework/Trixi.jl/pull/3126#issuecomment-4895445721.