### PR TITLE
Use tighter time integration tolerance to fix CI

### DIFF
--- a/examples/p4est_2d_dgsem/elixir_advection_diffusion_rotated.jl
+++ b/examples/p4est_2d_dgsem/elixir_advection_diffusion_rotated.jl
@@ -55,6 +55,6 @@ callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback)
 ###############################################################################
 # run the simulation
 
-time_int_tol = 1.0e-6
+time_int_tol = 1.0e-8
 sol = solve(ode, RDPK3SpFSAL49(); abstol = time_int_tol, reltol = time_int_tol,
             ode_default_options()..., callback = callbacks)

--- a/test/test_parabolic_2d.jl
+++ b/test/test_parabolic_2d.jl
@@ -815,7 +815,7 @@ end
 ] tags=[:parabolic_part1] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "p4est_2d_dgsem",
                                  "elixir_advection_diffusion_rotated.jl"),
-                        l2=[4.8533724384822306e-5], linf=[0.0006284491001110615])
+                        l2=[1.9587359234701733e-5], linf=[0.000577240851833416])
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)


### PR DESCRIPTION
In https://github.com/trixi-framework/Trixi.jl/actions/runs/32837116390/job/97768665341?pr=3204, there are two CI failures. I checked the elixir locally and also got very different l2 and linf error values to both the previous reference values and the values CI got. If we would only adjust the abstol, we would need to set it to 1e-6, which seems too high. I verified that the error was mostly dominated by the time integration error. So I propose to use a stricter time integration tolerance, which should increase stability.