### PR TITLE
Mark tests as not broken anymore

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -85,7 +85,7 @@ SparseConnectivityTracer = "1.0.1"
 SparseMatrixColorings = "0.4.27"
 StableRNGs = "1.0.2"
 Test = "1"
-TestItemRunner = "1.1"
+TestItemRunner = "1.3"
 TrixiTest = "0.2.6"
 
 [extras]

--- a/test/test_tree_2d_advection.jl
+++ b/test/test_tree_2d_advection.jl
@@ -123,14 +123,7 @@ end
 
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
-    # TODO: Investigate why this allocation tests fails.
-    # See https://github.com/trixi-framework/Trixi.jl/pull/3096 for more details.
-    let
-        t = sol.t[end]
-        u_ode = sol.u[end]
-        du_ode = similar(u_ode)
-        @test_broken (@allocated Trixi.rhs_hyperbolic!(du_ode, u_ode, semi, t)) < 1000
-    end
+    @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
 @testitem "TreeMesh2D Advection: elixir_advection_amr.jl" setup=[Setup, TreeMesh2DAdvection] tags=[:tree_part1] begin
@@ -140,14 +133,7 @@ end
                         linf=[0.00045263895394385967])
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
-    # TODO: Investigate why this allocation tests fails.
-    # See https://github.com/trixi-framework/Trixi.jl/pull/3096 for more details.
-    let
-        t = sol.t[end]
-        u_ode = sol.u[end]
-        du_ode = similar(u_ode)
-        @test_broken (@allocated Trixi.rhs_hyperbolic!(du_ode, u_ode, semi, t)) < 1000
-    end
+    @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
 @testitem "TreeMesh2D Advection: elixir_advection_amr_nonperiodic.jl" setup=[
@@ -160,14 +146,7 @@ end
                         linf=[0.0007508059772436404])
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
-    # TODO: Investigate why this allocation tests fails.
-    # See https://github.com/trixi-framework/Trixi.jl/pull/3096 for more details.
-    let
-        t = sol.t[end]
-        u_ode = sol.u[end]
-        du_ode = similar(u_ode)
-        @test_broken (@allocated Trixi.rhs_hyperbolic!(du_ode, u_ode, semi, t)) < 1000
-    end
+    @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
 @testitem "TreeMesh2D Advection: elixir_advection_amr_solution_independent.jl" setup=[
@@ -180,14 +159,7 @@ end
                         linf=[0.0004867846262313763])
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
-    # TODO: Investigate why this allocation tests fails.
-    # See https://github.com/trixi-framework/Trixi.jl/pull/3096 for more details.
-    let
-        t = sol.t[end]
-        u_ode = sol.u[end]
-        du_ode = similar(u_ode)
-        @test_broken (@allocated Trixi.rhs_hyperbolic!(du_ode, u_ode, semi, t)) < 1000
-    end
+    @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
 
 @testitem "TreeMesh2D Advection: elixir_advection_amr_visualization.jl" setup=[
@@ -229,14 +201,7 @@ end
     # integrator which are not *recorded* for the methods from
     # OrdinaryDiffEq.jl
     # Corresponding issue: https://github.com/trixi-framework/Trixi.jl/issues/1877
-    # TODO: Investigate why this allocation tests fails.
-    # See https://github.com/trixi-framework/Trixi.jl/pull/3096 for more details.
-    let
-        t = sol.t[end]
-        u_ode = sol.u[end]
-        du_ode = similar(u_ode)
-        @test_broken (@allocated Trixi.rhs_hyperbolic!(du_ode, u_ode, semi, t)) < 15000
-    end
+    @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 15000)
 end
 
 @testitem "TreeMesh2D Advection: elixir_advection_timeintegration.jl with carpenter_kennedy_erk43" setup=[
@@ -254,14 +219,7 @@ end
     # integrator which are not *recorded* for the methods from
     # OrdinaryDiffEq.jl
     # Corresponding issue: https://github.com/trixi-framework/Trixi.jl/issues/1877
-    # TODO: Investigate why this allocation tests fails.
-    # See https://github.com/trixi-framework/Trixi.jl/pull/3096 for more details.
-    let
-        t = sol.t[end]
-        u_ode = sol.u[end]
-        du_ode = similar(u_ode)
-        @test_broken (@allocated Trixi.rhs_hyperbolic!(du_ode, u_ode, semi, t)) < 15000
-    end
+    @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 15000)
 end
 
 @testitem "TreeMesh2D Advection: elixir_advection_timeintegration.jl with carpenter_kennedy_erk43 with maxiters=1" setup=[
@@ -280,14 +238,7 @@ end
     # integrator which are not *recorded* for the methods from
     # OrdinaryDiffEq.jl
     # Corresponding issue: https://github.com/trixi-framework/Trixi.jl/issues/1877
-    # TODO: Investigate why this allocation tests fails.
-    # See https://github.com/trixi-framework/Trixi.jl/pull/3096 for more details.
-    let
-        t = sol.t[end]
-        u_ode = sol.u[end]
-        du_ode = similar(u_ode)
-        @test_broken (@allocated Trixi.rhs_hyperbolic!(du_ode, u_ode, semi, t)) < 15000
-    end
+    @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 15000)
 end
 
 @testitem "TreeMesh2D Advection: elixir_advection_timeintegration.jl with parsani_ketcheson_deconinck_erk94" setup=[
@@ -304,14 +255,7 @@ end
     # integrator which are not *recorded* for the methods from
     # OrdinaryDiffEq.jl
     # Corresponding issue: https://github.com/trixi-framework/Trixi.jl/issues/1877
-    # TODO: Investigate why this allocation tests fails.
-    # See https://github.com/trixi-framework/Trixi.jl/pull/3096 for more details.
-    let
-        t = sol.t[end]
-        u_ode = sol.u[end]
-        du_ode = similar(u_ode)
-        @test_broken (@allocated Trixi.rhs_hyperbolic!(du_ode, u_ode, semi, t)) < 15000
-    end
+    @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 15000)
 end
 
 @testitem "TreeMesh2D Advection: elixir_advection_timeintegration.jl with parsani_ketcheson_deconinck_erk32" setup=[
@@ -329,14 +273,7 @@ end
     # integrator which are not *recorded* for the methods from
     # OrdinaryDiffEq.jl
     # Corresponding issue: https://github.com/trixi-framework/Trixi.jl/issues/1877
-    # TODO: Investigate why this allocation tests fails.
-    # See https://github.com/trixi-framework/Trixi.jl/pull/3096 for more details.
-    let
-        t = sol.t[end]
-        u_ode = sol.u[end]
-        du_ode = similar(u_ode)
-        @test_broken (@allocated Trixi.rhs_hyperbolic!(du_ode, u_ode, semi, t)) < 15000
-    end
+    @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 15000)
 end
 
 @testitem "TreeMesh2D Advection: elixir_advection_timeintegration.jl with parsani_ketcheson_deconinck_erk32 with maxiters=1" setup=[
@@ -355,14 +292,7 @@ end
     # integrator which are not *recorded* for the methods from
     # OrdinaryDiffEq.jl
     # Corresponding issue: https://github.com/trixi-framework/Trixi.jl/issues/1877
-    # TODO: Investigate why this allocation tests fails.
-    # See https://github.com/trixi-framework/Trixi.jl/pull/3096 for more details.
-    let
-        t = sol.t[end]
-        u_ode = sol.u[end]
-        du_ode = similar(u_ode)
-        @test_broken (@allocated Trixi.rhs_hyperbolic!(du_ode, u_ode, semi, t)) < 15000
-    end
+    @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 15000)
 end
 
 @testitem "TreeMesh2D Advection: elixir_advection_callbacks.jl" setup=[

--- a/test/test_tree_2d_blockfv.jl
+++ b/test/test_tree_2d_blockfv.jl
@@ -183,14 +183,7 @@ end
     res2 = @inferred analysis_callback(sol)
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
-    # TODO: Investigate why this allocation tests fails.
-    # See https://github.com/trixi-framework/Trixi.jl/pull/3096 for more details.
-    let
-        t = sol.t[end]
-        u_ode = sol.u[end]
-        du_ode = similar(u_ode)
-        @test_broken (@allocated Trixi.rhs_hyperbolic!(du_ode, u_ode, semi, t)) < 1000
-    end
+    @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 
     # Both setups have exactly the same degrees of freedom.
     # Thus, they should return the same errors (up to floating-point precision).


### PR DESCRIPTION
CI currently fails because some of the tests marked as broken are not broken anymore, which is good news :partying_face: 
This closes #3136. My guess is that some recent changes to the TestItems.jl (there happened a lot recently) fixed those allocations.

Edit: Yes, I am pretty sure it is resolved with https://github.com/julia-testitems/TestItemRunner.jl/releases/tag/v1.3.0. The last successful CI run (i.e. with broken tests) was with TestItemRunner.jl v1.2.1 and the first failing one was with v1.3.0.