### PR TITLE
Remove redundancies due to KA barrier in `FullSweep` GPU kernels

### DIFF
--- a/src/solvers/dgsem_p4est/dg_3d_gpu.jl
+++ b/src/solvers/dgsem_p4est/dg_3d_gpu.jl
@@ -320,7 +320,6 @@ end
     end
     @synchronize
 
-    u_node = get_node_vars(u_local, equations, dg, i, j, k)
     du_local = zero(SVector{NVARIABLES, eltype(du)})
 
     Ja1_node = get_contravariant_vector(1, contravariant_vectors, i, j, k, element)
@@ -392,7 +391,6 @@ end
     end
     @synchronize
 
-    u_node = get_node_vars(u_local, equations, dg, i, j, k)
     du_local = zero(SVector{NVARIABLES, eltype(du)})
 
     Ja1_node = get_contravariant_vector(1, contravariant_vectors, i, j, k, element)
@@ -462,6 +460,9 @@ end
     du_local = zero(SVector{NVARIABLES, eltype(du)})
 
     Ja1_node = get_contravariant_vector(1, contravariant_vectors, i, j, k, element)
+    Ja2_node = get_contravariant_vector(2, contravariant_vectors, i, j, k, element)
+    Ja3_node = get_contravariant_vector(3, contravariant_vectors, i, j, k, element)
+
     for ii in 1:NNODES
         # pull the contravariant vectors and compute the average
         Ja1_avg = 0.5f0 * (Ja1_node +
@@ -475,7 +476,6 @@ end
         du_local = du_local + derivative_split[i, ii] * fluxtilde1
     end
 
-    Ja2_node = get_contravariant_vector(2, contravariant_vectors, i, j, k, element)
     for jj in 1:NNODES
         Ja2_avg = 0.5f0 * (Ja2_node +
                    get_contravariant_vector(2, contravariant_vectors,
@@ -486,7 +486,6 @@ end
         du_local = du_local + derivative_split[j, jj] * fluxtilde2
     end
 
-    Ja3_node = get_contravariant_vector(3, contravariant_vectors, i, j, k, element)
     for kk in 1:NNODES
         Ja3_avg = 0.5f0 * (Ja3_node +
                    get_contravariant_vector(3, contravariant_vectors,
@@ -523,6 +522,9 @@ end
     du_local = zero(SVector{NVARIABLES, eltype(du)})
 
     Ja1_node = get_contravariant_vector(1, contravariant_vectors, i, j, k, element)
+    Ja2_node = get_contravariant_vector(2, contravariant_vectors, i, j, k, element)
+    Ja3_node = get_contravariant_vector(3, contravariant_vectors, i, j, k, element)
+
     for ii in 1:NNODES
         Ja1_avg = 0.5f0 * (Ja1_node +
                    get_contravariant_vector(1, contravariant_vectors,
@@ -534,7 +536,6 @@ end
         du_local = du_local + derivative_split[i, ii] * fluxtilde1_left
     end
 
-    Ja2_node = get_contravariant_vector(2, contravariant_vectors, i, j, k, element)
     for jj in 1:NNODES
         Ja2_avg = 0.5f0 * (Ja2_node +
                    get_contravariant_vector(2, contravariant_vectors,
@@ -546,7 +547,6 @@ end
         du_local = du_local + derivative_split[j, jj] * fluxtilde2_left
     end
 
-    Ja3_node = get_contravariant_vector(3, contravariant_vectors, i, j, k, element)
     for kk in 1:NNODES
         Ja3_avg = 0.5f0 * (Ja3_node +
                    get_contravariant_vector(3, contravariant_vectors,
@@ -630,8 +630,6 @@ end
         turbo_local[v, i, j, k] = turbo_node[v]
     end
     @synchronize
-
-    turbo_node = get_node_turbo(turbo_local, Val(NAUX), i, j, k)
 
     # pull the contravariant vectors in each coordinate direction
     Ja1_node = get_contravariant_vector(1, contravariant_vectors, i, j, k, element)
@@ -765,8 +763,6 @@ end
         turbo_local[v, i, j, k] = turbo_node[v]
     end
     @synchronize
-
-    turbo_node = get_node_turbo(turbo_local, Val(NAUX), i, j, k)
 
     # pull the contravariant vectors in each coordinate direction
     Ja1_node = get_contravariant_vector(1, contravariant_vectors, i, j, k, element)
@@ -917,10 +913,12 @@ end
     end
     @synchronize
 
-    turbo_node = get_node_turbo(turbo_local, Val(NAUX), i, j, k)
     du_local = zero(SVector{NVARIABLES, eltype(du)})
 
     Ja1_node = get_contravariant_vector(1, contravariant_vectors, i, j, k, element)
+    Ja2_node = get_contravariant_vector(2, contravariant_vectors, i, j, k, element)
+    Ja3_node = get_contravariant_vector(3, contravariant_vectors, i, j, k, element)
+
     for ii in 1:NNODES
         # pull the contravariant vectors and compute the average
         Ja1_avg = 0.5f0 * (Ja1_node +
@@ -938,7 +936,6 @@ end
                    derivative_split[i, ii] * fluxtilde1
     end
 
-    Ja2_node = get_contravariant_vector(2, contravariant_vectors, i, j, k, element)
     for jj in 1:NNODES
         Ja2_avg = 0.5f0 * (Ja2_node +
                    get_contravariant_vector(2, contravariant_vectors,
@@ -953,7 +950,6 @@ end
                    derivative_split[j, jj] * fluxtilde2
     end
 
-    Ja3_node = get_contravariant_vector(3, contravariant_vectors, i, j, k, element)
     for kk in 1:NNODES
         Ja3_avg = 0.5f0 * (Ja3_node +
                    get_contravariant_vector(3, contravariant_vectors,
@@ -1002,10 +998,12 @@ end
     end
     @synchronize
 
-    turbo_node = get_node_turbo(turbo_local, Val(NAUX), i, j, k)
     du_local = zero(SVector{NVARIABLES, eltype(du)})
 
     Ja1_node = get_contravariant_vector(1, contravariant_vectors, i, j, k, element)
+    Ja2_node = get_contravariant_vector(2, contravariant_vectors, i, j, k, element)
+    Ja3_node = get_contravariant_vector(3, contravariant_vectors, i, j, k, element)
+
     for ii in 1:NNODES
         # pull the contravariant vectors and compute the average
         Ja1_avg = 0.5f0 * (Ja1_node +
@@ -1024,7 +1022,6 @@ end
                    fluxtilde1_left
     end
 
-    Ja2_node = get_contravariant_vector(2, contravariant_vectors, i, j, k, element)
     for jj in 1:NNODES
         Ja2_avg = 0.5f0 * (Ja2_node +
                    get_contravariant_vector(2, contravariant_vectors,
@@ -1040,7 +1037,6 @@ end
                    fluxtilde2_left
     end
 
-    Ja3_node = get_contravariant_vector(3, contravariant_vectors, i, j, k, element)
     for kk in 1:NNODES
         Ja3_avg = 0.5f0 * (Ja3_node +
                    get_contravariant_vector(3, contravariant_vectors,

--- a/src/solvers/solvers.jl
+++ b/src/solvers/solvers.jl
@@ -97,7 +97,7 @@ struct FullSweepGlobal end
 
 # Fallback for CPU KernelAbstractions backend
 # This fallback is necessary to run tests on KernelAbstractions CPU backend
-@inline flux_differencing_kernel(::KernelAbstractions.CPU, ::HalfSweep) = FullSweep()
+@inline flux_differencing_kernel(::KernelAbstractions.CPU, ::HalfSweep) = FullSweepGlobal()
 @inline flux_differencing_kernel(::Backend, kernel) = kernel
 
 # define types for parabolic solvers


### PR DESCRIPTION
When I tried to make CI happy for KA, I was fighting to make the variables pass the `@synchronize` calls, therefore the duplicate reading of the `node` variables after the `@synchronize` calls have been added. Let's see if that was necessary...

Probably KA CPU will fail, but I have to measure whether this addition has an impact on the GPU performance.

To overcome that, I've set the `FullSweepGlobal()` kernel as default on the CPU KA backend.

As a summary, the redundant readings were necessary, but I've removed them and set `FullSweepGlobal()` as default for the CPU KA backend.