### PR TITLE
pass `show_axis` directly to `Makie.LScene` in `iplot`

### DIFF
--- a/ext/TrixiMakieExt.jl
+++ b/ext/TrixiMakieExt.jl
@@ -192,7 +192,7 @@ function iplot(pd::PlotData2DTriangulated;
                              tellheight = false, width = 200)
 
     # Create a zoomable interactive axis object on top of which to plot the solution.
-    ax = Makie.LScene(fig[1, 2], scenekw = (show_axis = show_axis,))
+    ax = Makie.LScene(fig[1, 2], show_axis = show_axis)
 
     # Initialize the dropdown menu to `variable_to_plot_in`
     # Since menu.selection is an Observable type, we need to dereference it using `[]` to set.
@@ -281,7 +281,7 @@ function iplot(pd::PlotData2DTriangulated{<:ScalarData};
     fig = Makie.Figure()
 
     # Create a zoomable interactive axis object on top of which to plot the solution.
-    ax = Makie.LScene(fig[1, 1], scenekw = (show_axis = show_axis,))
+    ax = Makie.LScene(fig[1, 1], show_axis = show_axis)
 
     # plot the user-defined ScalarData
     fig_axis_plt = iplot!(FigureAndAxes(fig, ax), pd; colormap = colormap,


### PR DESCRIPTION
While tinkering with the plotting in Trixi.jl i found that `show_axis` on `iplot` has no effect.

It gets passed to LScene as scenekw, but this has no effect on the plot. Unused scenekw arguments seem to be ignored silently.

I used the following example to test the new behavior:

```julia
using Trixi, GLMakie
trixi_include("../examples/unstructured_2d_dgsem/elixir_euler_wall_bc.jl")
iplot(sol; show_axis=false)
```

current output on main:
<img width="420" height="250" alt="Screenshot 2026-08-21 at 11 28 08" src="https://github.com/user-attachments/assets/5cc3cac7-3f59-4ca3-bb24-1e711d696164" />

with the applied fix:
<img width="420" height="250" alt="Screenshot 2026-08-21 at 11 26 12" src="https://github.com/user-attachments/assets/630aebf2-225a-4c32-bcd9-1be598356104" />

I only tested with the resolved Makie.jl version 0.24.13, but checked the docs for the two older supported versions 0.23 and 0.22 and they both show that `show_axis` is a direct attribute of `LScene`.

Let me know if i can check any more, or have overlooked something, as im just starting to get familiar with the Trixi.jl codebase.

I ran the full test suited and it passed. 

Disclaimer: I used Codex and Claude Code to ask questions about Trixi.jl and reviewing my assumptions.

Thanks for your work,
Gerrit