### PR TITLE
remove the need to pass `uEltype = real(dg)` to the `AnalysisCallback` for `DGMulti` solvers

### DIFF
--- a/docs/literate/src/files/DGMulti_1.jl
+++ b/docs/literate/src/files/DGMulti_1.jl
@@ -41,7 +41,7 @@ tspan = (0.0, 0.4)
 ode = semidiscretize(semi, tspan)
 
 alive_callback = AliveCallback(alive_interval = 10)
-analysis_callback = AnalysisCallback(semi, interval = 100, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = 100)
 callbacks = CallbackSet(analysis_callback, alive_callback);
 
 # Run the simulation with the same time integration algorithm as before.
@@ -90,7 +90,7 @@ tspan = (0.0, 0.4)
 ode = semidiscretize(semi, tspan)
 
 alive_callback = AliveCallback(alive_interval = 10)
-analysis_callback = AnalysisCallback(semi, interval = 100, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = 100)
 callbacks = CallbackSet(analysis_callback, alive_callback);
 
 sol = solve(ode, RDPK3SpFSAL49(); abstol = 1.0e-6, reltol = 1.0e-6,
@@ -130,7 +130,7 @@ tspan = (0.0, 0.4)
 ode = semidiscretize(semi, tspan)
 
 alive_callback = AliveCallback(alive_interval = 10)
-analysis_callback = AnalysisCallback(semi, interval = 100, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = 100)
 callbacks = CallbackSet(analysis_callback, alive_callback);
 
 sol = solve(ode, RDPK3SpFSAL49(); abstol = 1.0e-6, reltol = 1.0e-6,
@@ -183,7 +183,7 @@ tspan = (0.0, 0.2)
 ode = semidiscretize(semi, tspan)
 
 alive_callback = AliveCallback(alive_interval = 20)
-analysis_callback = AnalysisCallback(semi, interval = 200, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = 200)
 callbacks = CallbackSet(alive_callback, analysis_callback);
 
 sol = solve(ode, CarpenterKennedy2N54(williamson_condition = false);

--- a/examples/dgmulti_1d/elixir_advection_cgsbp_nonperiodic.jl
+++ b/examples/dgmulti_1d/elixir_advection_cgsbp_nonperiodic.jl
@@ -36,7 +36,7 @@ ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
-analysis_callback = AnalysisCallback(semi, interval = 100, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = 100)
 callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback)
 
 ###############################################################################

--- a/examples/dgmulti_1d/elixir_advection_diffusion_gradient_source_terms.jl
+++ b/examples/dgmulti_1d/elixir_advection_diffusion_gradient_source_terms.jl
@@ -54,7 +54,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 
 alive_callback = AliveCallback(analysis_interval = 100)
 

--- a/examples/dgmulti_1d/elixir_advection_diffusion_sbp.jl
+++ b/examples/dgmulti_1d/elixir_advection_diffusion_sbp.jl
@@ -56,7 +56,7 @@ summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 
 callbacks = CallbackSet(summary_callback, alive_callback,
                         analysis_callback)

--- a/examples/dgmulti_1d/elixir_advection_gauss_sbp.jl
+++ b/examples/dgmulti_1d/elixir_advection_gauss_sbp.jl
@@ -48,7 +48,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 
 # analyse the solution in regular intervals and prints the results
-analysis_callback = AnalysisCallback(semi, interval = 100, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = 100)
 
 # The SaveSolutionCallback allows to save the solution to a file in regular intervals
 save_solution = SaveSolutionCallback(interval = 100,

--- a/examples/dgmulti_1d/elixir_burgers_gauss_shock_capturing.jl
+++ b/examples/dgmulti_1d/elixir_burgers_gauss_shock_capturing.jl
@@ -53,7 +53,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 
 # analyse the solution in regular intervals and prints the results
-analysis_callback = AnalysisCallback(semi, interval = 100, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = 100)
 
 # SaveSolutionCallback allows to save the solution to a file in regular intervals
 save_solution = SaveSolutionCallback(interval = 100,

--- a/examples/dgmulti_1d/elixir_euler_cgsbp_periodic.jl
+++ b/examples/dgmulti_1d/elixir_euler_cgsbp_periodic.jl
@@ -26,7 +26,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 stepsize_callback = StepsizeCallback(cfl = 1.0)
 callbacks = CallbackSet(summary_callback, alive_callback, stepsize_callback,
                         analysis_callback)

--- a/examples/dgmulti_1d/elixir_euler_fdsbp_periodic.jl
+++ b/examples/dgmulti_1d/elixir_euler_fdsbp_periodic.jl
@@ -26,7 +26,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 stepsize_callback = StepsizeCallback(cfl = 1.0)
 callbacks = CallbackSet(summary_callback, alive_callback, stepsize_callback,
                         analysis_callback)

--- a/examples/dgmulti_1d/elixir_euler_flux_diff.jl
+++ b/examples/dgmulti_1d/elixir_euler_flux_diff.jl
@@ -32,7 +32,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = 100,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback,

--- a/examples/dgmulti_1d/elixir_euler_modified_sod.jl
+++ b/examples/dgmulti_1d/elixir_euler_modified_sod.jl
@@ -48,7 +48,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 100)
 analysis_interval = 1000
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 callbacks = CallbackSet(summary_callback,
                         analysis_callback,
                         alive_callback)

--- a/examples/dgmulti_1d/elixir_euler_quasi_1d.jl
+++ b/examples/dgmulti_1d/elixir_euler_quasi_1d.jl
@@ -31,7 +31,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 
 alive_callback = AliveCallback(analysis_interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,

--- a/examples/dgmulti_1d/elixir_euler_shu_osher_gauss_shock_capturing.jl
+++ b/examples/dgmulti_1d/elixir_euler_shu_osher_gauss_shock_capturing.jl
@@ -78,7 +78,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 
 # analyse the solution in regular intervals and prints the results
-analysis_callback = AnalysisCallback(semi, interval = 100, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = 100)
 
 # SaveSolutionCallback allows to save the solution to a file in regular intervals
 save_solution = SaveSolutionCallback(interval = 100,

--- a/examples/dgmulti_1d/elixir_navierstokes_convergence_periodic.jl
+++ b/examples/dgmulti_1d/elixir_navierstokes_convergence_periodic.jl
@@ -119,7 +119,7 @@ summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 
 callbacks = CallbackSet(summary_callback, alive_callback,
                         analysis_callback)

--- a/examples/dgmulti_2d/elixir_advection_diffusion.jl
+++ b/examples/dgmulti_2d/elixir_advection_diffusion.jl
@@ -51,7 +51,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_2d/elixir_advection_diffusion_nonperiodic.jl
+++ b/examples/dgmulti_2d/elixir_advection_diffusion_nonperiodic.jl
@@ -67,7 +67,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_2d/elixir_advection_diffusion_periodic.jl
+++ b/examples/dgmulti_2d/elixir_advection_diffusion_periodic.jl
@@ -26,7 +26,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_2d/elixir_euler_bilinear.jl
+++ b/examples/dgmulti_2d/elixir_euler_bilinear.jl
@@ -43,7 +43,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_2d/elixir_euler_brown_minion_vortex.jl
+++ b/examples/dgmulti_2d/elixir_euler_brown_minion_vortex.jl
@@ -49,7 +49,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback, save_solution)

--- a/examples/dgmulti_2d/elixir_euler_cgsbp_periodic.jl
+++ b/examples/dgmulti_2d/elixir_euler_cgsbp_periodic.jl
@@ -26,7 +26,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 stepsize_callback = StepsizeCallback(cfl = 1.0)
 callbacks = CallbackSet(summary_callback, alive_callback, stepsize_callback,
                         analysis_callback)

--- a/examples/dgmulti_2d/elixir_euler_curved.jl
+++ b/examples/dgmulti_2d/elixir_euler_curved.jl
@@ -36,7 +36,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_2d/elixir_euler_fdsbp_periodic.jl
+++ b/examples/dgmulti_2d/elixir_euler_fdsbp_periodic.jl
@@ -26,7 +26,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 stepsize_callback = StepsizeCallback(cfl = 1.0)
 callbacks = CallbackSet(summary_callback, alive_callback, stepsize_callback,
                         analysis_callback)

--- a/examples/dgmulti_2d/elixir_euler_gmsh_square_cylinder.jl
+++ b/examples/dgmulti_2d/elixir_euler_gmsh_square_cylinder.jl
@@ -59,7 +59,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 50)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback,

--- a/examples/dgmulti_2d/elixir_euler_hohqmesh.jl
+++ b/examples/dgmulti_2d/elixir_euler_hohqmesh.jl
@@ -56,7 +56,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 
 alive_callback = AliveCallback(analysis_interval = analysis_interval)
 

--- a/examples/dgmulti_2d/elixir_euler_kelvin_helmholtz_instability.jl
+++ b/examples/dgmulti_2d/elixir_euler_kelvin_helmholtz_instability.jl
@@ -51,7 +51,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback,

--- a/examples/dgmulti_2d/elixir_euler_kelvin_helmholtz_instability_adaptive_vol_int.jl
+++ b/examples/dgmulti_2d/elixir_euler_kelvin_helmholtz_instability_adaptive_vol_int.jl
@@ -65,7 +65,7 @@ alive_callback = AliveCallback(alive_interval = 50)
 stepsize_callback = StepsizeCallback(cfl = 1.0)
 
 analysis_interval = 10
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg),
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval,
                                      save_analysis = true,
                                      analysis_errors = Symbol[],
                                      extra_analysis_integrals = (entropy,))

--- a/examples/dgmulti_2d/elixir_euler_laplace_diffusion.jl
+++ b/examples/dgmulti_2d/elixir_euler_laplace_diffusion.jl
@@ -34,7 +34,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 callbacks = CallbackSet(summary_callback,
                         analysis_callback,
                         alive_callback)

--- a/examples/dgmulti_2d/elixir_euler_rayleigh_taylor_instability.jl
+++ b/examples/dgmulti_2d/elixir_euler_rayleigh_taylor_instability.jl
@@ -84,7 +84,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 
 alive_callback = AliveCallback(analysis_interval = analysis_interval)
 

--- a/examples/dgmulti_2d/elixir_euler_shockcapturing.jl
+++ b/examples/dgmulti_2d/elixir_euler_shockcapturing.jl
@@ -77,7 +77,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_2d/elixir_euler_shockcapturing_curved.jl
+++ b/examples/dgmulti_2d/elixir_euler_shockcapturing_curved.jl
@@ -50,7 +50,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_2d/elixir_euler_triangulate_pkg_mesh.jl
+++ b/examples/dgmulti_2d/elixir_euler_triangulate_pkg_mesh.jl
@@ -30,7 +30,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_2d/elixir_euler_triangulate_scramjet.jl
+++ b/examples/dgmulti_2d/elixir_euler_triangulate_scramjet.jl
@@ -51,7 +51,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 100)
 analysis_interval = 1000
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 cfl = 0.7

