### PR TITLE
Add Makie contour plots for `PlotData2DCartesian`

### DIFF
--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -568,6 +568,43 @@ Colorbar(fig[1, 2], plt)
 plot!(getmesh(pd))
 ```
 
+### Contour plots
+
+For solutions on Cartesian meshes, Trixi.jl also supports unfilled contour lines
+(`contour`) and filled contour bands (`contourf`). Contour lines for a single variable:
+```@example makie-2d
+Makie.contour(pd["rho"])
+```
+
+Filled contour bands:
+```@example makie-2d
+Makie.contourf(pd["rho"])
+```
+
+All variables at once, optionally with mesh overlay:
+```@example makie-2d
+Makie.contour(pd, plot_mesh = true)
+```
+
+`Makie.contour` also accepts the solution directly:
+```@example makie-2d
+Makie.contour(sol)
+```
+
+Keyword arguments are forwarded to the underlying Makie plot. For example, the number of
+contour lines is controlled by `levels`, which takes either the number of levels or a
+vector of level values:
+```@example makie-2d
+Makie.contour(pd["rho"], levels = 5, colormap = :berlin, linewidth = 2)
+```
+
+Finally, `contour!` adds contour lines on top of the plot in the currently active axis,
+e.g., to overlay them on a heatmap:
+```@example makie-2d
+Makie.plot(pd["rho"])
+Makie.contour!(pd["rho"], color = :white)
+```
+
 ### Interactive visualization
 
 Trixi.jl also supports interactive surface plots using [`iplot`](@ref).

--- a/ext/TrixiMakieExt.jl
+++ b/ext/TrixiMakieExt.jl
@@ -500,6 +500,133 @@ function Makie.plot(pd::PlotData2DCartesian, fig = Makie.Figure();
     return FigureAndAxes(fig, axes)
 end
 
+# Makie recipe for 2D contour plots of PlotDataSeries
+function Makie.convert_arguments(::Type{<:Makie.Contour},
+                                 pds::PlotDataSeries{<:PlotData2DCartesian})
+    @unpack plot_data, variable_id = pds
+    @unpack x, y, data = plot_data
+    return (x, y, permutedims(data[variable_id])) # permutedims to match the axis convention of Plots.jl
+end
+
+function Makie.contour(pds::PlotDataSeries{<:PlotData2DCartesian},
+                       fig = Makie.Figure(); kwargs...)
+    @unpack plot_data, variable_id = pds
+    @unpack x, y, variable_names = plot_data
+    ax = Makie.Axis(fig[1, 1],
+                    title = variable_names[variable_id],
+                    xlabel = _makie_guide(plot_data.orientation_x),
+                    ylabel = _makie_guide(plot_data.orientation_y))
+
+    plt = Makie.contour!(ax, pds; colormap = default_Makie_colormap(), kwargs...)
+    Makie.Colorbar(fig[1, 2], plt)
+    ax.aspect = Makie.DataAspect()
+    Makie.xlims!(ax, x[begin], x[end])
+    Makie.ylims!(ax, y[begin], y[end])
+    return Makie.FigureAxisPlot(fig, ax, plt)
+end
+
+function Makie.contour!(pds::PlotDataSeries{<:PlotData2DCartesian}; kwargs...)
+    ax = Makie.current_axis()
+    plt = Makie.contour!(ax, pds; kwargs...)
+    display(Makie.current_figure())
+    return plt
+end
+
+function Makie.contour(pd::PlotData2DCartesian, fig = Makie.Figure();
+                       plot_mesh = false, colormap = default_Makie_colormap(),
+                       kwargs...)
+    n = length(pd)
+    cols = n <= 3 ? n : ceil(Int, sqrt(n))
+    rows = cld(n, cols)
+
+    ticks = _makie_ticks(n)
+    axes = Matrix{Makie.Axis}(undef, rows, cols)
+    for (i, (variable_name, pds)) in enumerate(pd)
+        row, col = cld(i, cols), mod1(i, cols)
+        @unpack x, y, mesh_vertices_x, mesh_vertices_y = pds.plot_data
+
+        ax = Makie.Axis(fig[row, col][1, 1],
+                        title = variable_name,
+                        xlabel = _makie_guide(pd.orientation_x),
+                        ylabel = _makie_guide(pd.orientation_y),
+                        xticks = ticks, yticks = ticks)
+        axes[row, col] = ax
+        plt = Makie.contour!(ax, pds; colormap, kwargs...)
+        Makie.Colorbar(fig[row, col][1, 2], plt; ticks)
+        ax.aspect = Makie.DataAspect()
+        Makie.xlims!(ax, x[begin], x[end])
+        Makie.ylims!(ax, y[begin], y[end])
+        if plot_mesh
+            Makie.lines!(ax, mesh_vertices_x, mesh_vertices_y;
+                         color = :grey, linewidth = 1)
+        end
+    end
+    _fill_empty_axes!(axes, fig, n, rows, cols)
+
+    display(fig)
+    return FigureAndAxes(fig, axes)
+end
+
+# Makie recipe for 2D filled contour plots of PlotDataSeries
+function Makie.convert_arguments(::Type{<:Makie.Contourf},
+                                 pds::PlotDataSeries{<:PlotData2DCartesian})
+    @unpack plot_data, variable_id = pds
+    @unpack x, y, data = plot_data
+    return (x, y, permutedims(data[variable_id])) # permutedims to match the axis convention of Plots.jl
+end
+
+function Makie.contourf(pds::PlotDataSeries{<:PlotData2DCartesian},
+                        fig = Makie.Figure(); kwargs...)
+    @unpack plot_data, variable_id = pds
+    @unpack x, y, variable_names = plot_data
+    ax = Makie.Axis(fig[1, 1],
+                    title = variable_names[variable_id],
+                    xlabel = _makie_guide(plot_data.orientation_x),
+                    ylabel = _makie_guide(plot_data.orientation_y))
+
+    plt = Makie.contourf!(ax, pds; colormap = default_Makie_colormap(), kwargs...)
+    Makie.Colorbar(fig[1, 2], plt)
+    ax.aspect = Makie.DataAspect()
+    Makie.xlims!(ax, x[begin], x[end])
+    Makie.ylims!(ax, y[begin], y[end])
+    return Makie.FigureAxisPlot(fig, ax, plt)
+end
+
+function Makie.contourf(pd::PlotData2DCartesian, fig = Makie.Figure();
+                        plot_mesh = false, colormap = default_Makie_colormap(),
+                        kwargs...)
+    n = length(pd)
+    cols = n <= 3 ? n : ceil(Int, sqrt(n))
+    rows = cld(n, cols)
+
+    ticks = _makie_ticks(n)
+    axes = Matrix{Makie.Axis}(undef, rows, cols)
+    for (i, (variable_name, pds)) in enumerate(pd)
+        row, col = cld(i, cols), mod1(i, cols)
+        @unpack x, y, mesh_vertices_x, mesh_vertices_y = pds.plot_data
+
+        ax = Makie.Axis(fig[row, col][1, 1],
+                        title = variable_name,
+                        xlabel = _makie_guide(pd.orientation_x),
+                        ylabel = _makie_guide(pd.orientation_y),
+                        xticks = ticks, yticks = ticks)
+        axes[row, col] = ax
+        plt = Makie.contourf!(ax, pds; colormap, kwargs...)
+        Makie.Colorbar(fig[row, col][1, 2], plt; ticks)
+        ax.aspect = Makie.DataAspect()
+        Makie.xlims!(ax, x[begin], x[end])
+        Makie.ylims!(ax, y[begin], y[end])
+        if plot_mesh
+            Makie.lines!(ax, mesh_vertices_x, mesh_vertices_y;
+                         color = :grey, linewidth = 1)
+        end
+    end
+    _fill_empty_axes!(axes, fig, n, rows, cols)
+
+    display(fig)
+    return FigureAndAxes(fig, axes)
+end
+
 # Makie does not yet support layouts in its plot recipes, so we overload `Makie.plot` directly.
 function Makie.plot(sol::TrixiODESolution; solution_variables = nothing, kwargs...)
     if ndims(sol.prob.p) == 1
@@ -507,6 +634,15 @@ function Makie.plot(sol::TrixiODESolution; solution_variables = nothing, kwargs.
     else
         pd = PlotData2D(sol; solution_variables) # use Julias dispatch here
         return Makie.plot(pd; kwargs...)
+    end
+end
+
+function Makie.contour(sol::TrixiODESolution; solution_variables = nothing, kwargs...)
+    if ndims(sol.prob.p) == 1
+        throw(ArgumentError("Contour plots are not supported for 1D solutions."))
+    else
+        pd = PlotData2D(sol; solution_variables) # use Julias dispatch here
+        return Makie.contour(pd; kwargs...)
     end
 end
 

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -1080,6 +1080,9 @@ end
     Makie.plot(pd["scalar"])
     @trixi_test_nowarn Makie.plot!(Trixi.PlotMesh(pd), color = :black,
                                    linestyle = :dash)
+
+    # contour plots are only defined for 2D solutions
+    @test_throws ArgumentError Makie.contour(sol)
 end
 @testitem "Visualization: Makie visualization tests for TreeMesh2D" setup=[
     Setup,
@@ -1121,6 +1124,33 @@ end
     @trixi_test_nowarn Makie.plot!(Trixi.PlotMesh(pd), color = :black,
                                    linestyle = :dash)
 
+    # Makie.contour(pds) gives title, xlabel, ylabel and colorbar
+    @trixi_test_nowarn Makie.contour(pd["scalar"])
+
+    # kwargs are forwarded to contour!
+    @trixi_test_nowarn Makie.contour(pd["scalar"], levels = 5)
+
+    # Makie.contour(pd) gives layout for all variables
+    @trixi_test_nowarn Makie.contour(pd)
+    @trixi_test_nowarn Makie.contour(pd, plot_mesh = true)
+
+    # Makie.contour(sol) for 2D TreeMesh solutions
+    @trixi_test_nowarn Makie.contour(sol)
+
+    # the same for filled contours
+    @trixi_test_nowarn Makie.contourf(pd["scalar"])
+    @trixi_test_nowarn Makie.contourf(pd["scalar"], levels = 5)
+    @trixi_test_nowarn Makie.contourf(pd)
+    @trixi_test_nowarn Makie.contourf(pd, plot_mesh = true)
+
+    # contour! overlay on the current axis
+    Makie.plot(pd["scalar"])
+    @trixi_test_nowarn Makie.contour!(pd["scalar"])
+
+    # kwargs are forwarded to contour! in the overlay
+    Makie.plot(pd["scalar"])
+    @trixi_test_nowarn Makie.contour!(pd["scalar"], levels = 5, color = :white)
+
     # FV (polydeg = 0): `pd_fv.x`/`.y` are the `length(data)+1` cell edges.
     @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_2d_dgsem",
                                  "elixir_advection_basic.jl"),
@@ -1148,6 +1178,12 @@ end
         @test limits[1] < limits[2]
     end
     @trixi_test_nowarn Makie.plot(pd_const["v1_mean"])
+
+    # Constant variables have no contour lines, but the plots must still be created.
+    @trixi_test_nowarn Makie.contour(pd_const)
+    @trixi_test_nowarn Makie.contour(pd_const["v1_mean"])
+    @trixi_test_nowarn Makie.contourf(pd_const)
+    @trixi_test_nowarn Makie.contourf(pd_const["v1_mean"])
 
     # The seven variables do not fill the 3x3 layout, so the unused cells must still
     # hold (empty) axes instead of undefined references.


### PR DESCRIPTION
This PR addresses the Makie.jl part of https://github.com/trixi-framework/Trixi.jl/issues/3075
for `PlotData2DCartesian`. A separate PR for `PlotData2DTriangulated` will follow.

## Added

- `Makie.contour` and `Makie.contourf`, both for a single variable and for all variables of a
  `PlotData2DCartesian`
- `Makie.contour!` adds colored isolines on top of the plot
- `Makie.contour(sol)`
- Keyword arguments such as `levels`, `colormap`, `linewidth` and `labels` are forwarded to
  Makie.jl, and `plot_mesh = true` overlays the mesh

## Visual results

```julia
using Trixi, CairoMakie
trixi_include(joinpath(examples_dir(), "tree_2d_dgsem", "elixir_acoustics_gauss.jl"))

