### PR TITLE
Fix segfault in GPU save_solution_file/save_restart

### DIFF
--- a/src/callbacks_step/save_restart.jl
+++ b/src/callbacks_step/save_restart.jl
@@ -114,8 +114,10 @@ end
     end
     mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
     u = wrap_array_native(u_ode, mesh, equations, solver, cache)
-    return save_restart_file(u, t, dt, iter, mesh, equations, solver, cache,
-                             restart_callback)
+    # See the matching comment in `save_solution_file` (save_solution.jl): `u_ode`
+    # must stay alive for as long as `u`, an unsafe alias into its memory, is used.
+    return GC.@preserve u_ode save_restart_file(u, t, dt, iter, mesh, equations, solver,
+                                                cache, restart_callback)
 end
 
 """

--- a/src/callbacks_step/save_solution.jl
+++ b/src/callbacks_step/save_solution.jl
@@ -304,7 +304,8 @@ end
     mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
     u = wrap_array_native(u_ode, mesh, equations, solver, cache)
     # `u` is an `unsafe_wrap`-based view into `u_ode`'s memory (see the "Segfaults"
-    # warning on `wrap_array` above). When `backend !== nothing`, `u_ode` was just
+    # warning in the definition of `wrap_array` in src/solvers/dg.j).
+    # When `backend !== nothing`, `u_ode` was just
     # rebound to a fresh host `Array` with no other reference anywhere, so without
     # `GC.@preserve` the GC is free to collect it while `u` is still in use below,
     # leaving `u` dangling and causing a segfault instead of a catchable error.

--- a/src/callbacks_step/save_solution.jl
+++ b/src/callbacks_step/save_solution.jl
@@ -303,10 +303,17 @@ end
     end
     mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
     u = wrap_array_native(u_ode, mesh, equations, solver, cache)
-    save_solution_file(u, t, dt, iter, mesh, equations, solver, cache,
-                       solution_callback,
-                       element_variables,
-                       node_variables; system = system)
+    # `u` is an `unsafe_wrap`-based view into `u_ode`'s memory (see the "Segfaults"
+    # warning on `wrap_array` above). When `backend !== nothing`, `u_ode` was just
+    # rebound to a fresh host `Array` with no other reference anywhere, so without
+    # `GC.@preserve` the GC is free to collect it while `u` is still in use below,
+    # leaving `u` dangling and causing a segfault instead of a catchable error.
+    GC.@preserve u_ode begin
+        save_solution_file(u, t, dt, iter, mesh, equations, solver, cache,
+                           solution_callback,
+                           element_variables,
+                           node_variables; system = system)
+    end
 
     return nothing
 end


### PR DESCRIPTION
In both `save_solution_file` and `save_restart_file`, we use `u` (an `unsafe_wrap`-based view into `u_ode`'s memory). When `backend !== nothing`, `u_ode` was just copied into a fresh host `Array` with no other reference anywhere. I was getting a segfault when saving the solution because `o_ode` was getting out of scope and leaving `u` dangling. The fix just uses `GC.@preserve`.