--- a/examples/dgmulti_2d/elixir_euler_weakform.jl
+++ b/examples/dgmulti_2d/elixir_euler_weakform.jl
@@ -31,7 +31,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 stepsize_callback = StepsizeCallback(cfl = 1.5)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)

--- a/examples/dgmulti_2d/elixir_euler_weakform_periodic.jl
+++ b/examples/dgmulti_2d/elixir_euler_weakform_periodic.jl
@@ -21,7 +21,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_2d/elixir_mhd_weak_blast_wave.jl
+++ b/examples/dgmulti_2d/elixir_mhd_weak_blast_wave.jl
@@ -37,7 +37,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 alive_callback = AliveCallback(analysis_interval = analysis_interval)
 
 cfl = 1.0

--- a/examples/dgmulti_2d/elixir_mhd_weak_blast_wave_SBP.jl
+++ b/examples/dgmulti_2d/elixir_mhd_weak_blast_wave_SBP.jl
@@ -40,7 +40,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 alive_callback = AliveCallback(analysis_interval = analysis_interval)
 
 # See comment above and https://github.com/trixi-framework/Trixi.jl/issues/881

--- a/examples/dgmulti_2d/elixir_navierstokes_convergence.jl
+++ b/examples/dgmulti_2d/elixir_navierstokes_convergence.jl
@@ -217,7 +217,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_2d/elixir_navierstokes_convergence_curved.jl
+++ b/examples/dgmulti_2d/elixir_navierstokes_convergence_curved.jl
@@ -225,7 +225,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_2d/elixir_navierstokes_lid_driven_cavity.jl
+++ b/examples/dgmulti_2d/elixir_navierstokes_lid_driven_cavity.jl
@@ -70,7 +70,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_3d/elixir_advection_tensor_wedge.jl
+++ b/examples/dgmulti_3d/elixir_advection_tensor_wedge.jl
@@ -35,7 +35,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 
 alive_callback = AliveCallback(analysis_interval = analysis_interval)
 

