### PR TITLE
fix `save_solution_file` for `SemidiscretizationEulerGravity`

### DIFF
--- a/src/semidiscretization/semidiscretization_euler_gravity.jl
+++ b/src/semidiscretization/semidiscretization_euler_gravity.jl
@@ -557,7 +557,8 @@ end
 @inline function save_solution_file(u_ode, t, dt, iter,
                                     semi::SemidiscretizationEulerGravity,
                                     solution_callback,
-                                    element_variables = Dict{Symbol, Any}();
+                                    element_variables = Dict{Symbol, Any}(),
+                                    node_variables = Dict{Symbol, Any}();
                                     system = "")
     # If this is called already as part of a multi-system setup (i.e., system is non-empty),
     # we build a combined system name
@@ -569,16 +570,21 @@ end
         system_gravity = "gravity"
     end
 
+    # The `element_variables` and `node_variables` are computed for the Euler system since
+    # `mesh_equations_solver_cache(semi)` returns the data of `semi.semi_euler`. We store
+    # them in both files since they are defined on the same mesh.
     u_euler = wrap_array_native(u_ode, semi.semi_euler)
     filename_euler = save_solution_file(u_euler, t, dt, iter,
                                         mesh_equations_solver_cache(semi.semi_euler)...,
                                         solution_callback, element_variables,
+                                        node_variables,
                                         system = system_euler)
 
     u_gravity = wrap_array_native(semi.cache.u_ode, semi.semi_gravity)
     filename_gravity = save_solution_file(u_gravity, t, dt, iter,
                                           mesh_equations_solver_cache(semi.semi_gravity)...,
                                           solution_callback, element_variables,
+                                          node_variables,
                                           system = system_gravity)
 
     return filename_euler, filename_gravity

--- a/test/test_tree_1d_eulergravity.jl
+++ b/test/test_tree_1d_eulergravity.jl
@@ -19,3 +19,51 @@ end
     # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs_hyperbolic!, semi, sol, 1000)
 end
+
+@testitem "TreeMesh1D EulerGravity: SaveSolutionCallback saves both systems" setup=[
+    Setup,
+    TreeMesh1DEulerGravity
+] tags=[:tree_part1] begin
+    using Trixi: Trixi
+
+    # Start with a clean environment: remove Trixi.jl output directory if it exists
+    outdir = "out"
+    isdir(outdir) && rm(outdir, recursive = true)
+
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_eulergravity_convergence.jl"),
+                        tspan=(0.0, 0.1))
+
+    solution_file(system, iter) = joinpath(outdir,
+                                           "solution_" * system * "_" *
+                                           lpad(iter, 9, '0') * ".h5")
+
+    # Both the initial and the final solution must be saved for both systems
+    for iter in (0, sol.stats.naccept)
+        @test isfile(solution_file("euler", iter))
+        @test isfile(solution_file("gravity", iter))
+        # There must not be any file without a system name, which would indicate
+        # that the generic (Euler-only) version of `save_solution_file` was used
+        @test !isfile(joinpath(outdir, "solution_" * lpad(iter, 9, '0') * ".h5"))
+    end
+
+    Trixi.h5open(solution_file("euler", 0), "r") do file
+        @test read(Trixi.attributes(file)["equations"]) ==
+              "CompressibleEulerEquations1D"
+        @test read(Trixi.attributes(file)["n_vars"]) == 3
+        @test [read(Trixi.attributes(file["variables_$v"])["name"]) for v in 1:3] ==
+              ["rho", "v1", "p"]
+    end
+
+    # The gravity file must contain the gravity state stored in `semi.cache.u_ode`
+    # and not (a copy of) the Euler state
+    u_gravity = Trixi.wrap_array_native(semi.cache.u_ode, semi.semi_gravity)
+    Trixi.h5open(solution_file("gravity", sol.stats.naccept), "r") do file
+        @test read(Trixi.attributes(file)["equations"]) ==
+              "HyperbolicDiffusionEquations1D"
+        @test read(Trixi.attributes(file)["n_vars"]) == 2
+        @test [read(Trixi.attributes(file["variables_$v"])["name"]) for v in 1:2] ==
+              ["phi", "q1"]
+        @test read(file["variables_1"]) ≈ vec(u_gravity[1, :, :])
+        @test read(file["variables_2"]) ≈ vec(u_gravity[2, :, :])
+    end
+end

--- a/test/test_tree_1d_eulergravity.jl
+++ b/test/test_tree_1d_eulergravity.jl
@@ -24,8 +24,6 @@ end
     Setup,
     TreeMesh1DEulerGravity
 ] tags=[:tree_part1] begin
-    using Trixi: Trixi
-
     # Start with a clean environment: remove Trixi.jl output directory if it exists
     outdir = "out"
     isdir(outdir) && rm(outdir, recursive = true)


### PR DESCRIPTION
Codex 5.6-Sol found the reason why @andrewwinters5000 and I were confused in https://github.com/trixi-framework/Trixi.jl/pull/3212: We introduced a bug in https://github.com/trixi-framework/Trixi.jl/pull/2298 by not passing the new `node_variables` to the specialized method. Thus, Euler-gravity systems were not saved correctly after the PR. I asked Claude to implement a regression test and fix the issue. Here is the result after removin unnecessary boilerplate stuff.

CC @DanielDoehring 