### PR TITLE
[DO NOT MERGE] Test new version of TrixiBase.jl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,12 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
         env:
           PYTHON: ''
+      - name: Use branch `jl/pass-symbols-as-values` of TrixiBase.jl
+        shell: julia --project="." --color=yes {0}
+        run: |
+          using Pkg
+          Pkg.add(PackageSpec(url = "https://github.com/trixi-framework/TrixiBase.jl",
+                              rev = "jl/pass-symbols-as-values"))
       - name: Run tests
         uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -85,6 +85,8 @@ jobs:
         run: |
           using Pkg
           Pkg.develop(PackageSpec(path="."))
+          Pkg.add(PackageSpec(url = "https://github.com/trixi-framework/TrixiBase.jl",
+                              rev = "jl/pass-symbols-as-values"))
           Pkg.update()
       - name: Run downstream tests (without coverage)
         shell: julia --color=yes --project=downstream {0}


### PR DESCRIPTION
This tests https://github.com/trixi-framework/TrixiBase.jl/pull/78 to see if it breaks tests in Trixi.jl. I expect failing tests as long as TrixiTest.jl v0.2.7 is not registered and green tests after it is registered.