### PR TITLE
Thread-parallel interface loops for subcell bounds computation

### DIFF
--- a/src/solvers/dgsem_p4est/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_p4est/subcell_limiters_2d.jl
@@ -12,57 +12,71 @@ function calc_bounds_twosided_interface!(var_min, var_max, variable, u,
     (; neighbor_ids, node_indices) = cache.interfaces
     index_range = eachnode(dg)
 
-    for interface in eachinterface(dg, cache)
-        # Get element and side index information on the primary element
-        primary_element = neighbor_ids[1, interface]
-        primary_indices = node_indices[1, interface]
+    # Process interfaces on different axes separately. Interfaces on the
+    # same axis update disjoint faces of each element. The barrier
+    # between these loops prevents races at element corners.
+    for axis in 1:ndims(mesh)
+        @threaded for interface in eachinterface(dg, cache)
+            # Get side index information on the elements
+            primary_indices = node_indices[1, interface]
+            secondary_indices = node_indices[2, interface]
 
-        # Get element and side index information on the secondary element
-        secondary_element = neighbor_ids[2, interface]
-        secondary_indices = node_indices[2, interface]
+            primary_axis = cld(indices2direction(primary_indices), 2)
+            secondary_axis = cld(indices2direction(secondary_indices), 2)
 
-        # Create the local i,j indexing
-        i_primary_start, i_primary_step = index_to_start_step_2d(primary_indices[1],
-                                                                 index_range)
-        j_primary_start, j_primary_step = index_to_start_step_2d(primary_indices[2],
-                                                                 index_range)
-        i_secondary_start, i_secondary_step = index_to_start_step_2d(secondary_indices[1],
+            update_primary = primary_axis == axis
+            update_secondary = secondary_axis == axis
+            (update_primary || update_secondary) || continue
+
+            # Get element index information on the elements
+            primary_element = neighbor_ids[1, interface]
+            secondary_element = neighbor_ids[2, interface]
+
+            # Create the local i,j indexing
+            i_primary_start, i_primary_step = index_to_start_step_2d(primary_indices[1],
                                                                      index_range)
-        j_secondary_start, j_secondary_step = index_to_start_step_2d(secondary_indices[2],
+            j_primary_start, j_primary_step = index_to_start_step_2d(primary_indices[2],
                                                                      index_range)
+            i_secondary_start, i_secondary_step = index_to_start_step_2d(secondary_indices[1],
+                                                                         index_range)
+            j_secondary_start, j_secondary_step = index_to_start_step_2d(secondary_indices[2],
+                                                                         index_range)
 
-        i_primary = i_primary_start
-        j_primary = j_primary_start
-        i_secondary = i_secondary_start
-        j_secondary = j_secondary_start
+            i_primary = i_primary_start
+            j_primary = j_primary_start
+            i_secondary = i_secondary_start
+            j_secondary = j_secondary_start
+            for node in eachnode(dg)
+                if update_primary
+                    var_secondary = u[variable, i_secondary, j_secondary,
+                                      secondary_element]
+                    var_min[i_primary, j_primary, primary_element] = min(var_min[i_primary,
+                                                                                 j_primary,
+                                                                                 primary_element],
+                                                                         var_secondary)
+                    var_max[i_primary, j_primary, primary_element] = max(var_max[i_primary,
+                                                                                 j_primary,
+                                                                                 primary_element],
+                                                                         var_secondary)
+                end
+                if update_secondary
+                    var_primary = u[variable, i_primary, j_primary, primary_element]
+                    var_min[i_secondary, j_secondary, secondary_element] = min(var_min[i_secondary,
+                                                                                       j_secondary,
+                                                                                       secondary_element],
+                                                                               var_primary)
+                    var_max[i_secondary, j_secondary, secondary_element] = max(var_max[i_secondary,
+                                                                                       j_secondary,
+                                                                                       secondary_element],
+                                                                               var_primary)
+                end
 
-        for node in eachnode(dg)
-            var_primary = u[variable, i_primary, j_primary, primary_element]
-            var_secondary = u[variable, i_secondary, j_secondary, secondary_element]
-
-            var_min[i_primary, j_primary, primary_element] = min(var_min[i_primary,
-                                                                         j_primary,
-                                                                         primary_element],
-                                                                 var_secondary)
-            var_max[i_primary, j_primary, primary_element] = max(var_max[i_primary,
-                                                                         j_primary,
-                                                                         primary_element],
-                                                                 var_secondary)
-
-            var_min[i_secondary, j_secondary, secondary_element] = min(var_min[i_secondary,
-                                                                               j_secondary,
-                                                                               secondary_element],
-                                                                       var_primary)
-            var_max[i_secondary, j_secondary, secondary_element] = max(var_max[i_secondary,
-                                                                               j_secondary,
-                                                                               secondary_element],
-                                                                       var_primary)
-
-            # Increment primary element indices
-            i_primary += i_primary_step
-            j_primary += j_primary_step
-            i_secondary += i_secondary_step
-            j_secondary += j_secondary_step
+                # Increment primary element indices
+                i_primary += i_primary_step
+                j_primary += j_primary_step
+                i_secondary += i_secondary_step
+                j_secondary += j_secondary_step
+            end
         end
     end
 
@@ -134,48 +148,64 @@ function calc_bounds_onesided_interface!(var_minmax, minmax, variable, u,
     (; neighbor_ids, node_indices) = cache.interfaces
     index_range = eachnode(dg)
 
-    for interface in eachinterface(dg, cache)
-        # Get element and side index information on the primary element
-        primary_element = neighbor_ids[1, interface]
-        primary_indices = node_indices[1, interface]
+    # Process interfaces on different axes separately. Interfaces on the
+    # same axis update disjoint faces of each element. The barrier
+    # between these loops prevents races at element corners.
+    for axis in 1:ndims(mesh)
+        @threaded for interface in eachinterface(dg, cache)
+            # Get side index information on the elements
+            primary_indices = node_indices[1, interface]
+            secondary_indices = node_indices[2, interface]
 
-        # Get element and side index information on the secondary element
-        secondary_element = neighbor_ids[2, interface]
-        secondary_indices = node_indices[2, interface]
+            primary_axis = cld(indices2direction(primary_indices), 2)
+            secondary_axis = cld(indices2direction(secondary_indices), 2)
 
-        # Create the local i,j indexing
-        i_primary_start, i_primary_step = index_to_start_step_2d(primary_indices[1],
-                                                                 index_range)
-        j_primary_start, j_primary_step = index_to_start_step_2d(primary_indices[2],
-                                                                 index_range)
-        i_secondary_start, i_secondary_step = index_to_start_step_2d(secondary_indices[1],
+            update_primary = primary_axis == axis
+            update_secondary = secondary_axis == axis
+            (update_primary || update_secondary) || continue
+
+            # Get element index information on the elements
+            primary_element = neighbor_ids[1, interface]
+            secondary_element = neighbor_ids[2, interface]
+
+            # Create the local i,j indexing
+            i_primary_start, i_primary_step = index_to_start_step_2d(primary_indices[1],
                                                                      index_range)
-        j_secondary_start, j_secondary_step = index_to_start_step_2d(secondary_indices[2],
+            j_primary_start, j_primary_step = index_to_start_step_2d(primary_indices[2],
                                                                      index_range)
+            i_secondary_start, i_secondary_step = index_to_start_step_2d(secondary_indices[1],
+                                                                         index_range)
+            j_secondary_start, j_secondary_step = index_to_start_step_2d(secondary_indices[2],
+                                                                         index_range)
 
-        i_primary = i_primary_start
-        j_primary = j_primary_start
-        i_secondary = i_secondary_start
-        j_secondary = j_secondary_start
+            i_primary = i_primary_start
+            j_primary = j_primary_start
+            i_secondary = i_secondary_start
+            j_secondary = j_secondary_start
+            for node in eachnode(dg)
+                if update_primary
+                    var_secondary = variable_values[i_secondary, j_secondary,
+                                                    secondary_element]
+                    var_minmax[i_primary, j_primary, primary_element] = minmax(var_minmax[i_primary,
+                                                                                          j_primary,
+                                                                                          primary_element],
+                                                                               var_secondary)
+                end
 
-        for node in eachnode(dg)
-            var_primary = variable_values[i_primary, j_primary, primary_element]
-            var_secondary = variable_values[i_secondary, j_secondary, secondary_element]
+                if update_secondary
+                    var_primary = variable_values[i_primary, j_primary, primary_element]
+                    var_minmax[i_secondary, j_secondary, secondary_element] = minmax(var_minmax[i_secondary,
+                                                                                                j_secondary,
+                                                                                                secondary_element],
+                                                                                     var_primary)
+                end
 
-            var_minmax[i_primary, j_primary, primary_element] = minmax(var_minmax[i_primary,
-                                                                                  j_primary,
-                                                                                  primary_element],
-                                                                       var_secondary)
-            var_minmax[i_secondary, j_secondary, secondary_element] = minmax(var_minmax[i_secondary,
-                                                                                        j_secondary,
-                                                                                        secondary_element],
-                                                                             var_primary)
-
-            # Increment primary element indices
-            i_primary += i_primary_step
-            j_primary += j_primary_step
-            i_secondary += i_secondary_step
-            j_secondary += j_secondary_step
+                # Increment primary element indices
+                i_primary += i_primary_step
+                j_primary += j_primary_step
+                i_secondary += i_secondary_step
+                j_secondary += j_secondary_step
+            end
         end
     end
 

--- a/src/solvers/dgsem_p4est/subcell_limiters_3d.jl
+++ b/src/solvers/dgsem_p4est/subcell_limiters_3d.jl
@@ -12,84 +12,99 @@ function calc_bounds_twosided_interface!(var_min, var_max, variable, u,
     (; neighbor_ids, node_indices) = cache.interfaces
     index_range = eachnode(dg)
 
-    for interface in eachinterface(dg, cache)
-        # Get element and side index information on the primary element
-        primary_element = neighbor_ids[1, interface]
-        primary_indices = node_indices[1, interface]
+    # Process interfaces on different axes separately. Interfaces on the
+    # same axis update disjoint faces of each element. The barrier
+    # between these loops prevents races at element corners.
+    for axis in 1:ndims(mesh)
+        @threaded for interface in eachinterface(dg, cache)
+            # Get side index information on the elements
+            primary_indices = node_indices[1, interface]
+            secondary_indices = node_indices[2, interface]
 
-        # Get element and side index information on the secondary element
-        secondary_element = neighbor_ids[2, interface]
-        secondary_indices = node_indices[2, interface]
+            primary_axis = cld(indices2direction(primary_indices), 2)
+            secondary_axis = cld(indices2direction(secondary_indices), 2)
 
-        # Create the local i,j,k indexing
-        i_primary_start, i_primary_step_i, i_primary_step_j = index_to_start_step_3d(primary_indices[1],
-                                                                                     index_range)
-        j_primary_start, j_primary_step_i, j_primary_step_j = index_to_start_step_3d(primary_indices[2],
-                                                                                     index_range)
-        k_primary_start, k_primary_step_i, k_primary_step_j = index_to_start_step_3d(primary_indices[3],
-                                                                                     index_range)
+            update_primary = primary_axis == axis
+            update_secondary = secondary_axis == axis
+            (update_primary || update_secondary) || continue
 
-        i_primary = i_primary_start
-        j_primary = j_primary_start
-        k_primary = k_primary_start
+            # Get element index information on the elements
+            primary_element = neighbor_ids[1, interface]
+            secondary_element = neighbor_ids[2, interface]
 
-        i_secondary_start, i_secondary_step_i, i_secondary_step_j = index_to_start_step_3d(secondary_indices[1],
-                                                                                           index_range)
-        j_secondary_start, j_secondary_step_i, j_secondary_step_j = index_to_start_step_3d(secondary_indices[2],
-                                                                                           index_range)
-        k_secondary_start, k_secondary_step_i, k_secondary_step_j = index_to_start_step_3d(secondary_indices[3],
-                                                                                           index_range)
+            # Create the local i,j,k indexing
+            i_primary_start, i_primary_step_i, i_primary_step_j = index_to_start_step_3d(primary_indices[1],
+                                                                                         index_range)
+            j_primary_start, j_primary_step_i, j_primary_step_j = index_to_start_step_3d(primary_indices[2],
+                                                                                         index_range)
+            k_primary_start, k_primary_step_i, k_primary_step_j = index_to_start_step_3d(primary_indices[3],
+                                                                                         index_range)
 
-        i_secondary = i_secondary_start
-        j_secondary = j_secondary_start
-        k_secondary = k_secondary_start
+            i_primary = i_primary_start
+            j_primary = j_primary_start
+            k_primary = k_primary_start
 
-        for j in eachnode(dg)
-            for i in eachnode(dg)
-                var_primary = u[variable, i_primary, j_primary, k_primary,
-                                primary_element]
-                var_secondary = u[variable, i_secondary, j_secondary, k_secondary,
-                                  secondary_element]
+            i_secondary_start, i_secondary_step_i, i_secondary_step_j = index_to_start_step_3d(secondary_indices[1],
+                                                                                               index_range)
+            j_secondary_start, j_secondary_step_i, j_secondary_step_j = index_to_start_step_3d(secondary_indices[2],
+                                                                                               index_range)
+            k_secondary_start, k_secondary_step_i, k_secondary_step_j = index_to_start_step_3d(secondary_indices[3],
+                                                                                               index_range)
 
-                var_min[i_primary, j_primary, k_primary, primary_element] = min(var_min[i_primary,
-                                                                                        j_primary,
-                                                                                        k_primary,
-                                                                                        primary_element],
-                                                                                var_secondary)
-                var_max[i_primary, j_primary, k_primary, primary_element] = max(var_max[i_primary,
-                                                                                        j_primary,
-                                                                                        k_primary,
-                                                                                        primary_element],
-                                                                                var_secondary)
+            i_secondary = i_secondary_start
+            j_secondary = j_secondary_start
+            k_secondary = k_secondary_start
 
-                var_min[i_secondary, j_secondary, k_secondary, secondary_element] = min(var_min[i_secondary,
-                                                                                                j_secondary,
-                                                                                                k_secondary,
-                                                                                                secondary_element],
-                                                                                        var_primary)
-                var_max[i_secondary, j_secondary, k_secondary, secondary_element] = max(var_max[i_secondary,
-                                                                                                j_secondary,
-                                                                                                k_secondary,
-                                                                                                secondary_element],
-                                                                                        var_primary)
+            for j in eachnode(dg)
+                for i in eachnode(dg)
+                    if update_primary
+                        var_secondary = u[variable, i_secondary, j_secondary,
+                                          k_secondary,
+                                          secondary_element]
+                        var_min[i_primary, j_primary, k_primary, primary_element] = min(var_min[i_primary,
+                                                                                                j_primary,
+                                                                                                k_primary,
+                                                                                                primary_element],
+                                                                                        var_secondary)
+                        var_max[i_primary, j_primary, k_primary, primary_element] = max(var_max[i_primary,
+                                                                                                j_primary,
+                                                                                                k_primary,
+                                                                                                primary_element],
+                                                                                        var_secondary)
+                    end
+                    if update_secondary
+                        var_primary = u[variable, i_primary, j_primary, k_primary,
+                                        primary_element]
+                        var_min[i_secondary, j_secondary, k_secondary, secondary_element] = min(var_min[i_secondary,
+                                                                                                        j_secondary,
+                                                                                                        k_secondary,
+                                                                                                        secondary_element],
+                                                                                                var_primary)
+                        var_max[i_secondary, j_secondary, k_secondary, secondary_element] = max(var_max[i_secondary,
+                                                                                                        j_secondary,
+                                                                                                        k_secondary,
+                                                                                                        secondary_element],
+                                                                                                var_primary)
+                    end
 
+                    # Increment the primary element indices
+                    i_primary += i_primary_step_i
+                    j_primary += j_primary_step_i
+                    k_primary += k_primary_step_i
+                    # Increment the secondary element surface indices
+                    i_secondary += i_secondary_step_i
+                    j_secondary += j_secondary_step_i
+                    k_secondary += k_secondary_step_i
+                end
                 # Increment the primary element indices
-                i_primary += i_primary_step_i
-                j_primary += j_primary_step_i
-                k_primary += k_primary_step_i
+                i_primary += i_primary_step_j
+                j_primary += j_primary_step_j
+                k_primary += k_primary_step_j
                 # Increment the secondary element surface indices
-                i_secondary += i_secondary_step_i
-                j_secondary += j_secondary_step_i
-                k_secondary += k_secondary_step_i
+                i_secondary += i_secondary_step_j
+                j_secondary += j_secondary_step_j
+                k_secondary += k_secondary_step_j
             end
-            # Increment the primary element indices
-            i_primary += i_primary_step_j
-            j_primary += j_primary_step_j
-            k_primary += k_primary_step_j
-            # Increment the secondary element surface indices
-            i_secondary += i_secondary_step_j
-            j_secondary += j_secondary_step_j
-            k_secondary += k_secondary_step_j
         end
     end
 
@@ -178,73 +193,89 @@ function calc_bounds_onesided_interface!(var_minmax, minmax, variable, u,
     (; neighbor_ids, node_indices) = cache.interfaces
     index_range = eachnode(dg)
 
-    for interface in eachinterface(dg, cache)
-        # Get element and side index information on the primary element
-        primary_element = neighbor_ids[1, interface]
-        primary_indices = node_indices[1, interface]
+    # Process interfaces on different axes separately. Interfaces on the
+    # same axis update disjoint faces of each element. The barrier
+    # between these loops prevents races at element corners.
+    for axis in 1:ndims(mesh)
+        @threaded for interface in eachinterface(dg, cache)
+            # Get side index information on the elements
+            primary_indices = node_indices[1, interface]
+            secondary_indices = node_indices[2, interface]
 
-        # Get element and side index information on the secondary element
-        secondary_element = neighbor_ids[2, interface]
-        secondary_indices = node_indices[2, interface]
+            primary_axis = cld(indices2direction(primary_indices), 2)
+            secondary_axis = cld(indices2direction(secondary_indices), 2)
 
-        # Create the local i,j,k indexing
-        i_primary_start, i_primary_step_i, i_primary_step_j = index_to_start_step_3d(primary_indices[1],
-                                                                                     index_range)
-        j_primary_start, j_primary_step_i, j_primary_step_j = index_to_start_step_3d(primary_indices[2],
-                                                                                     index_range)
-        k_primary_start, k_primary_step_i, k_primary_step_j = index_to_start_step_3d(primary_indices[3],
-                                                                                     index_range)
+            update_primary = primary_axis == axis
+            update_secondary = secondary_axis == axis
+            (update_primary || update_secondary) || continue
 
-        i_primary = i_primary_start
-        j_primary = j_primary_start
-        k_primary = k_primary_start
+            # Get element index information on the elements
+            primary_element = neighbor_ids[1, interface]
+            secondary_element = neighbor_ids[2, interface]
 
-        i_secondary_start, i_secondary_step_i, i_secondary_step_j = index_to_start_step_3d(secondary_indices[1],
-                                                                                           index_range)
-        j_secondary_start, j_secondary_step_i, j_secondary_step_j = index_to_start_step_3d(secondary_indices[2],
-                                                                                           index_range)
-        k_secondary_start, k_secondary_step_i, k_secondary_step_j = index_to_start_step_3d(secondary_indices[3],
-                                                                                           index_range)
+            # Create the local i,j,k indexing
+            i_primary_start, i_primary_step_i, i_primary_step_j = index_to_start_step_3d(primary_indices[1],
+                                                                                         index_range)
+            j_primary_start, j_primary_step_i, j_primary_step_j = index_to_start_step_3d(primary_indices[2],
+                                                                                         index_range)
+            k_primary_start, k_primary_step_i, k_primary_step_j = index_to_start_step_3d(primary_indices[3],
+                                                                                         index_range)
 
-        i_secondary = i_secondary_start
-        j_secondary = j_secondary_start
-        k_secondary = k_secondary_start
+            i_primary = i_primary_start
+            j_primary = j_primary_start
+            k_primary = k_primary_start
 
-        for j in eachnode(dg)
-            for i in eachnode(dg)
-                var_primary = variable_values[i_primary, j_primary, k_primary,
-                                              primary_element]
-                var_secondary = variable_values[i_secondary, j_secondary, k_secondary,
-                                                secondary_element]
+            i_secondary_start, i_secondary_step_i, i_secondary_step_j = index_to_start_step_3d(secondary_indices[1],
+                                                                                               index_range)
+            j_secondary_start, j_secondary_step_i, j_secondary_step_j = index_to_start_step_3d(secondary_indices[2],
+                                                                                               index_range)
+            k_secondary_start, k_secondary_step_i, k_secondary_step_j = index_to_start_step_3d(secondary_indices[3],
+                                                                                               index_range)
 
-                var_minmax[i_primary, j_primary, k_primary, primary_element] = minmax(var_minmax[i_primary,
-                                                                                                 j_primary,
-                                                                                                 k_primary,
-                                                                                                 primary_element],
-                                                                                      var_secondary)
-                var_minmax[i_secondary, j_secondary, k_secondary, secondary_element] = minmax(var_minmax[i_secondary,
-                                                                                                         j_secondary,
-                                                                                                         k_secondary,
-                                                                                                         secondary_element],
-                                                                                              var_primary)
+            i_secondary = i_secondary_start
+            j_secondary = j_secondary_start
+            k_secondary = k_secondary_start
 
+            for j in eachnode(dg)
+                for i in eachnode(dg)
+                    if update_primary
+                        var_secondary = variable_values[i_secondary, j_secondary,
+                                                        k_secondary,
+                                                        secondary_element]
+                        var_minmax[i_primary, j_primary, k_primary, primary_element] = minmax(var_minmax[i_primary,
+                                                                                                         j_primary,
+                                                                                                         k_primary,
+                                                                                                         primary_element],
+                                                                                              var_secondary)
+                    end
+                    if update_secondary
+                        var_primary = variable_values[i_primary, j_primary, k_primary,
+                                                      primary_element]
+                        var_minmax[i_secondary, j_secondary, k_secondary, secondary_element] = minmax(var_minmax[i_secondary,
+                                                                                                                 j_secondary,
+                                                                                                                 k_secondary,
+                                                                                                                 secondary_element],
+                                                                                                      var_primary)
+                    end
+
+                    # Increment the primary element indices
+                    i_primary += i_primary_step_i
+                    j_primary += j_primary_step_i
+                    k_primary += k_primary_step_i
+                    # Increment the secondary element surface indices
+                    i_secondary += i_secondary_step_i
+                    j_secondary += j_secondary_step_i
+                    k_secondary += k_secondary_step_i
+                end
                 # Increment the primary element indices
-                i_primary += i_primary_step_i
-                j_primary += j_primary_step_i
-                k_primary += k_primary_step_i
+                i_primary += i_primary_step_j
+                j_primary += j_primary_step_j
+                k_primary += k_primary_step_j
                 # Increment the secondary element surface indices
-                i_secondary += i_secondary_step_i
-                j_secondary += j_secondary_step_i
-                k_secondary += k_secondary_step_i
+                i_secondary += i_secondary_step_j
+                j_secondary += j_secondary_step_j
+                k_secondary += k_secondary_step_j
             end
-            # Increment the primary element indices
-            i_primary += i_primary_step_j
-            j_primary += j_primary_step_j
-            k_primary += k_primary_step_j
-            # Increment the secondary element surface indices
-            i_secondary += i_secondary_step_j
-            j_secondary += j_secondary_step_j
-            k_secondary += k_secondary_step_j
         end
     end
 

--- a/src/solvers/dgsem_structured/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_structured/subcell_limiters_2d.jl
@@ -9,10 +9,10 @@ function calc_bounds_twosided_interface!(var_min, var_max, variable, u,
                                          semi, mesh::StructuredMesh{2}, equations)
     _, _, dg, cache = mesh_equations_solver_cache(semi)
 
-    for element in eachelement(dg, cache)
-        # Get neighboring element ids
+    # Process x- and y-oriented interfaces separately. Within one loop each face is written by exactly one element iteration; the barrier between the loops prevents races at element corners.
+    @threaded for element in eachelement(dg, cache)
+        # Get neighboring element id
         left = cache.elements.left_neighbors[1, element]
-        lower = cache.elements.left_neighbors[2, element]
 
         if left != 0
             for j in eachnode(dg)
@@ -28,6 +28,11 @@ function calc_bounds_twosided_interface!(var_min, var_max, variable, u,
                                                    var_element)
             end
         end
+    end
+    @threaded for element in eachelement(dg, cache)
+        # Get neighboring element id
+        lower = cache.elements.left_neighbors[2, element]
+
         if lower != 0
             for i in eachnode(dg)
                 var_lower = u[variable, i, nnodes(dg), lower]
@@ -143,10 +148,12 @@ function calc_bounds_onesided_interface!(var_minmax, minmax, variable, u,
     (; variable_values) = subcell_limiter_coefficients(dg.volume_integral)
     n_nodes = nnodes(dg)
 
-    for element in eachelement(dg, cache)
-        # Get neighboring element ids
+    # Process x- and y-oriented interfaces separately. Interfaces with the
+    # same orientation update disjoint faces of each element. The barrier
+    # between these loops prevents races at element corners.
+    @threaded for element in eachelement(dg, cache)
+        # Get neighboring element id
         left = cache.elements.left_neighbors[1, element]
-        lower = cache.elements.left_neighbors[2, element]
 
         if left != 0
             for j in eachnode(dg)
@@ -158,6 +165,11 @@ function calc_bounds_onesided_interface!(var_minmax, minmax, variable, u,
                                                       var_element)
             end
         end
+    end
+    @threaded for element in eachelement(dg, cache)
+        # Get neighboring element id
+        lower = cache.elements.left_neighbors[2, element]
+
         if lower != 0
             for i in eachnode(dg)
                 var_lower = variable_values[i, n_nodes, lower]

--- a/src/solvers/dgsem_tree/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_2d.jl
@@ -68,50 +68,57 @@ end
                                                  semi, mesh::TreeMesh2D, equations)
     _, _, dg, cache = mesh_equations_solver_cache(semi)
 
-    for interface in eachinterface(dg, cache)
-        # Get neighboring element ids
-        left_element = cache.interfaces.neighbor_ids[1, interface]
-        right_element = cache.interfaces.neighbor_ids[2, interface]
+    (; neighbor_ids, orientations) = cache.interfaces
 
-        limit_left = perform_subcell_limiting(dg.volume_integral, left_element)
-        limit_right = perform_subcell_limiting(dg.volume_integral, right_element)
-        if limit_left || limit_right
-            # Subcell limiting is necessary for at least one of the elements => Calculate bounds at this interface
-        else
-            # Subcell limiting is not necessary for both elements => Skip this interface
-            continue
-        end
+    # Process x- and y-oriented interfaces separately. Interfaces with the
+    # same orientation update disjoint faces of each element. The barrier
+    # between these loops prevents races at element corners.
+    for selected_orientation in 1:2
+        @threaded for interface in eachinterface(dg, cache)
+            orientations[interface] == selected_orientation || continue
 
-        orientation = cache.interfaces.orientations[interface]
+            # Get neighboring element ids
+            left_element = neighbor_ids[1, interface]
+            right_element = neighbor_ids[2, interface]
 
-        for i in eachnode(dg)
-            # Define node indices for left and right element based on the interface orientation
-            if orientation == 1
-                index_left = (nnodes(dg), i)
-                index_right = (1, i)
-            else # if orientation == 2
-                index_left = (i, nnodes(dg))
-                index_right = (i, 1)
+            limit_left = perform_subcell_limiting(dg.volume_integral, left_element)
+            limit_right = perform_subcell_limiting(dg.volume_integral, right_element)
+            if limit_left || limit_right
+                # Subcell limiting is necessary for at least one of the elements => Calculate bounds at this interface
+            else
+                # Subcell limiting is not necessary for both elements => Skip this interface
+                continue
             end
 
-            if limit_right
-                var_left = u[variable, index_left..., left_element]
-                var_min[index_right..., right_element] = min(var_min[index_right...,
-                                                                     right_element],
-                                                             var_left)
-                var_max[index_right..., right_element] = max(var_max[index_right...,
-                                                                     right_element],
-                                                             var_left)
-            end
+            for i in eachnode(dg)
+                # Define node indices for left and right element based on the interface orientation
+                if orientations[interface] == 1
+                    index_left = (nnodes(dg), i)
+                    index_right = (1, i)
+                else # if orientation == 2
+                    index_left = (i, nnodes(dg))
+                    index_right = (i, 1)
+                end
 
-            if limit_left
-                var_right = u[variable, index_right..., right_element]
-                var_min[index_left..., left_element] = min(var_min[index_left...,
-                                                                   left_element],
-                                                           var_right)
-                var_max[index_left..., left_element] = max(var_max[index_left...,
-                                                                   left_element],
-                                                           var_right)
+                if limit_right
+                    var_left = u[variable, index_left..., left_element]
+                    var_min[index_right..., right_element] = min(var_min[index_right...,
+                                                                         right_element],
+                                                                 var_left)
+                    var_max[index_right..., right_element] = max(var_max[index_right...,
+                                                                         right_element],
+                                                                 var_left)
+                end
+
+                if limit_left
+                    var_right = u[variable, index_right..., right_element]
+                    var_min[index_left..., left_element] = min(var_min[index_left...,
+                                                                       left_element],
+                                                               var_right)
+                    var_max[index_left..., left_element] = max(var_max[index_left...,
+                                                                       left_element],
+                                                               var_right)
+                end
             end
         end
     end
@@ -219,55 +226,62 @@ end
     (; variable_values) = subcell_limiter_coefficients(dg.volume_integral)
     n_nodes = nnodes(dg)
 
-    for interface in eachinterface(dg, cache)
-        # Get neighboring element ids
-        left_element = cache.interfaces.neighbor_ids[1, interface]
-        right_element = cache.interfaces.neighbor_ids[2, interface]
+    (; neighbor_ids, orientations) = cache.interfaces
 
-        limit_left = perform_subcell_limiting(dg.volume_integral, left_element)
-        limit_right = perform_subcell_limiting(dg.volume_integral, right_element)
-        if limit_left || limit_right
-            # Subcell limiting is necessary for at least one of the elements => Calculate bounds at this interface
-        else
-            # Subcell limiting is not necessary for both elements => Skip this interface
-            continue
-        end
+    # Process x- and y-oriented interfaces separately. Interfaces with the
+    # same orientation update disjoint faces of each element. The barrier
+    # between these loops prevents races at element corners.
+    for selected_orientation in 1:2
+        @threaded for interface in eachinterface(dg, cache)
+            orientations[interface] == selected_orientation || continue
 
-        orientation = cache.interfaces.orientations[interface]
+            # Get neighboring element ids
+            left_element = neighbor_ids[1, interface]
+            right_element = neighbor_ids[2, interface]
 
-        for i in eachnode(dg)
-            # Define node indices for left and right element based on the interface orientation
-            if orientation == 1
-                index_left = (n_nodes, i)
-                index_right = (1, i)
-            else # if orientation == 2
-                index_left = (i, n_nodes)
-                index_right = (i, 1)
+            limit_left = perform_subcell_limiting(dg.volume_integral, left_element)
+            limit_right = perform_subcell_limiting(dg.volume_integral, right_element)
+            if limit_left || limit_right
+                # Subcell limiting is necessary for at least one of the elements => Calculate bounds at this interface
+            else
+                # Subcell limiting is not necessary for both elements => Skip this interface
+                continue
             end
 
-            if limit_right
-                # Use cached value if available, otherwise compute it
-                var_left = if limit_left
-                    variable_values[index_left..., left_element]
-                else
-                    variable(get_node_vars(u, equations, dg, index_left...,
-                                           left_element), equations)
+            for i in eachnode(dg)
+                # Define node indices for left and right element based on the interface orientation
+                if orientations[interface] == 1
+                    index_left = (n_nodes, i)
+                    index_right = (1, i)
+                else # if orientation == 2
+                    index_left = (i, n_nodes)
+                    index_right = (i, 1)
                 end
-                var_minmax[index_right..., right_element] = min_or_max(var_minmax[index_right...,
-                                                                                  right_element],
-                                                                       var_left)
-            end
-            if limit_left
-                # Use cached value if available, otherwise compute it
-                var_right = if limit_right
-                    variable_values[index_right..., right_element]
-                else
-                    variable(get_node_vars(u, equations, dg, index_right...,
-                                           right_element), equations)
+
+                if limit_right
+                    # Use cached value if available, otherwise compute it
+                    var_left = if limit_left
+                        variable_values[index_left..., left_element]
+                    else
+                        variable(get_node_vars(u, equations, dg, index_left...,
+                                               left_element), equations)
+                    end
+                    var_minmax[index_right..., right_element] = min_or_max(var_minmax[index_right...,
+                                                                                      right_element],
+                                                                           var_left)
                 end
-                var_minmax[index_left..., left_element] = min_or_max(var_minmax[index_left...,
-                                                                                left_element],
-                                                                     var_right)
+                if limit_left
+                    # Use cached value if available, otherwise compute it
+                    var_right = if limit_right
+                        variable_values[index_right..., right_element]
+                    else
+                        variable(get_node_vars(u, equations, dg, index_right...,
+                                               right_element), equations)
+                    end
+                    var_minmax[index_left..., left_element] = min_or_max(var_minmax[index_left...,
+                                                                                    left_element],
+                                                                         var_right)
+                end
             end
         end
     end

--- a/src/solvers/dgsem_tree/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_2d.jl
@@ -255,7 +255,7 @@ end
                 end
                 var_minmax[index_right..., right_element] = min_or_max(var_minmax[index_right...,
                                                                                   right_element],
-                                                                       value_left)
+                                                                       var_left)
             end
             if limit_left
                 # Use cached value if available, otherwise compute it
@@ -267,7 +267,7 @@ end
                 end
                 var_minmax[index_left..., left_element] = min_or_max(var_minmax[index_left...,
                                                                                 left_element],
-                                                                     value_right)
+                                                                     var_right)
             end
         end
     end

--- a/src/solvers/dgsem_tree/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_2d.jl
@@ -443,6 +443,11 @@ end
     (; variable_bounds) = limiter.cache.subcell_limiter_coefficients
     var_min = variable_bounds[Symbol(string(variable), "_min")]
 
+    # Check if this variable was already limited by the local two-sided limiter,
+    # which can impose a stricter lower bound than the positivity limiting below.
+    local_twosided_variable = limiter.local_twosided &&
+                              (variable in limiter.local_twosided_variables_cons)
+
     @threaded for element in eachelement(dg, semi.cache)
 
         # detect if subcell limiting is necessary
@@ -457,8 +462,7 @@ end
             end
 
             # Compute bound
-            if limiter.local_twosided &&
-               (variable in limiter.local_twosided_variables_cons) &&
+            if local_twosided_variable &&
                (var_min[i, j, element] >= positivity_correction_factor * var)
                 # Local limiting is more restrictive that positivity limiting
                 # => Skip positivity limiting for this node

--- a/src/solvers/dgsem_tree/subcell_limiters_2d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_2d.jl
@@ -255,7 +255,7 @@ end
                 end
                 var_minmax[index_right..., right_element] = min_or_max(var_minmax[index_right...,
                                                                                   right_element],
-                                                                       var_left)
+                                                                       value_left)
             end
             if limit_left
                 # Use cached value if available, otherwise compute it
@@ -267,7 +267,7 @@ end
                 end
                 var_minmax[index_left..., left_element] = min_or_max(var_minmax[index_left...,
                                                                                 left_element],
-                                                                     var_right)
+                                                                     value_right)
             end
         end
     end

--- a/src/solvers/dgsem_tree/subcell_limiters_3d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_3d.jl
@@ -79,57 +79,63 @@ end
 @inline function calc_bounds_twosided_interface!(var_min, var_max, variable, u,
                                                  semi, mesh::TreeMesh3D, equations)
     _, _, dg, cache = mesh_equations_solver_cache(semi)
+    (; orientations, neighbor_ids) = cache.interfaces
 
-    for interface in eachinterface(dg, cache)
-        # Get neighboring element ids
-        left_element = cache.interfaces.neighbor_ids[1, interface]
-        right_element = cache.interfaces.neighbor_ids[2, interface]
+    # Process x-, y-, and z-oriented interfaces separately. Interfaces with the
+    # same orientation update disjoint faces of each element. The barrier
+    # between these loops prevents races at element corners.
+    for selected_orientation in 1:3
+        @threaded for interface in eachinterface(dg, cache)
+            orientations[interface] == selected_orientation || continue
 
-        limit_left = perform_subcell_limiting(dg.volume_integral, left_element)
-        limit_right = perform_subcell_limiting(dg.volume_integral, right_element)
-        if limit_left || limit_right
-            # Subcell limiting is necessary for at least one of the elements => Calculate bounds at this interface
-        else
-            # Subcell limiting is not necessary for both elements => Skip this interface
-            continue
-        end
+            # Get neighboring element ids
+            left_element = neighbor_ids[1, interface]
+            right_element = neighbor_ids[2, interface]
 
-        orientation = cache.interfaces.orientations[interface]
-
-        for j in eachnode(dg), i in eachnode(dg)
-            # Define node indices for left and right element based on the interface orientation
-            if orientation == 1
-                # interface in x-direction
-                index_left = (nnodes(dg), i, j)
-                index_right = (1, i, j)
-            elseif orientation == 2
-                # interface in y-direction
-                index_left = (i, nnodes(dg), j)
-                index_right = (i, 1, j)
-            else # if orientation == 3
-                # interface in z-direction
-                index_left = (i, j, nnodes(dg))
-                index_right = (i, j, 1)
+            limit_left = perform_subcell_limiting(dg.volume_integral, left_element)
+            limit_right = perform_subcell_limiting(dg.volume_integral, right_element)
+            if limit_left || limit_right
+                # Subcell limiting is necessary for at least one of the elements => Calculate bounds at this interface
+            else
+                # Subcell limiting is not necessary for both elements => Skip this interface
+                continue
             end
 
-            if limit_right
-                var_left = u[variable, index_left..., left_element]
-                var_min[index_right..., right_element] = min(var_min[index_right...,
-                                                                     right_element],
-                                                             var_left)
-                var_max[index_right..., right_element] = max(var_max[index_right...,
-                                                                     right_element],
-                                                             var_left)
-            end
+            for j in eachnode(dg), i in eachnode(dg)
+                # Define node indices for left and right element based on the interface orientation
+                if orientations[interface] == 1
+                    # interface in x-direction
+                    index_left = (nnodes(dg), i, j)
+                    index_right = (1, i, j)
+                elseif orientations[interface] == 2
+                    # interface in y-direction
+                    index_left = (i, nnodes(dg), j)
+                    index_right = (i, 1, j)
+                else # if orientation == 3
+                    # interface in z-direction
+                    index_left = (i, j, nnodes(dg))
+                    index_right = (i, j, 1)
+                end
 
-            if limit_left
-                var_right = u[variable, index_right..., right_element]
-                var_min[index_left..., left_element] = min(var_min[index_left...,
-                                                                   left_element],
-                                                           var_right)
-                var_max[index_left..., left_element] = max(var_max[index_left...,
-                                                                   left_element],
-                                                           var_right)
+                if limit_right
+                    var_left = u[variable, index_left..., left_element]
+                    var_min[index_right..., right_element] = min(var_min[index_right...,
+                                                                         right_element],
+                                                                 var_left)
+                    var_max[index_right..., right_element] = max(var_max[index_right...,
+                                                                         right_element],
+                                                                 var_left)
+                end
+
+                if limit_left
+                    var_right = u[variable, index_right..., right_element]
+                    var_min[index_left..., left_element] = min(var_min[index_left...,
+                                                                       left_element],
+                                                               var_right)
+                    var_max[index_left..., left_element] = max(var_max[index_left...,
+                                                                       left_element],
+                                                               var_right)
+                end
             end
         end
     end
@@ -263,65 +269,71 @@ end
 @inline function calc_bounds_onesided_interface!(var_minmax, min_or_max, variable, u,
                                                  semi, mesh::TreeMesh3D)
     _, equations, dg, cache = mesh_equations_solver_cache(semi)
+    (; orientations, neighbor_ids) = cache.interfaces
     (; variable_values) = subcell_limiter_coefficients(dg.volume_integral)
     n_nodes = nnodes(dg)
 
-    for interface in eachinterface(dg, cache)
-        # Get neighboring element ids
-        left_element = cache.interfaces.neighbor_ids[1, interface]
-        right_element = cache.interfaces.neighbor_ids[2, interface]
+    # Process x-, y-, and z-oriented interfaces separately. Interfaces with the
+    # same orientation update disjoint faces of each element. The barrier
+    # between these loops prevents races at element corners.
+    for selected_orientation in 1:3
+        @threaded for interface in eachinterface(dg, cache)
+            orientations[interface] == selected_orientation || continue
 
-        limit_left = perform_subcell_limiting(dg.volume_integral, left_element)
-        limit_right = perform_subcell_limiting(dg.volume_integral, right_element)
-        if limit_left || limit_right
-            # Subcell limiting is necessary for at least one of the elements => Calculate bounds at this interface
-        else
-            # Subcell limiting is not necessary for both elements => Skip this interface
-            continue
-        end
+            # Get neighboring element ids
+            left_element = neighbor_ids[1, interface]
+            right_element = neighbor_ids[2, interface]
 
-        orientation = cache.interfaces.orientations[interface]
-
-        for j in eachnode(dg), i in eachnode(dg)
-            # Define node indices for left and right element based on the interface orientation
-            if orientation == 1
-                # interface in x-direction
-                index_left = (n_nodes, i, j)
-                index_right = (1, i, j)
-            elseif orientation == 2
-                # interface in y-direction
-                index_left = (i, n_nodes, j)
-                index_right = (i, 1, j)
-            else # if orientation == 3
-                # interface in z-direction
-                index_left = (i, j, n_nodes)
-                index_right = (i, j, 1)
+            limit_left = perform_subcell_limiting(dg.volume_integral, left_element)
+            limit_right = perform_subcell_limiting(dg.volume_integral, right_element)
+            if limit_left || limit_right
+                # Subcell limiting is necessary for at least one of the elements => Calculate bounds at this interface
+            else
+                # Subcell limiting is not necessary for both elements => Skip this interface
+                continue
             end
 
-            if limit_right
-                # Use cached value if available, otherwise compute it
-                var_left = if limit_left
-                    variable_values[index_left..., left_element]
-                else
-                    variable(get_node_vars(u, equations, dg, index_left...,
-                                           left_element),
-                             equations)
+            for j in eachnode(dg), i in eachnode(dg)
+                # Define node indices for left and right element based on the interface orientation
+                if orientations[interface] == 1
+                    # interface in x-direction
+                    index_left = (n_nodes, i, j)
+                    index_right = (1, i, j)
+                elseif orientations[interface] == 2
+                    # interface in y-direction
+                    index_left = (i, n_nodes, j)
+                    index_right = (i, 1, j)
+                else # if orientation == 3
+                    # interface in z-direction
+                    index_left = (i, j, n_nodes)
+                    index_right = (i, j, 1)
                 end
-                var_minmax[index_right..., right_element] = min_or_max(var_minmax[index_right...,
-                                                                                  right_element],
-                                                                       var_left)
-            end
-            if limit_left
-                # Use cached value if available, otherwise compute it
-                var_right = if limit_right
-                    variable_values[index_right..., right_element]
-                else
-                    variable(get_node_vars(u, equations, dg, index_right...,
-                                           right_element), equations)
+
+                if limit_right
+                    # Use cached value if available, otherwise compute it
+                    var_left = if limit_left
+                        variable_values[index_left..., left_element]
+                    else
+                        variable(get_node_vars(u, equations, dg, index_left...,
+                                               left_element),
+                                 equations)
+                    end
+                    var_minmax[index_right..., right_element] = min_or_max(var_minmax[index_right...,
+                                                                                      right_element],
+                                                                           var_left)
                 end
-                var_minmax[index_left..., left_element] = min_or_max(var_minmax[index_left...,
-                                                                                left_element],
-                                                                     var_right)
+                if limit_left
+                    # Use cached value if available, otherwise compute it
+                    var_right = if limit_right
+                        variable_values[index_right..., right_element]
+                    else
+                        variable(get_node_vars(u, equations, dg, index_right...,
+                                               right_element), equations)
+                    end
+                    var_minmax[index_left..., left_element] = min_or_max(var_minmax[index_left...,
+                                                                                    left_element],
+                                                                         var_right)
+                end
             end
         end
     end

--- a/src/solvers/dgsem_tree/subcell_limiters_3d.jl
+++ b/src/solvers/dgsem_tree/subcell_limiters_3d.jl
@@ -516,6 +516,11 @@ end
     (; variable_bounds) = limiter.cache.subcell_limiter_coefficients
     var_min = variable_bounds[Symbol(string(variable), "_min")]
 
+    # Check if this variable was already limited by the local two-sided limiter,
+    # which can impose a stricter lower bound than the positivity limiting below.
+    local_twosided_variable = limiter.local_twosided &&
+                              (variable in limiter.local_twosided_variables_cons)
+
     @threaded for element in eachelement(dg, semi.cache)
 
         # detect if subcell limiting is necessary
@@ -530,8 +535,7 @@ end
             end
 
             # Compute bound
-            if limiter.local_twosided &&
-               (variable in limiter.local_twosided_variables_cons) &&
+            if local_twosided_variable &&
                (var_min[i, j, k, element] >= positivity_correction_factor * var)
                 # Local limiting is more restrictive that positivity limiting
                 # => Skip positivity limiting for this node


### PR DESCRIPTION
The subcell bounds computation at the interfaces is a/the bottleneck for thread-parallel scaling. This PR currently contains a simple approach to parallelize the subcell bounds computation at the interfaces by simply splitting it up into one threaded loop per dimension.
This has a small overhead in serial runs (depending on the mesh type) but is significantly faster on multiple threads.

Benchmark for TreeMesh 2D: `tree_2d_dgsem/elixir_euler_sedov_blast_wave_sc_subcell.jl` with `initial_refinement_level=6` and `tspan=(0.0, 0.25)`.

### Subcell limiter threading: `main` vs. this PR

Median timer values (seconds) from `TimerOutputs`, 1–16 threads.

#### Speedup of PR over `main` at equal thread count (`main / PR`)

| Timer | 1 | 2 | 4 | 8 | 16 |
| --- | ---: | ---: | ---: | ---: | ---: |
| **simulation** | 0.99 | **1.22** | **1.31** | **1.43** | **1.66** |
| `rhs_hyperbolic` | 1.00 | 1.01 | 1.01 | 0.95 | 1.00 |
| `check_bounds` | 1.00 | 1.01 | 1.00 | 1.01 | 1.02 |
| `step_callbacks` | 1.00 | 1.00 | 1.01 | 0.98 | 0.94 |
| **`a_posteriori_limiter`** | 0.96 | **2.05** | **2.46** | **3.29** | **3.86** |
| `local_onesided` | 0.99 | 1.52 | 1.91 | 2.23 | 2.44 |
| `calc_bounds_onesided` | 0.96 | 2.28 | 2.98 | 4.25 | 5.41 |
| `calc_bounds_onesided_interface` | **0.89** | 4.16 | 6.73 | 13.41 | 16.43 |
| `local_twosided` | 0.88 | 2.19 | 3.67 | 6.54 | 7.91 |
| `calc_bounds_twosided` | **0.73** | 3.43 | 5.72 | 8.93 | 9.37 |
| `calc_bounds_twosided_interface` | 0.92 | 6.74 | 12.40 | 32.57 | 43.21 |
| `~main loop~` | 0.98 | 1.01 | 0.98 | 1.01 | 0.99 |

#### Parallel scaling (`t=1 / t=N`)

##### `main`

| Timer | 1 | 2 | 4 | 8 | 16 |
| --- | ---: | ---: | ---: | ---: | ---: |
| simulation | 1.00 | 1.64 | 2.74 | 3.77 | 4.67 |
| `rhs_hyperbolic` | 1.00 | 1.91 | 3.78 | 6.83 | 11.49 |
| `check_bounds` | 1.00 | 2.86 | 5.51 | 8.99 | 12.07 |
| `step_callbacks` | 1.00 | 1.08 | 2.02 | 2.19 | 2.18 |
| `a_posteriori_limiter` | 1.00 | 1.28 | 1.89 | 2.12 | 2.30 |
| `local_onesided` | 1.00 | 1.51 | 2.12 | 2.54 | 2.73 |
| `calc_bounds_onesided` | 1.00 | 1.11 | 1.31 | 1.57 | 1.69 |
| `calc_bounds_onesided_interface` | 1.00 | 0.73 | 0.67 | 0.57 | **0.50** |
| `local_twosided` | 1.00 | 1.66 | 1.69 | 1.29 | 1.20 |
| `calc_bounds_twosided` | 1.00 | 0.90 | 0.78 | 0.55 | **0.51** |
| `calc_bounds_twosided_interface` | 1.00 | 0.47 | 0.37 | 0.26 | **0.24** |
| `~main loop~` | 1.00 | 0.41 | 0.33 | 0.30 | 0.32 |

##### This PR

| Timer | 1 | 2 | 4 | 8 | 16 |
| --- | ---: | ---: | ---: | ---: | ---: |
| simulation | 1.00 | 2.03 | 3.64 | 5.46 | **7.81** |
| `rhs_hyperbolic` | 1.00 | 1.93 | 3.81 | 6.48 | 11.50 |
| `check_bounds` | 1.00 | 2.90 | 5.51 | 9.11 | 12.34 |
| `step_callbacks` | 1.00 | 1.09 | 2.04 | 2.13 | 2.05 |
| `a_posteriori_limiter` | 1.00 | 2.73 | 4.85 | 7.30 | **9.28** |
| `local_onesided` | 1.00 | 2.32 | 4.11 | 5.73 | 6.74 |
| `calc_bounds_onesided` | 1.00 | 2.63 | 4.04 | 6.93 | 9.47 |
| `calc_bounds_onesided_interface` | 1.00 | 3.43 | 5.04 | 8.60 | 9.17 |
| `local_twosided` | 1.00 | 4.16 | 7.07 | 9.61 | 10.86 |
| `calc_bounds_twosided` | 1.00 | 4.22 | 6.15 | 6.78 | 6.62 |
| `calc_bounds_twosided_interface` | 1.00 | 3.42 | 5.03 | 9.10 | 11.23 |
| `~main loop~` | 1.00 | 0.43 | 0.34 | 0.31 | 0.32 |

#### Takeaways

- **Serial performance is unchanged.** At one thread the total simulation time is
  within noise (0.99x). The limiter itself is ~4% slower serially, with the largest
  relative regression in `calc_bounds_twosided` (0.73x, +0.15 s) - small in absolute
  terms, but the one spot worth a look.
- **The bound-calculation kernels went from anti-scaling to scaling.** On `main`,
  `calc_bounds_twosided_interface` became *4x slower* going from 1 to 16 threads
  (0.168 s -> 0.699 s), and `calc_bounds_twosided` / `calc_bounds_onesided_interface`
  likewise degraded with thread count - the signature of serialization/contention.
  In this PR all three scale by 6.6-11.2x instead.
- **The limiter is no longer the scaling bottleneck.** On `main` the a-posteriori
  limiter plateaued near 1.36 s regardless of thread count (2.3x max), so at 16 threads
  it accounted for 54% of the simulation time while `rhs_hyperbolic` was only 28%.
  In this PR it falls to 0.351 s (23%), and overall scaling improves from 4.67x to 7.81x.
- **Nothing outside the limiter moved**, as expected: `rhs_hyperbolic`,
  `check_bounds`, `step_callbacks` and `~main loop~` all stay within +/-6% at every
  thread count.
- **The win grows with thread count** (1.22x -> 1.66x on total simulation time), so
  the benefit should keep increasing beyond 16 threads until the limiter stops being a
  meaningful fraction of the runtime.

Claude Code was used in this PR to create a simple script for performance check and later to analyze and summarize the timer outputs.