### PR TITLE
fix Burgers `flux_ec` for `DGMulti`

### DIFF
--- a/src/equations/inviscid_burgers_1d.jl
+++ b/src/equations/inviscid_burgers_1d.jl
@@ -135,7 +135,8 @@ Godunov (upwind) numerical flux for the inviscid Burgers' equation.
 See https://metaphor.ethz.ch/x/2019/hs/401-4671-00L/literature/mishra_hyperbolic_pdes.pdf ,
 section 4.1.5 and especially equation (4.16).
 """
-function flux_godunov(u_ll, u_rr, orientation::Integer, equation::InviscidBurgersEquation1D)
+function flux_godunov(u_ll, u_rr, orientation::Integer,
+                      equation::InviscidBurgersEquation1D)
     u_L = u_ll[1]
     u_R = u_rr[1]
 

--- a/src/equations/inviscid_burgers_1d.jl
+++ b/src/equations/inviscid_burgers_1d.jl
@@ -106,18 +106,26 @@ end
 end
 
 @doc raw"""
-    flux_ec(u_ll, u_rr, orientation, equations::InviscidBurgersEquation1D)
+    flux_ec(u_ll, u_rr, orientation_or_normal_direction,
+            equations::InviscidBurgersEquation1D)
 
 Entropy-conserving, symmetric flux for the inviscid Burgers' equation.
 ```math
 F(u_L, u_R) = \frac{u_L^2 + u_L u_R + u_R^2}{6}
 ```
 """
-function flux_ec(u_ll, u_rr, orientation, equation::InviscidBurgersEquation1D)
+function flux_ec(u_ll, u_rr, orientation::Integer, equation::InviscidBurgersEquation1D)
     u_L = u_ll[1]
     u_R = u_rr[1]
 
     return SVector((u_L^2 + u_L * u_R + u_R^2) / 6)
+end
+
+# While `normal_direction` isn't strictly necessary in 1D, certain solvers assume that
+# the normal component is incorporated into the numerical flux.
+@inline function flux_ec(u_ll, u_rr, normal_direction::AbstractVector,
+                         equations::InviscidBurgersEquation1D)
+    return normal_direction[1] * flux_ec(u_ll, u_rr, 1, equations)
 end
 
 """
