### PR TITLE
Reduce CI time

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -60,6 +60,7 @@ jobs:
           # - unstructured_dgmulti
           # - parabolic_part1
           # - parabolic_part2
+          # - parabolic_part3
           # - paper_self_gravitating_gas_dynamics
           # - misc_part1
           # - misc_part2

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -51,7 +51,6 @@ jobs:
           # - tree_part3
           # - tree_part4
           # - tree_part5
-          # - tree_part6
           # - structured
           # - p4est_part1
           # - p4est_part2

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -55,7 +55,6 @@ jobs:
           # - p4est_part1
           # - p4est_part2
           # - t8code_part1
-          # - t8code_part2
           # - unstructured_dgmulti
           # - parabolic_part1
           # - parabolic_part2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
           - tree_part3
           - tree_part4
           - tree_part5
-          - tree_part6
           - structured
           - p4est_part1
           - p4est_part2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           - unstructured_dgmulti
           - parabolic_part1
           - parabolic_part2
+          - parabolic_part3
           - paper_self_gravitating_gas_dynamics
           - misc_part1
           - misc_part2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
           - p4est_part1
           - p4est_part2
           - t8code_part1
-          - t8code_part2
           - unstructured_dgmulti
           - parabolic_part1
           - parabolic_part2

--- a/test/test_parabolic_2d.jl
+++ b/test/test_parabolic_2d.jl
@@ -1097,7 +1097,7 @@ end
 @testitem "Parabolic2D: elixir_navierstokes_NACA0012airfoil_mach08.jl" setup=[
     Setup,
     Parabolic2D
-] tags=[:parabolic_part1] begin
+] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_NACA0012airfoil_mach08.jl"),
                         l2=[0.000186486564226516,
@@ -1145,7 +1145,7 @@ end
 @testitem "Parabolic2D: elixir_navierstokes_NACA0012airfoil_mach085_restart.jl" setup=[
     Setup,
     Parabolic2D
-] tags=[:parabolic_part1] begin
+] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_NACA0012airfoil_mach085_restart.jl"),
                         l2=[
@@ -1169,7 +1169,7 @@ end
 @testitem "Parabolic2D: P4estMesh2D: elixir_navierstokes_viscous_shock.jl" setup=[
     Setup,
     Parabolic2D
-] tags=[:parabolic_part1] begin
+] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_viscous_shock.jl"),
                         l2=[
@@ -1193,7 +1193,7 @@ end
 @testitem "Parabolic2D: P4estMesh2D: elixir_navierstokes_viscous_shock.jl (boundary_condition_do_nothing)" setup=[
     Setup,
     Parabolic2D
-] tags=[:parabolic_part1] begin
+] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_viscous_shock.jl"),
                         boundary_conditions_parabolic=(;
@@ -1220,7 +1220,7 @@ end
 @testitem "Parabolic2D: P4estMesh2D: elixir_navierstokes_viscous_shock_newton_krylov.jl" setup=[
     Setup,
     Parabolic2D
-] tags=[:parabolic_part1] begin
+] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_viscous_shock_newton_krylov.jl"),
                         tspan=(0.0, 0.1),
@@ -1246,7 +1246,7 @@ end
     @test_allocations(Trixi.rhs_parabolic!, semi, sol, 1000)
 end
 
-@testitem "Parabolic2D: elixir_navierstokes_SD7003airfoil.jl" setup=[Setup, Parabolic2D] tags=[:parabolic_part1] begin
+@testitem "Parabolic2D: elixir_navierstokes_SD7003airfoil.jl" setup=[Setup, Parabolic2D] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_SD7003airfoil.jl"),
                         l2=[
@@ -1271,7 +1271,7 @@ end
 @testitem "Parabolic2D: elixir_navierstokes_SD7003airfoil.jl (CFL-Interval)" setup=[
     Setup,
     Parabolic2D
-] tags=[:parabolic_part1] begin
+] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_SD7003airfoil.jl"),
                         l2=[
@@ -1297,7 +1297,7 @@ end
 @testitem "Parabolic2D: elixir_navierstokes_RAE2822airfoil_separation.jl" setup=[
     Setup,
     Parabolic2D
-] tags=[:parabolic_part1] begin
+] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_RAE2822airfoil_separation.jl"),
                         l2=[
@@ -1322,7 +1322,7 @@ end
 @testitem "Parabolic2D: elixir_navierstokes_vortex_street.jl (Re=20)" setup=[
     Setup,
     Parabolic2D
-] tags=[:parabolic_part1] begin
+] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_vortex_street.jl"),
                         tspan=(0.0, 0.5),
@@ -1351,7 +1351,7 @@ end
     @test_allocations(Trixi.rhs_parabolic!, semi, sol, 1000)
 end
 
-@testitem "Parabolic2D: elixir_navierstokes_vortex_street.jl" setup=[Setup, Parabolic2D] tags=[:parabolic_part1] begin
+@testitem "Parabolic2D: elixir_navierstokes_vortex_street.jl" setup=[Setup, Parabolic2D] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_vortex_street.jl"),
                         l2=[
@@ -1376,7 +1376,7 @@ end
 @testitem "Parabolic2D: elixir_navierstokes_vortex_street.jl (GradientVariablesEntropy)" setup=[
     Setup,
     Parabolic2D
-] tags=[:parabolic_part1] begin
+] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_vortex_street.jl"),
                         gradient_variables=GradientVariablesEntropy(),
@@ -1399,7 +1399,7 @@ end
     @test_allocations(Trixi.rhs_parabolic!, semi, sol, 1000)
 end
 
