### PR TITLE
Fuse `calc_sources!`, `apply_jacobian!` and `calc_surface_integral!` kernels for GPU backend

### DIFF
--- a/src/solvers/dgsem_p4est/dg_2d_gpu.jl
+++ b/src/solvers/dgsem_p4est/dg_2d_gpu.jl
@@ -514,7 +514,7 @@ end
                                          equations, dg, i, j, element)
     jacobian_factor = inverse_jacobian[i, j, element]
     du_local = get_node_vars(du, equations, dg, i, j, element) + factor * surface_node
-    du_node = source_node  - jacobian_factor * du_local
+    du_node = source_node - jacobian_factor * du_local
     set_node_vars!(du, du_node, equations, dg, i, j, element)
 end
 

--- a/src/solvers/dgsem_p4est/dg_2d_gpu.jl
+++ b/src/solvers/dgsem_p4est/dg_2d_gpu.jl
@@ -65,14 +65,11 @@ function rhs_hyperbolic!(backend::Backend,
                                dg.surface_integral, dg, cache)
     end
 
-    # Apply Jacobian from mapping to reference element
-    @trixi_timeit_ext backend timer() "Jacobian" begin
-        apply_jacobian!(backend, du, mesh, equations, dg, cache)
-    end
-
-    # Calculate source terms
-    @trixi_timeit_ext backend timer() "source terms" begin
-        calc_sources!(backend, du, u, t, source_terms, equations, dg, cache)
+    # Apply Jacobian from mapping to reference element 
+    # and calculate source terms
+    @trixi_timeit_ext backend timer() "Jacobian + source terms" begin
+        apply_jacobian_and_calc_sources!(backend, du, u, t, source_terms, mesh,
+                                         equations, dg, cache)
     end
 
     return nothing
@@ -504,53 +501,52 @@ end
     end
 end
 
-function apply_jacobian!(backend::Backend, du,
-                         mesh::Union{P4estMesh{2}, P4estMeshView{2},
-                                     T8codeMesh{2}},
-                         equations, dg::DG, cache)
+function apply_jacobian_and_calc_sources!(backend::Backend, du, u, t, source_terms,
+                                          mesh::Union{P4estMesh{2}, P4estMeshView{2},
+                                                      T8codeMesh{2}},
+                                          equations, dg::DG, cache)
     nelements(dg, cache) == 0 && return nothing