@@ -127,7 +135,7 @@ Godunov (upwind) numerical flux for the inviscid Burgers' equation.
 See https://metaphor.ethz.ch/x/2019/hs/401-4671-00L/literature/mishra_hyperbolic_pdes.pdf ,
 section 4.1.5 and especially equation (4.16).
 """
-function flux_godunov(u_ll, u_rr, orientation, equation::InviscidBurgersEquation1D)
+function flux_godunov(u_ll, u_rr, orientation::Integer, equation::InviscidBurgersEquation1D)
     u_L = u_ll[1]
     u_R = u_rr[1]
 
@@ -136,7 +144,7 @@ end
 
 # See https://metaphor.ethz.ch/x/2019/hs/401-4671-00L/literature/mishra_hyperbolic_pdes.pdf ,
 # section 4.2.5 and especially equation (4.34).
-function flux_engquist_osher(u_ll, u_rr, orientation,
+function flux_engquist_osher(u_ll, u_rr, orientation::Integer,
                              equation::InviscidBurgersEquation1D)
     u_L = u_ll[1]
     u_R = u_rr[1]

--- a/test/test_type.jl
+++ b/test/test_type.jl
@@ -2017,6 +2017,7 @@ end
         t = zero(RealT)
         u = u_ll = u_rr = SVector(one(RealT))
         orientation = 1
+        normal_direction = SVector(one(RealT))
 
         @test eltype(@inferred initial_condition_constant(x, t, equations)) == RealT
         @test eltype(@inferred initial_condition_convergence_test(x, t, equations)) ==
@@ -2027,6 +2028,7 @@ end
 
         @test eltype(@inferred flux(u, orientation, equations)) == RealT
         @test eltype(@inferred flux_ec(u_ll, u_rr, orientation, equations)) == RealT
+        @test eltype(@inferred flux_ec(u_ll, u_rr, normal_direction, equations)) == RealT
         @test eltype(@inferred flux_godunov(u_ll, u_rr, orientation, equations)) ==
               RealT
         @test eltype(@inferred Trixi.flux_engquist_osher(u_ll, u_rr, orientation,

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -2008,7 +2008,10 @@ end
     end
 end
 
-@testitem "Unit: Consistency check for entropy-conserving Burgers flux" setup=[Setup, UnitTests] tags=[:misc_part1] begin
+@testitem "Unit: Consistency check for entropy-conserving Burgers flux" setup=[
+    Setup,
+    UnitTests
+] tags=[:misc_part1] begin
     equations = InviscidBurgersEquation1D()
     u_ll = SVector(2.0)
     u_rr = SVector(-1.0)

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -1007,7 +1007,7 @@ end
     UnitTests
 ] tags=[:misc_part1] begin
     let equations = CompressibleEulerEquations1D(1.4)
-        # this state results in base < 0 in the implementation of 
+        # this state results in base < 0 in the implementation of
         # boundary_condition_slip_wall.
         u_inner = prim2cons(SVector(1.4, -6, 1), equations)
 
@@ -1018,12 +1018,12 @@ end
         flux = boundary_condition_slip_wall(u_inner, orientation, direction, x, t,
                                             surface_flux_function, equations)
 
-        # boundary_condition_slip_wall should return exactly zero                                            
+        # boundary_condition_slip_wall should return exactly zero
         @test flux == zero(flux)
     end
 
     let equations = CompressibleEulerEquations2D(1.4)
-        # this state results in base < 0 in the implementation of 
+        # this state results in base < 0 in the implementation of
         # boundary_condition_slip_wall.
         u_inner = prim2cons(SVector(1.4, -6, 0, 1), equations)
         normal_direction = SVector(1.0, 0.0)
@@ -1033,12 +1033,12 @@ end
         flux = boundary_condition_slip_wall(u_inner, normal_direction, x, t,
                                             surface_flux_function, equations)
 
-        # boundary_condition_slip_wall should return exactly zero                                            
+        # boundary_condition_slip_wall should return exactly zero
         @test flux == zero(flux)
     end
 
     let equations = CompressibleEulerEquations3D(1.4)
-        # this state results in base < 0 in the implementation of 
+        # this state results in base < 0 in the implementation of
         # boundary_condition_slip_wall.
         u_inner = prim2cons(SVector(1.4, -6, 0, 0, 1), equations)
         normal_direction = SVector(1.0, 0.0, 0.0)
@@ -1048,7 +1048,7 @@ end
         flux = boundary_condition_slip_wall(u_inner, normal_direction, x, t,
                                             surface_flux_function, equations)
 
-        # boundary_condition_slip_wall should return exactly zero                                            
+        # boundary_condition_slip_wall should return exactly zero
         @test flux == zero(flux)
     end
 end
@@ -2006,6 +2006,22 @@ end
         @test flux_godunov(u, u, normal_direction, equation) ≈
               flux(u, normal_direction, equation)
     end
+end
+
+@testitem "Unit: Consistency check for entropy-conserving Burgers flux" setup=[Setup, UnitTests] tags=[:misc_part1] begin
+    equations = InviscidBurgersEquation1D()
+    u_ll = SVector(2.0)
+    u_rr = SVector(-1.0)
+
+    for normal_direction in (SVector(1.0), SVector(-1.2))
+        @test flux_ec(u_ll, u_rr, normal_direction, equations) ≈
+              normal_direction[1] * flux_ec(u_ll, u_rr, 1, equations)
+    end
+
+    u = SVector(42.0)
+    normal_direction = SVector(-1.2)
+    @test flux_ec(u, u, normal_direction, equations) ≈
+          flux(u, normal_direction, equations)
 end
 
 @testitem "Unit: Consistency check for Engquist-Osher flux" setup=[Setup, UnitTests] tags=[:misc_part1] begin
@@ -4148,8 +4164,8 @@ end
         @test energy_internal(u_projected, equations) > lower_bounds[2] - arithmetic_tol
     end
 
-    # this test failed without the rationalized approximation of 
-    # 0.5 * (rho - sqrt_discriminant_rho) in PositivityPreservingLimiterLiuZhang. 
+    # this test failed without the rationalized approximation of
+    # 0.5 * (rho - sqrt_discriminant_rho) in PositivityPreservingLimiterLiuZhang.
     @testset "2D projection near zero momentum boundary" begin
         equations = CompressibleEulerEquations2D(1.4)
         u = SVector(0.9376339560775117,


### PR DESCRIPTION
`DGMulti` passes the `normal_direction` as vector. Before this PR, the magnitude and sign of the numerical flux was wrong, leading to completely wrong results.