-@testitem "Parabolic2D: elixir_navierstokes_poiseuille_flow.jl" setup=[Setup, Parabolic2D] tags=[:parabolic_part1] begin
+@testitem "Parabolic2D: elixir_navierstokes_poiseuille_flow.jl" setup=[Setup, Parabolic2D] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_poiseuille_flow.jl"),
                         l2=[
@@ -1423,7 +1423,7 @@ end
 @testitem "Parabolic2D: elixir_navierstokes_sedov_limiter_liu_zhang.jl" setup=[
     Setup,
     Parabolic2D
-] tags=[:parabolic_part1] begin
+] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_2d_dgsem",
                                  "elixir_navierstokes_sedov_limiter_liu_zhang.jl"),
                         l2=[
@@ -1453,7 +1453,7 @@ end
 @testitem "Parabolic2D: elixir_navierstokes_kelvin_helmholtz_instability_sc_subcell.jl" setup=[
     Setup,
     Parabolic2D
-] tags=[:parabolic_part1] begin
+] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_2d_dgsem",
                                  "elixir_navierstokes_kelvin_helmholtz_instability_sc_subcell.jl"),
                         l2=[
@@ -1482,7 +1482,7 @@ end
 @testitem "Parabolic2D: elixir_navierstokes_freestream_symmetry.jl" setup=[
     Setup,
     Parabolic2D
-] tags=[:parabolic_part1] begin
+] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_freestream_symmetry.jl"),
                         l2=[
@@ -1505,7 +1505,7 @@ end
 @testitem "Parabolic2D: elixir_navierstokes_freestream_symmetry.jl (GradientVariablesEntropy)" setup=[
     Setup,
     Parabolic2D
-] tags=[:parabolic_part1] begin
+] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_freestream_symmetry.jl"),
                         gradient_variables=GradientVariablesEntropy(),
@@ -1526,7 +1526,7 @@ end
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
-@testitem "Parabolic2D: elixir_navierstokes_freestream_ldg.jl" setup=[Setup, Parabolic2D] tags=[:parabolic_part1] begin
+@testitem "Parabolic2D: elixir_navierstokes_freestream_ldg.jl" setup=[Setup, Parabolic2D] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_freestream_ldg.jl"),
                         tspan=(0.0, 0.2),
@@ -1548,7 +1548,7 @@ end
     @test_allocations(Trixi.rhs_parabolic!, semi, sol, 1000)
 end
 
-@testitem "Parabolic2D: elixir_navierstokes_couette_flow.jl" setup=[Setup, Parabolic2D] tags=[:parabolic_part1] begin
+@testitem "Parabolic2D: elixir_navierstokes_couette_flow.jl" setup=[Setup, Parabolic2D] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_couette_flow.jl"),
                         l2=[
@@ -1569,7 +1569,7 @@ end
     @test_allocations(Trixi.rhs_parabolic!, semi, sol, 1000)
 end
 
-@testitem "Parabolic2D: elixir_navierstokes_blast_reflective.jl" setup=[Setup, Parabolic2D] tags=[:parabolic_part1] begin
+@testitem "Parabolic2D: elixir_navierstokes_blast_reflective.jl" setup=[Setup, Parabolic2D] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_navierstokes_blast_reflective.jl"),
                         l2=[
@@ -1597,7 +1597,7 @@ end
 @testitem "Parabolic2D: TreeMesh2D: elixir_diffusion_steady_state_linear_map.jl" setup=[
     Setup,
     Parabolic2D
-] tags=[:parabolic_part1] begin
+] tags=[:parabolic_part2] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_2d_dgsem",
                                  "elixir_diffusion_steady_state_linear_map.jl"),
                         tspan=(0.0, 1.0e-4),

--- a/test/test_parabolic_3d.jl
+++ b/test/test_parabolic_3d.jl
@@ -5,7 +5,7 @@ end
 @testitem "Parabolic3D: DGMulti: elixir_navierstokes_convergence.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "dgmulti_3d",
                                  "elixir_navierstokes_convergence.jl"),
                         cells_per_dimension=(4, 4, 4), tspan=(0.0, 0.1),
@@ -32,7 +32,7 @@ end
 @testitem "Parabolic3D: DGMulti: elixir_navierstokes_convergence_curved.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "dgmulti_3d",
                                  "elixir_navierstokes_convergence_curved.jl"),
                         cells_per_dimension=(4, 4, 4), tspan=(0.0, 0.1),
@@ -59,7 +59,7 @@ end
 @testitem "Parabolic3D: DGMulti: elixir_navierstokes_taylor_green_vortex.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "dgmulti_3d",
                                  "elixir_navierstokes_taylor_green_vortex.jl"),
                         cells_per_dimension=(4, 4, 4), tspan=(0.0, 0.25),
@@ -86,7 +86,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_navierstokes_convergence.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_navierstokes_convergence.jl"),
                         initial_refinement_level=2, tspan=(0.0, 0.1),
@@ -113,7 +113,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_navierstokes_convergence.jl (isothermal walls)" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_navierstokes_convergence.jl"),
                         initial_refinement_level=2, tspan=(0.0, 0.1),
@@ -144,7 +144,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_navierstokes_convergence.jl (Entropy gradient variables)" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_navierstokes_convergence.jl"),
                         initial_refinement_level=2, tspan=(0.0, 0.1),
@@ -172,7 +172,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_navierstokes_convergence.jl (Entropy gradient variables, isothermal walls)" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_navierstokes_convergence.jl"),
                         initial_refinement_level=2, tspan=(0.0, 0.1),