--- a/examples/dgmulti_3d/elixir_euler_curved.jl
+++ b/examples/dgmulti_3d/elixir_euler_curved.jl
@@ -37,7 +37,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)

--- a/examples/dgmulti_3d/elixir_euler_shockcapturing.jl
+++ b/examples/dgmulti_3d/elixir_euler_shockcapturing.jl
@@ -40,7 +40,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_3d/elixir_euler_weakform.jl
+++ b/examples/dgmulti_3d/elixir_euler_weakform.jl
@@ -31,7 +31,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_3d/elixir_euler_weakform_periodic.jl
+++ b/examples/dgmulti_3d/elixir_euler_weakform_periodic.jl
@@ -22,7 +22,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_3d/elixir_navierstokes_convergence.jl
+++ b/examples/dgmulti_3d/elixir_navierstokes_convergence.jl
@@ -260,7 +260,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_3d/elixir_navierstokes_convergence_curved.jl
+++ b/examples/dgmulti_3d/elixir_navierstokes_convergence_curved.jl
@@ -268,7 +268,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg))
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
 save_solution = SaveSolutionCallback(interval = analysis_interval,
                                      solution_variables = cons2prim)
 callbacks = CallbackSet(summary_callback, alive_callback, analysis_callback, save_solution)

--- a/examples/dgmulti_3d/elixir_navierstokes_taylor_green_vortex.jl
+++ b/examples/dgmulti_3d/elixir_navierstokes_taylor_green_vortex.jl
@@ -69,7 +69,7 @@ ode = semidiscretize(semi, tspan)
 summary_callback = SummaryCallback()
 alive_callback = AliveCallback(alive_interval = 10)
 analysis_interval = 100
