### PR TITLE
Thread parallel time update for custom SSP method

### DIFF
--- a/src/callbacks_stage/subcell_bounds_check_2d.jl
+++ b/src/callbacks_stage/subcell_bounds_check_2d.jl
@@ -105,8 +105,7 @@
                 for j in eachnode(solver), i in eachnode(solver)
                     var = variable(get_node_vars(u, equations, solver, i, j, element),
                                    equations)
-                    deviation = max(deviation,
-                                    bounds[i, j, element] - var)
+                    deviation = max(deviation, bounds[i, j, element] - var)
                 end
             end
             idp_bounds_delta_local[key] = deviation

--- a/src/time_integration/methods_SSP.jl
+++ b/src/time_integration/methods_SSP.jl
@@ -205,7 +205,8 @@ function step!(integrator::SimpleIntegratorSSP)
         # skip the stage if a = 0 (and therefore b = denominator = 1), because then the
         # convex combination is simply u = u and is not needed
         if !iszero(alg.numerator_a[stage])
-            a, b, d = alg.numerator_a[stage], alg.numerator_b[stage], alg.denominator[stage]
+            a, b, d = alg.numerator_a[stage], alg.numerator_b[stage],
+                      alg.denominator[stage]
             @threaded for i in eachindex(integrator.u)
                 u[i] = (a * u_tmp[i] + b * u[i]) / d
             end

--- a/src/time_integration/methods_SSP.jl
+++ b/src/time_integration/methods_SSP.jl
@@ -182,23 +182,34 @@ function step!(integrator::SimpleIntegratorSSP)
 
     limit_dt!(integrator, t_end)
 
-    @. integrator.u_tmp = integrator.u
+    @threaded for i in eachindex(integrator.u)
+        integrator.u_tmp[i] = integrator.u[i]
+    end
     for stage in eachindex(alg.c)
-        t_stage = integrator.t + integrator.dt * alg.c[stage]
+        u, du, u_tmp, dt = integrator.u, integrator.du, integrator.u_tmp, integrator.dt
+
+        t_stage = integrator.t + dt * alg.c[stage]
         # compute du
-        integrator.f(integrator.du, integrator.u, integrator.p, t_stage)
+        integrator.f(du, u, integrator.p, t_stage)
 
         # perform forward Euler step
-        @. integrator.u = integrator.u + integrator.dt * integrator.du
+        @threaded for i in eachindex(integrator.u)
+            u[i] = u[i] + dt * du[i]
+        end
 
         for stage_callback in alg.stage_callbacks
             stage_callback(integrator.u, integrator, stage)
         end
 
         # perform convex combination
-        @. integrator.u = (alg.numerator_a[stage] * integrator.u_tmp +
-                           alg.numerator_b[stage] * integrator.u) /
-                          alg.denominator[stage]
+        # skip the stage if a = 0 (and therefore b = denominator = 1), because then the
+        # convex combination is simply u = u and is not needed
+        if !iszero(alg.numerator_a[stage])
+            a, b, d = alg.numerator_a[stage], alg.numerator_b[stage], alg.denominator[stage]
+            @threaded for i in eachindex(integrator.u)
+                u[i] = (a * u_tmp[i] + b * u[i]) / d
+            end
+        end
     end
     integrator.iter += 1
     integrator.t += integrator.dt

--- a/src/time_integration/methods_SSP.jl
+++ b/src/time_integration/methods_SSP.jl
@@ -182,8 +182,9 @@ function step!(integrator::SimpleIntegratorSSP)
 
     limit_dt!(integrator, t_end)
 
-    @threaded for i in eachindex(integrator.u)
-        integrator.u_tmp[i] = integrator.u[i]
+    u, u_tmp = integrator.u, integrator.u_tmp
+    @threaded for i in eachindex(u)
+        u_tmp[i] = u[i]
     end
     for stage in eachindex(alg.c)
         u, du, u_tmp, dt = integrator.u, integrator.du, integrator.u_tmp, integrator.dt

--- a/src/time_integration/methods_SSP.jl
+++ b/src/time_integration/methods_SSP.jl
@@ -172,6 +172,7 @@ function step!(integrator::SimpleIntegratorSSP)
     @unpack alg = integrator
     t_end = last(prob.tspan)
     callbacks = integrator.opts.callback
+    (; numerator_a, numerator_b, denominator) = alg
 
     @assert !integrator.finalstep
     if isnan(integrator.dt)
@@ -182,13 +183,11 @@ function step!(integrator::SimpleIntegratorSSP)
 
     limit_dt!(integrator, t_end)
 
-    u, u_tmp = integrator.u, integrator.u_tmp
+    (; u, u_tmp, du, dt) = integrator
     @threaded for i in eachindex(u)
         u_tmp[i] = u[i]
     end
     for stage in eachindex(alg.c)
-        u, du, u_tmp, dt = integrator.u, integrator.du, integrator.u_tmp, integrator.dt
-
         t_stage = integrator.t + dt * alg.c[stage]
         # compute du
         integrator.f(du, u, integrator.p, t_stage)
@@ -203,11 +202,12 @@ function step!(integrator::SimpleIntegratorSSP)
         end
 
         # perform convex combination