@@ -204,7 +204,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_navierstokes_convergence.jl (flux differencing)" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_navierstokes_convergence.jl"),
                         initial_refinement_level=2, tspan=(0.0, 0.1),
@@ -232,7 +232,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_navierstokes_convergence.jl (Refined mesh)" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_navierstokes_convergence.jl"),
                         tspan=(0.0, 0.0))
@@ -274,7 +274,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_navierstokes_taylor_green_vortex.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_navierstokes_taylor_green_vortex.jl"),
                         initial_refinement_level=2, tspan=(0.0, 0.25),
@@ -311,7 +311,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_navierstokes_taylor_green_vortex.jl (GradientVariablesEntropy)" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_navierstokes_taylor_green_vortex.jl"),
                         initial_refinement_level=2, tspan=(0.0, 0.25),
@@ -349,7 +349,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_navierstokes_taylor_green_vortex.jl (Refined mesh)" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_navierstokes_taylor_green_vortex.jl"),
                         tspan=(0.0, 0.0))
@@ -397,7 +397,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_navierstokes_taylor_green_vortex_adaptive_vol_int.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_navierstokes_taylor_green_vortex_adaptive_vol_int.jl"),
                         initial_refinement_level=2, tspan=(0.0, 0.25),
@@ -424,7 +424,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_advection_diffusion_nonperiodic.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_advection_diffusion_nonperiodic.jl"),
                         l2=[0.006421164728264022], linf=[0.41638021060047015])
@@ -437,7 +437,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_navierstokes_convergence.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_navierstokes_convergence.jl"),
                         initial_refinement_level=2, tspan=(0.0, 0.1),
@@ -464,7 +464,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_navierstokes_taylor_green_vortex.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_navierstokes_taylor_green_vortex.jl"),
                         initial_refinement_level=2, tspan=(0.0, 0.25),
@@ -492,7 +492,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_navierstokes_taylor_green_vortex.jl (Parabolic CFL)" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_navierstokes_taylor_green_vortex.jl"),
                         tspan=(0.0, 0.1),
@@ -526,7 +526,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_advection_diffusion_amr.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_advection_diffusion_amr.jl"),
                         initial_refinement_level=2,
@@ -544,7 +544,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_advection_diffusion_amr.jl (LDG)" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_advection_diffusion_amr.jl"),
                         solver_parabolic=ParabolicFormulationLocalDG(),
@@ -563,7 +563,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_advection_diffusion_gradient_source_terms.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_advection_diffusion_gradient_source_terms.jl"),
                         initial_refinement_level=2, tspan=(0.0, 0.4), polydeg=3,
@@ -577,7 +577,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_advection_diffusion_nonperiodic.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_advection_diffusion_nonperiodic.jl"),
                         l2=[0.0009808996243280868],
@@ -591,7 +591,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_advection_diffusion_nonperiodic.jl (LDG)" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_advection_diffusion_nonperiodic.jl"),
                         solver_parabolic=ParabolicFormulationLocalDG(),
@@ -604,7 +604,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_advection_diffusion_nonconforming.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_advection_diffusion_nonconforming.jl"),
                         l2=[0.00098089913839922], linf=[0.017326216776220663])
@@ -617,7 +617,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_advection_diffusion_nonconforming.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_advection_diffusion_nonconforming.jl"),
                         l2=[0.0009808996243281306], linf=[0.017326215591354437])
@@ -630,7 +630,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_advection_diffusion_nonperiodic.jl (LDG)" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_advection_diffusion_nonperiodic.jl"),
                         solver_parabolic=ParabolicFormulationLocalDG(),
@@ -645,7 +645,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_advection_diffusion_amr_curved.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_advection_diffusion_amr_curved.jl"),
                         l2=[0.000683123952524889], linf=[0.023601069354373894])
@@ -658,7 +658,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_advection_diffusion_amr_curved.jl (LDG)" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_advection_diffusion_amr_curved.jl"),
                         solver_parabolic=ParabolicFormulationLocalDG(),
@@ -672,7 +672,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_navierstokes_freestream_boundaries.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_navierstokes_freestream_boundaries.jl"),
                         tspan=(0.0, 0.1),
@@ -699,7 +699,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_navierstokes_freestream_symmetry.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_navierstokes_freestream_symmetry.jl"),
                         tspan=(0.0, 0.1),
@@ -726,7 +726,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_navierstokes_freestream_symmetry.jl (GradientVariablesEntropy)" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_navierstokes_freestream_symmetry.jl"),
                         tspan=(0.0, 0.1),
@@ -754,7 +754,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_navierstokes_taylor_green_vortex_amr.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_navierstokes_taylor_green_vortex_amr.jl"),
                         initial_refinement_level=0,
@@ -783,7 +783,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_navierstokes_taylor_green_vortex_amr.jl static AMR" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_navierstokes_taylor_green_vortex_amr.jl"),
                         tspan=(0.0, 5.0),