pd = PlotData2D(sol)

plot(pd["v1_prime"])
contour!(pd["v1_prime"], labels = true)
```

<img width="1200" height="900" alt="download-9" src="https://github.com/user-attachments/assets/dc4ee2cf-0fe0-4e8b-979a-7dde98eff8c3" />

```julia
contourf(pd["v1_prime"])
```

<img width="1200" height="900" alt="download-10" src="https://github.com/user-attachments/assets/84b59b50-f541-4a64-a824-b2f5c776e2ef" />

## Constant fields

`elixir_acoustics_gauss.jl` has four constant variables (`v1_mean`, `v2_mean`, `c_mean` and
`rho_mean`).

```julia
contour(pd)
```

<img width="1200" height="900" alt="download-13" src="https://github.com/user-attachments/assets/e746b9b2-22bb-4d88-9cdc-13409aed5543" />

`contour` leaves the constant variables empty.

However, `contourf` draws those same variables speckled:

```julia
contourf(pd["v1_mean"])
```

<img width="1200" height="900" alt="download-15" src="https://github.com/user-attachments/assets/5294a252-26e0-4a9d-9edd-5d589d04fe95" />

This comes from how Makie.jl builds levels for a constant field(https://github.com/MakieOrg/Makie.jl/pull/5682): they are symmetric around the
constant value, so with the default of ten bands the middle band edge falls exactly on it.
Interpolating onto the plotting nodes leaves a spread in the data, and every node
below that edge is drawn in the neighbouring band, a full colormap step away.

I have opened https://github.com/MakieOrg/Makie.jl/pull/5787, which puts the constant value in
the middle of a band instead of on an edge. Once that is merged and released, these plots come
out in a single color with no change needed here. Until then, an odd number of levels works
around it:

```julia
contourf(pd["v1_mean"], levels = 11)
```

<img width="1200" height="900" alt="download-16" src="https://github.com/user-attachments/assets/2474e68d-ad92-4d18-852e-20d5a83e64bf" />