-analysis_callback = AnalysisCallback(semi, interval = analysis_interval, uEltype = real(dg),
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval,
                                      extra_analysis_integrals = (energy_kinetic,
                                                                  energy_internal))
 save_solution = SaveSolutionCallback(interval = analysis_interval,

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -110,7 +110,7 @@ function AnalysisCallback(mesh, equations::AbstractEquations, solver, cache;
                           analysis_integrals = union(default_analysis_integrals(equations),
                                                      extra_analysis_integrals),
                           RealT = real(solver),
-                          uEltype = eltype(cache.elements),
+                          uEltype = solution_eltype(solver, cache),
                           kwargs...)
     # Decide when the callback is activated.
     # With error-based step size control, some steps can be rejected. Thus,

--- a/src/solvers/dg.jl
+++ b/src/solvers/dg.jl
@@ -7,6 +7,9 @@
 
 abstract type AbstractVolumeIntegral end
 
+# Element type used to store the conservative variables in solver caches.
+@inline solution_eltype(solver, cache) = eltype(cache.elements)
+
 function get_element_variables!(element_variables, u, mesh, equations,
                                 volume_integral::AbstractVolumeIntegral, dg, cache)
     return nothing

--- a/src/solvers/dgmulti/dg.jl
+++ b/src/solvers/dgmulti/dg.jl
@@ -205,6 +205,10 @@ struct DGMultiSolutionContainer{uType, ufType, ffType, lType}
     local_values_threaded::lType
 end
 
+@inline function solution_eltype(dg::DGMulti, cache)
+    return eltype(eltype(cache.solution_container.u_values))
+end
+
 # Allocates arrays shared across most DGMulti cache types.
 function initialize_dgmulti_solution_container(mesh::DGMultiMesh, equations,
                                                dg::DGMulti,

--- a/test/test_dgmulti_1d.jl
+++ b/test/test_dgmulti_1d.jl
@@ -2,6 +2,20 @@
     EXAMPLES_DIR = joinpath(examples_dir(), "dgmulti_1d")
 end
 
+@testitem "DGMulti1D: AnalysisCallback infers uEltype" setup=[Setup, DGMulti1D] tags=[:unstructured_dgmulti] begin
+    equations = LinearScalarAdvectionEquation1D(1.0f0)
+    solver = DGMulti(polydeg = 1, element_type = Line())
+    mesh = DGMultiMesh(solver, (2,))
+    semi = SemidiscretizationHyperbolic(mesh, equations,
+                                        initial_condition_convergence_test, solver,
+                                        boundary_conditions = boundary_condition_periodic,
+                                        uEltype = Float32)
+
+    analysis_callback = AnalysisCallback(semi)
+
+    @test eltype(analysis_callback.affect!.initial_state_integrals) === Float32
+end
+
 @testitem "DGMulti1D: elixir_advection_gauss_sbp.jl " setup=[Setup, DGMulti1D] tags=[:unstructured_dgmulti] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_gauss_sbp.jl"),
                         cells_per_dimension=(8,),


### PR DESCRIPTION
The requirement was never documented in a docstring and made it less obvious to switch from one solver type to another.