### PR TITLE
Harden `boundary_condition_slip_wall` for Euler

### DIFF
--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -254,10 +254,14 @@ Should be used together with [`TreeMesh`](@ref).
     # [DOI: 10.1007/b79761](https://doi.org/10.1007/b79761)
     if v_normal <= 0
         sound_speed = sqrt(equations.gamma * p_local / rho_local) # local sound speed
-        p_star = p_local *
-                 (1 + 0.5f0 * (equations.gamma - 1) * v_normal / sound_speed)^(2 *
-                                                                               equations.gamma *
-                                                                               equations.inv_gamma_minus_one)
+        base = (1 + 0.5f0 * (equations.gamma - 1) * v_normal / sound_speed)
+        @show base
+        if base >= 0
+            p_star = p_local *
+                     base^(2 * equations.gamma * equations.inv_gamma_minus_one)
+        else # avoid taking powers of if base < 0
+            p_star = zero(p_local)
+        end
     else # v_normal > 0
         A = 2 / ((equations.gamma + 1) * rho_local)
         B = p_local * (equations.gamma - 1) / (equations.gamma + 1)

--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -234,6 +234,12 @@ are available in the paper:
   the Euler equations of gas dynamics
   [PDF](https://reports.nlr.nl/bitstream/handle/10921/692/TP-2002-300.pdf?sequence=1)
 
+The implementation is modified to ensure non-negativity of `p_star`. This modification 
+preserves entropy stability based on the analysis in the paper:
+- F. J. Hindenlang, G. J. Gassner, D. A. Kopriva (2020)
+  Stability of wall boundary condition procedures for discontinuous Galerkin spectral element approximations of the compressible Euler equations
+  [DOI: 10.1007/978-3-030-39647-3_1](https://doi.org/10.1007/978-3-030-39647-3_1)
+
 Should be used together with [`TreeMesh`](@ref).
 """
 @inline function boundary_condition_slip_wall(u_inner, orientation,

--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -255,10 +255,11 @@ Should be used together with [`TreeMesh`](@ref).
     if v_normal <= 0
         sound_speed = sqrt(equations.gamma * p_local / rho_local) # local sound speed
         p_scaling_base = (1 + 0.5f0 * (equations.gamma - 1) * v_normal / sound_speed)
-        if base >= 0
+        if p_scaling_base >= 0
             p_star = p_local *
-                     base^(2 * equations.gamma * equations.inv_gamma_minus_one)
-        else # avoid taking powers if base < 0
+                     p_scaling_base^(2 * equations.gamma *
+                                     equations.inv_gamma_minus_one)
+        else # avoid taking powers if p_scaling_base < 0
             p_star = zero(p_local)
         end
     else # v_normal > 0

--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -254,7 +254,7 @@ Should be used together with [`TreeMesh`](@ref).
     # [DOI: 10.1007/b79761](https://doi.org/10.1007/b79761)
     if v_normal <= 0
         sound_speed = sqrt(equations.gamma * p_local / rho_local) # local sound speed
-        base = (1 + 0.5f0 * (equations.gamma - 1) * v_normal / sound_speed)
+        p_scaling_base = (1 + 0.5f0 * (equations.gamma - 1) * v_normal / sound_speed)
         if base >= 0
             p_star = p_local *
                      base^(2 * equations.gamma * equations.inv_gamma_minus_one)

--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -255,7 +255,6 @@ Should be used together with [`TreeMesh`](@ref).
     if v_normal <= 0
         sound_speed = sqrt(equations.gamma * p_local / rho_local) # local sound speed
         base = (1 + 0.5f0 * (equations.gamma - 1) * v_normal / sound_speed)
-        @show base
         if base >= 0
             p_star = p_local *
                      base^(2 * equations.gamma * equations.inv_gamma_minus_one)

--- a/src/equations/compressible_euler_1d.jl
+++ b/src/equations/compressible_euler_1d.jl
@@ -258,7 +258,7 @@ Should be used together with [`TreeMesh`](@ref).
         if base >= 0
             p_star = p_local *
                      base^(2 * equations.gamma * equations.inv_gamma_minus_one)
-        else # avoid taking powers of if base < 0
+        else # avoid taking powers if base < 0
             p_star = zero(p_local)
         end
     else # v_normal > 0

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -334,11 +334,12 @@ Should be used together with [`UnstructuredMesh2D`](@ref), [`P4estMesh`](@ref), 
     # [DOI: 10.1007/b79761](https://doi.org/10.1007/b79761)
     if v_normal <= 0
         sound_speed = sqrt(equations.gamma * p_local / rho_local) # local sound speed
-        base = (1 + 0.5f0 * (equations.gamma - 1) * v_normal / sound_speed)
-        if base >= 0
+        p_scaling_base = (1 + 0.5f0 * (equations.gamma - 1) * v_normal / sound_speed)
+        if p_scaling_base >= 0
             p_star = p_local *
-                     base^(2 * equations.gamma * equations.inv_gamma_minus_one)
-        else # avoid taking powers if base < 0
+                     p_scaling_base^(2 * equations.gamma *
+                                     equations.inv_gamma_minus_one)
+        else # avoid taking powers if p_scaling_base < 0
             p_star = zero(p_local)
         end
     else # v_normal > 0

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -338,7 +338,7 @@ Should be used together with [`UnstructuredMesh2D`](@ref), [`P4estMesh`](@ref), 
         if base >= 0
             p_star = p_local *
                      base^(2 * equations.gamma * equations.inv_gamma_minus_one)
-        else # avoid taking powers of if base < 0
+        else # avoid taking powers if base < 0
             p_star = zero(p_local)
         end
     else # v_normal > 0

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -334,10 +334,13 @@ Should be used together with [`UnstructuredMesh2D`](@ref), [`P4estMesh`](@ref), 
     # [DOI: 10.1007/b79761](https://doi.org/10.1007/b79761)
     if v_normal <= 0
         sound_speed = sqrt(equations.gamma * p_local / rho_local) # local sound speed
-        p_star = p_local *
-                 (1 + 0.5f0 * (equations.gamma - 1) * v_normal / sound_speed)^(2 *
-                                                                               equations.gamma *
-                                                                               equations.inv_gamma_minus_one)
+        base = (1 + 0.5f0 * (equations.gamma - 1) * v_normal / sound_speed)
+        if base >= 0
+            p_star = p_local *
+                     base^(2 * equations.gamma * equations.inv_gamma_minus_one)
+        else # avoid taking powers of if base < 0
+            p_star = zero(p_local)
+        end
     else # v_normal > 0
         A = 2 / ((equations.gamma + 1) * rho_local)
         B = p_local * (equations.gamma - 1) / (equations.gamma + 1)

--- a/src/equations/compressible_euler_2d.jl
+++ b/src/equations/compressible_euler_2d.jl
@@ -311,6 +311,12 @@ Details about the 1D pressure Riemann solution can be found in Section 6.3.3 of 
   3rd edition
   [DOI: 10.1007/b79761](https://doi.org/10.1007/b79761)
 
+The implementation is modified to ensure non-negativity of `p_star`. This modification 
+preserves entropy stability based on the analysis in the paper:  
+- F. J. Hindenlang, G. J. Gassner, D. A. Kopriva (2020)
+  Stability of wall boundary condition procedures for discontinuous Galerkin spectral element approximations of the compressible Euler equations
+  [DOI: 10.1007/978-3-030-39647-3_1](https://doi.org/10.1007/978-3-030-39647-3_1)
+
 Should be used together with [`UnstructuredMesh2D`](@ref), [`P4estMesh`](@ref), or [`T8codeMesh`](@ref).
 """
 @inline function boundary_condition_slip_wall(u_inner, normal_direction::AbstractVector,

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -335,10 +335,13 @@ Should be used together with [`P4estMesh`](@ref) or [`T8codeMesh`](@ref).
     # [DOI: 10.1007/b79761](https://doi.org/10.1007/b79761)
     if v_normal <= 0
         sound_speed = sqrt(equations.gamma * p_local / rho_local) # local sound speed
-        p_star = p_local *
-                 (1 + 0.5f0 * (equations.gamma - 1) * v_normal / sound_speed)^(2 *
-                                                                               equations.gamma *
-                                                                               equations.inv_gamma_minus_one)
+        base = (1 + 0.5f0 * (equations.gamma - 1) * v_normal / sound_speed)
+        if base >= 0
+            p_star = p_local *
+                     base^(2 * equations.gamma * equations.inv_gamma_minus_one)
+        else # avoid taking powers of if base < 0
+            p_star = zero(p_local)
+        end
     else # v_normal > 0
         A = 2 / ((equations.gamma + 1) * rho_local)
         B = p_local * (equations.gamma - 1) / (equations.gamma + 1)

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -335,11 +335,12 @@ Should be used together with [`P4estMesh`](@ref) or [`T8codeMesh`](@ref).
     # [DOI: 10.1007/b79761](https://doi.org/10.1007/b79761)
     if v_normal <= 0
         sound_speed = sqrt(equations.gamma * p_local / rho_local) # local sound speed
-        base = (1 + 0.5f0 * (equations.gamma - 1) * v_normal / sound_speed)
-        if base >= 0
+        p_scaling_base = (1 + 0.5f0 * (equations.gamma - 1) * v_normal / sound_speed)
+        if p_scaling_base >= 0
             p_star = p_local *
-                     base^(2 * equations.gamma * equations.inv_gamma_minus_one)
-        else # avoid taking powers if base < 0
+                     p_scaling_base^(2 * equations.gamma *
+                                     equations.inv_gamma_minus_one)
+        else # avoid taking powers if p_scaling_base < 0
             p_star = zero(p_local)
         end
     else # v_normal > 0

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -303,6 +303,13 @@ Details about the 1D pressure Riemann solution can be found in Section 6.3.3 of 
   3rd edition
   [DOI: 10.1007/b79761](https://doi.org/10.1007/b79761)
 
+The implementation is modified to ensure non-negativity of `p_star`. This modification 
+preserves entropy stability based on the analysis in the paper:  
+- F. J. Hindenlang, G. J. Gassner, D. A. Kopriva (2020)
+  Stability of wall boundary condition procedures for discontinuous Galerkin spectral element approximations of the compressible Euler equations
+  [DOI: 10.1007/978-3-030-39647-3_1](https://doi.org/10.1007/978-3-030-39647-3_1)
+
+
 Should be used together with [`P4estMesh`](@ref) or [`T8codeMesh`](@ref).
 """
 @inline function boundary_condition_slip_wall(u_inner, normal_direction::AbstractVector,

--- a/src/equations/compressible_euler_3d.jl
+++ b/src/equations/compressible_euler_3d.jl
@@ -339,7 +339,7 @@ Should be used together with [`P4estMesh`](@ref) or [`T8codeMesh`](@ref).
         if base >= 0
             p_star = p_local *
                      base^(2 * equations.gamma * equations.inv_gamma_minus_one)
-        else # avoid taking powers of if base < 0
+        else # avoid taking powers if base < 0
             p_star = zero(p_local)
         end
     else # v_normal > 0

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -983,6 +983,57 @@ end
     end
 end
 
+@testitem "Unit: hardened boundary_condition_slip_wall" setup=[
+    Setup,
+    UnitTests
+] tags=[:misc_part1] begin
+    let equations = CompressibleEulerEquations1D(1.4)
+        # this state results in base < 0 in the implementation of 
+        # boundary_condition_slip_wall.
+        u_inner = prim2cons(SVector(1.4, -6, 1), equations)
+
+        x, t = 0, 0
+        orientation = 1
+        direction = 2 # even direction: v_normal stays <= 0
+        surface_flux_function = flux_lax_friedrichs
+        flux = boundary_condition_slip_wall(u_inner, orientation, direction, x, t,
+                                            surface_flux_function, equations)
+
+        # boundary_condition_slip_wall should return exactly zero                                            
+        @test flux == zero(flux)
+    end
+
+    let equations = CompressibleEulerEquations2D(1.4)
+        # this state results in base < 0 in the implementation of 
+        # boundary_condition_slip_wall.
+        u_inner = prim2cons(SVector(1.4, -6, 0, 1), equations)
+        normal_direction = SVector(1.0, 0.0)
+
+        x, t = 0, 0
+        surface_flux_function = flux_lax_friedrichs
+        flux = boundary_condition_slip_wall(u_inner, normal_direction, x, t,
+                                            surface_flux_function, equations)
+
+        # boundary_condition_slip_wall should return exactly zero                                            
+        @test flux == zero(flux)
+    end
+
+    let equations = CompressibleEulerEquations3D(1.4)
+        # this state results in base < 0 in the implementation of 
+        # boundary_condition_slip_wall.
+        u_inner = prim2cons(SVector(1.4, -6, 0, 0, 1), equations)
+        normal_direction = SVector(1.0, 0.0, 0.0)
+
+        x, t = 0, 0
+        surface_flux_function = flux_lax_friedrichs
+        flux = boundary_condition_slip_wall(u_inner, normal_direction, x, t,
+                                            surface_flux_function, equations)
+
+        # boundary_condition_slip_wall should return exactly zero                                            
+        @test flux == zero(flux)
+    end
+end
+
 @testitem "Unit: Helmholtz ideal gas equation of state (AD vs analytical)" setup=[
     Setup,
     UnitTests


### PR DESCRIPTION
The implementation of `boundary_condition_slip_wall` for Euler takes the power of an expression when computing the intermediate pressure state. 
https://github.com/trixi-framework/Trixi.jl/blob/12f0483c373b7779dc20bbda020f99915de05c97/src/equations/compressible_euler_1d.jl#L257-L259
However, this can be negative, resulting in an error being thrown. This PR hardens this by setting the intermediate pressure state to zero when this happens. This hardening retains entropy stability based on the analysis in https://arxiv.org/abs/1901.04924

This modification was necessary for running the Mach 3 cylinder with no shock capturing and Liu-Zhang positivity limiting. 