@@ -826,7 +826,7 @@ end
 @testitem "Parabolic3D: TreeMesh3D: elixir_navierstokes_viscous_shock.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_3d_dgsem",
                                  "elixir_navierstokes_viscous_shock.jl"),
                         l2=[
@@ -848,7 +848,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_navierstokes_blast_wave_amr.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_navierstokes_blast_wave_amr.jl"),
                         tspan=(0.0, 0.01),
@@ -875,7 +875,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_navierstokes_viscous_shock.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_navierstokes_viscous_shock.jl"),
                         l2=[
@@ -901,7 +901,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_navierstokes_viscous_shock.jl (boundary_condition_do_nothing)" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_navierstokes_viscous_shock.jl"),
                         boundary_conditions_parabolic=(;
@@ -930,7 +930,7 @@ end
 @testitem "Parabolic3D: P4estMesh3D: elixir_navierstokes_viscous_shock_dirichlet_bc.jl" setup=[
     Setup,
     Parabolic3D
-] tags=[:parabolic_part2] begin
+] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_navierstokes_viscous_shock_dirichlet_bc.jl"),
                         l2=[
@@ -953,7 +953,7 @@ end
     @test_allocations(Trixi.rhs_parabolic!, semi, sol, 1000)
 end
 
-@testitem "Parabolic3D: P4estMesh3D: elixir_navierstokes_crm.jl" setup=[Setup, Parabolic3D] tags=[:parabolic_part2] begin
+@testitem "Parabolic3D: P4estMesh3D: elixir_navierstokes_crm.jl" setup=[Setup, Parabolic3D] tags=[:parabolic_part3] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_3d_dgsem",
                                  "elixir_navierstokes_crm.jl"),
                         l2=[

--- a/test/test_t8code_3d.jl
+++ b/test/test_t8code_3d.jl
@@ -5,7 +5,7 @@ end
 @testitem "T8codeMesh3D: test t8code mesh from p8est connectivity" setup=[
     Setup,
     T8codeMesh3D
-] tags=[:t8code_part2] begin
+] tags=[:t8code_part1] begin
     @test begin
         using Trixi: Trixi, T8codeMesh
         # Here we use the connectivity constructor from `P4est.jl` since the
@@ -19,7 +19,7 @@ end
 end
 
 # This test is identical to the one in `test_p4est_3d.jl`.
-@testitem "T8codeMesh3D: elixir_advection_basic.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part2] begin
+@testitem "T8codeMesh3D: elixir_advection_basic.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_basic.jl"),
                         # Expected errors are exactly the same as with TreeMesh!
                         l2=[0.00016263963870641478],
@@ -33,7 +33,7 @@ end
 @testitem "T8codeMesh3D: elixir_advection_unstructured_curved.jl" setup=[
     Setup,
     T8codeMesh3D
-] tags=[:t8code_part2] begin
+] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "elixir_advection_unstructured_curved.jl"),
                         l2=[0.0004750004258546538],
@@ -44,7 +44,7 @@ end
 end
 
 # This test is identical to the one in `test_p4est_3d.jl`.
-@testitem "T8codeMesh3D: elixir_advection_nonconforming.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part2] begin
+@testitem "T8codeMesh3D: elixir_advection_nonconforming.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_nonconforming.jl"),
                         l2=[0.00253595715323843],
                         linf=[0.016486952252155795])
@@ -55,7 +55,7 @@ end
 
 # This test is identical to the one in `test_p4est_3d.jl` besides minor
 # deviations from the expected error norms.
-@testitem "T8codeMesh3D: elixir_advection_amr.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part2] begin
+@testitem "T8codeMesh3D: elixir_advection_amr.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr.jl"),
                         # Expected errors are exactly the same as with TreeMesh!
                         l2=[1.1302812803902801e-5],
@@ -70,7 +70,7 @@ end
 @testitem "T8codeMesh3D: elixir_advection_amr_unstructured_curved.jl" setup=[
     Setup,
     T8codeMesh3D
-] tags=[:t8code_part2] begin
+] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "elixir_advection_amr_unstructured_curved.jl"),
                         l2=[2.0535121347526814e-5],
@@ -83,7 +83,7 @@ end
 
 # This test differs from the one in `test_p4est_3d.jl` in the latitudinal and
 # longitudinal dimensions.
-@testitem "T8codeMesh3D: elixir_advection_cubed_sphere.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part2] begin
+@testitem "T8codeMesh3D: elixir_advection_cubed_sphere.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_cubed_sphere.jl"),
                         l2=[0.002006918015656413],
                         linf=[0.027655117058380085])
@@ -93,7 +93,7 @@ end
 end
 
 # This test is identical to the one in `test_p4est_3d.jl`.
-@testitem "T8codeMesh3D: elixir_advection_restart.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part2] begin
+@testitem "T8codeMesh3D: elixir_advection_restart.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_restart.jl"),
                         l2=[0.002590388934758452],
                         linf=[0.01840757696885409])