-    @unpack inverse_jacobian = cache.elements
-    kernel! = apply_jacobian_KAkernel!(backend)
-    kernel!(du, typeof(mesh), equations, dg, inverse_jacobian,
+    @unpack inverse_jacobian, node_coordinates = cache.elements
+    kernel_cache = kernel_filter_cache(cache)
+    kernel! = apply_jacobian_and_calc_sources_KAkernel!(backend)
+    kernel!(du, u, t, source_terms, node_coordinates, typeof(mesh), equations, dg,
+            inverse_jacobian, kernel_cache,
             ndrange = (nnodes(dg), nnodes(dg), nelements(dg, cache)))
 end
 
-@kernel function apply_jacobian_KAkernel!(du,
-                                          MeshT::Type{<:Union{P4estMesh{2},
-                                                              P4estMeshView{2},
-                                                              T8codeMesh{2}}},
-                                          equations, dg::DG, inverse_jacobian)
+@kernel function apply_jacobian_and_calc_sources_KAkernel!(du, u, t, source_terms,
+                                                           node_coordinates,
+                                                           MeshT::Type{<:Union{P4estMesh{2},
+                                                                               P4estMeshView{2},
+                                                                               T8codeMesh{2}}},
+                                                           equations::AbstractEquations{2},
+                                                           dg::DG, inverse_jacobian,
+                                                           cache)
     i, j, element = @index(Global, NTuple)
-    apply_jacobian_per_quadrature_node!(du, MeshT, equations, dg, inverse_jacobian,
-                                        i, j, element)
+
+    factor = -inverse_jacobian[i, j, element]
+
+    for v in eachvariable(equations)
+        du[v, i, j, element] *= factor
+    end
+    calc_sources_per_quadrature_node!(du, u, t, source_terms, node_coordinates,
+                                      equations, dg, i, j, element)
 end
 
-@kernel function calc_sources_KAkernel!(du, u, t, source_terms,
-                                        node_coordinates,
-                                        equations::AbstractEquations{2}, dg, cache)
-    i, j, element = @index(Global, NTuple)
-    u_local = get_node_vars(u, equations, dg, i, j, element)
-    x_local = get_node_coords(node_coordinates, equations, dg, i, j, element)
+@inline function calc_sources_per_quadrature_node!(du, u, t, source_terms,
+                                                   node_coordinates, equations, dg::DG,
+                                                   indices...)
+    u_local = get_node_vars(u, equations, dg, indices...)
+    x_local = get_node_coords(node_coordinates, equations, dg, indices...)
 
     du_local = source_terms(u_local, x_local, t, equations)
 
-    add_to_node_vars!(du, du_local, equations, dg, i, j, element)
+    add_to_node_vars!(du, du_local, equations, dg, indices...)
 end
 
-function calc_sources!(backend::Backend, du, u, t, source_terms,
-                       equations::AbstractEquations{2}, dg::DG, cache)
-    nelements(dg, cache) == 0 && return nothing
-    @unpack node_coordinates = cache.elements
-    kernel_cache = kernel_filter_cache(cache)
-    kernel! = calc_sources_KAkernel!(backend)
-    kernel!(du, u, t, source_terms, node_coordinates, equations, dg, kernel_cache,
-            ndrange = (nnodes(dg), nnodes(dg), nelements(dg, cache)))
-
-    return nothing
-end
-
-function calc_sources!(backend::Backend, du, u, t, source_terms::Nothing,
-                       equations::AbstractEquations{2}, dg::DG, cache)
+@inline function calc_sources_per_quadrature_node!(du, u, t, source_terms::Nothing,
+                                                   node_coordinates, equations, dg::DG,
+                                                   indices...)
     return nothing
 end
 end #muladd

--- a/src/solvers/dgsem_p4est/dg_2d_gpu.jl
+++ b/src/solvers/dgsem_p4est/dg_2d_gpu.jl
@@ -61,7 +61,7 @@ function rhs_hyperbolic!(backend::Backend,
 
     # Calculate surface integrals, apply Jacobian from mapping to reference element
     # and calculate source terms
-    @trixi_timeit_ext backend timer() "surface integral + Jacobian + source terms" begin
+    @trixi_timeit_ext backend timer() "surface, Jacobian + source terms" begin
         calc_surface_integral_and_apply_jacobian_and_calc_sources!(backend, du, u, t,
                                                                    source_terms, mesh,
                                                                    equations,

--- a/src/solvers/dgsem_p4est/dg_2d_gpu.jl
+++ b/src/solvers/dgsem_p4est/dg_2d_gpu.jl
@@ -59,17 +59,14 @@ function rhs_hyperbolic!(backend::Backend,
                           dg.mortar, dg.surface_integral, dg, cache)
     end
 
-    # Calculate surface integrals
-    @trixi_timeit_ext backend timer() "surface integral" begin
-        calc_surface_integral!(backend, du, u, mesh, equations,
-                               dg.surface_integral, dg, cache)
-    end
-
-    # Apply Jacobian from mapping to reference element 
+    # Calculate surface integrals, apply Jacobian from mapping to reference element
     # and calculate source terms
-    @trixi_timeit_ext backend timer() "Jacobian + source terms" begin
-        apply_jacobian_and_calc_sources!(backend, du, u, t, source_terms, mesh,
-                                         equations, dg, cache)
+    @trixi_timeit_ext backend timer() "surface integral + Jacobian + source terms" begin
+        calc_surface_integral_and_apply_jacobian_and_calc_sources!(backend, du, u, t,
+                                                                   source_terms, mesh,
+                                                                   equations,
+                                                                   dg.surface_integral,
+                                                                   dg, cache)
     end
 
     return nothing
@@ -450,36 +447,50 @@ function calc_mortar_flux!(backend::Backend, surface_flux_values, mesh,
     @assert isempty(eachmortar(dg, cache))
 end
 
-function calc_surface_integral!(backend::Backend, du, u,
-                                mesh::Union{P4estMesh{2}, T8codeMesh{2},
-                                            P4estMeshView{2}},
-                                equations,
-                                surface_integral::SurfaceIntegralWeakForm,
-                                dg::DGSEM{<:LobattoLegendreBasis},
-                                cache)
+function calc_surface_integral_and_apply_jacobian_and_calc_sources!(backend::Backend,
+                                                                    du, u, t,
+                                                                    source_terms,
+                                                                    mesh::Union{P4estMesh{2},
+                                                                                T8codeMesh{2},
+                                                                                P4estMeshView{2}},
+                                                                    equations,
+                                                                    surface_integral::SurfaceIntegralWeakForm,
+                                                                    dg::DGSEM{<:LobattoLegendreBasis},
+                                                                    cache)
+    nelements(dg, cache) == 0 && return nothing
     @unpack inverse_weights = dg.basis
-    @unpack surface_flux_values = cache.elements
+    @unpack surface_flux_values, inverse_jacobian, node_coordinates = cache.elements
+    kernel_cache = kernel_filter_cache(cache)
     NNODES = nnodes(dg)
-    kernel! = calc_surface_integral_KAkernel!(backend)
-    kernel!(du, typeof(mesh), equations, inverse_weights[1],
-            Val(NNODES),
-            surface_flux_values,
+    kernel! = calc_surface_integral_and_apply_jacobian_and_calc_sources_KAkernel!(backend)
+    kernel!(du, u, t, source_terms, node_coordinates, typeof(mesh), equations,
+            inverse_weights[1], Val(NNODES), surface_flux_values, dg, inverse_jacobian,
+            kernel_cache,
             ndrange = (NNODES, NNODES, nelements(dg, cache)))
 
     return nothing
 end
 
-@kernel function calc_surface_integral_KAkernel!(du,
-                                                 MeshT::Type{<:Union{P4estMesh{2},
-                                                                     P4estMeshView{2},
-                                                                     T8codeMesh{2}}},
-                                                 equations, factor, ::Val{NNODES},
-                                                 surface_flux_values) where {NNODES}
+@kernel function calc_surface_integral_and_apply_jacobian_and_calc_sources_KAkernel!(du,
+                                                                                     u,
+                                                                                     t,
+                                                                                     source_terms,
+                                                                                     node_coordinates,
+                                                                                     MeshT::Type{<:Union{P4estMesh{2},
+                                                                                                         P4estMeshView{2},
+                                                                                                         T8codeMesh{2}}},
+                                                                                     equations::AbstractEquations{2},
+                                                                                     factor,
+                                                                                     ::Val{NNODES},
+                                                                                     surface_flux_values,
+                                                                                     dg::DGSEM,
+                                                                                     inverse_jacobian,
+                                                                                     cache) where {NNODES}
     i, j, element = @index(Global, NTuple)
     # Note that all fluxes have been computed with outward-pointing normal vectors.
     # This computes the **negative** surface integral contribution,
     # i.e., M^{-1} * boundary_interpolation^T (which is for Gauss-Lobatto DGSEM just M^{-1} * B)
-    # and the missing "-" is taken care of by `apply_jacobian!`.
+    # and the missing "-" is taken care of by the Jacobian factor below.
     #
     # We also use explicit assignments instead of `+=` to let `@muladd` turn these
     # into FMAs (see comment at the top of the file).
@@ -491,62 +502,32 @@ end
     x_face = ifelse(i == 1, 1, 2)
     y_face = ifelse(j == 1, 3, 4)
     _zero = zero(eltype(du))
-    for v in eachvariable(equations)
-        x_contribution = ifelse(x_node_interface,
-                                surface_flux_values[v, j, x_face, element], _zero)
-        y_contribution = ifelse(y_node_interface,
-                                surface_flux_values[v, i, y_face, element], _zero)
-        du_node = x_contribution + y_contribution
-        du[v, i, j, element] = du[v, i, j, element] + du_node * factor
-    end
+    surface_node = SVector(ntuple(@inline(v->ifelse(x_node_interface,
+                                                    surface_flux_values[v, j, x_face,
+                                                                        element],
+                                                    _zero) +
+                                             ifelse(y_node_interface,
+                                                    surface_flux_values[v, i, y_face,
+                                                                        element], _zero)),
+                                  Val(nvariables(equations))))
+    source_node = calc_source_terms_node(u, t, source_terms, node_coordinates,
+                                         equations, dg, i, j, element)
+    jacobian_factor = -inverse_jacobian[i, j, element]
+    du_local = get_node_vars(du, equations, dg, i, j, element) + factor * surface_node
+    du_node = jacobian_factor * du_local + source_node
+    set_node_vars!(du, du_node, equations, dg, i, j, element)
 end
 
-function apply_jacobian_and_calc_sources!(backend::Backend, du, u, t, source_terms,
-                                          mesh::Union{P4estMesh{2}, P4estMeshView{2},
-                                                      T8codeMesh{2}},
-                                          equations, dg::DG, cache)
-    nelements(dg, cache) == 0 && return nothing
-    @unpack inverse_jacobian, node_coordinates = cache.elements
-    kernel_cache = kernel_filter_cache(cache)
-    kernel! = apply_jacobian_and_calc_sources_KAkernel!(backend)
-    kernel!(du, u, t, source_terms, node_coordinates, typeof(mesh), equations, dg,
-            inverse_jacobian, kernel_cache,
-            ndrange = (nnodes(dg), nnodes(dg), nelements(dg, cache)))
-end
-
-@kernel function apply_jacobian_and_calc_sources_KAkernel!(du, u, t, source_terms,
-                                                           node_coordinates,
-                                                           MeshT::Type{<:Union{P4estMesh{2},
-                                                                               P4estMeshView{2},
-                                                                               T8codeMesh{2}}},
-                                                           equations::AbstractEquations{2},
-                                                           dg::DG, inverse_jacobian,
-                                                           cache)
-    i, j, element = @index(Global, NTuple)
-
-    factor = -inverse_jacobian[i, j, element]
-
-    for v in eachvariable(equations)
-        du[v, i, j, element] *= factor
-    end
-    calc_sources_per_quadrature_node!(du, u, t, source_terms, node_coordinates,
-                                      equations, dg, i, j, element)
-end
-
-@inline function calc_sources_per_quadrature_node!(du, u, t, source_terms,
-                                                   node_coordinates, equations, dg::DG,
-                                                   indices...)
+@inline function calc_source_terms_node(u, t, source_terms, node_coordinates,
+                                        equations, dg::DG, indices...)
     u_local = get_node_vars(u, equations, dg, indices...)
     x_local = get_node_coords(node_coordinates, equations, dg, indices...)
 
-    du_local = source_terms(u_local, x_local, t, equations)
-
-    add_to_node_vars!(du, du_local, equations, dg, indices...)
+    return source_terms(u_local, x_local, t, equations)
 end
 
-@inline function calc_sources_per_quadrature_node!(du, u, t, source_terms::Nothing,
-                                                   node_coordinates, equations, dg::DG,
-                                                   indices...)
-    return nothing
+@inline function calc_source_terms_node(u, t, source_terms::Nothing, node_coordinates,
+                                        equations, dg::DG, indices...)
+    return zero(SVector{nvariables(equations), eltype(u)})
 end
 end #muladd

--- a/src/solvers/dgsem_p4est/dg_2d_gpu.jl
+++ b/src/solvers/dgsem_p4est/dg_2d_gpu.jl
@@ -512,9 +512,9 @@ end
                                   Val(nvariables(equations))))
     source_node = calc_source_terms_node(u, t, source_terms, node_coordinates,
                                          equations, dg, i, j, element)
-    jacobian_factor = -inverse_jacobian[i, j, element]
+    jacobian_factor = inverse_jacobian[i, j, element]
     du_local = get_node_vars(du, equations, dg, i, j, element) + factor * surface_node
-    du_node = jacobian_factor * du_local + source_node
+    du_node = source_node  - jacobian_factor * du_local
     set_node_vars!(du, du_node, equations, dg, i, j, element)
 end
 

--- a/src/solvers/dgsem_p4est/dg_3d_gpu.jl
+++ b/src/solvers/dgsem_p4est/dg_3d_gpu.jl
@@ -769,53 +769,33 @@ end
     end
 end
 
-function apply_jacobian!(backend::Backend, du,
-                         mesh::Union{P4estMesh{3}, T8codeMesh{3}},
-                         equations, dg::DG, cache)
-    @unpack inverse_jacobian = cache.elements
-
-    kernel! = apply_jacobian_KAkernel!(backend)
-    kernel!(du, typeof(mesh), equations, dg, inverse_jacobian,
-            ndrange = (nnodes(dg), nnodes(dg), nnodes(dg), nelements(dg, cache)))
-    return nothing
-end
-
-@kernel function apply_jacobian_KAkernel!(du,
-                                          MeshT::Type{<:Union{P4estMesh{3},
-                                                              T8codeMesh{3}}},
-                                          equations, dg::DG,
-                                          inverse_jacobian)
-    i, j, k, element = @index(Global, NTuple)
-    apply_jacobian_per_quadrature_node!(du, MeshT, equations, dg, inverse_jacobian,
-                                        i, j, k, element)
-end
-
-@kernel function calc_sources_KAkernel!(du, u, t, source_terms,
-                                        node_coordinates,
-                                        equations::AbstractEquations{3}, dg, cache)
-    i, j, k, element = @index(Global, NTuple)
-    u_local = get_node_vars(u, equations, dg, i, j, k, element)
-    x_local = get_node_coords(node_coordinates, equations, dg, i, j, k, element)
-
-    du_local = source_terms(u_local, x_local, t, equations)
-
-    add_to_node_vars!(du, du_local, equations, dg, i, j, k, element)
-end
-
-function calc_sources!(backend::Backend, du, u, t, source_terms,
-                       equations::AbstractEquations{3}, dg::DG, cache)
+function apply_jacobian_and_calc_sources!(backend::Backend, du, u, t, source_terms,
+                                          mesh::Union{P4estMesh{3}, T8codeMesh{3}},
+                                          equations, dg::DG, cache)
     nelements(dg, cache) == 0 && return nothing
-    @unpack node_coordinates = cache.elements
+    @unpack inverse_jacobian, node_coordinates = cache.elements
     kernel_cache = kernel_filter_cache(cache)
-    kernel! = calc_sources_KAkernel!(backend)
-    kernel!(du, u, t, source_terms, node_coordinates, equations, dg, kernel_cache,
+    kernel! = apply_jacobian_and_calc_sources_KAkernel!(backend)
+    kernel!(du, u, t, source_terms, node_coordinates, typeof(mesh), equations, dg,
+            inverse_jacobian, kernel_cache,
             ndrange = (nnodes(dg), nnodes(dg), nnodes(dg), nelements(dg, cache)))
-
-    return nothing
 end
 
-function calc_sources!(backend::Backend, du, u, t, source_terms::Nothing,
-                       equations::AbstractEquations{3}, dg::DG, cache)
-    return nothing
+@kernel function apply_jacobian_and_calc_sources_KAkernel!(du, u, t, source_terms,
+                                                           node_coordinates,
+                                                           MeshT::Type{<:Union{P4estMesh{3},
+                                                                               T8codeMesh{3}}},
+                                                           equations::AbstractEquations{3},
+                                                           dg::DG, inverse_jacobian,
+                                                           cache)
+    i, j, k, element = @index(Global, NTuple)
+
+    factor = -inverse_jacobian[i, j, k, element]
+
+    for v in eachvariable(equations)
+        du[v, i, j, k, element] *= factor
+    end
+    calc_sources_per_quadrature_node!(du, u, t, source_terms, node_coordinates,
+                                      equations, dg, i, j, k, element)
 end
 end #muladd

--- a/src/solvers/dgsem_p4est/dg_3d_gpu.jl
+++ b/src/solvers/dgsem_p4est/dg_3d_gpu.jl
@@ -785,10 +785,10 @@ end
                                   Val(nvariables(equations))))
     source_node = calc_source_terms_node(u, t, source_terms, node_coordinates,
                                          equations, dg, i, j, k, element)
-    jacobian_factor = -inverse_jacobian[i, j, k, element]
+    jacobian_factor = inverse_jacobian[i, j, k, element]
     du_local = get_node_vars(du, equations, dg, i, j, k, element) +
                factor * surface_node
-    du_node = jacobian_factor * du_local + source_node
+    du_node = source_node  - jacobian_factor * du_local
     set_node_vars!(du, du_node, equations, dg, i, j, k, element)
 end
 end #muladd

--- a/src/solvers/dgsem_p4est/dg_3d_gpu.jl
+++ b/src/solvers/dgsem_p4est/dg_3d_gpu.jl
@@ -788,7 +788,7 @@ end
     jacobian_factor = inverse_jacobian[i, j, k, element]
     du_local = get_node_vars(du, equations, dg, i, j, k, element) +
                factor * surface_node
-    du_node = source_node  - jacobian_factor * du_local
+    du_node = source_node - jacobian_factor * du_local
     set_node_vars!(du, du_node, equations, dg, i, j, k, element)
 end
 end #muladd

--- a/src/solvers/dgsem_p4est/dg_3d_gpu.jl
+++ b/src/solvers/dgsem_p4est/dg_3d_gpu.jl
@@ -716,40 +716,54 @@ end
     return nothing
 end
 
-function calc_surface_integral!(backend::Backend, du, u,
-                                mesh::Union{P4estMesh{3}, T8codeMesh{3}},
-                                equations,
-                                surface_integral::SurfaceIntegralWeakForm,
-                                dg::DGSEM{<:LobattoLegendreBasis},
-                                cache)
+function calc_surface_integral_and_apply_jacobian_and_calc_sources!(backend::Backend,
+                                                                    du, u, t,
+                                                                    source_terms,
+                                                                    mesh::Union{P4estMesh{3},
+                                                                                T8codeMesh{3}},
+                                                                    equations,
+                                                                    surface_integral::SurfaceIntegralWeakForm,
+                                                                    dg::DGSEM{<:LobattoLegendreBasis},
+                                                                    cache)
+    nelements(dg, cache) == 0 && return nothing
     @unpack inverse_weights = dg.basis
-    @unpack surface_flux_values = cache.elements
+    @unpack surface_flux_values, inverse_jacobian, node_coordinates = cache.elements
+    kernel_cache = kernel_filter_cache(cache)
     NNODES = nnodes(dg)
-    kernel! = calc_surface_integral_KAkernel!(backend)
-    kernel!(du, typeof(mesh), equations, inverse_weights[1],
-            Val(NNODES),
-            surface_flux_values,
+    kernel! = calc_surface_integral_and_apply_jacobian_and_calc_sources_KAkernel!(backend)
+    kernel!(du, u, t, source_terms, node_coordinates, typeof(mesh), equations,
+            inverse_weights[1], Val(NNODES), surface_flux_values, dg, inverse_jacobian,
+            kernel_cache,
             ndrange = (NNODES, NNODES, NNODES, nelements(dg, cache)))
 
     return nothing
 end
 
-@kernel function calc_surface_integral_KAkernel!(du,
-                                                 MeshT::Type{<:Union{P4estMesh{3},
-                                                                     T8codeMesh{3}}},
-                                                 equations, factor, ::Val{NNODES},
-                                                 surface_flux_values) where {NNODES}
+@kernel function calc_surface_integral_and_apply_jacobian_and_calc_sources_KAkernel!(du,
+                                                                                     u,
+                                                                                     t,
+                                                                                     source_terms,
+                                                                                     node_coordinates,
+                                                                                     MeshT::Type{<:Union{P4estMesh{3},
+                                                                                                         T8codeMesh{3}}},
+                                                                                     equations::AbstractEquations{3},
+                                                                                     factor,
+                                                                                     ::Val{NNODES},
+                                                                                     surface_flux_values,
+                                                                                     dg::DGSEM,
+                                                                                     inverse_jacobian,
+                                                                                     cache) where {NNODES}
     i, j, k, element = @index(Global, NTuple)
     # Note that all fluxes have been computed with outward-pointing normal vectors.
     # This computes the **negative** surface integral contribution,
     # i.e., M^{-1} * boundary_interpolation^T (which is for Gauss-Lobatto DGSEM just M^{-1} * B)
-    # and the missing "-" is taken care of by `apply_jacobian!`.
+    # and the missing "-" is taken care of by the Jacobian factor below.
     #
     # We also use explicit assignments instead of `+=` to let `@muladd` turn these
     # into FMAs (see comment at the top of the file).
     #
     # factor = inverse_weights[1]
-    # For LGL basis: Identical to weighted boundary interpolation at x = ±1	
+    # For LGL basis: Identical to weighted boundary interpolation at x = ±1
     x_node_interface = (i == 1) | (i == NNODES)
     y_node_interface = (j == 1) | (j == NNODES)
     z_node_interface = (k == 1) | (k == NNODES)
@@ -757,45 +771,24 @@ end
     y_face = ifelse(j == 1, 3, 4)
     z_face = ifelse(k == 1, 5, 6)
     _zero = zero(eltype(du))
-    for v in eachvariable(equations)
-        x_contribution = ifelse(x_node_interface,
-                                surface_flux_values[v, j, k, x_face, element], _zero)
-        y_contribution = ifelse(y_node_interface,
-                                surface_flux_values[v, i, k, y_face, element], _zero)
-        z_contribution = ifelse(z_node_interface,
-                                surface_flux_values[v, i, j, z_face, element], _zero)
-        du_node = x_contribution + y_contribution + z_contribution
-        du[v, i, j, k, element] = du[v, i, j, k, element] + du_node * factor
-    end
-end
-
-function apply_jacobian_and_calc_sources!(backend::Backend, du, u, t, source_terms,
-                                          mesh::Union{P4estMesh{3}, T8codeMesh{3}},
-                                          equations, dg::DG, cache)
-    nelements(dg, cache) == 0 && return nothing
-    @unpack inverse_jacobian, node_coordinates = cache.elements
-    kernel_cache = kernel_filter_cache(cache)
-    kernel! = apply_jacobian_and_calc_sources_KAkernel!(backend)
-    kernel!(du, u, t, source_terms, node_coordinates, typeof(mesh), equations, dg,
-            inverse_jacobian, kernel_cache,
-            ndrange = (nnodes(dg), nnodes(dg), nnodes(dg), nelements(dg, cache)))
-end
-
-@kernel function apply_jacobian_and_calc_sources_KAkernel!(du, u, t, source_terms,
-                                                           node_coordinates,
-                                                           MeshT::Type{<:Union{P4estMesh{3},
-                                                                               T8codeMesh{3}}},
-                                                           equations::AbstractEquations{3},
-                                                           dg::DG, inverse_jacobian,
-                                                           cache)
-    i, j, k, element = @index(Global, NTuple)
-
-    factor = -inverse_jacobian[i, j, k, element]
-
-    for v in eachvariable(equations)
-        du[v, i, j, k, element] *= factor
-    end
-    calc_sources_per_quadrature_node!(du, u, t, source_terms, node_coordinates,
-                                      equations, dg, i, j, k, element)
+    surface_node = SVector(ntuple(@inline(v->ifelse(x_node_interface,
+                                                    surface_flux_values[v, j, k, x_face,
+                                                                        element],
+                                                    _zero) +
+                                             ifelse(y_node_interface,
+                                                    surface_flux_values[v, i, k, y_face,
+                                                                        element],
+                                                    _zero) +
+                                             ifelse(z_node_interface,
+                                                    surface_flux_values[v, i, j, z_face,
+                                                                        element], _zero)),
+                                  Val(nvariables(equations))))
+    source_node = calc_source_terms_node(u, t, source_terms, node_coordinates,
+                                         equations, dg, i, j, k, element)
+    jacobian_factor = -inverse_jacobian[i, j, k, element]
+    du_local = get_node_vars(du, equations, dg, i, j, k, element) +
+               factor * surface_node
+    du_node = jacobian_factor * du_local + source_node
+    set_node_vars!(du, du_node, equations, dg, i, j, k, element)
 end
 end #muladd


### PR DESCRIPTION
These three kernels share the same structure, i.e., they are parallelized on each quadrature node, so it makes sense to fuse them.

fused jacobian and sources
```
────────────────────────────────────────────────────────────────────────────────────────────────────
Trixi.jl simulation finished.  Final time: 5.0  Time steps: 1264 (accepted), 1264 (total)
────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────
               Trixi.jl                        Time                    Allocations
                                      ───────────────────────   ────────────────────────
          Tot / % measured:                46.0s /  96.2%           1.52GiB /  87.5%

Section                       ncalls     time    %tot     avg     alloc    %tot      avg
────────────────────────────────────────────────────────────────────────────────────────
rhs_hyperbolic!                6.32k    41.9s   94.5%  6.62ms    401MiB   29.5%  64.9KiB
  volume integral              6.32k    34.7s   78.4%  5.49ms   64.1MiB    4.7%  10.4KiB
  prolong2boundaries           6.32k    1.51s    3.4%   240μs   62.2MiB    4.6%  10.1KiB
  prolong2interfaces + flux    6.32k    1.37s    3.1%   217μs   65.0MiB    4.8%  10.5KiB
  boundary flux                6.32k    1.30s    2.9%   206μs   65.6MiB    4.8%  10.6KiB
  reset ∂u/∂t                  6.32k    1.20s    2.7%   191μs   43.3MiB    3.2%  7.01KiB
  surface integral             6.32k    982ms    2.2%   155μs   39.9MiB    2.9%  6.46KiB
  Jacobian + source terms      6.32k    742ms    1.7%   117μs   60.7MiB    4.5%  9.83KiB
  ~rhs_hyperbolic!~            6.32k   16.5ms    0.0%  2.62μs   6.61KiB    0.0%    1.07B
  prolong2mortars              6.32k   3.48ms    0.0%   551ns     0.00B    0.0%    0.00B
  mortar flux                  6.32k   2.96ms    0.0%   468ns     0.00B    0.0%    0.00B
analyze solution                  14    1.10s    2.5%  78.9ms    333MiB   24.5%  23.8MiB
calculate dt                   1.26k    940ms    2.1%   743μs   64.3MiB    4.7%  52.0KiB
I/O                               15    378ms    0.9%  25.2ms    560MiB   41.2%  37.4MiB
  save solution                   14    366ms    0.8%  26.2ms    560MiB   41.2%  40.0MiB
  ~I/O~                           15   11.7ms    0.0%   780μs    158KiB    0.0%  10.6KiB
  get element variables           14   39.1μs    0.0%  2.79μs   18.4KiB    0.0%  1.31KiB
  save mesh                       14   5.01μs    0.0%   358ns     0.00B    0.0%    0.00B
  get node variables              14   3.20μs    0.0%   229ns     0.00B    0.0%    0.00B
────────────────────────────────────────────────────────────────────────────────────────
```

fuse jacobian, sources and surface integral
```
─────────────────────────────────────────────────────────────────────────────────────────────────────────
                       Trixi.jl                                 Time                    Allocations
                                                       ───────────────────────   ────────────────────────
                   Tot / % measured:                        43.0s /  98.9%           1.26GiB /  94.8%

Section                                        ncalls     time    %tot     avg     alloc    %tot      avg
─────────────────────────────────────────────────────────────────────────────────────────────────────────
rhs_hyperbolic!                                 6.32k    41.1s   96.5%  6.50ms    363MiB   29.7%  58.8KiB
  volume integral                               6.32k    34.6s   81.3%  5.48ms   64.1MiB    5.2%  10.4KiB
  prolong2boundaries                            6.32k    1.50s    3.5%   237μs   62.1MiB    5.1%  10.1KiB
  prolong2interfaces + flux                     6.32k    1.36s    3.2%   215μs   64.3MiB    5.3%  10.4KiB
  boundary flux                                 6.32k    1.30s    3.0%   205μs   65.3MiB    5.3%  10.6KiB
  reset ∂u/∂t                                   6.32k    1.19s    2.8%   188μs   42.5MiB    3.5%  6.88KiB
  surface integral + Jacobian + source terms    6.32k    1.08s    2.5%   171μs   65.0MiB    5.3%  10.5KiB
  ~rhs_hyperbolic!~                             6.32k   14.9ms    0.0%  2.36μs   5.88KiB    0.0%    0.95B
  prolong2mortars                               6.32k   3.51ms    0.0%   555ns     0.00B    0.0%    0.00B
  mortar flux                                   6.32k   3.07ms    0.0%   486ns     0.00B    0.0%    0.00B
I/O                                                15    542ms    1.3%  36.1ms    561MiB   45.8%  37.4MiB
  save solution                                    14    539ms    1.3%  38.5ms    561MiB   45.8%  40.0MiB
  ~I/O~                                            15   2.66ms    0.0%   177μs    158KiB    0.0%  10.6KiB
  get element variables                            14   38.8μs    0.0%  2.77μs   18.4KiB    0.0%  1.31KiB
  get node variables                               14   3.77μs    0.0%   269ns     0.00B    0.0%    0.00B
  save mesh                                        14   3.11μs    0.0%   222ns     0.00B    0.0%    0.00B
calculate dt                                    1.26k    526ms    1.2%   416μs   15.6MiB    1.3%  12.6KiB
analyze solution                                   14    429ms    1.0%  30.7ms    285MiB   23.3%  20.3MiB
─────────────────────────────────────────────────────────────────────────────────────────────────────────
```

## Large problem

`trixi_include("examples/p4est_3d_dgsem/elixir_euler_source_terms_nonperiodic.jl", storage_type = ROCArray, trees_per_dimension = (10, 10, 10), polydeg = 5, tspan = (0.0, 0.25))`

this branch
```
────────────────────────────────────────────────────────────────────────────────────────────────────
 Simulation running 'CompressibleEulerEquations3D' with DGSEM(polydeg=5)
────────────────────────────────────────────────────────────────────────────────────────────────────
 #timesteps:                119                run time:       2.35888535e+01 s
 Δt:             1.00038615e-03                └── GC time:    1.57068524e-01 s (0.666%)
 sim. time:      2.50000000e-01 (100.000%)     time/DOF/RHS:   1.45357116e-08 s
                                               PID:            1.58667747e-08 s
 #DOFs per field:       1728000                alloc'd memory:       1477.167 MiB
 #elements:                8000                device memory:        1258.500 MiB

 Variable:       rho              rho_v1           rho_v2           rho_v3           rho_e_total
 L2 error:       3.82290175e-10   4.01360595e-10   4.01360606e-10   4.01360620e-10   1.03809360e-09
 Linf error:     1.56382121e-08   1.85677536e-08   1.85677538e-08   1.85677542e-08   7.10125319e-08
 ∑∂S/∂U ⋅ Uₜ :   1.72231026e-09
────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────
Trixi.jl simulation finished.  Final time: 0.25  Time steps: 119 (accepted), 119 (total)
────────────────────────────────────────────────────────────────────────────────────────────────────

─────────────────────────────────────────────────────────────────────────────────────────────────────────
                       Trixi.jl                                 Time                    Allocations
                                                       ───────────────────────   ────────────────────────
                   Tot / % measured:                        25.5s /  91.4%           2.20GiB /  89.9%

Section                                        ncalls     time    %tot     avg     alloc    %tot      avg
─────────────────────────────────────────────────────────────────────────────────────────────────────────
rhs_hyperbolic!                                   596    15.0s   64.3%  25.2ms   40.1MiB    2.0%  68.9KiB
  volume integral                                 596    12.5s   53.4%  20.9ms   6.40MiB    0.3%  11.0KiB
  reset ∂u/∂t                                     596    1.17s    5.0%  1.96ms   4.60MiB    0.2%  7.90KiB
  surface integral + Jacobian + source terms      596    485ms    2.1%   814μs   8.11MiB    0.4%  13.9KiB
  prolong2interfaces + flux                       596    448ms    1.9%   751μs   7.37MiB    0.4%  12.7KiB
  boundary flux                                   596    234ms    1.0%   392μs   7.22MiB    0.4%  12.4KiB
  prolong2boundaries                              596    211ms    0.9%   354μs   6.40MiB    0.3%  11.0KiB
  ~rhs_hyperbolic!~                               596   1.95ms    0.0%  3.27μs   5.88KiB    0.0%    10.1B
  prolong2mortars                                 596    386μs    0.0%   647ns     0.00B    0.0%    0.00B
  mortar flux                                     596    270μs    0.0%   453ns     0.00B    0.0%    0.00B
analyze solution                                    3    6.19s   26.5%   2.06s   0.96GiB   48.4%   326MiB
calculate dt                                      120    1.64s    7.0%  13.6ms    213MiB   10.5%  1.78MiB
I/O                                                 4    491ms    2.1%   123ms    791MiB   39.1%   198MiB
  save solution                                     3    476ms    2.0%   159ms    791MiB   39.1%   264MiB
  ~I/O~                                             4   15.4ms    0.1%  3.86ms    290KiB    0.0%  72.5KiB
  get element variables                             3   14.9μs    0.0%  4.97μs   3.94KiB    0.0%  1.31KiB
  save mesh                                         3    859ns    0.0%   286ns     0.00B    0.0%    0.00B
  get node variables                                3    740ns    0.0%   247ns     0.00B    0.0%    0.00B
─────────────────────────────────────────────────────────────────────────────────────────────────────────
```

main
```
────────────────────────────────────────────────────────────────────────────────────────────────────
Trixi.jl simulation finished.  Final time: 0.25  Time steps: 119 (accepted), 119 (total)
────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────
               Trixi.jl                        Time                    Allocations
                                      ───────────────────────   ────────────────────────
          Tot / % measured:                26.9s /  91.2%           2.26GiB /  90.2%

Section                       ncalls     time    %tot     avg     alloc    %tot      avg
────────────────────────────────────────────────────────────────────────────────────────
rhs_hyperbolic!                  596    15.7s   63.9%  26.3ms   52.0MiB    2.5%  89.3KiB
  volume integral                596    12.5s   50.8%  20.9ms   6.41MiB    0.3%  11.0KiB
  reset ∂u/∂t                    596    1.14s    4.7%  1.92ms   4.59MiB    0.2%  7.88KiB
  surface integral               596    475ms    1.9%   796μs   5.25MiB    0.3%  9.02KiB
  prolong2interfaces + flux      596    447ms    1.8%   750μs   7.36MiB    0.4%  12.6KiB
  Jacobian                       596    350ms    1.4%   588μs   7.25MiB    0.3%  12.5KiB
  source terms                   596    333ms    1.4%   559μs   7.47MiB    0.4%  12.8KiB
  boundary flux                  596    236ms    1.0%   397μs   7.21MiB    0.3%  12.4KiB
  prolong2boundaries             596    214ms    0.9%   359μs   6.41MiB    0.3%  11.0KiB
  ~rhs_hyperbolic!~              596   2.62ms    0.0%  4.40μs   7.34KiB    0.0%    12.6B
  prolong2mortars                596    405μs    0.0%   680ns     0.00B    0.0%    0.00B
  mortar flux                    596    290μs    0.0%   487ns     0.00B    0.0%    0.00B
analyze solution                   3    6.72s   27.4%   2.24s   1.01GiB   49.5%   345MiB
calculate dt                     120    1.62s    6.6%  13.5ms    213MiB   10.2%  1.78MiB
I/O                                4    509ms    2.1%   127ms    791MiB   37.8%   198MiB
  save solution                    3    493ms    2.0%   164ms    791MiB   37.8%   264MiB
  ~I/O~                            4   15.5ms    0.1%  3.89ms    290KiB    0.0%  72.5KiB
  get element variables            3   14.5μs    0.0%  4.82μs   3.94KiB    0.0%  1.31KiB
  get node variables               3    760ns    0.0%   253ns     0.00B    0.0%    0.00B
  save mesh                        3    750ns    0.0%   250ns     0.00B    0.0%    0.00B
────────────────────────────────────────────────────────────────────────────────────────
```

This is mainly motivated when I was testing the baroclinic instability in TrixiAtmo.jl and saw:
```
────────────────────────────────────────────────────────────────────────────────────────
               Trixi.jl                        Time                    Allocations      
                                      ───────────────────────   ────────────────────────
          Tot / % measured:                 302s /  86.2%           3.48GiB /  87.2%    

Section                       ncalls     time    %tot     avg     alloc    %tot      avg
────────────────────────────────────────────────────────────────────────────────────────
rhs_hyperbolic!                20.6k     239s   91.7%  11.6ms   1.80GiB   59.3%  91.4KiB
  surface integral             20.6k    46.9s   18.0%  2.27ms    194MiB    6.2%  9.63KiB
  volume integral              20.6k    38.8s   14.9%  1.88ms    230MiB    7.4%  11.4KiB
  reset ∂u/∂t                  20.6k    33.4s   12.8%  1.62ms    163MiB    5.2%  8.07KiB
  source terms                 20.6k    31.4s   12.1%  1.52ms    262MiB    8.4%  13.0KiB
  prolong2interfaces + flux    20.6k    30.2s   11.6%  1.46ms    259MiB    8.3%  12.8KiB
  Jacobian                     20.6k    28.4s   10.9%  1.37ms    255MiB    8.2%  12.6KiB
  boundary flux                20.6k    15.0s    5.8%   726μs    253MiB    8.1%  12.6KiB
  prolong2boundaries           20.6k    14.4s    5.5%   697μs    227MiB    7.3%  11.3KiB
  ~rhs_hyperbolic!~            20.6k    172ms    0.1%  8.34μs   7.34KiB    0.0%    0.36B
  prolong2mortars              20.6k   38.0ms    0.0%  1.84μs     0.00B    0.0%    0.00B
  mortar flux                  20.6k   27.0ms    0.0%  1.31μs     0.00B    0.0%    0.00B
analyze solution                   2    21.7s    8.3%   10.9s   1.24GiB   40.7%   634MiB
────────────────────────────────────────────────────────────────────────────────────────
```


this branch
```
────────────────────────────────────────────────────────────────────────────────────────────────────
 Simulation running 'CompressibleEulerPotentialTemperatureEquationsWithGravity3D' with DGSEM(polydeg=4)
────────────────────────────────────────────────────────────────────────────────────────────────────
 #timesteps:               5152                run time:       2.03710556e+02 s
 Δt:             1.36352338e+00                └── GC time:    1.01775199e+00 s (0.500%)
 sim. time:      8.64000000e+03 (100.000%)     time/DOF/RHS:   1.97209929e-09 s
                                               PID:            2.35606505e-09 s
 #DOFs per field:       3900000                alloc'd memory:       1373.430 MiB
 #elements:               31200                device memory:       44761.250 MiB

 Variable:       rho              rho_v1           rho_v2           rho_v3           rho_theta        phi           
 L2 error:       8.58576408e-06   3.22142106e-03   3.68667150e-03   3.71861480e-03   1.49007301e-03   8.40316960e-03
 Linf error:     9.51100721e-04   2.50040395e-01   4.51399781e-01   3.06300063e-01   1.42817542e-01   4.33849841e-02
 ∑∂S/∂U ⋅ Uₜ :   5.38419921e-18
────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────
Trixi.jl simulation finished.  Final time: 8640.0  Time steps: 5152 (accepted), 5160 (total)
────────────────────────────────────────────────────────────────────────────────────────────────────

─────────────────────────────────────────────────────────────────────────────────────────────────────────
                       Trixi.jl                                 Time                    Allocations      
                                                       ───────────────────────   ────────────────────────
                   Tot / % measured:                         210s /  81.8%           3.02GiB /  85.2%    

Section                                        ncalls     time    %tot     avg     alloc    %tot      avg
─────────────────────────────────────────────────────────────────────────────────────────────────────────
rhs_hyperbolic!                                 20.6k     153s   89.1%  7.40ms   1.39GiB   53.9%  70.5KiB
  volume integral                               20.6k    38.4s   22.4%  1.86ms    230MiB    8.7%  11.4KiB
  reset ∂u/∂t                                   20.6k    32.1s   18.7%  1.56ms    163MiB    6.2%  8.10KiB
  prolong2interfaces + flux                     20.6k    30.1s   17.5%  1.46ms    261MiB    9.9%  12.9KiB
  surface integral + Jacobian + source terms    20.6k    23.8s   13.9%  1.15ms    288MiB   10.9%  14.3KiB
  boundary flux                                 20.6k    14.4s    8.4%   697μs    253MiB    9.6%  12.6KiB
  prolong2boundaries                            20.6k    13.9s    8.1%   672μs    226MiB    8.6%  11.2KiB
  ~rhs_hyperbolic!~                             20.6k    117ms    0.1%  5.69μs   5.88KiB    0.0%    0.29B
  prolong2mortars                               20.6k   31.0ms    0.0%  1.50μs     0.00B    0.0%    0.00B
  mortar flux                                   20.6k   21.4ms    0.0%  1.04μs     0.00B    0.0%    0.00B
analyze solution                                    2    18.6s   10.9%   9.30s   1.19GiB   46.1%   608MiB
─────────────────────────────────────────────────────────────────────────────────────────────────────────
```