### PR TITLE
Restore CPU code before GPU support

### DIFF
--- a/src/solvers/dgsem_p4est/dg_2d.jl
+++ b/src/solvers/dgsem_p4est/dg_2d.jl
@@ -1057,20 +1057,49 @@ end
     return nothing
 end
 
-function calc_surface_integral!(backend::Nothing, du, u,
+function calc_surface_integral!(du, u,
                                 mesh::Union{P4estMesh{2}, P4estMeshView{2},
                                             T8codeMesh{2}},
                                 equations, surface_integral::SurfaceIntegralWeakForm,
                                 dg::DGSEM{<:LobattoLegendreBasis}, cache)
     @unpack inverse_weights = dg.basis
     @unpack surface_flux_values = cache.elements
-    MeshT = typeof(mesh)
 
+    # Note that all fluxes have been computed with outward-pointing normal vectors.
+    # This computes the **negative** surface integral contribution,
+    # i.e., M^{-1} * boundary_interpolation^T (which is for Gauss-Lobatto DGSEM just M^{-1} * B)
+    # and the missing "-" is taken care of by `apply_jacobian!`.
+    #
+    # We also use explicit assignments instead of `+=` to let `@muladd` turn these
+    # into FMAs (see comment at the top of the file).
+    factor = inverse_weights[1] # For LGL basis: Identical to weighted boundary interpolation at x = ±1
     @threaded for element in eachelement(dg, cache)
-        calc_surface_integral_per_element!(du, MeshT, equations,
-                                           surface_integral, dg, inverse_weights[1],
-                                           surface_flux_values, element)
+        for l in eachnode(dg)
+            for v in eachvariable(equations)
+                # surface at -x
+                du[v, 1, l, element] = (du[v, 1, l, element] +
+                                        surface_flux_values[v, l, 1, element] *
+                                        factor)
+
+                # surface at +x
+                du[v, nnodes(dg), l, element] = (du[v, nnodes(dg), l, element] +
+                                                 surface_flux_values[v, l, 2, element] *
+                                                 factor)
+
+                # surface at -y
+                du[v, l, 1, element] = (du[v, l, 1, element] +
+                                        surface_flux_values[v, l, 3, element] *
+                                        factor)
+
+                # surface at +y
+                du[v, l, nnodes(dg), element] = (du[v, l, nnodes(dg), element] +
+                                                 surface_flux_values[v, l, 4, element] *
+                                                 factor)
+            end
+        end
     end
+
+    return nothing
 end
 
 function calc_surface_integral!(backend::Nothing, du, u,
@@ -1079,69 +1108,7 @@ function calc_surface_integral!(backend::Nothing, du, u,
                                 dg::DGSEM{<:GaussLegendreBasis}, cache)
     @unpack boundary_interpolation_inverse_weights = dg.basis
     @unpack surface_flux_values = cache.elements
-    MeshT = typeof(mesh)
 
-    @threaded for element in eachelement(dg, cache)
-        calc_surface_integral_per_element!(du, MeshT, equations,
-                                           surface_integral, dg,
-                                           boundary_interpolation_inverse_weights,
-                                           surface_flux_values, element)
-    end
-end
-
-@inline function calc_surface_integral_per_element!(du,
-                                                    ::Type{<:Union{P4estMesh{2},
-                                                                   P4estMeshView{2},
-                                                                   T8codeMesh{2}}},
-                                                    equations,
-                                                    surface_integral::SurfaceIntegralWeakForm,
-                                                    dg::DGSEM{<:LobattoLegendreBasis},
-                                                    factor,
-                                                    surface_flux_values, element)
-    # Note that all fluxes have been computed with outward-pointing normal vectors.
-    # This computes the **negative** surface integral contribution,
-    # i.e., M^{-1} * boundary_interpolation^T (which is for Gauss-Lobatto DGSEM just M^{-1} * B)
-    # and the missing "-" is taken care of by `apply_jacobian!`.
-    #
-    # We also use explicit assignments instead of `+=` to let `@muladd` turn these
-    # into FMAs (see comment at the top of the file).
-    #
-    # factor = inverse_weights[1]
-    # For LGL basis: Identical to weighted boundary interpolation at x = ±1
-    for l in eachnode(dg)
-        for v in eachvariable(equations)
-            # surface at -x
-            du[v, 1, l, element] = (du[v, 1, l, element] +
-                                    surface_flux_values[v, l, 1, element] *
-                                    factor)
-
-            # surface at +x
-            du[v, nnodes(dg), l, element] = (du[v, nnodes(dg), l, element] +
-                                             surface_flux_values[v, l, 2, element] *
-                                             factor)
-
-            # surface at -y
-            du[v, l, 1, element] = (du[v, l, 1, element] +
-                                    surface_flux_values[v, l, 3, element] *
-                                    factor)
-
-            # surface at +y
-            du[v, l, nnodes(dg), element] = (du[v, l, nnodes(dg), element] +
-                                             surface_flux_values[v, l, 4, element] *
-                                             factor)
-        end
-    end
-    return nothing
-end
-
-function calc_surface_integral_per_element!(du,
-                                            ::Type{<:Union{P4estMesh{2},
-                                                           P4estMeshView{2}}},
-                                            equations,
-                                            surface_integral::SurfaceIntegralWeakForm,
-                                            dg::DGSEM{<:GaussLegendreBasis},
-                                            boundary_interpolation_inverse_weights,
-                                            surface_flux_values, element)
     # Note that all fluxes have been computed with outward-pointing normal vectors.
     # This computes the **negative** surface integral contribution,
     # i.e., M^{-1} * boundary_interpolation^T
@@ -1149,42 +1116,42 @@ function calc_surface_integral_per_element!(du,
     #
     # We also use explicit assignments instead of `+=` to let `@muladd` turn these
     # into FMAs (see comment at the top of the file).
-    for l in eachnode(dg)
-        for v in eachvariable(equations)
-            # Aliases for repeatedly accessed variables
-            surface_flux_minus_x = surface_flux_values[v, l, 1, element]
-            surface_flux_plus_x = surface_flux_values[v, l, 2, element]
-            for ii in eachnode(dg)
-                # surface at -x
-                du[v, ii, l, element] = (du[v, ii, l, element] +
-                                         surface_flux_minus_x *
-                                         boundary_interpolation_inverse_weights[ii,
-                                                                                1])
-                # surface at +x
-                du[v, ii, l, element] = (du[v, ii, l, element] +
-                                         surface_flux_plus_x *
-                                         boundary_interpolation_inverse_weights[ii,
-                                                                                2])
-            end
+    @threaded for element in eachelement(dg, cache)
+        for l in eachnode(dg)
+            for v in eachvariable(equations)
+                # Aliases for repeatedly accessed variables
+                surface_flux_minus_x = surface_flux_values[v, l, 1, element]
+                surface_flux_plus_x = surface_flux_values[v, l, 2, element]
+                for ii in eachnode(dg)
+                    # surface at -x
+                    du[v, ii, l, element] = (du[v, ii, l, element] +
+                                             surface_flux_minus_x *
+                                             boundary_interpolation_inverse_weights[ii,
+                                                                                    1])
+                    # surface at +x
+                    du[v, ii, l, element] = (du[v, ii, l, element] +
+                                             surface_flux_plus_x *
+                                             boundary_interpolation_inverse_weights[ii,
+                                                                                    2])
+                end
 
-            surface_flux_minus_y = surface_flux_values[v, l, 3, element]
-            surface_flux_plus_y = surface_flux_values[v, l, 4, element]
-            for jj in eachnode(dg)
-                # surface at -y
-                du[v, l, jj, element] = (du[v, l, jj, element] +
-                                         surface_flux_minus_y *
-                                         boundary_interpolation_inverse_weights[jj,
-                                                                                1])
-                # surface at +y
-                du[v, l, jj, element] = (du[v, l, jj, element] +
-                                         surface_flux_plus_y *
-                                         boundary_interpolation_inverse_weights[jj,
-                                                                                2])
+                surface_flux_minus_y = surface_flux_values[v, l, 3, element]
+                surface_flux_plus_y = surface_flux_values[v, l, 4, element]
+                for jj in eachnode(dg)
+                    # surface at -y
+                    du[v, l, jj, element] = (du[v, l, jj, element] +
+                                             surface_flux_minus_y *
+                                             boundary_interpolation_inverse_weights[jj,
+                                                                                    1])
+                    # surface at +y
+                    du[v, l, jj, element] = (du[v, l, jj, element] +
+                                             surface_flux_plus_y *
+                                             boundary_interpolation_inverse_weights[jj,
+                                                                                    2])
+                end
             end
         end
     end
-
-    return nothing
 end
 
 # Call this for coupled P4estMeshView simulations.

--- a/src/solvers/dgsem_p4est/dg_2d.jl
+++ b/src/solvers/dgsem_p4est/dg_2d.jl
@@ -1057,7 +1057,7 @@ end
     return nothing
 end
 
-function calc_surface_integral!(du, u,
+function calc_surface_integral!(backend::Nothing, du, u,
                                 mesh::Union{P4estMesh{2}, P4estMeshView{2},
                                             T8codeMesh{2}},
                                 equations, surface_integral::SurfaceIntegralWeakForm,

--- a/src/solvers/dgsem_p4est/dg_3d.jl
+++ b/src/solvers/dgsem_p4est/dg_3d.jl
@@ -981,24 +981,6 @@ function calc_surface_integral!(backend::Nothing, du, u,
     @unpack surface_flux_values = cache.elements
     MeshT = typeof(mesh)
 
-    @threaded for element in eachelement(dg, cache)
-        calc_surface_integral_per_element!(du, MeshT,
-                                           equations, surface_integral,
-                                           dg, inverse_weights[1],
-                                           surface_flux_values,
-                                           element)
-    end
-    return nothing
-end
-
-@inline function calc_surface_integral_per_element!(du,
-                                                    ::Type{<:Union{P4estMesh{3},
-                                                                   T8codeMesh{3}}},
-                                                    equations,
-                                                    surface_integral::SurfaceIntegralWeakForm,
-                                                    dg::DGSEM, factor,
-                                                    surface_flux_values,
-                                                    element)
     # Note that all fluxes have been computed with outward-pointing normal vectors.
     # This computes the **negative** surface integral contribution,
     # i.e., M^{-1} * boundary_interpolation^T (which is for Gauss-Lobatto DGSEM just M^{-1} * B)
@@ -1007,45 +989,46 @@ end
     # We also use explicit assignments instead of `+=` to let `@muladd` turn these
     # into FMAs (see comment at the top of the file).
     #
-    # factor = inverse_weights[1]
-    # For LGL basis: Identical to weighted boundary interpolation at x = ±1
-    for m in eachnode(dg), l in eachnode(dg)
-        for v in eachvariable(equations)
-            # surface at -x
-            du[v, 1, l, m, element] = (du[v, 1, l, m, element] +
-                                       surface_flux_values[v, l, m, 1,
-                                                           element] *
-                                       factor)
+    factor = inverse_weights[1] # For LGL basis: Identical to weighted boundary interpolation at x = ±1
+    @threaded for element in eachelement(dg, cache)
+        for m in eachnode(dg), l in eachnode(dg)
+            for v in eachvariable(equations)
+                # surface at -x
+                du[v, 1, l, m, element] = (du[v, 1, l, m, element] +
+                                           surface_flux_values[v, l, m, 1,
+                                                               element] *
+                                           factor)
 
-            # surface at +x
-            du[v, nnodes(dg), l, m, element] = (du[v, nnodes(dg), l, m, element] +
-                                                surface_flux_values[v, l, m, 2,
-                                                                    element] *
-                                                factor)
+                # surface at +x
+                du[v, nnodes(dg), l, m, element] = (du[v, nnodes(dg), l, m, element] +
+                                                    surface_flux_values[v, l, m, 2,
+                                                                        element] *
+                                                    factor)
 
-            # surface at -y
-            du[v, l, 1, m, element] = (du[v, l, 1, m, element] +
-                                       surface_flux_values[v, l, m, 3,
-                                                           element] *
-                                       factor)
+                # surface at -y
+                du[v, l, 1, m, element] = (du[v, l, 1, m, element] +
+                                           surface_flux_values[v, l, m, 3,
+                                                               element] *
+                                           factor)
 
-            # surface at +y
-            du[v, l, nnodes(dg), m, element] = (du[v, l, nnodes(dg), m, element] +
-                                                surface_flux_values[v, l, m, 4,
-                                                                    element] *
-                                                factor)
+                # surface at +y
+                du[v, l, nnodes(dg), m, element] = (du[v, l, nnodes(dg), m, element] +
+                                                    surface_flux_values[v, l, m, 4,
+                                                                        element] *
+                                                    factor)
 
-            # surface at -z
-            du[v, l, m, 1, element] = (du[v, l, m, 1, element] +
-                                       surface_flux_values[v, l, m, 5,
-                                                           element] *
-                                       factor)
+                # surface at -z
+                du[v, l, m, 1, element] = (du[v, l, m, 1, element] +
+                                           surface_flux_values[v, l, m, 5,
+                                                               element] *
+                                           factor)
 
-            # surface at +z
-            du[v, l, m, nnodes(dg), element] = (du[v, l, m, nnodes(dg), element] +
-                                                surface_flux_values[v, l, m, 6,
-                                                                    element] *
-                                                factor)
+                # surface at +z
+                du[v, l, m, nnodes(dg), element] = (du[v, l, m, nnodes(dg), element] +
+                                                    surface_flux_values[v, l, m, 6,
+                                                                        element] *
+                                                    factor)
+            end
         end
     end
     return nothing

--- a/src/solvers/dgsem_p4est/dg_3d.jl
+++ b/src/solvers/dgsem_p4est/dg_3d.jl
@@ -979,7 +979,6 @@ function calc_surface_integral!(backend::Nothing, du, u,
                                 dg::DGSEM, cache)
     @unpack inverse_weights = dg.basis
     @unpack surface_flux_values = cache.elements
-    MeshT = typeof(mesh)
 
     # Note that all fluxes have been computed with outward-pointing normal vectors.
     # This computes the **negative** surface integral contribution,

--- a/src/solvers/dgsem_structured/dg_2d.jl
+++ b/src/solvers/dgsem_structured/dg_2d.jl
@@ -758,7 +758,7 @@ function apply_jacobian!(backend::Nothing, du,
     @threaded for element in eachelement(dg, cache)
         for j in eachnode(dg), i in eachnode(dg)
             # Negative sign included to account for the negated surface and volume terms,
-            # see e.g. the computation of `derivative_hat` in the basis setup and 
+            # see e.g. the computation of `derivative_hat` in the basis setup and
             # the comment in `calc_surface_integral!`.
             factor = -inverse_jacobian[i, j, element]
 

--- a/src/solvers/dgsem_structured/dg_2d.jl
+++ b/src/solvers/dgsem_structured/dg_2d.jl
@@ -748,40 +748,26 @@ function calc_boundary_flux!(cache, t,
     return nothing
 end
 
-function apply_jacobian!(backend::Nothing, du,
+function apply_jacobian!(du,
                          mesh::Union{StructuredMesh{2}, StructuredMeshView{2},
                                      UnstructuredMesh2D, P4estMesh{2}, P4estMeshView{2},
                                      T8codeMesh{2}},
                          equations, dg::DG, cache)
     @unpack inverse_jacobian = cache.elements
-    MeshT = typeof(mesh)
+
     @threaded for element in eachelement(dg, cache)
         for j in eachnode(dg), i in eachnode(dg)
-            apply_jacobian_per_quadrature_node!(du, MeshT, equations, dg,
-                                                inverse_jacobian,
-                                                i, j, element)
+            # Negative sign included to account for the negated surface and volume terms,
+            # see e.g. the computation of `derivative_hat` in the basis setup and 
+            # the comment in `calc_surface_integral!`.
+            factor = -inverse_jacobian[i, j, element]
+
+            for v in eachvariable(equations)
+                du[v, i, j, element] *= factor
+            end
         end
     end
-end
 
-@inline function apply_jacobian_per_quadrature_node!(du,
-                                                     ::Type{<:Union{StructuredMesh{2},
-                                                                    StructuredMeshView{2},
-                                                                    UnstructuredMesh2D,
-                                                                    P4estMesh{2},
-                                                                    P4estMeshView{2},
-                                                                    T8codeMesh{2}}},
-                                                     equations, dg::DG,
-                                                     inverse_jacobian,
-                                                     i, j, element)
-    # Negative sign included to account for the negated surface and volume terms,
-    # see e.g. the computation of `derivative_hat` in the basis setup and 
-    # the comment in `calc_surface_integral!`.
-    factor = -inverse_jacobian[i, j, element]
-
-    for v in eachvariable(equations)
-        du[v, i, j, element] *= factor
-    end
     return nothing
 end
 end # @muladd

--- a/src/solvers/dgsem_structured/dg_2d.jl
+++ b/src/solvers/dgsem_structured/dg_2d.jl
@@ -748,7 +748,7 @@ function calc_boundary_flux!(cache, t,
     return nothing
 end
 
-function apply_jacobian!(du,
+function apply_jacobian!(backend::Nothing, du,
                          mesh::Union{StructuredMesh{2}, StructuredMeshView{2},
                                      UnstructuredMesh2D, P4estMesh{2}, P4estMeshView{2},
                                      T8codeMesh{2}},

--- a/src/solvers/dgsem_structured/dg_3d.jl
+++ b/src/solvers/dgsem_structured/dg_3d.jl
@@ -934,7 +934,7 @@ function calc_boundary_flux!(cache, t,
     return nothing
 end
 
-function apply_jacobian!(du,
+function apply_jacobian!(backend::Nothing, du,
                          mesh::Union{StructuredMesh{3}, P4estMesh{3}, T8codeMesh{3}},
                          equations, dg::DG, cache)
     @unpack inverse_jacobian = cache.elements

--- a/src/solvers/dgsem_structured/dg_3d.jl
+++ b/src/solvers/dgsem_structured/dg_3d.jl
@@ -942,7 +942,7 @@ function apply_jacobian!(backend::Nothing, du,
     @threaded for element in eachelement(dg, cache)
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
             # Negative sign included to account for the negated surface and volume terms,
-            # see e.g. the computation of `derivative_hat` in the basis setup and 
+            # see e.g. the computation of `derivative_hat` in the basis setup and
             # the comment in `calc_surface_integral!`.
             factor = -inverse_jacobian[i, j, k, element]
 

--- a/src/solvers/dgsem_structured/dg_3d.jl
+++ b/src/solvers/dgsem_structured/dg_3d.jl
@@ -934,35 +934,24 @@ function calc_boundary_flux!(cache, t,
     return nothing
 end
 
-function apply_jacobian!(backend::Nothing, du,
+function apply_jacobian!(du,
                          mesh::Union{StructuredMesh{3}, P4estMesh{3}, T8codeMesh{3}},
                          equations, dg::DG, cache)
     @unpack inverse_jacobian = cache.elements
-    MeshT = typeof(mesh)
+
     @threaded for element in eachelement(dg, cache)
         for k in eachnode(dg), j in eachnode(dg), i in eachnode(dg)
-            apply_jacobian_per_quadrature_node!(du, MeshT, equations, dg,
-                                                inverse_jacobian, i, j, k,
-                                                element)
+            # Negative sign included to account for the negated surface and volume terms,
+            # see e.g. the computation of `derivative_hat` in the basis setup and 
+            # the comment in `calc_surface_integral!`.
+            factor = -inverse_jacobian[i, j, k, element]
+
+            for v in eachvariable(equations)
+                du[v, i, j, k, element] *= factor
+            end
         end
     end
-    return nothing
-end
 
-@inline function apply_jacobian_per_quadrature_node!(du,
-                                                     ::Type{<:Union{StructuredMesh{3},
-                                                                    P4estMesh{3},
-                                                                    T8codeMesh{3}}},
-                                                     equations, dg, inverse_jacobian,
-                                                     i, j, k, element)
-    # Negative sign included to account for the negated surface and volume terms,
-    # see e.g. the computation of `derivative_hat` in the basis setup and 
-    # the comment in `calc_surface_integral!`.
-    factor = -inverse_jacobian[i, j, k, element]
-
-    for v in eachvariable(equations)
-        du[v, i, j, k, element] *= factor
-    end
     return nothing
 end
 end # @muladd


### PR DESCRIPTION
Since now the entire GPU implementation lives entirely in the two files `dg_2d_gpu.jl` and `dg_3d_gpu.jl` and there aren't anymore parts/functions that are shared (solver wise), I restored the original CPU code to before we have merged the first GPU PR.