@@ -106,7 +106,7 @@ end
 @testitem "T8codeMesh3D: elixir_euler_source_terms_nonconforming_unstructured_curved.jl" setup=[
     Setup,
     T8codeMesh3D
-] tags=[:t8code_part2] begin
+] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "elixir_euler_source_terms_nonconforming_unstructured_curved.jl"),
                         l2=[
@@ -133,7 +133,7 @@ end
 @testitem "T8codeMesh3D: elixir_euler_source_terms_nonperiodic.jl" setup=[
     Setup,
     T8codeMesh3D
-] tags=[:t8code_part2] begin
+] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "elixir_euler_source_terms_nonperiodic.jl"),
                         l2=[
@@ -157,7 +157,7 @@ end
 end
 
 # This test is identical to the one in `test_p4est_3d.jl`.
-@testitem "T8codeMesh3D: elixir_euler_free_stream.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part2] begin
+@testitem "T8codeMesh3D: elixir_euler_free_stream.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_free_stream.jl"),
                         l2=[
                             5.162664597942288e-15,
@@ -180,7 +180,7 @@ end
 end
 
 # This test is identical to the one in `test_p4est_3d.jl`.
-@testitem "T8codeMesh3D: elixir_euler_free_stream_extruded.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part2] begin
+@testitem "T8codeMesh3D: elixir_euler_free_stream_extruded.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_free_stream_extruded.jl"),
                         l2=[
                             8.444868392439035e-16,
@@ -203,7 +203,7 @@ end
 end
 
 # This test is identical to the one in `test_p4est_3d.jl`.
-@testitem "T8codeMesh3D: elixir_euler_ec.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part2] begin
+@testitem "T8codeMesh3D: elixir_euler_ec.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_ec.jl"),
                         l2=[
                             0.010380390326164493,
@@ -227,7 +227,7 @@ end
 
 # This test is identical to the one in `test_p4est_3d.jl` besides minor
 # deviations in the expected error norms.
-@testitem "T8codeMesh3D: elixir_euler_sedov.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part2] begin
+@testitem "T8codeMesh3D: elixir_euler_sedov.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_sedov.jl"),
                         l2=[
                             7.82070951e-02,
@@ -249,7 +249,7 @@ end
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
-@testitem "T8codeMesh3D: elixir_euler_convergence_pure_fv.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part2] begin
+@testitem "T8codeMesh3D: elixir_euler_convergence_pure_fv.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part1] begin
     using Trixi: Trixi
     @test_trixi_include(joinpath(pkgdir(Trixi, "examples", "tree_3d_dgsem"),
                                  "elixir_euler_convergence_pure_fv.jl"),
@@ -281,7 +281,7 @@ end
 end
 
 # This test is identical to the one in `test_p4est_3d.jl`.
-@testitem "T8codeMesh3D: elixir_euler_baroclinic_instability.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part2] begin
+@testitem "T8codeMesh3D: elixir_euler_baroclinic_instability.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "elixir_euler_baroclinic_instability.jl"),
                         l2=[
@@ -306,7 +306,7 @@ end
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
-@testitem "T8codeMesh3D: elixir_euler_weak_blast_wave_amr.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part2] begin
+@testitem "T8codeMesh3D: elixir_euler_weak_blast_wave_amr.jl" setup=[Setup, T8codeMesh3D] tags=[:t8code_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_weak_blast_wave_amr.jl"),
                         l2=[
                             0.010014531529951328,

--- a/test/test_tree_3d_advection.jl
+++ b/test/test_tree_3d_advection.jl
@@ -5,7 +5,7 @@ end
 @testitem "TreeMesh3D Advection: elixir_advection_basic.jl" setup=[
     Setup,
     TreeMesh3DAdvection
-] tags=[:tree_part5] begin
+] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_basic.jl"),
                         l2=[0.00016263963870641478],
                         linf=[0.0014537194925779984])
@@ -17,7 +17,7 @@ end
 @testitem "TreeMesh3D Advection: elixir_advection_convergence_fvO2.jl" setup=[
     Setup,
     TreeMesh3DAdvection
-] tags=[:tree_part5] begin
+] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_convergence_fvO2.jl"),
                         l2=[0.023417734889807557], linf=[0.0713577997489736])
     # Ensure that we do not have excessive memory allocations
@@ -28,7 +28,7 @@ end
 @testitem "TreeMesh3D Advection: elixir_advection_restart.jl" setup=[
     Setup,
     TreeMesh3DAdvection
-] tags=[:tree_part5] begin
+] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_restart.jl"),
                         l2=[0.00016017848135651983],
                         linf=[0.0014175368788298393])
@@ -40,7 +40,7 @@ end
 @testitem "TreeMesh3D Advection: elixir_advection_extended.jl with initial_condition_sin" setup=[
     Setup,
     TreeMesh3DAdvection
-] tags=[:tree_part5] begin
+] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_extended.jl"),
                         l2=[0.002647730309275237],
                         linf=[0.02114324070353557],
@@ -53,7 +53,7 @@ end
 @testitem "TreeMesh3D Advection: elixir_advection_extended.jl with initial_condition_constant" setup=[
     Setup,
     TreeMesh3DAdvection
-] tags=[:tree_part5] begin
+] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_extended.jl"),
                         l2=[7.728011630010656e-16],
                         linf=[3.9968028886505635e-15],
@@ -66,7 +66,7 @@ end
 @testitem "TreeMesh3D Advection: elixir_advection_extended.jl with initial_condition_linear_z and periodicity=false" setup=[
     Setup,
     TreeMesh3DAdvection
-] tags=[:tree_part5] begin
+] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_extended.jl"),
                         l2=[3.007995700405795e-16],
                         linf=[2.886579864025407e-15],
@@ -81,7 +81,7 @@ end
 @testitem "TreeMesh3D Advection: elixir_advection_mortar.jl" setup=[
     Setup,
     TreeMesh3DAdvection
-] tags=[:tree_part5] begin
+] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_mortar.jl"),
                         l2=[0.001810141301577316],
                         linf=[0.017848192256602058])
@@ -91,7 +91,7 @@ end
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
-@testitem "TreeMesh3D Advection: elixir_advection_amr.jl" setup=[Setup, TreeMesh3DAdvection] tags=[:tree_part5] begin
+@testitem "TreeMesh3D Advection: elixir_advection_amr.jl" setup=[Setup, TreeMesh3DAdvection] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_amr.jl"),
                         l2=[9.773852895157622e-6],
                         linf=[0.0005853874124926162])
@@ -104,7 +104,7 @@ end
 @testitem "TreeMesh3D Advection: elixir_advection_limiter_liu_zhang.jl" setup=[
     Setup,
     TreeMesh3DAdvection
-] tags=[:tree_part5] begin
+] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "elixir_advection_limiter_liu_zhang.jl"),
                         l2=[0.39212005674820044],