-        # skip the stage if a = 0 (and therefore b = denominator = 1), because then the
-        # convex combination is simply u = u and is not needed
-        if !iszero(alg.numerator_a[stage])
-            a, b, d = alg.numerator_a[stage], alg.numerator_b[stage],
-                      alg.denominator[stage]
+        a = numerator_a[stage]
+        # Skip the convex combination if a = 0. In that case, b = denominator = 1 holds
+        # as well, such that the combination reduces to the identity u = u.
+        if !iszero(a)
+            b = numerator_b[stage]
+            d = denominator[stage]
             @threaded for i in eachindex(integrator.u)
                 u[i] = (a * u_tmp[i] + b * u[i]) / d
             end


### PR DESCRIPTION
The PR changes three things in `step!` for `SimpleSSPRK33`:
1. thread the two per-stage vector updates (forward Euler step, convex combination) (This is already done in the other custom time integration methods in Trixi.jl),
2. thread the `u_tmp = u` copy at the start of each step,
3. skip the convex combination in stage 1, where `numerator_a = 0`, `numerator_b = 1`, `denominator = 1` make it the identity.

The state arrays and `dt` are bound to local variables before each threaded loop. They are
fields of a mutable struct, so leaving them in the loop body costs vectorization — the previous `@.` broadcasts got
this for free, since a broadcast is itself a function call.

I used the following setup for the benchmarking `tree_2d_dgsem/elixir_euler_sedov_blast_wave_sc_subcell.jl` with disabled `save_solution` and adapted `initial_refinement_level =6`, `tspan=(0.0, 0.5)`.

## Speedup of PR over main (main / PR, >1 = PR faster)

| threads | simulation | rhs_hyperbolic | check_bounds | step_callbacks | ~main loop~ | a_posteriori_limiter |
|---|---|---|---|---|---|---|
| 1 | **1.04x** | 1.00x | 1.01x | 1.00x | **1.25x** | 1.16x |
| 2 | **1.07x** | 1.02x | 0.99x | 1.00x | **2.81x** | 1.06x |
| 4 | **1.10x** | 1.01x | 0.99x | 1.04x | **5.86x** | 1.03x |
| 8 | **1.26x** | 1.06x | 0.99x | 1.79x | **10.76x** | 1.18x |
| 16 | **1.33x** | 1.05x | 0.99x | 2.82x | **16.54x** | 1.22x |

## Strong scaling (T1/Tn)

**main**

| threads | simulation | rhs_hyperbolic | check_bounds | step_callbacks | ~main loop~ | a_posteriori_limiter |
|---|---|---|---|---|---|---|
| 2 | 1.66x | 1.90x | 2.77x | 1.02x | **0.43x** | 1.38x |
| 4 | 2.72x | 3.69x | 5.40x | 1.90x | **0.33x** | 2.01x |
| 8 | 3.55x | 6.54x | 8.52x | 2.05x | **0.31x** | 2.14x |
| 16 | 4.52x | 12.20x | 11.57x | 2.05x | **0.34x** | 2.30x |
**PR**

| threads | simulation | rhs_hyperbolic | check_bounds | step_callbacks | ~main loop~ | a_posteriori_limiter |
|---|---|---|---|---|---|---|
| 2 | 1.70x | 1.95x | 2.74x | 1.02x | **0.95x** | 1.27x |
| 4 | 2.87x | 3.76x | 5.32x | 1.98x | **1.56x** | 1.78x |
| 8 | 4.27x | 6.94x | 8.38x | 3.66x | **2.69x** | 2.18x |
| 16 | 5.78x | 12.89x | 11.37x | 5.77x | **4.47x** | 2.43x |

## Summary

- **Serial (1 thread) the two are essentially identical** — total 21.19 s vs 20.31 s (1.04x), and `rhs_hyperbolic`/`check_bounds`/`step_callbacks` are within noise. So this is not a per-operation cost reduction; it's a parallel-overhead reduction.
- **The gain grows with thread count**: 1.04x → 1.33x total from 1 to 16 threads. Overall strong scaling improves from 4.52x to 5.78x at 16 threads (28% → 36% parallel efficiency).
- **`~main loop~` is where the change lands.** On main this is *anti-scaling*: 0.218 s at 1 thread growing to 0.64–0.70 s at 4–16 threads (0.3x "speedup"), i.e. classic thread-synchronization/serial-overhead cost paid outside the timed kernels. In the PR it drops to 0.039 s at 16 threads — 16.5x faster there — and actually scales (4.47x). That accounts for ~0.60 s of the ~1.17 s total improvement at 16 threads.
- **`step_callbacks`** also stops stalling: main plateaus at ~0.036 s from 4 threads on (2.05x, flat), the PR keeps going to 0.0129 s (5.77x), giving 2.82x at 16 threads.
- **`a_posteriori_limiter` is now the bottleneck.** It scales worst in both versions (2.30x main, 2.43x PR, ~15% efficiency) and the PR only helps it by 1.03–1.22x. At 16 threads it is 2.32 s of the 3.51 s total — 66% of runtime, up from 60% on main. Amdahl's law on this term caps further total speedup, so it's the obvious next target.
- **`rhs_hyperbolic` and `check_bounds` are unaffected and already scale well** (12.9x and 11.4x at 16 threads); `check_bounds` is marginally 1% slower in the PR at ≥2 threads, which is noise-level.

Claude Code was used in this PR to create a simple script for performance check and later to analyze and summarize the timer outputs.