@@ -115,7 +115,7 @@ end
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
-@testitem "TreeMesh3D Advection: elixir_advection_er.jl" setup=[Setup, TreeMesh3DAdvection] tags=[:tree_part5] begin
+@testitem "TreeMesh3D Advection: elixir_advection_er.jl" setup=[Setup, TreeMesh3DAdvection] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_er.jl"),
                         l2=[0.005193350046445726], linf=[0.025986449692943836])
 

--- a/test/test_tree_3d_eulergravity.jl
+++ b/test/test_tree_3d_eulergravity.jl
@@ -5,7 +5,7 @@ end
 @testitem "TreeMesh3D EulerGravity: elixir_eulergravity_convergence.jl" setup=[
     Setup,
     TreeMesh3DEulerGravity
-] tags=[:tree_part5] begin
+] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_eulergravity_convergence.jl"),
                         l2=[
                             0.0004276779201667428,

--- a/test/test_tree_3d_fdsbp.jl
+++ b/test/test_tree_3d_fdsbp.jl
@@ -2,7 +2,7 @@
     EXAMPLES_DIR = joinpath(examples_dir(), "tree_3d_fdsbp")
 end
 
-@testitem "TreeMesh3D FDSBP: elixir_advection_extended.jl" setup=[Setup, TreeMesh3DFDSBP] tags=[:tree_part6] begin
+@testitem "TreeMesh3D FDSBP: elixir_advection_extended.jl" setup=[Setup, TreeMesh3DFDSBP] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_advection_extended.jl"),
                         l2=[0.005355755365412444],
                         linf=[0.01856044696350767])
@@ -15,7 +15,7 @@ end
 @testitem "TreeMesh3D FDSBP: elixir_advection_extended.jl with periodic operators" setup=[
     Setup,
     TreeMesh3DFDSBP
-] tags=[:tree_part6] begin
+] tags=[:tree_part5] begin
     using Trixi: periodic_derivative_operator
     global D = periodic_derivative_operator(derivative_order = 1,
                                             accuracy_order = 4,
@@ -34,7 +34,7 @@ end
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
-@testitem "TreeMesh3D FDSBP: elixir_euler_convergence.jl" setup=[Setup, TreeMesh3DFDSBP] tags=[:tree_part6] begin
+@testitem "TreeMesh3D FDSBP: elixir_euler_convergence.jl" setup=[Setup, TreeMesh3DFDSBP] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_convergence.jl"),
                         l2=[
                             2.247522803543667e-5,
@@ -60,7 +60,7 @@ end
 @testitem "TreeMesh3D FDSBP: elixir_euler_convergence.jl with VolumeIntegralStrongForm" setup=[
     Setup,
     TreeMesh3DFDSBP
-] tags=[:tree_part6] begin
+] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_convergence.jl"),
                         l2=[
                             4.084919840272202e-5,
@@ -88,7 +88,7 @@ end
 @testitem "TreeMesh3D FDSBP: elixir_euler_taylor_green_vortex.jl" setup=[
     Setup,
     TreeMesh3DFDSBP
-] tags=[:tree_part6] begin
+] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_euler_taylor_green_vortex.jl"),
                         l2=[
                             3.529693407280806e-6,

--- a/test/test_tree_3d_hypdiff.jl
+++ b/test/test_tree_3d_hypdiff.jl
@@ -5,7 +5,7 @@ end
 @testitem "TreeMesh3D HypDiff: elixir_hypdiff_lax_friedrichs.jl" setup=[
     Setup,
     TreeMesh3DHypDiff
-] tags=[:tree_part5] begin
+] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hypdiff_lax_friedrichs.jl"),
                         l2=[
                             0.001530331609036682,
@@ -22,8 +22,8 @@ end
                         initial_refinement_level=2)
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
-    # Larger values for allowed allocations due to usage of custom 
-    # integrator which are not *recorded* for the methods from 
+    # Larger values for allowed allocations due to usage of custom
+    # integrator which are not *recorded* for the methods from
     # OrdinaryDiffEq.jl
     # Corresponding issue: https://github.com/trixi-framework/Trixi.jl/issues/1877
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 15000)
@@ -32,7 +32,7 @@ end
 @testitem "TreeMesh3D HypDiff: elixir_hypdiff_lax_friedrichs.jl with surface_flux=flux_godunov)" setup=[
     Setup,
     TreeMesh3DHypDiff
-] tags=[:tree_part5] begin
+] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hypdiff_lax_friedrichs.jl"),
                         l2=[
                             0.0015377731806850128,
@@ -49,8 +49,8 @@ end
                         initial_refinement_level=2, surface_flux=flux_godunov)
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
-    # Larger values for allowed allocations due to usage of custom 
-    # integrator which are not *recorded* for the methods from 
+    # Larger values for allowed allocations due to usage of custom
+    # integrator which are not *recorded* for the methods from
     # OrdinaryDiffEq.jl
     # Corresponding issue: https://github.com/trixi-framework/Trixi.jl/issues/1877
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 15000)
@@ -59,7 +59,7 @@ end
 @testitem "TreeMesh3D HypDiff: elixir_hypdiff_nonperiodic.jl" setup=[
     Setup,
     TreeMesh3DHypDiff
-] tags=[:tree_part5] begin
+] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_hypdiff_nonperiodic.jl"),
                         l2=[
                             0.00022868320512754316,
@@ -75,8 +75,8 @@ end
                         ])
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
-    # Larger values for allowed allocations due to usage of custom 
-    # integrator which are not *recorded* for the methods from 
+    # Larger values for allowed allocations due to usage of custom
+    # integrator which are not *recorded* for the methods from
     # OrdinaryDiffEq.jl
     # Corresponding issue: https://github.com/trixi-framework/Trixi.jl/issues/1877
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 15000)

--- a/test/test_tree_3d_lbm.jl
+++ b/test/test_tree_3d_lbm.jl
@@ -2,7 +2,7 @@
     EXAMPLES_DIR = joinpath(examples_dir(), "tree_3d_dgsem")
 end
 
-@testitem "TreeMesh3D LBM: elixir_lbm_constant.jl" setup=[Setup, TreeMesh3DLBM] tags=[:tree_part6] begin
+@testitem "TreeMesh3D LBM: elixir_lbm_constant.jl" setup=[Setup, TreeMesh3DLBM] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_lbm_constant.jl"),
                         l2=[5.861930511199053e-16, 6.282772442363201e-16,
                             5.47591540767842e-16,
@@ -46,7 +46,7 @@ end
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
-@testitem "TreeMesh3D LBM: elixir_lbm_taylor_green_vortex.jl" setup=[Setup, TreeMesh3DLBM] tags=[:tree_part6] begin
+@testitem "TreeMesh3D LBM: elixir_lbm_taylor_green_vortex.jl" setup=[Setup, TreeMesh3DLBM] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_lbm_taylor_green_vortex.jl"),
                         l2=[7.516128821554829e-5, 7.516128821554695e-5,
                             7.516128821554932e-5,

--- a/test/test_tree_3d_linearizedeuler.jl
+++ b/test/test_tree_3d_linearizedeuler.jl
@@ -5,7 +5,7 @@ end
 @testitem "TreeMesh3D LinearizedEuler: elixir_linearizedeuler_gauss_wall.jl" setup=[
     Setup,
     TreeMesh3DLinearizedEuler
-] tags=[:tree_part5] begin
+] tags=[:tree_part4] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_linearizedeuler_gauss_wall.jl"),
                         l2=[
                             0.020380328336745232, 0.027122442311921492,

--- a/test/test_tree_3d_mhd.jl
+++ b/test/test_tree_3d_mhd.jl
@@ -2,7 +2,7 @@
     EXAMPLES_DIR = joinpath(examples_dir(), "tree_3d_dgsem")
 end
 
-@testitem "TreeMesh3D MHD: elixir_mhd_ec.jl" setup=[Setup, TreeMesh3DMHD] tags=[:tree_part6] begin
+@testitem "TreeMesh3D MHD: elixir_mhd_ec.jl" setup=[Setup, TreeMesh3DMHD] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_ec.jl"),
                         l2=[
                             0.017590099293094203,
@@ -34,7 +34,7 @@ end
 @testitem "TreeMesh3D MHD: elixir_mhd_ec.jl with initial_condition=initial_condition_constant" setup=[
     Setup,
     TreeMesh3DMHD
-] tags=[:tree_part6] begin
+] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_ec.jl"),
                         l2=[
                             4.270231310667203e-16,
@@ -65,7 +65,7 @@ end
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
-@testitem "TreeMesh3D MHD: elixir_mhd_alfven_wave.jl" setup=[Setup, TreeMesh3DMHD] tags=[:tree_part6] begin
+@testitem "TreeMesh3D MHD: elixir_mhd_alfven_wave.jl" setup=[Setup, TreeMesh3DMHD] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_alfven_wave.jl"),
                         l2=[
                             0.0032217291057246157,
@@ -97,7 +97,7 @@ end
 @testitem "TreeMesh3D MHD: elixir_mhd_alfven_wave.jl with flux_derigs_etal" setup=[
     Setup,
     TreeMesh3DMHD
-] tags=[:tree_part6] begin
+] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_alfven_wave.jl"),
                         l2=[
                             0.003755235939722358,
@@ -127,7 +127,7 @@ end
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
-@testitem "TreeMesh3D MHD: elixir_mhd_alfven_wave_mortar.jl" setup=[Setup, TreeMesh3DMHD] tags=[:tree_part6] begin
+@testitem "TreeMesh3D MHD: elixir_mhd_alfven_wave_mortar.jl" setup=[Setup, TreeMesh3DMHD] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_alfven_wave_mortar.jl"),
                         l2=[
                             0.002117092205724962,
@@ -160,7 +160,7 @@ end
 @testitem "TreeMesh3D MHD: elixir_mhd_alfven_wave.jl with Orszag-Tang setup + flux_hlle" setup=[
     Setup,
     TreeMesh3DMHD
-] tags=[:tree_part6] begin
+] tags=[:tree_part5] begin
     using Trixi: prim2cons, flux_hlle, flux_nonconservative_powell, flux_central,
                  SVector
     # Note: This setup does not make much sense and is only used to exercise all components of the
@@ -222,7 +222,7 @@ end
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
-@testitem "TreeMesh3D MHD: elixir_mhd_convergence.jl" setup=[Setup, TreeMesh3DMHD] tags=[:tree_part6] begin
+@testitem "TreeMesh3D MHD: elixir_mhd_convergence.jl" setup=[Setup, TreeMesh3DMHD] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_convergence.jl"),
                         l2=[
                             0.009193403522877426,
@@ -251,7 +251,7 @@ end
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
-@testitem "TreeMesh3D MHD: elixir_mhd_ec_shockcapturing.jl" setup=[Setup, TreeMesh3DMHD] tags=[:tree_part6] begin
+@testitem "TreeMesh3D MHD: elixir_mhd_ec_shockcapturing.jl" setup=[Setup, TreeMesh3DMHD] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhd_ec_shockcapturing.jl"),
                         l2=[
                             0.0186712969755079,

--- a/test/test_tree_3d_mhdmultiion.jl
+++ b/test/test_tree_3d_mhdmultiion.jl
@@ -7,7 +7,7 @@ end
 @testitem "TreeMesh3D MHDMultiIon: elixir_mhdmultiion_ec.jl" setup=[
     Setup,
     TreeMesh3DMHDMultiIon
-] tags=[:tree_part6] begin
+] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhdmultiion_ec.jl"),
                         l2=[
                             0.005515087802594469,
@@ -51,12 +51,12 @@ end
 # In the `StepsizeCallback`, though, the less diffusive `max_abs_speeds` is employed which is consistent with `max_abs_speed`.
 # Thus, we exchanged in PR#2458 the default wave speed used in the LLF flux to `max_abs_speed`.
 # To ensure that every example still runs we specify explicitly `FluxLaxFriedrichs(max_abs_speed_naive)`.
-# We remark, however, that the now default `max_abs_speed` is in general recommended due to compliance with the 
+# We remark, however, that the now default `max_abs_speed` is in general recommended due to compliance with the
 # `StepsizeCallback` (CFL-Condition) and less diffusion.
 @testitem "TreeMesh3D MHDMultiIon: Provably entropy-stable LLF-type fluxes for multi-ion GLM-MHD" setup=[
     Setup,
     TreeMesh3DMHDMultiIon
-] tags=[:tree_part6] begin
+] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhdmultiion_ec.jl"),
                         l2=[
                             0.005460794624649135,
@@ -104,12 +104,12 @@ end
 # In the `StepsizeCallback`, though, the less diffusive `max_abs_speeds` is employed which is consistent with `max_abs_speed`.
 # Thus, we exchanged in PR#2458 the default wave speed used in the LLF flux to `max_abs_speed`.
 # To ensure that every example still runs we specify explicitly `FluxLaxFriedrichs(max_abs_speed_naive)`.
-# We remark, however, that the now default `max_abs_speed` is in general recommended due to compliance with the 
+# We remark, however, that the now default `max_abs_speed` is in general recommended due to compliance with the
 # `StepsizeCallback` (CFL-Condition) and less diffusion.
 @testitem "TreeMesh3D MHDMultiIon: elixir_mhdmultiion_ec.jl with local Lax-Friedrichs at the surface" setup=[
     Setup,
     TreeMesh3DMHDMultiIon
-] tags=[:tree_part6] begin
+] tags=[:tree_part5] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_mhdmultiion_ec.jl"),
                         l2=[
                             0.005460798875980804,

--- a/test/test_tree_3d_misc.jl
+++ b/test/test_tree_3d_misc.jl
@@ -2,7 +2,7 @@
     EXAMPLES_DIR = joinpath(examples_dir(), "tree_3d_dgsem")
 end
 
-@testitem "TreeMesh3D: Additional tests in 3D (compressible Euler)" setup=[Setup] tags=[:tree_part5] begin
+@testitem "TreeMesh3D: Additional tests in 3D (compressible Euler)" setup=[Setup] tags=[:tree_part4] begin
     using Trixi: CompressibleEulerEquations3D, energy_total, energy_kinetic,
                  energy_internal
     eqn = CompressibleEulerEquations3D(1.4)
@@ -12,13 +12,13 @@ end
     @test isapprox(energy_internal([1.0, 2.0, 3.0, 4.0, 20], eqn), 5.5)
 end
 
-@testitem "TreeMesh3D: Additional tests in 3D (hyperbolic diffusion)" setup=[Setup] tags=[:tree_part5] begin
+@testitem "TreeMesh3D: Additional tests in 3D (hyperbolic diffusion)" setup=[Setup] tags=[:tree_part4] begin
     using Trixi: HyperbolicDiffusionEquations3D
     @test_nowarn HyperbolicDiffusionEquations3D(nu = 1.0)
     eqn = HyperbolicDiffusionEquations3D(nu = 1.0)
 end
 
-@testitem "TreeMesh3D: Additional tests in 3D (ideal GLM MHD)" setup=[Setup] tags=[:tree_part6] begin
+@testitem "TreeMesh3D: Additional tests in 3D (ideal GLM MHD)" setup=[Setup] tags=[:tree_part5] begin
     using Trixi: Trixi, IdealGlmMhdEquations3D, density, pressure, density_pressure,
                  energy_total, energy_kinetic, energy_magnetic, energy_internal,
                  entropy, entropy_math, entropy_thermodynamic,
@@ -42,7 +42,7 @@ end
     @test isapprox(cross_helicity(u, eqn), 2.0)
 end
 
-@testitem "TreeMesh3D: Displaying components 3D" setup=[Setup, TreeMesh3DMisc] tags=[:tree_part5] begin
+@testitem "TreeMesh3D: Displaying components 3D" setup=[Setup, TreeMesh3DMisc] tags=[:tree_part4] begin
     @test_nowarn include(joinpath(EXAMPLES_DIR, "elixir_advection_amr.jl"))
 
     # test both short and long printing formats


### PR DESCRIPTION
Since I coordinated the breaking release, I noticed that our CI jobs are unablanced, see https://github.com/trixi-framework/Trixi.jl/actions/runs/30625362256. Thus, I made three changes summarized in the commit titles to distribute the CI time better and reduce the maximal CI time per job.

If the results are fine, we need to update the required checks before merging this.